### PR TITLE
MOB-1788 UI issue on Your Impact section

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -104,6 +104,7 @@
 		28E08C991AF44EF9009BA2FA /* SQLiteHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FCAE2551ABB531100877008 /* SQLiteHistory.swift */; };
 		28E08C9A1AF44F00009BA2FA /* BrowserSchema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 282915E51AF1A7920006EEB5 /* BrowserSchema.swift */; };
 		28EADE5D1AFC3A78007FB2FB /* UIImageView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28EADE381AFC3898007FB2FB /* UIImageView+Extension.swift */; };
+		2C1D049B29DDDC8E00ED43BA /* MyImpactCell+ViewFactories.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C1D049A29DDDC8E00ED43BA /* MyImpactCell+ViewFactories.swift */; };
 		2C28F96C201B2D4C00ABA8A5 /* MailAppSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C28F96B201B2D4C00ABA8A5 /* MailAppSettingsTests.swift */; };
 		2C2A5EF41E68469500F02659 /* PrivateBrowsingTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2A5EF31E68469500F02659 /* PrivateBrowsingTest.swift */; };
 		2C2A91291FA2410D002E36BD /* HistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2A91281FA2410D002E36BD /* HistoryTests.swift */; };
@@ -1701,6 +1702,7 @@
 		2B31494CBFF9DF6FA41953B2 /* ses */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ses; path = ses.lproj/FindInPage.strings; sourceTree = "<group>"; };
 		2BAA411FAF1D49B9990A7720 /* sat-Olck */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "sat-Olck"; path = "sat-Olck.lproj/Shared.strings"; sourceTree = "<group>"; };
 		2BAB4A40A318F5A577488909 /* mr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = mr; path = mr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		2C1D049A29DDDC8E00ED43BA /* MyImpactCell+ViewFactories.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MyImpactCell+ViewFactories.swift"; sourceTree = "<group>"; };
 		2C26401D9CCB8C2671EA2431 /* ta */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ta; path = ta.lproj/3DTouchActions.strings; sourceTree = "<group>"; };
 		2C28F96B201B2D4C00ABA8A5 /* MailAppSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailAppSettingsTests.swift; sourceTree = "<group>"; };
 		2C2A5EF31E68469500F02659 /* PrivateBrowsingTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateBrowsingTest.swift; sourceTree = "<group>"; };
@@ -6572,6 +6574,7 @@
 				CA4D9CAA28C8D801006AFB5D /* MyImpactCell.Indicator.swift */,
 				CA4D9CA128C8D801006AFB5D /* MyImpactCell.Progress.swift */,
 				CA4D9CAD28C8D801006AFB5D /* MyImpactCell.swift */,
+				2C1D049A29DDDC8E00ED43BA /* MyImpactCell+ViewFactories.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -9258,6 +9261,7 @@
 				F85C7F0E2711C556004BDBA4 /* SettingsViewController.swift in Sources */,
 				74C027451B2A348C001B1E88 /* SessionData.swift in Sources */,
 				C84266752728462900382274 /* AccessibilityIdentifiers.swift in Sources */,
+				2C1D049B29DDDC8E00ED43BA /* MyImpactCell+ViewFactories.swift in Sources */,
 				E1877A81286E0EFD00F5BDF2 /* WebViewNavigationHandler.swift in Sources */,
 				274A36CC239EB99400A21587 /* LibraryPanelContextMenu.swift in Sources */,
 				D314E7F71A37B98700426A76 /* TabToolbar.swift in Sources */,

--- a/Client/Ecosia/UI/Impact/Views/MyImpactCell+ViewFactories.swift
+++ b/Client/Ecosia/UI/Impact/Views/MyImpactCell+ViewFactories.swift
@@ -1,0 +1,188 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+extension MyImpactCell {
+    
+    func makeOutline() -> UIView {
+        let outline = UIView()
+        outline.layer.cornerRadius = UX.Outline.cornerRadius
+        outline.translatesAutoresizingMaskIntoConstraints = false
+        return outline
+    }
+    
+    func makeHowItWorksButton() -> UIControl {
+        let howItWorksButton = UIControl()
+        howItWorksButton.translatesAutoresizingMaskIntoConstraints = false
+        return howItWorksButton
+    }
+    
+    func makeProgressView() -> Progress {
+        Progress(size: UX.ProgressView.progressSize, lineWidth: UX.ProgressView.lineWidth)
+    }
+    
+    func makeIndicatorView() -> Indicator {
+        Indicator(size: UX.ProgressView.progressSize)
+    }
+    
+    func makeTreesIcon() -> UIImageView {
+        let treesIcon = UIImageView()
+        treesIcon.translatesAutoresizingMaskIntoConstraints = false
+        treesIcon.contentMode = .center
+        treesIcon.clipsToBounds = true
+        return treesIcon
+    }
+    
+    func makeTreesCountLabel() -> UILabel {
+        let treesCount = UILabel()
+        treesCount.translatesAutoresizingMaskIntoConstraints = false
+        treesCount.font = .preferredFont(forTextStyle: .title1).bold()
+        treesCount.adjustsFontForContentSizeCategory = true
+        return treesCount
+    }
+    
+    func makeTreesPlantedLabel() -> UILabel {
+        let treesPlanted = UILabel()
+        treesPlanted.translatesAutoresizingMaskIntoConstraints = false
+        treesPlanted.font = .preferredFont(forTextStyle: .body)
+        treesPlanted.adjustsFontForContentSizeCategory = true
+        return treesPlanted
+    }
+    
+    func makeHowItWorksLabel() -> UILabel {
+        let howItWorks = UILabel()
+        howItWorks.translatesAutoresizingMaskIntoConstraints = false
+        howItWorks.font = .preferredFont(forTextStyle: .callout)
+        howItWorks.adjustsFontForContentSizeCategory = true
+        howItWorks.text = .localized(.howItWorks)
+        return howItWorks
+    }
+    
+    func makeHowItWorksIcon() -> UIImageView {
+        let howItWorksIcon = UIImageView()
+        howItWorksIcon.translatesAutoresizingMaskIntoConstraints = false
+        howItWorksIcon.contentMode = .center
+        howItWorksIcon.clipsToBounds = true
+        return howItWorksIcon
+    }    
+}
+
+extension MyImpactCell {
+    
+    func makeYourSearchesContainerStackView() -> UIStackView {
+        let searchesStackView = UIStackView()
+        searchesStackView.translatesAutoresizingMaskIntoConstraints = false
+        searchesStackView.axis = .horizontal
+        searchesStackView.distribution = .fill
+        searchesStackView.alignment = .center
+        searchesStackView.spacing = UX.SearchAndFriends.stackViewSpacing
+        return searchesStackView
+    }
+    
+    func makeYourSearchesIcon() -> UIImageView {
+        let searchesIcon = UIImageView()
+        searchesIcon.translatesAutoresizingMaskIntoConstraints = false
+        searchesIcon.contentMode = .center
+        searchesIcon.clipsToBounds = true
+        searchesIcon.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        searchesIcon.setContentHuggingPriority(.defaultHigh, for: .vertical)
+        return searchesIcon
+    }
+    
+    func makeYourSearchesLabel() -> UILabel {
+        let searches = UILabel()
+        searches.translatesAutoresizingMaskIntoConstraints = false
+        searches.font = .preferredFont(forTextStyle: .body)
+        searches.adjustsFontForContentSizeCategory = true
+        searches.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        searches.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+        return searches
+    }
+    
+    func makeSearchesTreesLabel() -> UILabel {
+        let searchesTrees = UILabel()
+        searchesTrees.translatesAutoresizingMaskIntoConstraints = false
+        searchesTrees.font = .systemFont(ofSize: UIFont.preferredFont(forTextStyle: .subheadline).pointSize, weight: .semibold)
+        searchesTrees.adjustsFontForContentSizeCategory = true
+        searchesTrees.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        searchesTrees.setContentHuggingPriority(.defaultHigh, for: .vertical)
+        return searchesTrees
+    }
+    
+    func makeSearchesImpactIcon() -> UIImageView {
+        let searchesImpact = UIImageView()
+        searchesImpact.translatesAutoresizingMaskIntoConstraints = false
+        searchesImpact.contentMode = .center
+        searchesImpact.clipsToBounds = true
+        searchesImpact.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        searchesImpact.setContentHuggingPriority(.defaultHigh, for: .vertical)
+        return searchesImpact
+    }
+}
+
+extension MyImpactCell {
+    
+    func makeFriendsImpactContainerStackView() -> UIStackView {
+        let friendsImpactContainerStackView = UIStackView()
+        friendsImpactContainerStackView.translatesAutoresizingMaskIntoConstraints = false
+        friendsImpactContainerStackView.axis = .horizontal
+        friendsImpactContainerStackView.distribution = .fill
+        friendsImpactContainerStackView.alignment = .center
+        friendsImpactContainerStackView.spacing = UX.SearchAndFriends.stackViewSpacing
+        return friendsImpactContainerStackView
+    }
+    
+    func makeFriendsIcon() -> UIImageView {
+        let friendsIcon = UIImageView()
+        friendsIcon.translatesAutoresizingMaskIntoConstraints = false
+        friendsIcon.contentMode = .center
+        friendsIcon.clipsToBounds = true
+        friendsIcon.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        friendsIcon.setContentHuggingPriority(.defaultHigh, for: .vertical)
+        return friendsIcon
+    }
+    
+    func makeFriendsLabel() -> UILabel {
+        let friends = UILabel()
+        friends.translatesAutoresizingMaskIntoConstraints = false
+        friends.font = .preferredFont(forTextStyle: .body)
+        friends.adjustsFontForContentSizeCategory = true
+        friends.numberOfLines = UX.SearchAndFriends.maximumNumberOfLines
+        friends.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        return friends
+    }
+    
+    func makeFriendsTreesLabel() -> UILabel {
+        let friendsTrees = UILabel()
+        friendsTrees.translatesAutoresizingMaskIntoConstraints = false
+        friendsTrees.font = .systemFont(ofSize: UIFont.preferredFont(forTextStyle: .subheadline).pointSize, weight: .semibold)
+        friendsTrees.adjustsFontForContentSizeCategory = true
+        friendsTrees.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        friendsTrees.setContentHuggingPriority(.defaultHigh, for: .vertical)
+        return friendsTrees
+    }
+    
+    func makeFriendsImpactIcon() -> UIImageView {
+        let friendsImpact = UIImageView()
+        friendsImpact.translatesAutoresizingMaskIntoConstraints = false
+        friendsImpact.contentMode = .center
+        friendsImpact.clipsToBounds = true
+        friendsImpact.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        friendsImpact.setContentHuggingPriority(.defaultHigh, for: .vertical)
+        return friendsImpact
+    }
+}
+
+extension MyImpactCell {
+    
+    func makeSearchAndYourFriendsImpactContainerStackView() -> UIStackView {
+        let searchAndFriendsStackView = UIStackView()
+        searchAndFriendsStackView.translatesAutoresizingMaskIntoConstraints = false
+        searchAndFriendsStackView.alignment = .fill
+        searchAndFriendsStackView.axis = .vertical
+        searchAndFriendsStackView.spacing = UIStackView.spacingUseDefault
+        return searchAndFriendsStackView
+    }
+}

