### PR TITLE
Change close all tabs button to destructive style

### DIFF
--- a/Client/Frontend/Browser/GridTabViewController.swift
+++ b/Client/Frontend/Browser/GridTabViewController.swift
@@ -574,8 +574,9 @@ extension GridTabViewController {
         }
 
         let controller = AlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        // Ecosia: Change close all tabs button style
         controller.addAction(UIAlertAction(title: .AppMenu.AppMenuCloseAllTabsTitleString,
-                                           style: .default,
+                                           style: .destructive,
                                            handler: { _ in self.closeTabsTrayBackground() }),
                              accessibilityIdentifier: AccessibilityIdentifiers.TabTray.deleteCloseAllButton)
         controller.addAction(UIAlertAction(title: .TabTrayCloseAllTabsPromptCancel,

--- a/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
+++ b/Client/Frontend/Browser/Tabs/TabTrayViewController.swift
@@ -43,6 +43,8 @@ class TabTrayViewController: UIViewController {
         button.titleLabel?.adjustsFontForContentSizeCategory = true
         button.accessibilityIdentifier = "closeAllTabsButtonTabTray"
         button.setTitle(.localized(.closeAll), for: .normal)
+        // Ecosia: Change close all button title color
+        button.setTitleColor(.theme.ecosia.warning, for: .normal)
         button.addTarget(self, action: #selector(didTapDeleteTabs), for: .primaryActionTriggered)
         button.accessibilityLabel = .AppMenu.Toolbar.TabTrayDeleteMenuButtonAccessibilityLabel
         return UIBarButtonItem(customView: button)


### PR DESCRIPTION
[MOB-1648](https://ecosia.atlassian.net/browse/MOB-1648)

# Context

Since close all tabs is a destructive action, we should change it's style accordingly.

# Approach

For the action sheet, I continued using the system style and just switched it to destructive. I noticed the Figma text colours do not exactly match, but since that is the same case for the Cancel button, I assumed that is on purpose to use iOS default for such modals (will also raise this in the ticket as well).

Also updated the button in the bottom of the page using the ecosia theme colour, which matches exactly with Figma.

Use the comment pattern `// Ecosia:` so we can identify custom changes in FF code. 

# Screenshots

## Light theme
![Simulator Screenshot - iPhone 14 Pro - 2023-04-06 at 14 47 49](https://user-images.githubusercontent.com/19517744/230420228-bd68492d-cde0-453f-a911-af16d8b4baa4.png)
![Simulator Screenshot - iPhone 14 Pro - 2023-04-06 at 14 48 06](https://user-images.githubusercontent.com/19517744/230420235-fff89468-d831-4cd6-8dc1-168ad366dc7d.png)

## Dark theme
![Simulator Screenshot - iPhone 14 Pro - 2023-04-06 at 14 49 48](https://user-images.githubusercontent.com/19517744/230420291-4d58852b-1640-4d22-88e1-cce989d53ea0.png)
![Simulator Screenshot - iPhone 14 Pro - 2023-04-06 at 14 49 51](https://user-images.githubusercontent.com/19517744/230420294-5755e0ed-d41b-46e8-a3cd-c0c8ab444a22.png)
