### PR TITLE
use dict to speed up existing urls lookup

### DIFF
--- a/Client/Ecosia/Migration/EcosiaHistory.swift
+++ b/Client/Ecosia/Migration/EcosiaHistory.swift
@@ -100,7 +100,7 @@ final class EcosiaHistory {
 
             // add all visits
             let visit = SiteVisit(site: mappedSite.0, date: item.0.toMicrosecondTimestamp())
-            visits.append((visit, mappedSite.1))
+            visits.append((visit, mappedSite.0.id!))
 
             // only report every 50th entry to not over-report
             if i % 50 == 0 {

--- a/Client/Ecosia/Migration/EcosiaHistory.swift
+++ b/Client/Ecosia/Migration/EcosiaHistory.swift
@@ -11,7 +11,7 @@ final class EcosiaHistory {
 
     struct Data {
         let domains: [String: Int]
-        let sites: [Site: Int]
+        let sites: [(Site, Int)]
         let visits: [(SiteVisit, Int)]
     }
 
@@ -74,11 +74,12 @@ final class EcosiaHistory {
     static func prepare(history: [(Date, Core.Page)], progress: ((Double) -> ())? = nil) -> EcosiaHistory.Data {
         // extract distinct domains
         var domains = [String: Int]() //unique per domain e.g. ecosia.org + domain_id
-        var sites = [Site: Int]() // unique per url e.g. ecosia.org/search?q=foo + domain_id
+        var mappedSites = [String: (Site, Int)]() // unique per url, e.g. ecosia.org/search?q=foo + domain_id
         var visits = [(SiteVisit, Int)]() // all visitis + site_id
 
         for (i, item) in history.enumerated() {
-            guard let domain = item.1.url.normalizedHost, !isIgnoredURL(domain) else { continue }
+            let url = item.1.url
+            guard let domain = url.normalizedHost, !isIgnoredURL(domain) else { continue }
             var domainIndex: Int
             if let index = domains[domain] {
                 domainIndex = index
@@ -87,18 +88,19 @@ final class EcosiaHistory {
                 domains[domain] = domainIndex
             }
 
-            var site: Site
-            if let match = sites.first(where: { $0.key.url == item.1.url.absoluteString }) {
-                site = match.key
+            var mappedSite: (Site, Int)
+            if let match = mappedSites[url.absoluteString] {
+                mappedSite = match
             } else {
-                site = Site(url: item.1.url.absoluteString, title: item.1.title)
-                site.id = sites.count + 1
-                sites[site] = domainIndex
+                let site = Site(url: url.absoluteString, title: item.1.title)
+                site.id = mappedSites.count + 1
+                mappedSite = (site, domainIndex)
+                mappedSites[url.absoluteString] = mappedSite
             }
 
             // add all visits
-            let visit = SiteVisit(site: site, date: item.0.toMicrosecondTimestamp())
-            visits.append((visit, site.id!))
+            let visit = SiteVisit(site: mappedSite.0, date: item.0.toMicrosecondTimestamp())
+            visits.append((visit, mappedSite.1))
 
             // only report every 50th entry to not over-report
             if i % 50 == 0 {
@@ -108,6 +110,6 @@ final class EcosiaHistory {
             }
 
         }
-        return .init(domains: domains, sites: sites, visits: visits)
+        return .init(domains: domains, sites: Array(mappedSites.values), visits: visits)
     }
 }

--- a/ClientTests/TestHistoryMigration.swift
+++ b/ClientTests/TestHistoryMigration.swift
@@ -31,6 +31,10 @@ class TestHistoryMigration: TestHistory {
         XCTAssert(data.domains["apple.com"] == 1)
         XCTAssert(data.domains["ecosia.org"] == 2)
         XCTAssert(data.domains.count == 2)
+        XCTAssert(data.sites[0].1 == 1)
+        XCTAssert(data.sites[1].1 == 2)
+        XCTAssert(data.sites[2].1 == 2)
+
         XCTAssert(data.sites.count == 3)
         XCTAssert(data.visits.count == 4)
     }

--- a/ClientTests/TestHistoryMigration.swift
+++ b/ClientTests/TestHistoryMigration.swift
@@ -24,19 +24,27 @@ class TestHistoryMigration: TestHistory {
         let urls = [URL(string:"https://apple.com")!,
                     URL(string:"https://ecosia.org")!,
                     URL(string:"https://ecosia.org/blog")!,
-                    URL(string:"https://ecosia.org/blog")!]
+                    URL(string:"https://ecosia.org/blog")!,
+                    URL(string:"https://www.ecosia.org/blog")!]
 
         let items = urls.map { (Date(), Core.Page(url: $0, title: "Ecosia")) }
         let data = EcosiaHistory.prepare(history: items)
+        XCTAssert(data.domains.count == 2)
         XCTAssert(data.domains["apple.com"] == 1)
         XCTAssert(data.domains["ecosia.org"] == 2)
-        XCTAssert(data.domains.count == 2)
-        XCTAssert(data.sites[0].1 == 1)
-        XCTAssert(data.sites[1].1 == 2)
-        XCTAssert(data.sites[2].1 == 2)
 
-        XCTAssert(data.sites.count == 3)
-        XCTAssert(data.visits.count == 4)
+        XCTAssert(data.sites.count == 4)
+        XCTAssert(data.sites.first(where: {$0.0.url == "https://apple.com" })!.1 == 1)
+        XCTAssert(data.sites.first(where: {$0.0.url == "https://ecosia.org" })!.1 == 2)
+        XCTAssert(data.sites.first(where: {$0.0.url == "https://ecosia.org/blog" })!.1 == 2)
+        XCTAssert(data.sites.first(where: {$0.0.url == "https://www.ecosia.org/blog" })!.1 == 2)
+
+        XCTAssert(data.visits.count == 5)
+        XCTAssert(data.visits[0].1 == 1)
+        XCTAssert(data.visits[1].1 == 2)
+        XCTAssert(data.visits[2].1 == 3)
+        XCTAssert(data.visits[3].1 == 3)
+        XCTAssert(data.visits[4].1 == 4)
     }
 
     func testImportFailureDescription() {

--- a/Storage/SQL/SQLiteHistory.swift
+++ b/Storage/SQL/SQLiteHistory.swift
@@ -1049,11 +1049,11 @@ extension SQLiteHistory {
         return db.bulkInsert(TableDomains, op: .InsertOrIgnore, columns: ["domain", "id"], values: domainArgs)
     }
 
-    public func storeSites(_ sites: [Site: Int]) -> Success {
+    public func storeSites(_ sites: [(Site, Int)]) -> Success {
         let now = Date.now()
 
         let args = sites.map({ site in
-            [site.key.id!, Bytes.generateGUID(), site.key.url, site.key.title, now, 0, 0, site.value]
+            [site.0.id!, Bytes.generateGUID(), site.0.url, site.0.title, now, 0, 0, site.1]
         })
 
         let columns = ["id", "guid", "url", "title", "local_modified", "is_deleted", "should_upload", "domain_id"]


### PR DESCRIPTION
Improve migration preparation speed for history by using internal Foundation-Dictionary lookup instead of regular string comparision