### PR TITLE
Migration error: db connection not open

### DIFF
--- a/Client/Ecosia/Migration/EcosiaHistory.swift
+++ b/Client/Ecosia/Migration/EcosiaHistory.swift
@@ -33,6 +33,10 @@ final class EcosiaHistory {
         start = Date()
         DispatchQueue.global(qos: .userInitiated).async {
             let data = prepare(history: historyItems, progress: progress)
+            guard !profile.isShutdown else {
+                finished(.failure(.init(reasons: [NSError(domain: "shutdown", code: 0)])))
+                return
+            }
 
             DispatchQueue.main.async {
                 insertData(data, to: profile, finished: finished)

--- a/Client/Ecosia/Migration/EcosiaHistory.swift
+++ b/Client/Ecosia/Migration/EcosiaHistory.swift
@@ -34,7 +34,7 @@ final class EcosiaHistory {
         DispatchQueue.global(qos: .userInitiated).async {
             let data = prepare(history: historyItems, progress: progress)
             guard !profile.isShutdown else {
-                finished(.failure(.init(reasons: [NSError(domain: "database is shutdown", code: 0)])))
+                finished(.failure(.init(reasons: [NSError(domain: "Database is shutdown", code: EcosiaImport.Failure.Code.history.rawValue)])))
                 return
             }
 

--- a/Client/Ecosia/Migration/EcosiaHistory.swift
+++ b/Client/Ecosia/Migration/EcosiaHistory.swift
@@ -34,7 +34,7 @@ final class EcosiaHistory {
         DispatchQueue.global(qos: .userInitiated).async {
             let data = prepare(history: historyItems, progress: progress)
             guard !profile.isShutdown else {
-                finished(.failure(.init(reasons: [NSError(domain: "shutdown", code: 0)])))
+                finished(.failure(.init(reasons: [NSError(domain: "database is shutdown", code: 0)])))
                 return
             }
 

--- a/Client/Ecosia/Migration/EcosiaImport.swift
+++ b/Client/Ecosia/Migration/EcosiaImport.swift
@@ -22,8 +22,7 @@ final class EcosiaImport {
 
     struct Failure: Error {
         enum Code: Int {
-            case shutdown = 900,
-                 favourites = 911,
+            case favourites = 911,
                  history = 912,
                  tabs = 913
         }

--- a/Client/Ecosia/Migration/EcosiaImport.swift
+++ b/Client/Ecosia/Migration/EcosiaImport.swift
@@ -22,7 +22,8 @@ final class EcosiaImport {
 
     struct Failure: Error {
         enum Code: Int {
-            case favourites = 911,
+            case shutdown = 900,
+                 favourites = 911,
                  history = 912,
                  tabs = 913
         }


### PR DESCRIPTION
An option is to check whether the connection to the DB is still open after prepare but before inserting the new data.
This at least prevents leaving the app in an undefined state.
