### PR TITLE
Don't show stop when progress is zero

### DIFF
--- a/Client/Frontend/Browser/URLBarView.swift
+++ b/Client/Frontend/Browser/URLBarView.swift
@@ -428,7 +428,7 @@ class URLBarView: UIView {
     func updateProgressBar(_ progress: Float) {
         let shouldShowNewTabButton = profile?.prefs.boolForKey(PrefsKeys.ShowNewTabToolbarButton) ?? (newTabUserResearch?.newTabState ?? false)
         if shouldShowNewTabButton {
-            locationView.reloadButton.reloadButtonState = progress != 1 ? .stop : .reload
+            locationView.reloadButton.reloadButtonState = progress != 1 && progress != 0 ? .stop : .reload
         } else {
             locationView.reloadButton.reloadButtonState = .disabled
         }


### PR DESCRIPTION
Avoid showing stop button on search bar when progress is 0 (after clicking back for example)
