### PR TITLE
MOB-1643 icnognito icon update

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -110,6 +110,7 @@
 		2C31A7A91E8BFB2200DAC646 /* ReaderViewUITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C31A7A81E8BFB2200DAC646 /* ReaderViewUITest.swift */; };
 		2C31A8471E8D447F00DAC646 /* HomePageSettingsUITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C31A8461E8D447F00DAC646 /* HomePageSettingsUITest.swift */; };
 		2C3406C81E719F00000FD889 /* SettingsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3406C71E719F00000FD889 /* SettingsTest.swift */; };
+		2C3518BB29C34A0500D03ECD /* URLBarViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3518BA29C34A0500D03ECD /* URLBarViewTests.swift */; };
 		2C473BD0209778900008C853 /* DownloadFilesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C473BCF209778900008C853 /* DownloadFilesTests.swift */; };
 		2C49854E206173C800893DAE /* photon-colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C49854D206173C800893DAE /* photon-colors.swift */; };
 		2C4A07DC20246EAD0083E320 /* DragAndDropTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4A07DB20246EAD0083E320 /* DragAndDropTests.swift */; };
@@ -1705,6 +1706,7 @@
 		2C31A8461E8D447F00DAC646 /* HomePageSettingsUITest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomePageSettingsUITest.swift; sourceTree = "<group>"; };
 		2C33410CB7E921A125379D7C /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
 		2C3406C71E719F00000FD889 /* SettingsTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsTest.swift; sourceTree = "<group>"; };
+		2C3518BA29C34A0500D03ECD /* URLBarViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLBarViewTests.swift; sourceTree = "<group>"; };
 		2C473BCF209778900008C853 /* DownloadFilesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadFilesTests.swift; sourceTree = "<group>"; };
 		2C49854D206173C800893DAE /* photon-colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "photon-colors.swift"; sourceTree = "<group>"; };
 		2C4A07DB20246EAD0083E320 /* DragAndDropTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragAndDropTests.swift; sourceTree = "<group>"; };
@@ -7006,6 +7008,7 @@
 				E1AEC171286E0CF500062E29 /* HomepageViewControllerTests.swift */,
 				E1AEC172286E0CF500062E29 /* FirefoxHomeViewModelTests.swift */,
 				5A9A09D128AFD51900B6F51E /* MockHomepageDataModelDelegate.swift */,
+				2C3518BA29C34A0500D03ECD /* URLBarViewTests.swift */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -9628,6 +9631,7 @@
 				E1AEC17A286E0CF500062E29 /* WebViewNavigationHandlerTests.swift in Sources */,
 				D3D488591ABB54CD00A93597 /* FileAccessorTests.swift in Sources */,
 				0BA8964B1A250E6500C1010C /* ProfileTest.swift in Sources */,
+				2C3518BB29C34A0500D03ECD /* URLBarViewTests.swift in Sources */,
 				8AE80BAF2891960300BC12EA /* MockTraitCollection.swift in Sources */,
 				03CCC9181AF05E7300DBF30D /* RelativeDatesTests.swift in Sources */,
 				F84B21DA1A090F8100AAB793 /* ClientTests.swift in Sources */,

