### PR TITLE
Fix autosizing of .value1 table view cells in settings

### DIFF
--- a/Client/Ecosia/EcosiaSettings.swift
+++ b/Client/Ecosia/EcosiaSettings.swift
@@ -30,6 +30,15 @@ class SearchAreaSetting: Setting {
     override func onClick(_ navigationController: UINavigationController?) {
         navigationController?.pushViewController(MarketsController(), animated: true)
     }
+
+    override func onConfigureCell(_ cell: UITableViewCell) {
+        super.onConfigureCell(cell)
+        cell.detailTextLabel?.numberOfLines = 2
+        cell.detailTextLabel?.adjustsFontSizeToFitWidth = true
+        cell.detailTextLabel?.minimumScaleFactor = 0.8
+        cell.detailTextLabel?.allowsDefaultTighteningForTruncation = true
+        cell.textLabel?.numberOfLines = 2
+    }
 }
 
 class SafeSearchSettings: Setting {
@@ -48,6 +57,13 @@ class SafeSearchSettings: Setting {
     override func onClick(_ navigationController: UINavigationController?) {
         navigationController?.pushViewController(FilterController(), animated: true)
     }
+
+    override func onConfigureCell(_ cell: UITableViewCell) {
+        super.onConfigureCell(cell)
+        cell.detailTextLabel?.numberOfLines = 2
+        cell.textLabel?.numberOfLines = 2
+    }
+
 }
 
 class AutoCompleteSettings: BoolSetting {

--- a/Client/Ecosia/EcosiaSettings.swift
+++ b/Client/Ecosia/EcosiaSettings.swift
@@ -63,7 +63,6 @@ class SafeSearchSettings: Setting {
         cell.detailTextLabel?.numberOfLines = 2
         cell.textLabel?.numberOfLines = 2
     }
-
 }
 
 class AutoCompleteSettings: BoolSetting {

--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -1145,6 +1145,15 @@ class OpenWithSetting: Setting {
         }
         return NSAttributedString(string: "")
     }
+    
+    override func onConfigureCell(_ cell: UITableViewCell) {
+        super.onConfigureCell(cell)
+        cell.detailTextLabel?.numberOfLines = 2
+        cell.detailTextLabel?.adjustsFontSizeToFitWidth = true
+        cell.detailTextLabel?.minimumScaleFactor = 0.8
+        cell.detailTextLabel?.allowsDefaultTighteningForTruncation = true
+        cell.textLabel?.numberOfLines = 2
+    }
 
     override var style: UITableViewCell.CellStyle { return .value1 }
 
@@ -1211,6 +1220,12 @@ class ThemeSetting: Setting {
 
     override func onClick(_ navigationController: UINavigationController?) {
         navigationController?.pushViewController(ThemeSettingsController(), animated: true)
+    }
+
+    override func onConfigureCell(_ cell: UITableViewCell) {
+        super.onConfigureCell(cell)
+        cell.detailTextLabel?.numberOfLines = 1
+        cell.textLabel?.numberOfLines = 1
     }
 }
 


### PR DESCRIPTION
Cell autosizing for UITableViewCell Style **Value1** is broken when textLabel is very long and would need multiple lines even in latest iOS14 starting from iOS11. This fixes it with some very ugly pixel calculation code ^^
![Simulator Screen Shot - iPhone SE (1st generation) - 2021-05-25 at 16 04 37](https://user-images.githubusercontent.com/60604005/119522292-220ffe80-bd7c-11eb-87fa-0636326ae3df.png)
![Image-1](https://user-images.githubusercontent.com/60604005/119522376-318f4780-bd7c-11eb-8680-f2e3a0e3f972.jpeg)



