### PR TITLE
Sync referral instances

### DIFF
--- a/Client/Ecosia/Migration/LoadingScreen.swift
+++ b/Client/Ecosia/Migration/LoadingScreen.swift
@@ -8,7 +8,7 @@ final class LoadingScreen: UIViewController {
     private weak var profile: Profile!
     private weak var tabManager: TabManager!
     private weak var progress: UIProgressView!
-    private let referrals: Referrals
+    private weak var referrals: Referrals!
     private var referralCode: String?
 
     let loadingGroup = DispatchGroup()

--- a/Client/Ecosia/Migration/LoadingScreen.swift
+++ b/Client/Ecosia/Migration/LoadingScreen.swift
@@ -8,14 +8,16 @@ final class LoadingScreen: UIViewController {
     private weak var profile: Profile!
     private weak var tabManager: TabManager!
     private weak var progress: UIProgressView!
+    private let referrals: Referrals
     private var referralCode: String?
 
     let loadingGroup = DispatchGroup()
     
     required init?(coder: NSCoder) { nil }
-    init(profile: Profile, tabManager: TabManager, referralCode: String? = nil) {
+    init(profile: Profile, tabManager: TabManager, referrals: Referrals, referralCode: String? = nil) {
         self.profile = profile
         self.tabManager = tabManager
+        self.referrals = referrals
         self.referralCode = referralCode
         super.init(nibName: nil, bundle: nil)
         modalPresentationStyle = .fullScreen
@@ -152,10 +154,8 @@ final class LoadingScreen: UIViewController {
     }
 
     // MARK: Referrals
-    var referrals: Referrals?
     private func claimReferral(_ code: String) {
-        self.referrals = Referrals()
-        referrals?.claim(referrer: code) { [weak self] result in
+        referrals.claim(referrer: code) { [weak self] result in
             User.shared.referrals.pendingClaim = nil
 
             switch result {

--- a/Client/Ecosia/UI/MyImpact/EcosiaHome.swift
+++ b/Client/Ecosia/UI/MyImpact/EcosiaHome.swift
@@ -108,7 +108,7 @@ final class EcosiaHome: UICollectionViewController, UICollectionViewDelegateFlow
     private let images = Images(.init(configuration: .ephemeral))
     private let news = News()
     private let personalCounter = PersonalCounter()
-    private let referrals = Referrals()
+    private var referrals: Referrals!
 
     lazy var impactModel: MyImpactCellModel = {
         return refreshImpactModel()
@@ -148,7 +148,7 @@ final class EcosiaHome: UICollectionViewController, UICollectionViewDelegateFlow
                      spotlight: nil)
     }
 
-    convenience init(delegate: EcosiaHomeDelegate?) {
+    convenience init(delegate: EcosiaHomeDelegate?, referrals: Referrals) {
         let layout = EcosiaHomeLayout()
         layout.scrollDirection = .vertical
         layout.minimumInteritemSpacing = 16
@@ -158,6 +158,7 @@ final class EcosiaHome: UICollectionViewController, UICollectionViewDelegateFlow
         self.init(collectionViewLayout: layout)
         self.title = .localized(.myImpact).capitalized
         self.delegate = delegate
+        self.referrals = referrals
         navigationItem.largeTitleDisplayMode = .always
     }
 
@@ -321,7 +322,7 @@ final class EcosiaHome: UICollectionViewController, UICollectionViewDelegateFlow
                 }
             dismiss(animated: true, completion: nil)
         case .multiply:
-            navigationController?.pushViewController(MultiplyImpact(delegate: delegate), animated: true)
+            navigationController?.pushViewController(MultiplyImpact(delegate: delegate, referrals: referrals), animated: true)
         }
     }
 
@@ -422,7 +423,7 @@ final class EcosiaHome: UICollectionViewController, UICollectionViewDelegateFlow
     }
 
     @objc func inviteFriends() {
-        navigationController?.pushViewController(MultiplyImpact(delegate: delegate), animated: true)
+        navigationController?.pushViewController(MultiplyImpact(delegate: delegate, referrals: referrals), animated: true)
     }
 
     @objc func learnMore() {

--- a/Client/Ecosia/UI/MyImpact/EcosiaHome.swift
+++ b/Client/Ecosia/UI/MyImpact/EcosiaHome.swift
@@ -108,7 +108,7 @@ final class EcosiaHome: UICollectionViewController, UICollectionViewDelegateFlow
     private let images = Images(.init(configuration: .ephemeral))
     private let news = News()
     private let personalCounter = PersonalCounter()
-    private var referrals: Referrals!
+    private weak var referrals: Referrals!
 
     lazy var impactModel: MyImpactCellModel = {
         return refreshImpactModel()

--- a/Client/Ecosia/UI/MyImpact/EcosiaNavigation.swift
+++ b/Client/Ecosia/UI/MyImpact/EcosiaNavigation.swift
@@ -3,11 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import UIKit
+import Core
 
 final class EcosiaNavigation: UINavigationController, Themeable {
 
-    convenience init(delegate: EcosiaHomeDelegate?) {
-        self.init(rootViewController: EcosiaHome(delegate: delegate))
+    convenience init(delegate: EcosiaHomeDelegate?, referrals: Referrals) {
+        self.init(rootViewController: EcosiaHome(delegate: delegate, referrals: referrals))
         modalPresentationCapturesStatusBarAppearance = true
     }
 

--- a/Client/Ecosia/UI/MyImpact/MultiplyImpact.swift
+++ b/Client/Ecosia/UI/MyImpact/MultiplyImpact.swift
@@ -18,9 +18,11 @@ final class MultiplyImpact: UIViewController, Themeable {
     private weak var secondStep: MultiplyImpactStep?
     private weak var thirdStep: MultiplyImpactStep?
     private weak var delegate: EcosiaHomeDelegate?
+    private let referrals: Referrals
     
     required init?(coder: NSCoder) { nil }
-    init(delegate: EcosiaHomeDelegate?) {
+    init(delegate: EcosiaHomeDelegate?, referrals: Referrals) {
+        self.referrals = referrals
         super.init(nibName: nil, bundle: nil)
         self.delegate = delegate
     }
@@ -238,7 +240,6 @@ final class MultiplyImpact: UIViewController, Themeable {
     
     @objc private func inviteFriends() {
         guard let message = inviteMessage else {
-            let referrals = Referrals()
             referrals.refresh { error in
                 if let error = error {
                     self.showReferralError(error)

--- a/Client/Ecosia/UI/MyImpact/MultiplyImpact.swift
+++ b/Client/Ecosia/UI/MyImpact/MultiplyImpact.swift
@@ -18,7 +18,7 @@ final class MultiplyImpact: UIViewController, Themeable {
     private weak var secondStep: MultiplyImpactStep?
     private weak var thirdStep: MultiplyImpactStep?
     private weak var delegate: EcosiaHomeDelegate?
-    private let referrals: Referrals
+    private weak var referrals: Referrals!
     
     required init?(coder: NSCoder) { nil }
     init(delegate: EcosiaHomeDelegate?, referrals: Referrals) {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -135,9 +135,11 @@ class BrowserViewController: UIViewController {
 
     fileprivate var shouldShowIntroScreen: Bool { profile.prefs.intForKey(PrefsKeys.IntroSeen) == nil }
 
+    // Ecosia
     lazy var ecosiaNavigation: EcosiaNavigation = {
-        return EcosiaNavigation(delegate: self)
+        return EcosiaNavigation(delegate: self, referrals: referrals)
     }()
+    let referrals = Referrals()
 
     init(profile: Profile, tabManager: TabManager) {
         self.profile = profile
@@ -756,7 +758,7 @@ class BrowserViewController: UIViewController {
     func showFirefoxHome(inline: Bool) {
         homePanelIsInline = inline
         if self.firefoxHomeViewController == nil {
-            let firefoxHomeViewController = FirefoxHomeViewController(profile: profile, delegate: self)
+            let firefoxHomeViewController = FirefoxHomeViewController(profile: profile, delegate: self, referrals: referrals)
             firefoxHomeViewController.homePanelDelegate = self
             firefoxHomeViewController.libraryPanelDelegate = self
 			// Ecosia TODO: tweak animation
@@ -1980,11 +1982,11 @@ extension BrowserViewController {
             User.shared.migrated = true
             User.shared.hideWelcomeScreen()
         } else if User.shared.migrated != true {
-            present(LoadingScreen(profile: profile, tabManager: tabManager), animated: true)
+            present(LoadingScreen(profile: profile, tabManager: tabManager, referrals: referrals), animated: true)
         } else if User.shared.showsWelcomeScreen {
             present(UpgradeScreen(), animated: true)
         } else if let pendingClaim = User.shared.referrals.pendingClaim {
-            present(LoadingScreen(profile: profile, tabManager: tabManager, referralCode: pendingClaim), animated: true)
+            present(LoadingScreen(profile: profile, tabManager: tabManager, referrals: referrals, referralCode: pendingClaim), animated: true)
         }
     }
 

--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -167,7 +167,7 @@ class FirefoxHomeViewController: UICollectionViewController, HomePanel, FeatureF
     fileprivate var didRoate = false
     fileprivate let profile: Profile
     fileprivate let personalCounter = PersonalCounter()
-    fileprivate let referrals = Referrals()
+    fileprivate let referrals: Referrals
     fileprivate let flowLayout = NTPLayout()
     fileprivate weak var searchbarCell: UICollectionViewCell?
     fileprivate weak var emptyCell: EmptyCell?
@@ -265,9 +265,10 @@ class FirefoxHomeViewController: UICollectionViewController, HomePanel, FeatureF
     */
 
     // MARK: - Initializers
-    init(profile: Profile, delegate: FirefoxHomeViewControllerDelegate?) {
+    init(profile: Profile, delegate: FirefoxHomeViewControllerDelegate?, referrals: Referrals) {
         self.profile = profile
         self.delegate = delegate
+        self.referrals = referrals
         super.init(collectionViewLayout: flowLayout)
         self.collectionView?.delegate = self
         self.collectionView?.dataSource = self

--- a/Client/Frontend/Home/FirefoxHomeViewController.swift
+++ b/Client/Frontend/Home/FirefoxHomeViewController.swift
@@ -167,7 +167,7 @@ class FirefoxHomeViewController: UICollectionViewController, HomePanel, FeatureF
     fileprivate var didRoate = false
     fileprivate let profile: Profile
     fileprivate let personalCounter = PersonalCounter()
-    fileprivate let referrals: Referrals
+    fileprivate weak var referrals: Referrals!
     fileprivate let flowLayout = NTPLayout()
     fileprivate weak var searchbarCell: UICollectionViewCell?
     fileprivate weak var emptyCell: EmptyCell?

--- a/ClientTests/FirefoxHomeTests.swift
+++ b/ClientTests/FirefoxHomeTests.swift
@@ -8,6 +8,7 @@ import XCTest
 import Shared
 import Storage
 import SyncTelemetry
+import Core
 
 class FirefoxHomeTests: XCTestCase {
     var profile: MockProfile!
@@ -16,7 +17,7 @@ class FirefoxHomeTests: XCTestCase {
     override func setUp() {
         super.setUp()
         self.profile = MockProfile()
-        self.vc = FirefoxHomeViewController(profile: self.profile, delegate: nil)
+        self.vc = FirefoxHomeViewController(profile: self.profile, delegate: nil, referrals: Referrals())
     }
 
     override func tearDown() {


### PR DESCRIPTION
- Fix mismatch between referral counts
- use dependency injection to provide referrals instance across different view controllers
- original referrals instance lives in BrowserViewController

