### PR TITLE
Mob 1682 fix reload ntp crash

### DIFF
--- a/Client/Ecosia/Extensions/HomepageViewController+Ecosia.swift
+++ b/Client/Ecosia/Extensions/HomepageViewController+Ecosia.swift
@@ -26,7 +26,6 @@ extension HomepageViewController {
     func updateTreesCell() {
         guard let impactCell = viewModel.impactViewModel.cell else { return }
         impactCell.display(treesCellModel)
-        (collectionView.collectionViewLayout as? NTPLayout)?.invalidateLayout()
     }
 
     var treesCellModel: NTPImpactCell.Model {

--- a/Client/Ecosia/Extensions/HomepageViewController+Ecosia.swift
+++ b/Client/Ecosia/Extensions/HomepageViewController+Ecosia.swift
@@ -63,7 +63,7 @@ extension HomepageViewController: NTPTooltipDelegate {
     }
 
     func reloadTooltip() {
-        collectionView.collectionViewLayout.invalidateLayout()
+        reloadView()
     }
 }
 

--- a/Client/Ecosia/UI/NTP/Cells/NTPImpactCell.swift
+++ b/Client/Ecosia/UI/NTP/Cells/NTPImpactCell.swift
@@ -76,7 +76,6 @@ final class NTPImpactCell: UICollectionViewCell, NotificationThemeable, Reusable
             treesCount.text = "\(model.trees)"
         }
 
-        applyTheme()
         updateGlobalCount()
     }
 

--- a/Client/Ecosia/UI/NTP/News/NewsController.swift
+++ b/Client/Ecosia/UI/NTP/News/NewsController.swift
@@ -103,6 +103,7 @@ final class NewsController: UIViewController, UICollectionViewDelegate, UICollec
     
     override func viewWillTransition(to: CGSize, with: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: to, with: with)
+        collection?.reloadData()
         collection?.collectionViewLayout.invalidateLayout()
     }
     

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -204,7 +204,12 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable {
 
         // Force the entire collectionview to re-layout
         viewModel.refreshData(for: traitCollection)
+        collectionView.reloadData()
         collectionView.collectionViewLayout.invalidateLayout()
+
+        // This pushes a reload to the end of the main queue after all the work associated with
+        // rotating has been completed. This is important because some of the cells layout are
+        // based on the screen state
         DispatchQueue.main.async {
             self.collectionView.reloadData()
         }
@@ -475,6 +480,7 @@ extension HomepageViewController: HomepageViewModelDelegate {
 
             self.viewModel.refreshData(for: self.traitCollection)
             self.collectionView.reloadData()
+            self.collectionView.collectionViewLayout.invalidateLayout()
         }
     }
 }


### PR DESCRIPTION
[MOB-1682](https://ecosia.atlassian.net/browse/MOB-1682)

- potential fix for crashes inside of UICollectionViewCompositionalLayout
- we use this on NTP (HomePageViewController) and News (NewsController)
- the crash reports don't indicate where exactly it happens
- The potential fix makes sure that `invalidateLayout` is only called when also the data is updated accordingly (hint taken from Mozilla codebase)