--- a/Client/Application/ImageIdentifiers.swift
+++ b/Client/Application/ImageIdentifiers.swift
@@ -50,7 +50,7 @@ public struct ImageIdentifiers {
     public static let navAdd = "nav-add"
     public static let navTabCounter = "nav-tabcounter"
     public static let navMenu = "nav-menu"
-    public static let newPrivateTab = "quick_action_new_private_tab"
+    public static let newPrivateTab = "privateSearch"
     public static let newTab = "quick_action_new_tab"
     public static let nightMode = "menu-NightMode"
     public static let noImageMode = "menu-NoImageMode"

--- a/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -250,7 +250,7 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
     func updateSearchEngineImage() {
         if inOverlayMode {
             if isPrivate {
-                searchIconImageView.image = .init(named: "privateSearch")
+                searchIconImageView.image = .init(named: ImageIdentifiers.newPrivateTab)
             } else {
                 searchIconImageView.image = .init(themed: "searchLogo")
             }

--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -141,7 +141,7 @@
 		</dict>
 		<dict>
 			<key>UIApplicationShortcutItemIconFile</key>
-			<string>quick_action_new_private_tab</string>
+			<string>privateSearch</string>
 			<key>UIApplicationShortcutItemTitle</key>
 			<string>ShortcutItemTitleNewPrivateTab</string>
 			<key>UIApplicationShortcutItemType</key>

--- a/Tests/ClientTests/Frontend/Home/URLBarViewTests.swift
+++ b/Tests/ClientTests/Frontend/Home/URLBarViewTests.swift
@@ -56,10 +56,7 @@ class URLBarViewTests: XCTestCase {
         
         XCTAssertTrue(sut.urlBar.searchIconImageView.image?.pngData() == UIImage(named: ImageIdentifiers.newPrivateTab)?.pngData())
     }
-
-    
 }
-
 
 extension URLBarViewTests {
     

--- a/Tests/ClientTests/Frontend/Home/URLBarViewTests.swift
+++ b/Tests/ClientTests/Frontend/Home/URLBarViewTests.swift
@@ -1,0 +1,71 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+@testable import Client
+
+import XCTest
+
+class URLBarViewTests: XCTestCase {
+    
+    var profile: MockProfile!
+
+    override func setUp() {
+        super.setUp()
+        profile = MockProfile()
+        FeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        profile = nil
+    }
+
+    func testURLBarView_presentsStandardSearchIcon_onURLBarDefaultState() {
+        let sut = makeSUT()
+        sut.loadView()
+        sut.addSubviews()
+        sut.urlBar(sut.urlBar, didEnterText: "")
+        
+        XCTAssertTrue(sut.urlBar.isPrivate == false)
+        
+        XCTAssertTrue(sut.urlBar.searchIconImageView.image?.pngData() == UIImage(named: "search")?.pngData())
+    }
+    
+    func testURLBarView_presentsSearchLogoIcon_onURLBarSearchState() {
+        let sut = makeSUT()
+        sut.loadView()
+        sut.addSubviews()
+        sut.urlBar.inOverlayMode = true
+        sut.urlBar(sut.urlBar, didEnterText: "")
+
+        XCTAssertTrue(sut.urlBar.isPrivate == false)
+        
+        XCTAssertTrue(sut.urlBar.searchIconImageView.image?.pngData() == UIImage(themed: "searchLogo")?.pngData())
+    }
+    
+    func testURLBarView_presentsPrivateSearchIcon_onURLBarPrivateSeachState() {
+        let sut = makeSUT()
+        sut.loadView()
+        sut.addSubviews()
+        sut.urlBar.applyUIMode(isPrivate: true)
+        sut.urlBar.inOverlayMode = true
+        sut.urlBar(sut.urlBar, didEnterText: "")
+        
+        XCTAssertTrue(sut.urlBar.isPrivate == true)
+        
+        XCTAssertTrue(sut.urlBar.searchIconImageView.image?.pngData() == UIImage(named: ImageIdentifiers.newPrivateTab)?.pngData())
+    }
+
+    
+}
+
+
+extension URLBarViewTests {
+    
+    private func makeSUT() -> BrowserViewController {
+        let tabManager = TabManager(profile: profile, imageStore: nil)
+        return BrowserViewController(profile: profile, tabManager: tabManager)
+    }
+    
+}


### PR DESCRIPTION
[MOB-1643](https://ecosia.atlassian.net/browse/MOB-1643)

- Updating the icon reference from `quick_action_new_private_tab` to `privateSearch` throughout the codebase
- Added minimum test scenarios to make sure we always display the appropriate `URLBarView`'s search icon  
