### PR TITLE
try to skip 2FA for testflight

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -69,7 +69,10 @@ platform :ios do
       export_method: "app-store",
       configuration: "Ecosia"
     )
-    pilot(skip_waiting_for_build_processing: true)
+    pilot(
+      skip_waiting_for_build_processing: true, 
+      apple_id: "apple-dev@ecosia.org"
+    )
   end 
 
 end


### PR DESCRIPTION
Fastlane docs state that 2FA authentication can be skipped by providing those arguments to `pilot` .
http://docs.fastlane.tools/actions/pilot/#use-an-application-specific-password-to-upload

I also create a fresh specific application password. Let's see if that works out at next release
