### PR TITLE
Fix browser crash

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1634,7 +1634,7 @@ extension BrowserViewController: URLBarDelegate {
 extension BrowserViewController: TabDelegate {
 
     func tab(_ tab: Tab, didCreateWebView webView: WKWebView) {
-        webView.frame = webViewContainer.frame
+        webView.frame = webViewContainer?.frame ?? .init()
         // Observers that live as long as the tab. Make sure these are all cleared in willDeleteWebView below!
         KVOs.forEach { webView.addObserver(self, forKeyPath: $0.rawValue, options: .new, context: nil) }
         webView.scrollView.addObserver(self.scrollController, forKeyPath: KVOConstants.contentSize.rawValue, options: .new, context: nil)

--- a/Shared/AppConstants.swift
+++ b/Shared/AppConstants.swift
@@ -22,7 +22,7 @@ public enum AppBuildChannel: String {
 public enum KVOConstants: String {
     case loading = "loading"
     case estimatedProgress = "estimatedProgress"
-    case URL = "URL"
+    case URL = "url"
     case title = "title"
     case canGoBack = "canGoBack"
     case canGoForward = "canGoForward"


### PR DESCRIPTION
After some testing and being unable to reproduce the crashes, my understanding is that it could be related to KVO behaving as case sensitive in some cases regarding `URL`. (It is actually `url` the property in `WKWebView`).