--- a/Client/Ecosia/UI/Impact/Views/MyImpactCell+ViewFactories.swift
+++ b/Client/Ecosia/UI/Impact/Views/MyImpactCell+ViewFactories.swift
@@ -96,8 +96,7 @@ extension MyImpactCell {
         searches.translatesAutoresizingMaskIntoConstraints = false
         searches.font = .preferredFont(forTextStyle: .body)
         searches.adjustsFontForContentSizeCategory = true
-        searches.setContentHuggingPriority(.defaultLow, for: .horizontal)
-        searches.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+        searches.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         return searches
     }
     

--- a/Client/Ecosia/UI/Impact/Views/MyImpactCell+ViewFactories.swift
+++ b/Client/Ecosia/UI/Impact/Views/MyImpactCell+ViewFactories.swift
@@ -5,7 +5,9 @@
 import Foundation
 
 extension MyImpactCell {
-    
+
+    // MARK: - Outline and Progress View components
+
     func makeOutline() -> UIView {
         let outline = UIView()
         outline.layer.cornerRadius = UX.Outline.cornerRadius
@@ -69,7 +71,10 @@ extension MyImpactCell {
     }    
 }
 
+
 extension MyImpactCell {
+    
+    // MARK: - Search section container view and components
     
     func makeYourSearchesContainerStackView() -> UIStackView {
         let searchesStackView = UIStackView()
@@ -123,6 +128,8 @@ extension MyImpactCell {
 
 extension MyImpactCell {
     
+    // MARK: - Friends section container view and components
+
     func makeFriendsImpactContainerStackView() -> UIStackView {
         let friendsImpactContainerStackView = UIStackView()
         friendsImpactContainerStackView.translatesAutoresizingMaskIntoConstraints = false
@@ -175,6 +182,8 @@ extension MyImpactCell {
 }
 
 extension MyImpactCell {
+    
+    // MARK: - Friends and Friends container view
     
     func makeSearchAndYourFriendsImpactContainerStackView() -> UIStackView {
         let searchAndFriendsStackView = UIStackView()

--- a/Client/Ecosia/UI/Impact/Views/MyImpactCell.swift
+++ b/Client/Ecosia/UI/Impact/Views/MyImpactCell.swift
@@ -193,7 +193,7 @@ final class MyImpactCell: UICollectionViewCell, NotificationThemeable {
         outline.trailingAnchor.constraint(equalTo: contentView.safeAreaLayoutGuide.trailingAnchor).isActive = true
         outline.topAnchor.constraint(equalTo: contentView.topAnchor).isActive = true
         outline.bottomAnchor.constraint(equalTo: contentView.bottomAnchor).isActive = true
-        outline.widthAnchor.constraint(equalTo: widthAnchor).isActive = true
+        outline.widthAnchor.constraint(equalToConstant: frame.width).isActive = true
         
         totalProgress.topAnchor.constraint(equalTo: outline.topAnchor, constant: 25).isActive = true
         totalProgress.centerXAnchor.constraint(equalTo: outline.centerXAnchor).isActive = true

--- a/Client/Ecosia/UI/Impact/Views/MyImpactCell.swift
+++ b/Client/Ecosia/UI/Impact/Views/MyImpactCell.swift
@@ -90,61 +90,94 @@ final class MyImpactCell: UICollectionViewCell, NotificationThemeable {
         howItWorksButton.addSubview(howItWorksIcon)
         self.howItWorksIcon = howItWorksIcon
         
+        let searchesStackView = UIStackView()
+        searchesStackView.translatesAutoresizingMaskIntoConstraints = false
+        searchesStackView.axis = .horizontal
+        searchesStackView.distribution = .fill
+        searchesStackView.alignment = .center
+        searchesStackView.spacing = 8.0
+        
         let searchesIcon = UIImageView()
         searchesIcon.translatesAutoresizingMaskIntoConstraints = false
         searchesIcon.contentMode = .center
         searchesIcon.clipsToBounds = true
-        outline.addSubview(searchesIcon)
+        searchesIcon.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        searchesIcon.setContentHuggingPriority(.defaultHigh, for: .vertical)
         self.searchesIcon = searchesIcon
-        
+                
         let searches = UILabel()
         searches.translatesAutoresizingMaskIntoConstraints = false
         searches.font = .preferredFont(forTextStyle: .body)
         searches.adjustsFontForContentSizeCategory = true
+        searches.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         self.searches = searches
-        outline.addSubview(searches)
         
         let searchesTrees = UILabel()
         searchesTrees.translatesAutoresizingMaskIntoConstraints = false
         searchesTrees.font = .systemFont(ofSize: UIFont.preferredFont(forTextStyle: .subheadline).pointSize, weight: .semibold)
         searchesTrees.adjustsFontForContentSizeCategory = true
         self.searchesTrees = searchesTrees
-        outline.addSubview(searchesTrees)
         
         let searchesImpact = UIImageView()
         searchesImpact.translatesAutoresizingMaskIntoConstraints = false
         searchesImpact.contentMode = .center
         searchesImpact.clipsToBounds = true
-        outline.addSubview(searchesImpact)
         self.searchesImpact = searchesImpact
+        
+        searchesStackView.addArrangedSubview(self.searchesIcon)
+        searchesStackView.addArrangedSubview(self.searches)
+        searchesStackView.addArrangedSubview(self.searchesTrees)
+        searchesStackView.addArrangedSubview(self.searchesImpact)
+        
+        let friendsStackView = UIStackView()
+        friendsStackView.translatesAutoresizingMaskIntoConstraints = false
+        friendsStackView.axis = .horizontal
+        friendsStackView.distribution = .fill
+        friendsStackView.alignment = .center
+        friendsStackView.spacing = 8.0
 
         let friendsIcon = UIImageView()
         friendsIcon.translatesAutoresizingMaskIntoConstraints = false
         friendsIcon.contentMode = .center
         friendsIcon.clipsToBounds = true
-        outline.addSubview(friendsIcon)
+        friendsIcon.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        friendsIcon.setContentHuggingPriority(.defaultHigh, for: .vertical)
         self.friendsIcon = friendsIcon
         
         let friends = UILabel()
         friends.translatesAutoresizingMaskIntoConstraints = false
         friends.font = .preferredFont(forTextStyle: .body)
         friends.adjustsFontForContentSizeCategory = true
+        friends.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        friends.numberOfLines = 2
         self.friends = friends
-        outline.addSubview(friends)
         
         let friendsTrees = UILabel()
         friendsTrees.translatesAutoresizingMaskIntoConstraints = false
         friendsTrees.font = .systemFont(ofSize: UIFont.preferredFont(forTextStyle: .subheadline).pointSize, weight: .semibold)
         friendsTrees.adjustsFontForContentSizeCategory = true
         self.friendsTrees = friendsTrees
-        outline.addSubview(friendsTrees)
         
         let friendsImpact = UIImageView()
         friendsImpact.translatesAutoresizingMaskIntoConstraints = false
         friendsImpact.contentMode = .center
         friendsImpact.clipsToBounds = true
-        outline.addSubview(friendsImpact)
         self.friendsImpact = friendsImpact
+        
+        friendsStackView.addArrangedSubview(self.friendsIcon)
+        friendsStackView.addArrangedSubview(self.friends)
+        friendsStackView.addArrangedSubview(self.friendsTrees)
+        friendsStackView.addArrangedSubview(self.friendsImpact)
+        
+        let searchAndFriendsStackView = UIStackView()
+        searchAndFriendsStackView.translatesAutoresizingMaskIntoConstraints = false
+        searchAndFriendsStackView.alignment = .fill
+        searchAndFriendsStackView.axis = .vertical
+        searchAndFriendsStackView.spacing = UIStackView.spacingUseDefault
+
+        searchAndFriendsStackView.addArrangedSubview(searchesStackView)
+        searchAndFriendsStackView.addArrangedSubview(friendsStackView)
+        outline.addSubview(searchAndFriendsStackView)
 
         outline.leftAnchor.constraint(equalTo: contentView.leftAnchor).isActive = true
         outline.rightAnchor.constraint(equalTo: contentView.rightAnchor).isActive = true
@@ -179,31 +212,12 @@ final class MyImpactCell: UICollectionViewCell, NotificationThemeable {
         
         howItWorksIcon.centerYAnchor.constraint(equalTo: howItWorks.centerYAnchor).isActive = true
         howItWorksIcon.leftAnchor.constraint(equalTo: howItWorks.rightAnchor, constant: 4).isActive = true
-        
-        searchesIcon.leftAnchor.constraint(equalTo: outline.leftAnchor, constant: 16).isActive = true
-        searchesIcon.bottomAnchor.constraint(equalTo: friendsIcon.topAnchor, constant: -10).isActive = true
-        
-        searches.leftAnchor.constraint(equalTo: searchesIcon.rightAnchor, constant: 10).isActive = true
-        searches.centerYAnchor.constraint(equalTo: searchesIcon.centerYAnchor).isActive = true
-        
-        searchesTrees.rightAnchor.constraint(equalTo: searchesImpact.leftAnchor, constant: -7).isActive = true
-        searchesTrees.centerYAnchor.constraint(equalTo: searchesIcon.centerYAnchor).isActive = true
-        
-        searchesImpact.rightAnchor.constraint(equalTo: outline.rightAnchor, constant: -19).isActive = true
-        searchesImpact.centerYAnchor.constraint(equalTo: searchesIcon.centerYAnchor).isActive = true
-        
-        friendsIcon.leftAnchor.constraint(equalTo: outline.leftAnchor, constant: 16).isActive = true
-        friendsIcon.bottomAnchor.constraint(equalTo: outline.bottomAnchor, constant: -24).isActive = true
-        
-        friends.leftAnchor.constraint(equalTo: friendsIcon.rightAnchor, constant: 10).isActive = true
-        friends.centerYAnchor.constraint(equalTo: friendsIcon.centerYAnchor).isActive = true
-        
-        friendsTrees.rightAnchor.constraint(equalTo: friendsImpact.leftAnchor, constant: -7).isActive = true
-        friendsTrees.centerYAnchor.constraint(equalTo: friendsIcon.centerYAnchor).isActive = true
-        
-        friendsImpact.rightAnchor.constraint(equalTo: outline.rightAnchor, constant: -19).isActive = true
-        friendsImpact.centerYAnchor.constraint(equalTo: friendsIcon.centerYAnchor).isActive = true
-        
+
+        searchAndFriendsStackView.leftAnchor.constraint(equalTo: outline.leftAnchor, constant: 16).isActive = true
+        searchAndFriendsStackView.rightAnchor.constraint(equalTo: outline.rightAnchor, constant: -16).isActive = true
+        searchAndFriendsStackView.topAnchor.constraint(equalTo: totalProgress.bottomAnchor, constant: 12).isActive = true
+        searchAndFriendsStackView.bottomAnchor.constraint(equalTo: outline.bottomAnchor, constant: -24).isActive = true
+                        
         applyTheme()
     }
     

--- a/Client/Ecosia/UI/Impact/Views/MyImpactCell.swift
+++ b/Client/Ecosia/UI/Impact/Views/MyImpactCell.swift
@@ -5,7 +5,38 @@
 import UIKit
 import Core
 
-final class MyImpactCell: UICollectionViewCell, NotificationThemeable {
+final class MyImpactCell: UICollectionViewCell {
+    
+    struct UX {
+        
+        enum Outline {
+            static let cornerRadius: CGFloat = 10
+        }
+        
+        enum SearchAndFriends {
+            static let padding: CGFloat = 16
+            static let topPadding: CGFloat = 12
+            static let bottomPadding: CGFloat = 24
+            static let stackViewSpacing: CGFloat = 8
+            static let maximumNumberOfLines = 2
+        }
+        
+        enum ProgressView {
+            static let progressSize = CGSize(width: 240, height: 150)
+            static let lineWidth: CGFloat = 8
+            static let topAnchorOffset: CGFloat = 25
+            static let treesIconTopAnchorOffset: CGFloat = 34
+            static let treesCountBottomAnchorOffset: CGFloat = 2
+        }
+        
+        enum HowItWorksView {
+            static let buttonBottomAnchorOffset: CGFloat = 6
+            static let centerXOffset: CGFloat = -8
+            static let topAnchorOffset: CGFloat = 6
+            static let iconLeftAnchorOffset: CGFloat = 4
+        }
+    }
+    
     private(set) weak var howItWorksButton: UIControl!
     private weak var totalProgress: Progress!
     private weak var currentProgress: Progress!
@@ -14,223 +45,124 @@ final class MyImpactCell: UICollectionViewCell, NotificationThemeable {
     private weak var treesCount: UILabel!
     private weak var treesPlanted: UILabel!
     private weak var howItWorks: UILabel!
-    private weak var searches: UILabel!
-    private weak var searchesTrees: UILabel!
-    private weak var friends: UILabel!
-    private weak var friendsTrees: UILabel!
+    private weak var searchesLabel: UILabel!
+    private weak var searchesTreesLabel: UILabel!
+    private weak var friendsLabel: UILabel!
+    private weak var friendsTreesLabel: UILabel!
     private weak var treesIcon: UIImageView!
     private weak var howItWorksIcon: UIImageView!
     private weak var searchesIcon: UIImageView!
-    private weak var searchesImpact: UIImageView!
+    private weak var searchesImpactIcon: UIImageView!
     private weak var friendsIcon: UIImageView!
-    private weak var friendsImpact: UIImageView!
-
+    private weak var friendsImpactIcon: UIImageView!
+    private weak var searchAndYourFriendsImpactContainerView: UIView!
+    
     required init?(coder: NSCoder) { nil }
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-        
-        let outline = UIView()
-        outline.layer.cornerRadius = 10
-        outline.translatesAutoresizingMaskIntoConstraints = false
-        self.outline = outline
-        contentView.addSubview(outline)
+        setupView()
+        setupConstraints()
+        applyTheme()
+    }
+            
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        applyTheme()
+    }
+}
 
-        let howItWorksButton = UIControl()
-        howItWorksButton.translatesAutoresizingMaskIntoConstraints = false
+extension MyImpactCell {
+    
+    private func setupView() {
+        
+        let outline = makeOutline()
+        contentView.addSubview(outline)
+        self.outline = outline
+        
+        let howItWorksButton = makeHowItWorksButton()
         outline.addSubview(howItWorksButton)
         self.howItWorksButton = howItWorksButton
         
-        let progressSize = CGSize(width: 240, height: 150)
-        let totalProgress = Progress(size: progressSize, lineWidth: 8)
-        self.totalProgress = totalProgress
+        let totalProgress = makeProgressView()
         howItWorksButton.addSubview(totalProgress)
+        self.totalProgress = totalProgress
         
-        let currentProgress = Progress(size: progressSize, lineWidth: 8)
-        self.currentProgress = currentProgress
+        let currentProgress = makeProgressView()
         howItWorksButton.addSubview(currentProgress)
+        self.currentProgress = currentProgress
         
-        let indicator = Indicator(size: progressSize)
-        self.indicator = indicator
+        let indicator = makeIndicatorView()
         howItWorksButton.addSubview(indicator)
+        self.indicator = indicator
         
-        let treesIcon = UIImageView()
-        treesIcon.translatesAutoresizingMaskIntoConstraints = false
-        treesIcon.contentMode = .center
-        treesIcon.clipsToBounds = true
+        let treesIcon = makeTreesIcon()
         howItWorksButton.addSubview(treesIcon)
         self.treesIcon = treesIcon
         
-        let treesCount = UILabel()
-        treesCount.translatesAutoresizingMaskIntoConstraints = false
-        treesCount.font = .preferredFont(forTextStyle: .title1).bold()
-        treesCount.adjustsFontForContentSizeCategory = true
-        self.treesCount = treesCount
+        let treesCount = makeTreesCountLabel()
         howItWorksButton.addSubview(treesCount)
+        self.treesCount = treesCount
         
-        let treesPlanted = UILabel()
-        treesPlanted.translatesAutoresizingMaskIntoConstraints = false
-        treesPlanted.font = .preferredFont(forTextStyle: .body)
-        treesPlanted.adjustsFontForContentSizeCategory = true
-        self.treesPlanted = treesPlanted
+        let treesPlanted = makeTreesPlantedLabel()
         howItWorksButton.addSubview(treesPlanted)
+        self.treesPlanted = treesPlanted
         
-        let howItWorks = UILabel()
-        howItWorks.translatesAutoresizingMaskIntoConstraints = false
-        howItWorks.font = .preferredFont(forTextStyle: .callout)
-        howItWorks.adjustsFontForContentSizeCategory = true
-        howItWorks.text = .localized(.howItWorks)
-        self.howItWorks = howItWorks
+        let howItWorks = makeHowItWorksLabel()
         howItWorksButton.addSubview(howItWorks)
+        self.howItWorks = howItWorks
         
-        let howItWorksIcon = UIImageView()
-        howItWorksIcon.translatesAutoresizingMaskIntoConstraints = false
-        howItWorksIcon.contentMode = .center
-        howItWorksIcon.clipsToBounds = true
+        let howItWorksIcon = makeHowItWorksIcon()
         howItWorksButton.addSubview(howItWorksIcon)
         self.howItWorksIcon = howItWorksIcon
         
-        let searchesStackView = UIStackView()
-        searchesStackView.translatesAutoresizingMaskIntoConstraints = false
-        searchesStackView.axis = .horizontal
-        searchesStackView.distribution = .fill
-        searchesStackView.alignment = .center
-        searchesStackView.spacing = 8.0
-
-        let searchesIcon = UIImageView()
-        searchesIcon.translatesAutoresizingMaskIntoConstraints = false
-        searchesIcon.contentMode = .center
-        searchesIcon.clipsToBounds = true
-        searchesIcon.setContentHuggingPriority(.defaultHigh, for: .horizontal)
-        searchesIcon.setContentHuggingPriority(.defaultHigh, for: .vertical)
+        let searchesStackView = makeYourSearchesContainerStackView()
+        
+        let searchesIcon = makeYourSearchesIcon()
         self.searchesIcon = searchesIcon
-                
-        let searches = UILabel()
-        searches.translatesAutoresizingMaskIntoConstraints = false
-        searches.font = .preferredFont(forTextStyle: .body)
-        searches.adjustsFontForContentSizeCategory = true
-        searches.setContentHuggingPriority(.defaultLow, for: .horizontal)
-        searches.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
-        self.searches = searches
         
-        let searchesTrees = UILabel()
-        searchesTrees.translatesAutoresizingMaskIntoConstraints = false
-        searchesTrees.font = .systemFont(ofSize: UIFont.preferredFont(forTextStyle: .subheadline).pointSize, weight: .semibold)
-        searchesTrees.adjustsFontForContentSizeCategory = true
-        searchesTrees.setContentHuggingPriority(.defaultHigh, for: .horizontal)
-        searchesTrees.setContentHuggingPriority(.defaultHigh, for: .vertical)
-        self.searchesTrees = searchesTrees
+        let searchesLabel = makeYourSearchesLabel()
+        self.searchesLabel = searchesLabel
         
-        let searchesImpact = UIImageView()
-        searchesImpact.translatesAutoresizingMaskIntoConstraints = false
-        searchesImpact.contentMode = .center
-        searchesImpact.clipsToBounds = true
-        searchesImpact.setContentHuggingPriority(.defaultHigh, for: .horizontal)
-        searchesImpact.setContentHuggingPriority(.defaultHigh, for: .vertical)
-        self.searchesImpact = searchesImpact
-        
-        searchesStackView.addArrangedSubview(self.searchesIcon)
-        searchesStackView.addArrangedSubview(self.searches)
-        searchesStackView.addArrangedSubview(self.searchesTrees)
-        searchesStackView.addArrangedSubview(self.searchesImpact)
-        
-        let friendsStackView = UIStackView()
-        friendsStackView.translatesAutoresizingMaskIntoConstraints = false
-        friendsStackView.axis = .horizontal
-        friendsStackView.distribution = .fill
-        friendsStackView.alignment = .center
-        friendsStackView.spacing = 8.0
-        friendsStackView.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        let searchesTreesLabel = makeSearchesTreesLabel()
+        self.searchesTreesLabel = searchesLabel
 
-        let friendsIcon = UIImageView()
-        friendsIcon.translatesAutoresizingMaskIntoConstraints = false
-        friendsIcon.contentMode = .center
-        friendsIcon.clipsToBounds = true
-        friendsIcon.setContentHuggingPriority(.defaultHigh, for: .horizontal)
-        friendsIcon.setContentHuggingPriority(.defaultHigh, for: .vertical)
+        let searchesImpactIcon = makeSearchesImpactIcon()
+        self.searchesImpactIcon = searchesImpactIcon
+        
+        searchesStackView.addArrangedSubview(searchesIcon)
+        searchesStackView.addArrangedSubview(searchesLabel)
+        searchesStackView.addArrangedSubview(searchesTreesLabel)
+        searchesStackView.addArrangedSubview(searchesImpactIcon)
+                
+        let friendsStackView = makeFriendsImpactContainerStackView()
+        
+        let friendsIcon = makeFriendsIcon()
         self.friendsIcon = friendsIcon
         
-        let friends = UILabel()
-        friends.translatesAutoresizingMaskIntoConstraints = false
-        friends.font = .preferredFont(forTextStyle: .body)
-        friends.adjustsFontForContentSizeCategory = true
-        friends.numberOfLines = 2
-        friends.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-        self.friends = friends
+        let friendsLabel = makeFriendsLabel()
+        self.friendsLabel = friendsLabel
         
-        let friendsTrees = UILabel()
-        friendsTrees.translatesAutoresizingMaskIntoConstraints = false
-        friendsTrees.font = .systemFont(ofSize: UIFont.preferredFont(forTextStyle: .subheadline).pointSize, weight: .semibold)
-        friendsTrees.adjustsFontForContentSizeCategory = true
-        friendsTrees.setContentHuggingPriority(.defaultHigh, for: .horizontal)
-        friendsTrees.setContentHuggingPriority(.defaultHigh, for: .vertical)
-        self.friendsTrees = friendsTrees
+        let friendsTreesLabel = makeFriendsTreesLabel()
+        self.friendsTreesLabel = friendsTreesLabel
         
-        let friendsImpact = UIImageView()
-        friendsImpact.translatesAutoresizingMaskIntoConstraints = false
-        friendsImpact.contentMode = .center
-        friendsImpact.clipsToBounds = true
-        friendsImpact.setContentHuggingPriority(.defaultHigh, for: .horizontal)
-        friendsImpact.setContentHuggingPriority(.defaultHigh, for: .vertical)
-        self.friendsImpact = friendsImpact
+        let friendsImpactIcon = makeFriendsImpactIcon()
+        self.friendsImpactIcon = friendsImpactIcon
         
-        friendsStackView.addArrangedSubview(self.friendsIcon)
-        friendsStackView.addArrangedSubview(self.friends)
-        friendsStackView.addArrangedSubview(self.friendsTrees)
-        friendsStackView.addArrangedSubview(self.friendsImpact)
+        friendsStackView.addArrangedSubview(friendsIcon)
+        friendsStackView.addArrangedSubview(friendsLabel)
+        friendsStackView.addArrangedSubview(friendsTreesLabel)
+        friendsStackView.addArrangedSubview(friendsImpactIcon)
         
-        let searchAndFriendsStackView = UIStackView()
-        searchAndFriendsStackView.translatesAutoresizingMaskIntoConstraints = false
-        searchAndFriendsStackView.alignment = .fill
-        searchAndFriendsStackView.axis = .vertical
-        searchAndFriendsStackView.spacing = UIStackView.spacingUseDefault
-        
-        searchAndFriendsStackView.addArrangedSubview(searchesStackView)
-        searchAndFriendsStackView.addArrangedSubview(friendsStackView)
-        outline.addSubview(searchAndFriendsStackView)
-
-        outline.leadingAnchor.constraint(equalTo: contentView.safeAreaLayoutGuide.leadingAnchor).isActive = true
-        outline.trailingAnchor.constraint(equalTo: contentView.safeAreaLayoutGuide.trailingAnchor).isActive = true
-        outline.topAnchor.constraint(equalTo: contentView.topAnchor).isActive = true
-        outline.bottomAnchor.constraint(equalTo: contentView.bottomAnchor).isActive = true
-        outline.widthAnchor.constraint(equalToConstant: frame.width).isActive = true
-        
-        totalProgress.topAnchor.constraint(equalTo: outline.topAnchor, constant: 25).isActive = true
-        totalProgress.centerXAnchor.constraint(equalTo: outline.centerXAnchor).isActive = true
-        
-        currentProgress.centerYAnchor.constraint(equalTo: totalProgress.centerYAnchor).isActive = true
-        currentProgress.centerXAnchor.constraint(equalTo: totalProgress.centerXAnchor).isActive = true
-        
-        indicator.centerYAnchor.constraint(equalTo: totalProgress.centerYAnchor).isActive = true
-        indicator.centerXAnchor.constraint(equalTo: totalProgress.centerXAnchor).isActive = true
-
-        treesIcon.topAnchor.constraint(equalTo: totalProgress.topAnchor, constant: 34).isActive = true
-        treesIcon.centerXAnchor.constraint(equalTo: totalProgress.centerXAnchor).isActive = true
-        
-        treesCount.topAnchor.constraint(equalTo: treesIcon.bottomAnchor, constant: 2).isActive = true
-        treesCount.centerXAnchor.constraint(equalTo: totalProgress.centerXAnchor).isActive = true
-        
-        treesPlanted.topAnchor.constraint(equalTo: treesCount.bottomAnchor).isActive = true
-        treesPlanted.centerXAnchor.constraint(equalTo: totalProgress.centerXAnchor).isActive = true
-        
-        howItWorksButton.topAnchor.constraint(equalTo: outline.topAnchor).isActive = true
-        howItWorksButton.leftAnchor.constraint(equalTo: outline.leftAnchor).isActive = true
-        howItWorksButton.rightAnchor.constraint(equalTo: outline.rightAnchor).isActive = true
-        howItWorksButton.bottomAnchor.constraint(equalTo: totalProgress.bottomAnchor, constant: 6).isActive = true
-        
-        howItWorks.centerXAnchor.constraint(equalTo: outline.centerXAnchor, constant: -8).isActive = true
-        howItWorks.topAnchor.constraint(equalTo: treesPlanted.bottomAnchor, constant: 6).isActive = true
-        
-        howItWorksIcon.centerYAnchor.constraint(equalTo: howItWorks.centerYAnchor).isActive = true
-        howItWorksIcon.leftAnchor.constraint(equalTo: howItWorks.rightAnchor, constant: 4).isActive = true
-
-        searchAndFriendsStackView.leadingAnchor.constraint(equalTo: outline.leadingAnchor, constant: 16).isActive = true
-        searchAndFriendsStackView.trailingAnchor.constraint(equalTo: outline.trailingAnchor, constant: -16).isActive = true
-        searchAndFriendsStackView.topAnchor.constraint(equalTo: totalProgress.bottomAnchor, constant: 12).isActive = true
-        searchAndFriendsStackView.bottomAnchor.constraint(equalTo: outline.bottomAnchor, constant: -24).isActive = true
-                        
-        applyTheme()
+        let searchAndYourFriendsImpactContainerView = makeSearchAndYourFriendsImpactContainerStackView()
+        searchAndYourFriendsImpactContainerView.addArrangedSubview(searchesStackView)
+        searchAndYourFriendsImpactContainerView.addArrangedSubview(friendsStackView)
+        outline.addSubview(searchAndYourFriendsImpactContainerView)
+        self.searchAndYourFriendsImpactContainerView = searchAndYourFriendsImpactContainerView
     }
+}
+
+extension MyImpactCell {
     
     func update(personalCounter: Int, progress: Double) {
         currentProgress.value = progress
@@ -238,18 +170,23 @@ final class MyImpactCell: UICollectionViewCell, NotificationThemeable {
         
         if #available(iOS 15.0, *) {
             treesCount.text = User.shared.impact.formatted()
-            searchesTrees.text = User.shared.searchImpact.formatted()
-            friendsTrees.text = User.shared.referrals.impact.formatted()
+            searchesTreesLabel.text = User.shared.searchImpact.formatted()
+            friendsTreesLabel.text = User.shared.referrals.impact.formatted()
         } else {
             treesCount.text = "\(User.shared.impact)"
-            searchesTrees.text = "\(User.shared.searchImpact)"
-            friendsTrees.text = "\(User.shared.referrals.impact)"
+            searchesTreesLabel.text = "\(User.shared.searchImpact)"
+            friendsTreesLabel.text = "\(User.shared.referrals.impact)"
         }
-
+        
         treesPlanted.text = .localizedPlural(.treesPlantedPlural, num: User.shared.impact)
-        searches.text = .localizedPlural(.searches, num: personalCounter)
-        friends.text = .localizedPlural(.friendInvitesPlural, num: User.shared.referrals.count)
+        searchesLabel.text = .localizedPlural(.searches, num: personalCounter)
+        //        friends.text = .localizedPlural(.friendInvitesPlural, num: User.shared.referrals.count)
+        friendsLabel.text = "0 Lorem Ipsum ist ein einfacher Demo-Text für die Print- und Schriftindustrie. Lorem Ipsum ist in der Industrie bereits der Standard Demo-Text seit 1500"
     }
+    
+}
+
+extension MyImpactCell: NotificationThemeable {
     
     func applyTheme() {
         outline.backgroundColor = .theme.ecosia.ntpCellBackground
@@ -259,21 +196,64 @@ final class MyImpactCell: UICollectionViewCell, NotificationThemeable {
         treesCount.textColor = .theme.ecosia.primaryText
         treesPlanted.textColor = .theme.ecosia.primaryText
         howItWorks.textColor = .theme.ecosia.primaryButton
-        searches.textColor = .theme.ecosia.primaryText
-        searchesTrees.textColor = .theme.ecosia.primaryText
-        friends.textColor = .theme.ecosia.primaryText
-        friendsTrees.textColor = .theme.ecosia.primaryText
-
+        searchesLabel.textColor = .theme.ecosia.primaryText
+        searchesTreesLabel.textColor = .theme.ecosia.primaryText
+        friendsLabel.textColor = .theme.ecosia.primaryText
+        friendsTreesLabel.textColor = .theme.ecosia.primaryText
+        
         treesIcon.image = .init(themed: "yourImpact")
         howItWorksIcon.image = .init(themed: "howItWorks")
         searchesIcon.image = .init(themed: "searches")
-        searchesImpact.image = .init(themed: "yourImpact")
+        searchesImpactIcon.image = .init(themed: "yourImpact")
         friendsIcon.image = .init(themed: "friends")
-        friendsImpact.image = .init(themed: "yourImpact")
+        friendsImpactIcon.image = .init(themed: "yourImpact")
+    }
+}
+
+extension MyImpactCell {
+    
+    private func setupConstraints() {
+        
+        outline.leadingAnchor.constraint(equalTo: contentView.safeAreaLayoutGuide.leadingAnchor).isActive = true
+        outline.trailingAnchor.constraint(equalTo: contentView.safeAreaLayoutGuide.trailingAnchor).isActive = true
+        outline.topAnchor.constraint(equalTo: contentView.topAnchor).isActive = true
+        outline.bottomAnchor.constraint(equalTo: contentView.bottomAnchor).isActive = true
+        outline.widthAnchor.constraint(equalToConstant: frame.width).isActive = true
+        
+        totalProgress.topAnchor.constraint(equalTo: outline.topAnchor, constant: UX.ProgressView.topAnchorOffset).isActive = true
+        totalProgress.centerXAnchor.constraint(equalTo: outline.centerXAnchor).isActive = true
+        
+        currentProgress.centerYAnchor.constraint(equalTo: totalProgress.centerYAnchor).isActive = true
+        currentProgress.centerXAnchor.constraint(equalTo: totalProgress.centerXAnchor).isActive = true
+        
+        indicator.centerYAnchor.constraint(equalTo: totalProgress.centerYAnchor).isActive = true
+        indicator.centerXAnchor.constraint(equalTo: totalProgress.centerXAnchor).isActive = true
+        
+        treesIcon.topAnchor.constraint(equalTo: totalProgress.topAnchor, constant: UX.ProgressView.treesIconTopAnchorOffset).isActive = true
+        treesIcon.centerXAnchor.constraint(equalTo: totalProgress.centerXAnchor).isActive = true
+        
+        treesCount.topAnchor.constraint(equalTo: treesIcon.bottomAnchor, constant: UX.ProgressView.treesCountBottomAnchorOffset).isActive = true
+        treesCount.centerXAnchor.constraint(equalTo: totalProgress.centerXAnchor).isActive = true
+        
+        treesPlanted.topAnchor.constraint(equalTo: treesCount.bottomAnchor).isActive = true
+        treesPlanted.centerXAnchor.constraint(equalTo: totalProgress.centerXAnchor).isActive = true
+        
+        howItWorksButton.topAnchor.constraint(equalTo: outline.topAnchor).isActive = true
+        howItWorksButton.leftAnchor.constraint(equalTo: outline.leftAnchor).isActive = true
+        howItWorksButton.rightAnchor.constraint(equalTo: outline.rightAnchor).isActive = true
+        howItWorksButton.bottomAnchor.constraint(equalTo: totalProgress.bottomAnchor, constant: UX.HowItWorksView.buttonBottomAnchorOffset).isActive = true
+        
+        howItWorks.centerXAnchor.constraint(equalTo: outline.centerXAnchor, constant: UX.HowItWorksView.centerXOffset).isActive = true
+        howItWorks.topAnchor.constraint(equalTo: treesPlanted.bottomAnchor, constant: UX.HowItWorksView.topAnchorOffset).isActive = true
+        
+        howItWorksIcon.centerYAnchor.constraint(equalTo: howItWorks.centerYAnchor).isActive = true
+        howItWorksIcon.leftAnchor.constraint(equalTo: howItWorks.rightAnchor, constant: UX.HowItWorksView.iconLeftAnchorOffset).isActive = true
+        
+        searchAndYourFriendsImpactContainerView.leadingAnchor.constraint(equalTo: outline.leadingAnchor, constant: UX.SearchAndFriends.padding).isActive = true
+        searchAndYourFriendsImpactContainerView.trailingAnchor.constraint(equalTo: outline.trailingAnchor, constant: -UX.SearchAndFriends.padding).isActive = true
+        searchAndYourFriendsImpactContainerView.topAnchor.constraint(equalTo: totalProgress.bottomAnchor, constant: UX.SearchAndFriends.topPadding).isActive = true
+        searchAndYourFriendsImpactContainerView.bottomAnchor.constraint(equalTo: outline.bottomAnchor, constant: -UX.SearchAndFriends.bottomPadding).isActive = true
+
     }
     
-    override func prepareForReuse() {
-        super.prepareForReuse()
-        applyTheme()
-    }
 }

--- a/Client/Ecosia/UI/Impact/Views/MyImpactCell.swift
+++ b/Client/Ecosia/UI/Impact/Views/MyImpactCell.swift
@@ -180,8 +180,7 @@ extension MyImpactCell {
         
         treesPlanted.text = .localizedPlural(.treesPlantedPlural, num: User.shared.impact)
         searchesLabel.text = .localizedPlural(.searches, num: personalCounter)
-        //        friends.text = .localizedPlural(.friendInvitesPlural, num: User.shared.referrals.count)
-        friendsLabel.text = "0 Lorem Ipsum ist ein einfacher Demo-Text für die Print- und Schriftindustrie. Lorem Ipsum ist in der Industrie bereits der Standard Demo-Text seit 1500"
+        friendsLabel.text = .localizedPlural(.friendInvitesPlural, num: User.shared.referrals.count)
     }
     
 }

--- a/Client/Ecosia/UI/Impact/Views/MyImpactCell.swift
+++ b/Client/Ecosia/UI/Impact/Views/MyImpactCell.swift
@@ -96,7 +96,6 @@ final class MyImpactCell: UICollectionViewCell, NotificationThemeable {
         searchesStackView.distribution = .fill
         searchesStackView.alignment = .center
         searchesStackView.spacing = 8.0
-        searchesStackView.setContentHuggingPriority(.defaultLow, for: .horizontal)
 
         let searchesIcon = UIImageView()
         searchesIcon.translatesAutoresizingMaskIntoConstraints = false
@@ -110,7 +109,8 @@ final class MyImpactCell: UICollectionViewCell, NotificationThemeable {
         searches.translatesAutoresizingMaskIntoConstraints = false
         searches.font = .preferredFont(forTextStyle: .body)
         searches.adjustsFontForContentSizeCategory = true
-        searches.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        searches.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        searches.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
         self.searches = searches
         
         let searchesTrees = UILabel()
@@ -154,7 +154,6 @@ final class MyImpactCell: UICollectionViewCell, NotificationThemeable {
         friends.translatesAutoresizingMaskIntoConstraints = false
         friends.font = .preferredFont(forTextStyle: .body)
         friends.adjustsFontForContentSizeCategory = true
-        friends.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         friends.numberOfLines = 2
         self.friends = friends
         
@@ -184,8 +183,7 @@ final class MyImpactCell: UICollectionViewCell, NotificationThemeable {
         searchAndFriendsStackView.alignment = .fill
         searchAndFriendsStackView.axis = .vertical
         searchAndFriendsStackView.spacing = UIStackView.spacingUseDefault
-        searchAndFriendsStackView.setContentHuggingPriority(.defaultLow, for: .horizontal)
-
+        
         searchAndFriendsStackView.addArrangedSubview(searchesStackView)
         searchAndFriendsStackView.addArrangedSubview(friendsStackView)
         outline.addSubview(searchAndFriendsStackView)
@@ -224,8 +222,8 @@ final class MyImpactCell: UICollectionViewCell, NotificationThemeable {
         howItWorksIcon.centerYAnchor.constraint(equalTo: howItWorks.centerYAnchor).isActive = true
         howItWorksIcon.leftAnchor.constraint(equalTo: howItWorks.rightAnchor, constant: 4).isActive = true
 
-        searchAndFriendsStackView.leftAnchor.constraint(equalTo: outline.leftAnchor, constant: 16).isActive = true
-        searchAndFriendsStackView.rightAnchor.constraint(equalTo: outline.rightAnchor, constant: -16).isActive = true
+        searchAndFriendsStackView.leadingAnchor.constraint(equalTo: outline.leadingAnchor, constant: 16).isActive = true
+        searchAndFriendsStackView.trailingAnchor.constraint(equalTo: outline.trailingAnchor, constant: -16).isActive = true
         searchAndFriendsStackView.topAnchor.constraint(equalTo: totalProgress.bottomAnchor, constant: 12).isActive = true
         searchAndFriendsStackView.bottomAnchor.constraint(equalTo: outline.bottomAnchor, constant: -24).isActive = true
                         
@@ -245,7 +243,7 @@ final class MyImpactCell: UICollectionViewCell, NotificationThemeable {
             searchesTrees.text = "\(User.shared.searchImpact)"
             friendsTrees.text = "\(User.shared.referrals.impact)"
         }
-        
+
         treesPlanted.text = .localizedPlural(.treesPlantedPlural, num: User.shared.impact)
         searches.text = .localizedPlural(.searches, num: personalCounter)
         friends.text = .localizedPlural(.friendInvitesPlural, num: User.shared.referrals.count)

--- a/Client/Ecosia/UI/Impact/Views/MyImpactCell.swift
+++ b/Client/Ecosia/UI/Impact/Views/MyImpactCell.swift
@@ -192,6 +192,7 @@ final class MyImpactCell: UICollectionViewCell, NotificationThemeable {
         outline.trailingAnchor.constraint(equalTo: contentView.safeAreaLayoutGuide.trailingAnchor).isActive = true
         outline.topAnchor.constraint(equalTo: contentView.topAnchor).isActive = true
         outline.bottomAnchor.constraint(equalTo: contentView.bottomAnchor).isActive = true
+        outline.widthAnchor.constraint(equalTo: widthAnchor).isActive = true
         
         totalProgress.topAnchor.constraint(equalTo: outline.topAnchor, constant: 25).isActive = true
         totalProgress.centerXAnchor.constraint(equalTo: outline.centerXAnchor).isActive = true

--- a/Client/Ecosia/UI/Impact/Views/MyImpactCell.swift
+++ b/Client/Ecosia/UI/Impact/Views/MyImpactCell.swift
@@ -96,7 +96,8 @@ final class MyImpactCell: UICollectionViewCell, NotificationThemeable {
         searchesStackView.distribution = .fill
         searchesStackView.alignment = .center
         searchesStackView.spacing = 8.0
-        
+        searchesStackView.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
         let searchesIcon = UIImageView()
         searchesIcon.translatesAutoresizingMaskIntoConstraints = false
         searchesIcon.contentMode = .center
@@ -116,12 +117,16 @@ final class MyImpactCell: UICollectionViewCell, NotificationThemeable {
         searchesTrees.translatesAutoresizingMaskIntoConstraints = false
         searchesTrees.font = .systemFont(ofSize: UIFont.preferredFont(forTextStyle: .subheadline).pointSize, weight: .semibold)
         searchesTrees.adjustsFontForContentSizeCategory = true
+        searchesTrees.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        searchesTrees.setContentHuggingPriority(.defaultHigh, for: .vertical)
         self.searchesTrees = searchesTrees
         
         let searchesImpact = UIImageView()
         searchesImpact.translatesAutoresizingMaskIntoConstraints = false
         searchesImpact.contentMode = .center
         searchesImpact.clipsToBounds = true
+        searchesImpact.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        searchesImpact.setContentHuggingPriority(.defaultHigh, for: .vertical)
         self.searchesImpact = searchesImpact
         
         searchesStackView.addArrangedSubview(self.searchesIcon)
@@ -135,6 +140,7 @@ final class MyImpactCell: UICollectionViewCell, NotificationThemeable {
         friendsStackView.distribution = .fill
         friendsStackView.alignment = .center
         friendsStackView.spacing = 8.0
+        friendsStackView.setContentHuggingPriority(.defaultLow, for: .horizontal)
 
         let friendsIcon = UIImageView()
         friendsIcon.translatesAutoresizingMaskIntoConstraints = false
@@ -156,12 +162,16 @@ final class MyImpactCell: UICollectionViewCell, NotificationThemeable {
         friendsTrees.translatesAutoresizingMaskIntoConstraints = false
         friendsTrees.font = .systemFont(ofSize: UIFont.preferredFont(forTextStyle: .subheadline).pointSize, weight: .semibold)
         friendsTrees.adjustsFontForContentSizeCategory = true
+        friendsTrees.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        friendsTrees.setContentHuggingPriority(.defaultHigh, for: .vertical)
         self.friendsTrees = friendsTrees
         
         let friendsImpact = UIImageView()
         friendsImpact.translatesAutoresizingMaskIntoConstraints = false
         friendsImpact.contentMode = .center
         friendsImpact.clipsToBounds = true
+        friendsImpact.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        friendsImpact.setContentHuggingPriority(.defaultHigh, for: .vertical)
         self.friendsImpact = friendsImpact
         
         friendsStackView.addArrangedSubview(self.friendsIcon)
@@ -174,15 +184,16 @@ final class MyImpactCell: UICollectionViewCell, NotificationThemeable {
         searchAndFriendsStackView.alignment = .fill
         searchAndFriendsStackView.axis = .vertical
         searchAndFriendsStackView.spacing = UIStackView.spacingUseDefault
+        searchAndFriendsStackView.setContentHuggingPriority(.defaultLow, for: .horizontal)
 
         searchAndFriendsStackView.addArrangedSubview(searchesStackView)
         searchAndFriendsStackView.addArrangedSubview(friendsStackView)
         outline.addSubview(searchAndFriendsStackView)
 
-        outline.leftAnchor.constraint(equalTo: contentView.leftAnchor).isActive = true
-        outline.rightAnchor.constraint(equalTo: contentView.rightAnchor).isActive = true
-        outline.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 12).isActive = true
-        outline.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -4).isActive = true
+        outline.leadingAnchor.constraint(equalTo: contentView.safeAreaLayoutGuide.leadingAnchor).isActive = true
+        outline.trailingAnchor.constraint(equalTo: contentView.safeAreaLayoutGuide.trailingAnchor).isActive = true
+        outline.topAnchor.constraint(equalTo: contentView.topAnchor).isActive = true
+        outline.bottomAnchor.constraint(equalTo: contentView.bottomAnchor).isActive = true
         
         totalProgress.topAnchor.constraint(equalTo: outline.topAnchor, constant: 25).isActive = true
         totalProgress.centerXAnchor.constraint(equalTo: outline.centerXAnchor).isActive = true

--- a/Client/Ecosia/UI/Impact/Views/MyImpactCell.swift
+++ b/Client/Ecosia/UI/Impact/Views/MyImpactCell.swift
@@ -7,6 +7,8 @@ import Core
 
 final class MyImpactCell: UICollectionViewCell {
     
+    // MARK: - UX
+
     struct UX {
         
         enum Outline {
@@ -37,6 +39,8 @@ final class MyImpactCell: UICollectionViewCell {
         }
     }
     
+    // MARK: - Properties
+    
     private(set) weak var howItWorksButton: UIControl!
     private weak var totalProgress: Progress!
     private weak var currentProgress: Progress!
@@ -57,6 +61,8 @@ final class MyImpactCell: UICollectionViewCell {
     private weak var friendsImpactIcon: UIImageView!
     private weak var searchAndYourFriendsImpactContainerView: UIView!
     
+    // MARK: - Init
+
     required init?(coder: NSCoder) { nil }
     
     override init(frame: CGRect) {
@@ -65,7 +71,9 @@ final class MyImpactCell: UICollectionViewCell {
         setupConstraints()
         applyTheme()
     }
-            
+    
+    // MARK: - Reuse
+    
     override func prepareForReuse() {
         super.prepareForReuse()
         applyTheme()
@@ -74,6 +82,8 @@ final class MyImpactCell: UICollectionViewCell {
 
 extension MyImpactCell {
     
+    // MARK: - View Setup
+
     private func setupView() {
         
         let outline = makeOutline()
@@ -164,6 +174,8 @@ extension MyImpactCell {
 
 extension MyImpactCell {
     
+    // MARK: - View update helper
+
     func update(personalCounter: Int, progress: Double) {
         currentProgress.value = progress
         indicator.value = progress
@@ -187,6 +199,8 @@ extension MyImpactCell {
 
 extension MyImpactCell: NotificationThemeable {
     
+    // MARK: - Theme
+
     func applyTheme() {
         outline.backgroundColor = .theme.ecosia.ntpCellBackground
         totalProgress.update(color: .theme.ecosia.treeCounterProgressTotal)
@@ -210,6 +224,8 @@ extension MyImpactCell: NotificationThemeable {
 }
 
 extension MyImpactCell {
+    
+    // MARK: - Constraint helper
     
     private func setupConstraints() {
         

--- a/Client/Ecosia/UI/Impact/Views/MyImpactCell.swift
+++ b/Client/Ecosia/UI/Impact/Views/MyImpactCell.swift
@@ -155,6 +155,7 @@ final class MyImpactCell: UICollectionViewCell, NotificationThemeable {
         friends.font = .preferredFont(forTextStyle: .body)
         friends.adjustsFontForContentSizeCategory = true
         friends.numberOfLines = 2
+        friends.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         self.friends = friends
         
         let friendsTrees = UILabel()

--- a/Client/Ecosia/UI/Impact/Views/MyImpactCell.swift
+++ b/Client/Ecosia/UI/Impact/Views/MyImpactCell.swift
@@ -125,7 +125,7 @@ extension MyImpactCell {
         self.searchesLabel = searchesLabel
         
         let searchesTreesLabel = makeSearchesTreesLabel()
-        self.searchesTreesLabel = searchesLabel
+        self.searchesTreesLabel = searchesTreesLabel
 
         let searchesImpactIcon = makeSearchesImpactIcon()
         self.searchesImpactIcon = searchesImpactIcon

--- a/Client/Frontend/Home/TopSites/TopSitesDimension.swift
+++ b/Client/Frontend/Home/TopSites/TopSitesDimension.swift
@@ -52,7 +52,7 @@ class TopSitesDimensionImplementation: TopSitesDimension {
                              numberOfRows: Int,
                              interface: TopSitesUIInterface
     ) -> TopSitesSectionDimension {
-        let numberOfTilesPerRow = getNumberOfTilesPerRow(for: interface)
+        let numberOfTilesPerRow = getNumberOfTilesPerRow(for: interface, sites: sites)
         let numberOfRows = getNumberOfRows(for: sites,
                                            numberOfRows: numberOfRows,
                                            numberOfTilesPerRow: numberOfTilesPerRow)
@@ -79,7 +79,12 @@ class TopSitesDimensionImplementation: TopSitesDimension {
 
     //Ecosia: The design decided to have 4 tiles per row by default.
     /// Get the number of tiles per row the user will see. This depends on the UI interface the user has.
-    /// - Parameter interface: Tile number is based on layout, this param contains the parameters needed to computer the tile number
+    /// For `sites` less than 4 in a `horizontalSizeClass` of type `regular`
+    /// we check whether the `sites` are 4 maximum so the layout of the upper section containing `NTPLibraryCell`
+    /// will remain vertically aligned, providing a more consistent layout.
+    /// - Parameters:
+    ///   - interface: Tile number is based on layout, this param contains the parameters needed to computer the tile number
+    ///   - sites: The number of available `TopSite`s on a NTP we need to show
     /// - Returns: The number of tiles per row the user will see
     private func getNumberOfTilesPerRow(for interface: TopSitesUIInterface) -> Int {
         return 4

--- a/Client/Frontend/Home/TopSites/TopSitesDimension.swift
+++ b/Client/Frontend/Home/TopSites/TopSitesDimension.swift
@@ -52,7 +52,7 @@ class TopSitesDimensionImplementation: TopSitesDimension {
                              numberOfRows: Int,
                              interface: TopSitesUIInterface
     ) -> TopSitesSectionDimension {
-        let numberOfTilesPerRow = getNumberOfTilesPerRow(for: interface, sites: sites)
+        let numberOfTilesPerRow = getNumberOfTilesPerRow(for: interface)
         let numberOfRows = getNumberOfRows(for: sites,
                                            numberOfRows: numberOfRows,
                                            numberOfTilesPerRow: numberOfTilesPerRow)
@@ -79,12 +79,7 @@ class TopSitesDimensionImplementation: TopSitesDimension {
 
     //Ecosia: The design decided to have 4 tiles per row by default.
     /// Get the number of tiles per row the user will see. This depends on the UI interface the user has.
-    /// For `sites` less than 4 in a `horizontalSizeClass` of type `regular`
-    /// we check whether the `sites` are 4 maximum so the layout of the upper section containing `NTPLibraryCell`
-    /// will remain vertically aligned, providing a more consistent layout.
-    /// - Parameters:
-    ///   - interface: Tile number is based on layout, this param contains the parameters needed to computer the tile number
-    ///   - sites: The number of available `TopSite`s on a NTP we need to show
+    /// - Parameter interface: Tile number is based on layout, this param contains the parameters needed to computer the tile number
     /// - Returns: The number of tiles per row the user will see
     private func getNumberOfTilesPerRow(for interface: TopSitesUIInterface) -> Int {
         return 4


### PR DESCRIPTION
[MOB-1788](https://ecosia.atlassian.net/browse/MOB-1788)


## Context

The UI in the "Your Impact" section breaks when it comes to localized content in the "friends label" larger than its size.

## Approach

After extensive testing and trying out different solutions without having to rewrite the inner view components, I realized that the UI design needed a different approach in its drawing. 
The Content View wasn't following the UICollectionView layout size directives.
I went after choosing the `UIStackView` as per the main container of the entire Search and Friends info.

The layout is the following:

- Cell Content View
   - Progress View with buttons and icons
   - Search and Friends container StackView
        - Search Stack View with search view items
        - Friends Stack View with friends view items 

A refactor to better split the codebase has been also included. Factory methods are noew responsible to create the single view compoents.