### PR TITLE
MOB-1750 Clear history doesn't clear recently visited

### DIFF
--- a/Client/Frontend/Library/ClearHistorySheetProvider.swift
+++ b/Client/Frontend/Library/ClearHistorySheetProvider.swift
@@ -78,6 +78,9 @@ class ClearHistorySheetProvider {
                 deletionUtility.deleteHistoryFrom(timeRange) { dateOption in
                     NotificationCenter.default.post(name: .TopSitesUpdated, object: self)
                     didComplete?(dateOption)
+                    DispatchQueue.main.async {
+                        deletionUtility.deleteHistoryMetadataOlderThan(dateOption)
+                    }
                 }
             }
 
@@ -98,6 +101,11 @@ class ClearHistorySheetProvider {
                 }
                 NotificationCenter.default.post(name: .PrivateDataClearedHistory, object: nil)
                 didComplete?(dateOption)
+                // perform history metadata deletion that sends a notification and updates
+                // the data and the UI for recently visited section, which can only happen on main thread
+                DispatchQueue.main.async {
+                    deletionUtilitiy.deleteHistoryMetadataOlderThan(dateOption)
+                }
             }
         })
     }

--- a/Client/Utils/HistoryDeletionUtility.swift
+++ b/Client/Utils/HistoryDeletionUtility.swift
@@ -123,6 +123,12 @@ class HistoryDeletionUtility: HistoryDeletionProtocol {
         profile.places.deleteHistoryMetadata(since: dateInMilliseconds) { _ in }
     }
 
+    func deleteHistoryMetadataOlderThan(_ dateOption: HistoryDeletionUtilityDateOptions) {
+        guard let date = dateFor(dateOption) else { return }
+        let dateInMilliseconds = date.toMillisecondsSince1970()
+        self.profile.places.deleteHistoryMetadataOlderThan(olderThan: dateInMilliseconds).uponQueue(.global(qos: .userInteractive)) { _ in }
+    }
+
     private func clearRecentlyClosedTabs(using dateOption: HistoryDeletionUtilityDateOptions) {
 
         switch dateOption {
@@ -136,6 +142,11 @@ class HistoryDeletionUtility: HistoryDeletionProtocol {
     }
 
     // MARK: - Helper functions
+
+    public func deletionReferenceValue(for dateOption: HistoryDeletionUtilityDateOptions) -> Int64 {
+        return dateFor(dateOption)?.toMillisecondsSince1970() ?? Int64.max
+    }
+
     private func dateFor(
         _ dateOption: HistoryDeletionUtilityDateOptions,
         requiringAllTimeAsPresent: Bool = true

--- a/Tests/ClientTests/HistoryDeletionUtilityTests.swift
+++ b/Tests/ClientTests/HistoryDeletionUtilityTests.swift
@@ -137,6 +137,7 @@ class HistoryDeletionUtilityTests: XCTestCase {
             XCTAssertEqual(timeframe, returnedTimeFrame)
             self.assertDBIsEmpty(with: profile, shouldSkipMetadata: true)
         }
+        deleteHistoryMetadataOlderThan(dateOption: timeframe, using: profile)
     }
 
     func testDeletingItemsInLastHour_WithFurtherHistory() {
@@ -161,6 +162,7 @@ class HistoryDeletionUtilityTests: XCTestCase {
             XCTAssertEqual(timeframe, returnedTimeFrame)
             self.assertDBHistoryStateFor(sitesToRemain, with: profile)
         }
+        deleteHistoryMetadataOlderThan(dateOption: timeframe, using: profile)
     }
 
     func testDeletingAllItemsInHistoryUsingToday() {
@@ -183,6 +185,7 @@ class HistoryDeletionUtilityTests: XCTestCase {
             XCTAssertEqual(timeframe, returnedTimeFrame)
             self.assertDBIsEmpty(with: profile, shouldSkipMetadata: true)
         }
+        deleteHistoryMetadataOlderThan(dateOption: timeframe, using: profile)
     }
 
     func testDeletingItemsInHistoryUsingToday_WithFurtherHistory() {
@@ -208,6 +211,7 @@ class HistoryDeletionUtilityTests: XCTestCase {
             XCTAssertEqual(timeframe, returnedTimeFrame)
             self.assertDBHistoryStateFor(sitesToRemain, with: profile)
         }
+        deleteHistoryMetadataOlderThan(dateOption: timeframe, using: profile)
     }
 
     func testDeletingAllItemsInHistoryUsingYesterday() {
@@ -228,6 +232,7 @@ class HistoryDeletionUtilityTests: XCTestCase {
             XCTAssertEqual(timeframe, returnedTimeFrame)
             self.assertDBIsEmpty(with: profile, shouldSkipMetadata: true)
         }
+        deleteHistoryMetadataOlderThan(dateOption: timeframe, using: profile)
     }
 
     func testDeletingItemsInHistoryUsingYesterday_WithFurtherHistory() {
@@ -252,6 +257,7 @@ class HistoryDeletionUtilityTests: XCTestCase {
             XCTAssertEqual(timeframe, returnedTimeFrame)
             self.assertDBHistoryStateFor(sitesToRemain, with: profile)
         }
+        deleteHistoryMetadataOlderThan(dateOption: timeframe, using: profile)
     }
 
     func testDeletingAllItemsInHistoryUsingAllTime() {
@@ -288,6 +294,7 @@ class HistoryDeletionUtilityTests: XCTestCase {
             XCTAssertEqual(timeframe, returnedTimeFrame)
             self.assertDBIsEmpty(with: profile, shouldSkipMetadata: true)
         }
+        deleteHistoryMetadataOlderThan(dateOption: timeframe, using: profile)
     }
 }
 
@@ -336,6 +343,17 @@ private extension HistoryDeletionUtilityTests {
         }
 
         waitForExpectations(timeout: 5, handler: nil)
+    }
+
+    func deleteHistoryMetadataOlderThan(dateOption: HistoryDeletionUtilityDateOptions,
+                                        using profile: MockProfile) {
+        let deletionUtility = HistoryDeletionUtility(with: profile)
+        trackForMemoryLeaks(deletionUtility)
+        deletionUtility.deleteHistoryMetadataOlderThan(dateOption)
+        let emptyResultsRead = profile.places.getHistoryMetadataSince(since: deletionUtility.deletionReferenceValue(for: dateOption)).value
+        XCTAssertTrue(emptyResultsRead.isSuccess)
+        XCTAssertNotNil(emptyResultsRead.successValue)
+        XCTAssertEqual(emptyResultsRead.successValue!.count, 0)
     }
 
     func emptyDB(


### PR DESCRIPTION
[MOB-1750](https://ecosia.atlassian.net/browse/MOB-1750)

## Context

This PR fixes an issue in the history panel when a "Clear all" event happens.
The content has been cherry-picked from the master Firefox repo.

Reference https://github.com/mozilla-mobile/firefox-ios/pull/13744