### PR TITLE
MOB-1665 Fix on favicon expected `tintColor`

### DIFF
--- a/Client/Frontend/Browser/TopTabsViews.swift
+++ b/Client/Frontend/Browser/TopTabsViews.swift
@@ -115,7 +115,6 @@ class TopTabCell: UICollectionViewCell, NotificationThemeable, TabTrayCell, Reus
         closeButton.accessibilityLabel = String(format: .TopSitesRemoveButtonAccessibilityLabel, self.titleText.text ?? "")
 
         favicon.image = UIImage(named: "defaultFavicon")
-        favicon.tintColor = UIColor.theme.tabTray.faviconTint
         favicon.contentMode = .scaleAspectFit
         favicon.backgroundColor = .clear
 


### PR DESCRIPTION
[MOB-1665](https://ecosia.atlassian.net/browse/MOB-1665)

## Context

Removed default `tintColor` for the `favicon` as not needed. The `applyTheme()` function will take care of the rest.