### PR TITLE
Fix split view for iPad

### DIFF
--- a/Client/Frontend/Home/HomepageSectionType.swift
+++ b/Client/Frontend/Home/HomepageSectionType.swift
@@ -46,21 +46,21 @@ private let MinimumInsets: CGFloat = 16
 // Ecosia
 extension HomepageSectionType {
     func sectionInsets(_ traits: UITraitCollection) -> CGFloat {
-        var insets: CGFloat = traits.userInterfaceIdiom == .phone ? 0 : 100
-
+        var insets: CGFloat = traits.horizontalSizeClass == .regular ? 100 : 0
 
         switch self {
         case .libraryShortcuts, .topSites, .impact:
-            let window = UIApplication.shared.windows.first(where: \.isKeyWindow)
-            let safeAreaInsets = window?.safeAreaInsets.left ?? 0
+            guard let window = UIApplication.shared.windows.first(where: \.isKeyWindow) else { return MinimumInsets
+            }
+            let safeAreaInsets = window.safeAreaInsets.left
             insets += MinimumInsets + safeAreaInsets
 
-            /* Ecosia: center layout in landscape */
-            let orientation: UIInterfaceOrientation = UIApplication.shared.windows.first(where: { $0.isKeyWindow })?.windowScene?.interfaceOrientation ?? .portrait
-            if orientation.isLandscape {
-                insets = UIScreen.main.bounds.width / 4
-            }
+            let orientation: UIInterfaceOrientation = window.windowScene?.interfaceOrientation ?? .portrait
 
+            /* Ecosia: center layout in iphone landscape or regular size class */
+            if traits.horizontalSizeClass == .regular || (orientation.isLandscape && traits.userInterfaceIdiom == .phone) {
+                insets = window.bounds.width / 4
+            }
             return insets
         default:
             return 0

--- a/Client/Frontend/Home/TopSites/TopSitesDimension.swift
+++ b/Client/Frontend/Home/TopSites/TopSitesDimension.swift
@@ -81,10 +81,10 @@ class TopSitesDimensionImplementation: TopSitesDimension {
     /// - Parameter interface: Tile number is based on layout, this param contains the parameters needed to computer the tile number
     /// - Returns: The number of tiles per row the user will see
     private func getNumberOfTilesPerRow(for interface: TopSitesUIInterface) -> Int {
-        if interface.isIphone {
-            return 4
-        } else {
+        if interface.horizontalSizeClass == .regular {
             return 6
+        } else {
+            return 4
         }
     }
 }

--- a/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDimensionTests.swift
+++ b/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDimensionTests.swift
@@ -16,7 +16,7 @@ class TopSitesDimensionTests: XCTestCase {
 
         let dimension = sut.getSectionDimension(for: createSites(), numberOfRows: 2, interface: interface)
         XCTAssertEqual(dimension.numberOfRows, 2)
-        XCTAssertEqual(dimension.numberOfTilesPerRow, 4)
+        XCTAssertEqual(dimension.numberOfTilesPerRow, 6)
     }
 
     func testSectionDimension_landscapeIphone_defaultRowNumber() {
@@ -26,7 +26,7 @@ class TopSitesDimensionTests: XCTestCase {
 
         let dimension = sut.getSectionDimension(for: createSites(), numberOfRows: 2, interface: interface)
         XCTAssertEqual(dimension.numberOfRows, 2)
-        XCTAssertEqual(dimension.numberOfTilesPerRow, 4)
+        XCTAssertEqual(dimension.numberOfTilesPerRow, 6)
     }
 
     func testSectionDimension_portraitiPadRegular_defaultRowNumber() {
@@ -57,7 +57,7 @@ class TopSitesDimensionTests: XCTestCase {
 
         let dimension = sut.getSectionDimension(for: createSites(), numberOfRows: 2, interface: interface)
         XCTAssertEqual(dimension.numberOfRows, 2)
-        XCTAssertEqual(dimension.numberOfTilesPerRow, 6)
+        XCTAssertEqual(dimension.numberOfTilesPerRow, 4)
     }
 
     func testSectionDimension_landscapeiPadCompact_defaultRowNumber() {
@@ -68,7 +68,7 @@ class TopSitesDimensionTests: XCTestCase {
 
         let dimension = sut.getSectionDimension(for: createSites(), numberOfRows: 2, interface: interface)
         XCTAssertEqual(dimension.numberOfRows, 2)
-        XCTAssertEqual(dimension.numberOfTilesPerRow, 6)
+        XCTAssertEqual(dimension.numberOfTilesPerRow, 4)
     }
 
     func testSectionDimension_portraitiPadUnspecified_defaultRowNumber() {
@@ -79,7 +79,7 @@ class TopSitesDimensionTests: XCTestCase {
 
         let dimension = sut.getSectionDimension(for: createSites(), numberOfRows: 2, interface: interface)
         XCTAssertEqual(dimension.numberOfRows, 2)
-        XCTAssertEqual(dimension.numberOfTilesPerRow, 6)
+        XCTAssertEqual(dimension.numberOfTilesPerRow, 4)
     }
 
     func testSectionDimension_landscapeiPadUnspecified_defaultRowNumber() {
@@ -90,7 +90,7 @@ class TopSitesDimensionTests: XCTestCase {
 
         let dimension = sut.getSectionDimension(for: createSites(), numberOfRows: 2, interface: interface)
         XCTAssertEqual(dimension.numberOfRows, 2)
-        XCTAssertEqual(dimension.numberOfTilesPerRow, 6)
+        XCTAssertEqual(dimension.numberOfTilesPerRow, 4)
     }
 
     // MARK: Section dimension with stubbed data
@@ -102,7 +102,7 @@ class TopSitesDimensionTests: XCTestCase {
 
         let dimension = sut.getSectionDimension(for: createSites(count: 4), numberOfRows: 2, interface: interface)
         XCTAssertEqual(dimension.numberOfRows, 1)
-        XCTAssertEqual(dimension.numberOfTilesPerRow, 4)
+        XCTAssertEqual(dimension.numberOfTilesPerRow, 6)
     }
 
     func testSectionDimension_twoEmptyRow_shouldBeRemoved() {
@@ -112,7 +112,7 @@ class TopSitesDimensionTests: XCTestCase {
 
         let dimension = sut.getSectionDimension(for: createSites(count: 4), numberOfRows: 3, interface: interface)
         XCTAssertEqual(dimension.numberOfRows, 1)
-        XCTAssertEqual(dimension.numberOfTilesPerRow, 4)
+        XCTAssertEqual(dimension.numberOfTilesPerRow, 6)
     }
 
     func testSectionDimension_noEmptyRow_shouldNotBeRemoved() {
@@ -122,7 +122,7 @@ class TopSitesDimensionTests: XCTestCase {
 
         let dimension = sut.getSectionDimension(for: createSites(count: 8), numberOfRows: 2, interface: interface)
         XCTAssertEqual(dimension.numberOfRows, 2)
-        XCTAssertEqual(dimension.numberOfTilesPerRow, 4)
+        XCTAssertEqual(dimension.numberOfTilesPerRow, 6)
     }
 
     func testSectionDimension_halfFilledRow_shouldNotBeRemoved() {
@@ -131,8 +131,8 @@ class TopSitesDimensionTests: XCTestCase {
         let interface = TopSitesUIInterface(isLandscape: false, isIphone: true, trait: trait)
 
         let dimension = sut.getSectionDimension(for: createSites(count: 6), numberOfRows: 2, interface: interface)
-        XCTAssertEqual(dimension.numberOfRows, 2)
-        XCTAssertEqual(dimension.numberOfTilesPerRow, 4)
+        XCTAssertEqual(dimension.numberOfRows, 1)
+        XCTAssertEqual(dimension.numberOfTilesPerRow, 6)
     }
 }
 


### PR DESCRIPTION
Using screen traits instead of device traits to determine NTP layout. That way it also works for SplitViews on iPad OS