### PR TITLE
Upgrade snowplow SDK to current version 3.2.0

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -14015,7 +14015,7 @@
 			repositoryURL = "https://github.com/snowplow/snowplow-objc-tracker.git";
 			requirement = {
 				kind = exactVersion;
-				version = 2.2.2;
+				version = 3.2.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/snowplow/snowplow-objc-tracker.git",
         "state": {
           "branch": null,
-          "revision": "805dfc4aab4fd23c417677a5198a8860998f7f5a",
-          "version": "2.2.2"
+          "revision": "dc5ecb6ad2921a50f629ef600cc1ee700e608f66",
+          "version": "3.2.0"
         }
       }
     ]


### PR DESCRIPTION
Upgrade SnowPlow to Version 3.2.0 from 2.2.0

- followed the migration guide from [SnowPlow](https://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/mobile-trackers/migration-guides/migration-guide-for-snowplow-ios-tracker-sdk-from-version-2-x-to-3-0)
- fortunately there are no breaking changes and it just works 🎉 
- tested with SnowPlow Mini and events are arriving with updated Tracker version
<img width="1042" alt="Screenshot 2022-08-30 at 11 57 38" src="https://user-images.githubusercontent.com/60604005/187409086-67db16bd-115d-4a73-85d9-f7e084b45ee3.png">
