### PR TITLE
Hide backdrop when opening a new tab

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1914,6 +1914,8 @@ extension BrowserViewController: TabManagerDelegate {
             animation.fromValue = CATransform3DMakeScale(0.6, 0.6, 1)
             animation.timingFunction = .init(name: .easeInEaseOut)
             firefoxHomeViewController?.view.layer.add(animation, forKey: "scale")
+            
+            webViewContainerBackdrop.alpha = 0
 
             // This is a terrible workaround for a bad iOS 12 bug where PDF
             // content disappears any time the view controller changes (i.e.


### PR DESCRIPTION
Turns out the backdrop is only needed when the app is resigning active. So it should be hidden when opening a new tab.