### PR TITLE
MOB-1644 Top sites layout

### DIFF
--- a/Client/Frontend/Home/TopSites/TopSitesDimension.swift
+++ b/Client/Frontend/Home/TopSites/TopSitesDimension.swift
@@ -78,16 +78,10 @@ class TopSitesDimensionImplementation: TopSitesDimension {
     }
 
     //Ecosia: The design decided to have 4 tiles per row by default.
-    //Commenting the logic based on the interface and return 4.
     /// Get the number of tiles per row the user will see. This depends on the UI interface the user has.
     /// - Parameter interface: Tile number is based on layout, this param contains the parameters needed to computer the tile number
     /// - Returns: The number of tiles per row the user will see
     private func getNumberOfTilesPerRow(for interface: TopSitesUIInterface) -> Int {
-        // Ecosia if interface.horizontalSizeClass == .regular {
-        // Ecosia     return 6
-        // Ecosia } else {
-        // Ecosia     return 4
-        // Ecosia }
         return 4
     }
 }

--- a/Client/Frontend/Home/TopSites/TopSitesDimension.swift
+++ b/Client/Frontend/Home/TopSites/TopSitesDimension.swift
@@ -52,7 +52,7 @@ class TopSitesDimensionImplementation: TopSitesDimension {
                              numberOfRows: Int,
                              interface: TopSitesUIInterface
     ) -> TopSitesSectionDimension {
-        let numberOfTilesPerRow = getNumberOfTilesPerRow(for: interface, sites: sites)
+        let numberOfTilesPerRow = getNumberOfTilesPerRow(for: interface)
         let numberOfRows = getNumberOfRows(for: sites,
                                            numberOfRows: numberOfRows,
                                            numberOfTilesPerRow: numberOfTilesPerRow)
@@ -78,24 +78,13 @@ class TopSitesDimensionImplementation: TopSitesDimension {
     }
 
     /// Get the number of tiles per row the user will see. This depends on the UI interface the user has.
-    /// For `sites` less than 4 in a `horizontalSizeClass` of type `regular`
-    /// we check whether the `sites` are 4 maximum so the layout of the upper section containing `NTPLibraryCell`
-    /// will remain vertically aligned, providing a more consistent layout.
-    /// - Parameters:
-    ///   - interface: Tile number is based on layout, this param contains the parameters needed to computer the tile number
-    ///   - sites: The number of available `TopSite`s on a NTP we need to show
+    /// - Parameter interface: Tile number is based on layout, this param contains the parameters needed to computer the tile number
     /// - Returns: The number of tiles per row the user will see
-    private func getNumberOfTilesPerRow(for interface: TopSitesUIInterface, sites: [TopSite]) -> Int {
-        let defaultNumberOfTiles = 4
-        let expectedNumberOfTilesForRegularHorizontalSizeClass = 6
-        let isRegularHorizontalSizeClass = interface.horizontalSizeClass == .regular
-        let hasMoreThanDefaultNumberOfTiles = sites.count > defaultNumberOfTiles
-        
-        if isRegularHorizontalSizeClass &&
-            hasMoreThanDefaultNumberOfTiles {
-            return expectedNumberOfTilesForRegularHorizontalSizeClass
+    private func getNumberOfTilesPerRow(for interface: TopSitesUIInterface) -> Int {
+        if interface.horizontalSizeClass == .regular {
+            return 6
         } else {
-            return defaultNumberOfTiles
+            return 4
         }
     }
 }

--- a/Client/Frontend/Home/TopSites/TopSitesDimension.swift
+++ b/Client/Frontend/Home/TopSites/TopSitesDimension.swift
@@ -77,14 +77,17 @@ class TopSitesDimensionImplementation: TopSitesDimension {
         return numberOfRows - Int(numberOfEmptyCellRows.rounded(.down))
     }
 
+    //Ecosia: The design decided to have 4 tiles per row by default.
+    //Commenting the logic based on the interface and return 4.
     /// Get the number of tiles per row the user will see. This depends on the UI interface the user has.
     /// - Parameter interface: Tile number is based on layout, this param contains the parameters needed to computer the tile number
     /// - Returns: The number of tiles per row the user will see
     private func getNumberOfTilesPerRow(for interface: TopSitesUIInterface) -> Int {
-        if interface.horizontalSizeClass == .regular {
-            return 6
-        } else {
-            return 4
-        }
+        // Ecosia if interface.horizontalSizeClass == .regular {
+        // Ecosia     return 6
+        // Ecosia } else {
+        // Ecosia     return 4
+        // Ecosia }
+        return 4
     }
 }

--- a/Client/Frontend/Home/TopSites/TopSitesDimension.swift
+++ b/Client/Frontend/Home/TopSites/TopSitesDimension.swift
@@ -52,7 +52,7 @@ class TopSitesDimensionImplementation: TopSitesDimension {
                              numberOfRows: Int,
                              interface: TopSitesUIInterface
     ) -> TopSitesSectionDimension {
-        let numberOfTilesPerRow = getNumberOfTilesPerRow(for: interface)
+        let numberOfTilesPerRow = getNumberOfTilesPerRow(for: interface, sites: sites)
         let numberOfRows = getNumberOfRows(for: sites,
                                            numberOfRows: numberOfRows,
                                            numberOfTilesPerRow: numberOfTilesPerRow)
@@ -78,13 +78,24 @@ class TopSitesDimensionImplementation: TopSitesDimension {
     }
 
     /// Get the number of tiles per row the user will see. This depends on the UI interface the user has.
-    /// - Parameter interface: Tile number is based on layout, this param contains the parameters needed to computer the tile number
+    /// For `sites` less than 4 in a `horizontalSizeClass` of type `regular`
+    /// we check whether the `sites` are 4 maximum so the layout of the upper section containing `NTPLibraryCell`
+    /// will remain vertically aligned, providing a more consistent layout.
+    /// - Parameters:
+    ///   - interface: Tile number is based on layout, this param contains the parameters needed to computer the tile number
+    ///   - sites: The number of available `TopSite`s on a NTP we need to show
     /// - Returns: The number of tiles per row the user will see
-    private func getNumberOfTilesPerRow(for interface: TopSitesUIInterface) -> Int {
-        if interface.horizontalSizeClass == .regular {
-            return 6
+    private func getNumberOfTilesPerRow(for interface: TopSitesUIInterface, sites: [TopSite]) -> Int {
+        let defaultNumberOfTiles = 4
+        let expectedNumberOfTilesForRegularHorizontalSizeClass = 6
+        let isRegularHorizontalSizeClass = interface.horizontalSizeClass == .regular
+        let hasMoreThanDefaultNumberOfTiles = sites.count > defaultNumberOfTiles
+        
+        if isRegularHorizontalSizeClass &&
+            hasMoreThanDefaultNumberOfTiles {
+            return expectedNumberOfTilesForRegularHorizontalSizeClass
         } else {
-            return 4
+            return defaultNumberOfTiles
         }
     }
 }

--- a/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDimensionTests.swift
+++ b/Tests/ClientTests/Frontend/Home/TopSites/TopSitesDimensionTests.swift
@@ -16,7 +16,7 @@ class TopSitesDimensionTests: XCTestCase {
 
         let dimension = sut.getSectionDimension(for: createSites(), numberOfRows: 2, interface: interface)
         XCTAssertEqual(dimension.numberOfRows, 2)
-        XCTAssertEqual(dimension.numberOfTilesPerRow, 6)
+        XCTAssertEqual(dimension.numberOfTilesPerRow, 4)
     }
 
     func testSectionDimension_landscapeIphone_defaultRowNumber() {
@@ -26,7 +26,7 @@ class TopSitesDimensionTests: XCTestCase {
 
         let dimension = sut.getSectionDimension(for: createSites(), numberOfRows: 2, interface: interface)
         XCTAssertEqual(dimension.numberOfRows, 2)
-        XCTAssertEqual(dimension.numberOfTilesPerRow, 6)
+        XCTAssertEqual(dimension.numberOfTilesPerRow, 4)
     }
 
     func testSectionDimension_portraitiPadRegular_defaultRowNumber() {
@@ -36,7 +36,7 @@ class TopSitesDimensionTests: XCTestCase {
 
         let dimension = sut.getSectionDimension(for: createSites(), numberOfRows: 2, interface: interface)
         XCTAssertEqual(dimension.numberOfRows, 2)
-        XCTAssertEqual(dimension.numberOfTilesPerRow, 6)
+        XCTAssertEqual(dimension.numberOfTilesPerRow, 4)
     }
 
     func testSectionDimension_landscapeiPadRegular_defaultRowNumber() {
@@ -46,7 +46,7 @@ class TopSitesDimensionTests: XCTestCase {
 
         let dimension = sut.getSectionDimension(for: createSites(), numberOfRows: 2, interface: interface)
         XCTAssertEqual(dimension.numberOfRows, 2)
-        XCTAssertEqual(dimension.numberOfTilesPerRow, 6)
+        XCTAssertEqual(dimension.numberOfTilesPerRow, 4)
     }
 
     func testSectionDimension_portraitiPadCompact_defaultRowNumber() {
@@ -102,7 +102,7 @@ class TopSitesDimensionTests: XCTestCase {
 
         let dimension = sut.getSectionDimension(for: createSites(count: 4), numberOfRows: 2, interface: interface)
         XCTAssertEqual(dimension.numberOfRows, 1)
-        XCTAssertEqual(dimension.numberOfTilesPerRow, 6)
+        XCTAssertEqual(dimension.numberOfTilesPerRow, 4)
     }
 
     func testSectionDimension_twoEmptyRow_shouldBeRemoved() {
@@ -112,7 +112,7 @@ class TopSitesDimensionTests: XCTestCase {
 
         let dimension = sut.getSectionDimension(for: createSites(count: 4), numberOfRows: 3, interface: interface)
         XCTAssertEqual(dimension.numberOfRows, 1)
-        XCTAssertEqual(dimension.numberOfTilesPerRow, 6)
+        XCTAssertEqual(dimension.numberOfTilesPerRow, 4)
     }
 
     func testSectionDimension_noEmptyRow_shouldNotBeRemoved() {
@@ -122,7 +122,7 @@ class TopSitesDimensionTests: XCTestCase {
 
         let dimension = sut.getSectionDimension(for: createSites(count: 8), numberOfRows: 2, interface: interface)
         XCTAssertEqual(dimension.numberOfRows, 2)
-        XCTAssertEqual(dimension.numberOfTilesPerRow, 6)
+        XCTAssertEqual(dimension.numberOfTilesPerRow, 4)
     }
 
     func testSectionDimension_halfFilledRow_shouldNotBeRemoved() {
@@ -130,9 +130,9 @@ class TopSitesDimensionTests: XCTestCase {
         let trait = MockTraitCollection()
         let interface = TopSitesUIInterface(isLandscape: false, isIphone: true, trait: trait)
 
-        let dimension = sut.getSectionDimension(for: createSites(count: 6), numberOfRows: 2, interface: interface)
+        let dimension = sut.getSectionDimension(for: createSites(count: 3), numberOfRows: 2, interface: interface)
         XCTAssertEqual(dimension.numberOfRows, 1)
-        XCTAssertEqual(dimension.numberOfTilesPerRow, 6)
+        XCTAssertEqual(dimension.numberOfTilesPerRow, 4)
     }
 }
 


### PR DESCRIPTION
[MOB-1644](https://ecosia.atlassian.net/browse/MOB-1644)

## Context

The approach to this bug has been quite conservative in the first place.
I considered keeping the six items per row while reviewing the vertical alignment when the items were less than 5.
However, after catching up with the design, the final decision went to keep the four items regardless of the hosting interface.
This way, the layout is consistent with the upper items in the New Tab Page (Bookmarks, History, Reading List, and Downloads).

## Approach

Approached this ticket the standard way we usually update Firefox Codebase. Added the `//Ecosia` comment to explain the change.
Produced Loom video and got the design approval.

![Simulator Screenshot - iPhone SE (3rd generation) - 2023-04-05 at 11 57 45](https://user-images.githubusercontent.com/3584008/230048108-55f4db13-bde5-48b8-9ebf-00d6bf4c18de.png)
![Simulator Screenshot - iPad (10th generation) - 2023-04-05 at 11 58 21](https://user-images.githubusercontent.com/3584008/230048116-f65517bd-39f9-457f-8bf7-4d062cb735a0.png)

