### PR TITLE
Fix TreesCell dark appearance for impact screen

### DIFF
--- a/Client/Ecosia/UI/EcosiaTheme.swift
+++ b/Client/Ecosia/UI/EcosiaTheme.swift
@@ -40,6 +40,7 @@ class EcosiaTheme {
     var barSeparator: UIColor { UIColor.Photon.Grey20 }
     var treeCountText: UIColor { UIColor(named: "emerald")! }
     var treeCountBackground: UIColor { UIColor(rgb: 0xE2F7F1) }
+    var impactTreeCountBackground: UIColor { treeCountBackground }
     var ntpImpactBackground: UIColor { .white}
     var impactBackground: UIColor { UIColor.Photon.Grey10 }
     var impactMultiplyCardBackground: UIColor { .white }
@@ -79,6 +80,7 @@ final class DarkEcosiaTheme: EcosiaTheme {
     override var primaryBackground: UIColor { UIColor.Photon.Grey90 }
     override var treeCountText: UIColor { .white }
     override var treeCountBackground: UIColor { UIColor.Photon.Grey70 }
+    override var impactTreeCountBackground: UIColor { UIColor.Photon.Grey80 }
     override var ntpImpactBackground: UIColor { UIColor.Photon.Grey80}
     override var impactBackground: UIColor { UIColor.Photon.Grey60 }
     override var impactMultiplyCardBackground: UIColor { .Photon.Grey70 }

--- a/Client/Ecosia/UI/MyImpact/EcosiaHome.swift
+++ b/Client/Ecosia/UI/MyImpact/EcosiaHome.swift
@@ -143,6 +143,7 @@ final class EcosiaHome: UICollectionViewController, UICollectionViewDelegateFlow
     fileprivate var treesCellModel: TreesCellModel {
         return .init(title: .localizedPlural(.searches, num: personalCounter.state!),
                      subtitle: .localized(.onAverageItTakes),
+                     appearance: .impact,
                      highlight: nil,
                      spotlight: nil)
     }

--- a/Client/Ecosia/UI/NTP/TreesCell.swift
+++ b/Client/Ecosia/UI/NTP/TreesCell.swift
@@ -320,10 +320,12 @@ final class TreesCell: UICollectionViewCell, Themeable {
             background.backgroundColor = UIColor.theme.ecosia.primaryBackground
         }
 
-        impactBackground.backgroundColor = (isHighlighted || isSelected) ? UIColor.theme.ecosia.hoverBackgroundColor : UIColor.theme.ecosia.ntpImpactBackground
+        let backgroundColor = model?.appearance == .ntp ? UIColor.theme.ecosia.ntpImpactBackground : UIColor.theme.ecosia.highlightedBackground
+        impactBackground.backgroundColor = (isHighlighted || isSelected) ? UIColor.theme.ecosia.hoverBackgroundColor : backgroundColor
 
         spotlightBackground.backgroundColor = .clear
-        globalCountBackground.backgroundColor = UIColor.theme.ecosia.treeCountBackground
+        let treeCountBackground = model?.appearance == .ntp ? UIColor.theme.ecosia.treeCountBackground : UIColor.theme.ecosia.impactTreeCountBackground
+        globalCountBackground.backgroundColor = treeCountBackground
 
         let borderWidth: CGFloat = ThemeManager.instance.current.isDark ? 0 : 1
         background.layer.borderColor = UIColor.theme.ecosia.personalCounterBorder.cgColor

--- a/Client/Ecosia/UI/NTP/TreesCellModel.swift
+++ b/Client/Ecosia/UI/NTP/TreesCellModel.swift
@@ -5,8 +5,13 @@
 import Foundation
 
 struct TreesCellModel {
+    enum Appearance {
+        case ntp, impact
+    }
+
     let title: String
     let subtitle: String
+    let appearance: Appearance
 
     let highlight: String?
     var spotlight: Spotlight?

--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -1305,6 +1305,7 @@ extension FirefoxHomeViewController: TreesCellDelegate {
         guard Referrals.isActive else {
             return .init(title: .localizedPlural(.searches, num: personalCounter.state!),
                          subtitle: .localized(.viewMyImpact),
+                         appearance: .ntp,
                          highlight: nil,
                          spotlight: nil)
         }
@@ -1312,6 +1313,7 @@ extension FirefoxHomeViewController: TreesCellDelegate {
         if personalCounter.state == 0 && User.shared.referrals.impact == 0 {
             return .init(title: "0",
                          subtitle: .localized(.startPlanting),
+                         appearance: .ntp,
                          highlight: nil,
                          spotlight: spotlight)
         }
@@ -1319,6 +1321,7 @@ extension FirefoxHomeViewController: TreesCellDelegate {
         if User.shared.referrals.isNewClaim {
             return .init(title: "\(User.shared.impact)",
                          subtitle: .localized(.myTrees),
+                         appearance: .ntp,
                          highlight: .localized(.keepGoing),
                          spotlight: spotlight )
         }
@@ -1330,14 +1333,15 @@ extension FirefoxHomeViewController: TreesCellDelegate {
             } else {
                 highlight = .init(format: .localized(.referralsAccepted), "\(User.shared.referrals.newClaims)", "\(User.shared.referrals.newClaims)")
             }
-            return .init(title: "\(User.shared.impact)", subtitle: .localized(.myTrees), highlight: highlight, spotlight: spotlight)
+            return .init(title: "\(User.shared.impact)", subtitle: .localized(.myTrees), appearance: .ntp, highlight: highlight, spotlight: spotlight)
         }
 
         // default
         return .init(title: "\(User.shared.impact)",
                      subtitle: .localized(.myTrees),
+                     appearance: .ntp,
                      highlight: nil,
-                     spotlight: spotlight )
+                     spotlight: spotlight)
     }
 
     func treesCellDidTapSpotlight(_ cell: TreesCell) {


### PR DESCRIPTION
The same cell has a different appearance on ntp and my impact. Now fixed
<img width="399" alt="Screenshot 2022-02-08 at 14 58 53" src="https://user-images.githubusercontent.com/60604005/153001964-4744680d-a022-44ba-bbf0-12831395629a.png">
<img width="395" alt="Screenshot 2022-02-08 at 14 58 47" src="https://user-images.githubusercontent.com/60604005/153001969-2e3ea5a2-785c-4399-867c-e4828f094837.png">
 