### PR TITLE
observe cookie store instead of manual fetch

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+WebViewDelegates.swift
@@ -615,17 +615,6 @@ extension BrowserViewController: WKNavigationDelegate {
         // If none of our helpers are responsible for handling this response,
         // just let the webview handle it as normal.
         decisionHandler(.allow)
-
-        // Ecosia: Cookie handling / only read cookie for not private mode
-        if tabManager.selectedTab?.isPrivate == false {
-            DispatchQueue.main.async { 
-                webView.configuration.websiteDataStore.httpCookieStore.getAllCookies { cookies in
-                    DispatchQueue.main.async {
-                        Cookie.received(cookies)
-                    }
-                }
-            }
-        }
     }
 
     /// Invoked when an error occurs while starting to load data for the main frame.

--- a/Client/Frontend/Browser/TabManager.swift
+++ b/Client/Frontend/Browser/TabManager.swift
@@ -158,7 +158,15 @@ class TabManager: NSObject, FeatureFlagsProtocol {
 
         addNavigationDelegate(self)
 
+        // Ecosia: cookie observing
+        configuration.websiteDataStore.httpCookieStore.add(self)
+
         NotificationCenter.default.addObserver(self, selector: #selector(prefsDidChange), name: UserDefaults.didChangeNotification, object: nil)
+    }
+
+    // Ecosia: Cookie observing
+    deinit {
+        configuration.websiteDataStore.httpCookieStore.remove(self)
     }
 
     func addNavigationDelegate(_ delegate: WKNavigationDelegate) {
@@ -883,6 +891,17 @@ extension TabManager {
     func testClearArchive() {
         assert(AppConstants.IsRunningTest)
         store.clearArchive()
+    }
+}
+
+// Ecosia: Cookie observer
+extension TabManager: WKHTTPCookieStoreObserver {
+    func cookiesDidChange(in cookieStore: WKHTTPCookieStore) {
+        cookieStore.getAllCookies { cookies in
+            DispatchQueue.main.async {
+                Cookie.received(cookies)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
- fixes https://ecosia.atlassian.net/browse/MOB-1516 
- now we also monitor async cookie changes that originate from the Frontend 