### PR TITLE
Skip migration after it had crashed

### DIFF
--- a/Client/Ecosia/Analytics/Analytics.Values.swift
+++ b/Client/Ecosia/Analytics/Analytics.Values.swift
@@ -85,6 +85,7 @@ extension Analytics {
         case
         tabs,
         favourites,
-        history
+        history,
+        exception
     }
 }

--- a/Client/Ecosia/Migration/EcosiaImport.swift
+++ b/Client/Ecosia/Migration/EcosiaImport.swift
@@ -28,6 +28,24 @@ final class EcosiaImport {
         }
     }
 
+    struct Exception: Codable {
+        let reason: String
+
+        private static let path = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0].appendingPathComponent("migration.ecosia")
+
+        static func load() -> Exception? {
+            try? JSONDecoder().decode(Exception.self, from: .init(contentsOf: path))
+        }
+
+        func save() {
+            try? JSONEncoder().encode(self).write(to: Self.path, options: .atomic)
+        }
+
+        static func clear() {
+            try? FileManager.default.removeItem(at: path)
+        }
+    }
+
     let profile: Profile
 
     private var progress: ((Double) -> ())?


### PR DESCRIPTION
- detect and persist exception during migration
- if exception occured -> send reason to Analytics and skip migration

