### PR TITLE
Readme build troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ This branch works with [Xcode 14.2](https://developer.apple.com/download/more/?=
 
 #### Troubleshooting
 
+##### Emulation support software not installed when running on Rosetta simulator
+
+*Build error:* `iPhone 14 Pro supports emulating this architecture, but the emuluation support software is not installed`
+
+*Reason:* Rosetta 2 needs to be installed
+
+*Fix:* Open an app that needs Rosetta and you will be requested to install it. See [this link](https://support.apple.com/en-us/HT211861).
+
 ##### Missing content-blocker-lib-ios files
 *Build error:* `content-blocker-lib-ios/Lists/some-file.json: No such file or directory`
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This branch works with [Xcode 14.2](https://developer.apple.com/download/more/?=
     ```
     - If you run into a problem related to `content-blocker-lib-ios`, check the troubleshooting section [here](#missing-content-blocker-lib-ios-files).
 
-2. Open the project
+1. Open the project
 
     ```bash
     open Client.xcodeproj

--- a/README.md
+++ b/README.md
@@ -40,12 +40,24 @@ This branch works with [Xcode 14.2](https://developer.apple.com/download/more/?=
     cd ios-browser
     sh ./bootstrap.sh
     ```
+    - If you run into a problem related to `content-blocker-lib-ios`, check the troubleshooting section [here](#missing-content-blocker-lib-ios-files).
 
-1. Open the project
+2. Open the project
 
     ```bash
     open Client.xcodeproj
     ```
+
+#### Troubleshooting
+
+##### Missing content-blocker-lib-ios files
+*Build error:* `content-blocker-lib-ios/Lists/some-file.json: No such file or directory`
+
+*Reason:* If you get this error while building the project, probably something went wrong when running the `content_blocker_update.sh` script (which also runs as a step in `bootstrap.sh`).
+
+In case the error was due to `xcrun: error: unable to lookup item 'PlatformPath'`, you might have the incorrect xcode sdk path. You can check it by running `xcrun --show-sdk-path --sdk macosx`, if it shows `/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk` it is incorrect.
+
+*Fix:* Switch the default SDK location by running `sudo xcode-select -switch /Applications/Xcode.app/Contents/Developer`.
 
 ### CI/CD
 


### PR DESCRIPTION
# Context
This PR adds a troubleshooting subsection to our building steps on the Readme.

Two errors I face while building the project for the first time were added to that section:
- Emulation support software not installed when running on Rosetta simulator
- Missing content-blocker-lib-ios files