### PR TITLE
Use method through BVC to open new tab (fixes missing screenshot)

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
@@ -69,7 +69,7 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
     
     func tabToolbarDidPressAddNewTab(_ tabToolbar: TabToolbarProtocol, button: UIButton) {
         let isPrivate = tabManager.selectedTab?.isPrivate ?? false
-        tabManager.selectTab(tabManager.addTab(nil, isPrivate: isPrivate))
+        openBlankNewTab(focusLocationField: false, isPrivate: isPrivate)
     }
 
     func tabToolbarDidPressMenu(_ tabToolbar: TabToolbarProtocol, button: UIButton) {


### PR DESCRIPTION
https://ecosia.atlassian.net/browse/MOB-1378

I always had the impression that screenshots in the tabswitcher were not correctly updated. Finally I could reproduce and fix it 🤞 

