### PR TITLE
MOB-1633 Sticky top menu separator improvements

### DIFF
--- a/Client/Ecosia/UI/PageAction/PageActionMenu.swift
+++ b/Client/Ecosia/UI/PageAction/PageActionMenu.swift
@@ -131,9 +131,9 @@ extension PageActionMenu {
 
     private func setupConstraints() {
         NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
-            tableView.leftAnchor.constraint(equalTo: view.leftAnchor),
-            tableView.rightAnchor.constraint(equalTo: view.rightAnchor),
+            tableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            tableView.leftAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leftAnchor),
+            tableView.rightAnchor.constraint(equalTo: view.safeAreaLayoutGuide.rightAnchor),
             tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             knob.topAnchor.constraint(equalTo: view.topAnchor, constant: 8),
             knob.centerXAnchor.constraint(equalTo: view.centerXAnchor),
@@ -203,6 +203,7 @@ extension PageActionMenu: NotificationThemeable {
 
     func applyTheme() {
         tableView.reloadData()
+        view.backgroundColor = .theme.ecosia.modalBackground
         tableView.backgroundColor = .theme.ecosia.modalBackground
         tableView.separatorColor = .theme.ecosia.border
         knob.backgroundColor = .theme.ecosia.secondaryText

--- a/Client/Ecosia/UI/PageAction/PageActionMenuCell.swift
+++ b/Client/Ecosia/UI/PageAction/PageActionMenuCell.swift
@@ -61,6 +61,7 @@ final class PageActionMenuCell: UITableViewCell {
     
     override func prepareForReuse() {
         super.prepareForReuse()
+        separatorView?.removeFromSuperview()
         separatorView = nil
         textLabel?.text = nil
         imageView?.image = nil
@@ -146,10 +147,18 @@ extension PageActionMenuCell {
         
         contentView.addSubview(separatorView)
         
+        updateSeparatorViewConstraints(separatorView)
+    }
+        
+    private func updateSeparatorViewConstraints(_ separatorView: UIView) {
         separatorView.heightAnchor.constraint(equalToConstant: UX.separatorHeight).isActive = true
-        separatorView.widthAnchor.constraint(equalToConstant: contentView.frame.width).isActive = true
         separatorView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -UX.separatorHeight).isActive = true
-        separatorView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor).isActive = true
+        separatorView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -UX.padding).isActive = true
+        if let imageView {
+            separatorView.leadingAnchor.constraint(equalTo: imageView.leadingAnchor).isActive = true
+        } else if let textLabel {
+            separatorView.leadingAnchor.constraint(equalTo: textLabel.leadingAnchor).isActive = true
+        }
     }
 }
 
@@ -185,8 +194,6 @@ extension PageActionMenuCell {
 
         if separatorCellsPositions.contains(position) {
             addCustomGroupedStyleLikeSeparator()
-        } else {
-            separatorView?.removeFromSuperview()
         }
     }
 }

--- a/Client/Ecosia/UI/PageAction/PageActionsShortcutsHeader.swift
+++ b/Client/Ecosia/UI/PageAction/PageActionsShortcutsHeader.swift
@@ -70,7 +70,7 @@ class PageActionsShortcutsHeader: UITableViewHeaderFooterView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func applyTheme() {
+    private func applyTheme() {
         backgroundView?.backgroundColor = .clear
 
         shortcuts.forEach { item in


### PR DESCRIPTION
[MOB-1633](https://ecosia.atlassian.net/browse/MOB-1633)

## Context

The QA process spotted some issues in the separator width when moving from portrait to landscape and vice versa.
I took the occasion not only to fix the separator constraints thinking of the approach for trailing and leading from the start; It's been an excellent opportunity to review the UX on landscape and improve the Table View original behavior, taking care of the safe area layouts too.

<img src="https://user-images.githubusercontent.com/3584008/229146906-f883f3cc-39ff-465a-82d7-44dc1db4b6d3.png" width="300"/>

![Simulator Screenshot - iPhone 14 Pro - 2023-03-31 at 16 19 39](https://user-images.githubusercontent.com/3584008/229147132-df410885-8305-4526-9692-c425176f0a01.png)
