### PR TITLE
Remove incognito icon from bottom bar

### DIFF
--- a/Client/Frontend/Toolbar+URLBar/TabToolbar.swift
+++ b/Client/Frontend/Toolbar+URLBar/TabToolbar.swift
@@ -17,7 +17,8 @@ class TabToolbar: UIView {
     let multiStateButton = ToolbarButton()
     let actionButtons: [NotificationThemeable & UIButton]
 
-    fileprivate let privateModeBadge = BadgeWithBackdrop(imageName: "privateModeBadge", backdropCircleColor: UIColor.Defaults.MobilePrivatePurple)
+    // Ecosia: Remove private mode badge
+    // fileprivate let privateModeBadge = BadgeWithBackdrop(imageName: "privateModeBadge", backdropCircleColor: UIColor.Defaults.MobilePrivatePurple)
     fileprivate let appMenuBadge = BadgeWithBackdrop(imageName: "menuBadge")
     fileprivate let warningMenuBadge = BadgeWithBackdrop(imageName: "menuWarning", imageMask: "warning-mask")
 
@@ -33,7 +34,8 @@ class TabToolbar: UIView {
         helper = TabToolbarHelper(toolbar: self)
         addButtons(actionButtons)
 
-        privateModeBadge.add(toParent: contentView)
+        // Ecosia: Remove private mode badge
+        // privateModeBadge.add(toParent: contentView)
         appMenuBadge.add(toParent: contentView)
         warningMenuBadge.add(toParent: contentView)
 
@@ -42,7 +44,8 @@ class TabToolbar: UIView {
     }
 
     override func updateConstraints() {
-        privateModeBadge.layout(onButton: tabsButton)
+        // Ecosia: Remove private mode badge
+        // privateModeBadge.layout(onButton: tabsButton)
         appMenuBadge.layout(onButton: appMenuButton)
         warningMenuBadge.layout(onButton: appMenuButton)
 
@@ -97,7 +100,8 @@ extension TabToolbar: TabToolbarProtocol {
     var homeButton: ToolbarButton { multiStateButton }
 
     func privateModeBadge(visible: Bool) {
-        privateModeBadge.show(visible)
+        // Ecosia: Remove private mode badge
+        // privateModeBadge.show(visible)
     }
 
     func warningMenuBadge(setVisible: Bool) {
@@ -131,15 +135,17 @@ extension TabToolbar: NotificationThemeable, PrivateModeUI {
     func applyTheme() {
         backgroundColor = UIColor.theme.ecosia.barBackground
         helper?.setTheme(forButtons: actionButtons)
-
+        
+        /* Ecosia: Remove private mode badge
         privateModeBadge.badge.tintBackground(color: UIColor.theme.ecosia.barBackground)
         privateModeBadge.backdrop.backgroundColor = UIColor.theme.ecosia.personalCounterSelection
-        privateModeBadge.backdrop.alpha = 1
+        privateModeBadge.backdrop.alpha = 1*/
         appMenuBadge.badge.tintBackground(color: UIColor.theme.ecosia.barBackground)
         warningMenuBadge.badge.tintBackground(color: UIColor.theme.ecosia.barBackground)
     }
 
     func applyUIMode(isPrivate: Bool) {
-        privateModeBadge(visible: isPrivate)
+        // Ecosia: Remove private mode badge
+        // privateModeBadge(visible: isPrivate)
     }
 }


### PR DESCRIPTION
[MOB-1645](https://ecosia.atlassian.net/browse/MOB-1645)

# Context
Remove small incognito badge on the bottom bar tabs item. This change is requested by Yann since it is firefox's approach of showing incognito and it is not "adding value to the interface, besides cluttering the bottom navigation with a non-legible icon. We have other visual cues on the app showing user browse incognito (eg. search bar)."

# Approach
Just commented out the `privateModeBadge` ui component and all places where it was used with the Ecosia style comment explaining the change.

# Screenshot
![Simulator Screenshot - iPhone 14 Pro Max - 2023-04-11 at 14 23 41](https://user-images.githubusercontent.com/19517744/231193912-c9ab650f-af34-40b7-b26f-2c87560aeda5.png)
