### PR TITLE
Don't close DB when migration is still ongoing / tweak scenario

### DIFF
--- a/Client/Ecosia/Migration/AppDelegate+Ecosia.swift
+++ b/Client/Ecosia/Migration/AppDelegate+Ecosia.swift
@@ -7,7 +7,10 @@ import Core
 
 extension AppDelegate {
     func migrateEcosiaContents() {
-        guard EcosiaImport.isNeeded, let profile = profile else { return }
+        guard EcosiaImport.isNeeded, let profile = profile else {
+            User.shared.migrated = true
+            return
+        }
         window?.rootViewController?.present(LoadingScreen(profile: profile, tabManager: tabManager), animated: false)
     }
 }

--- a/Client/Ecosia/Migration/EcosiaImport+PerformanceTests.swift
+++ b/Client/Ecosia/Migration/EcosiaImport+PerformanceTests.swift
@@ -94,7 +94,7 @@ extension EcosiaImport {
         let history = Core.History()
         let favs = Core.Favourites()
 
-        let items = mockHistory(days: 100, visits: 50) // 100 TLDs
+        let items = mockHistory(days: 1000, visits: 50) // 50 different sites in last 1000 days
         history.items = items
 
         let topSiteUrls = getTopSiteURLs()

--- a/ClientTests/TestHistoryMigration.swift
+++ b/ClientTests/TestHistoryMigration.swift
@@ -26,7 +26,7 @@ class TestHistoryMigration: TestHistory {
                     URL(string:"https://ecosia.org/blog")!,
                     URL(string:"https://ecosia.org/blog")!]
 
-        let items = urls.map{ (Date(), Core.Page(url: $0, title: "Ecosia")) }
+        let items = urls.map { (Date(), Core.Page(url: $0, title: "Ecosia")) }
         let data = EcosiaHistory.prepare(history: items)
         XCTAssert(data.domains["apple.com"] == 1)
         XCTAssert(data.domains["ecosia.org"] == 2)

--- a/Providers/Profile.swift
+++ b/Providers/Profile.swift
@@ -14,6 +14,7 @@ import Sync
 import XCGLogger
 import SwiftKeychainWrapper
 import SyncTelemetry
+import Core
 
 // Import these dependencies ONLY for the main `Client` application target.
 #if MOZ_TARGET_CLIENT
@@ -331,6 +332,8 @@ open class BrowserProfile: Profile {
     }
 
     func _shutdown() {
+        guard User.shared.migrated == true else { return }
+
         log.debug("Shutting down profile.")
         isShutdown = true
 


### PR DESCRIPTION
- make migration more resilient
- increase migration test scenario to 1000 days of history (was 100)
- do not close profile when migration has not finished (so continues after going to BG)
- tested on iPhone 7
