### PR TITLE
Fix remove incognito icon on landscape

### DIFF
--- a/Client/Frontend/Toolbar+URLBar/TabToolbar.swift
+++ b/Client/Frontend/Toolbar+URLBar/TabToolbar.swift
@@ -99,10 +99,10 @@ class TabToolbar: UIView {
 extension TabToolbar: TabToolbarProtocol {
     var homeButton: ToolbarButton { multiStateButton }
 
+    /* Ecosia: Remove private mode badge
     func privateModeBadge(visible: Bool) {
-        // Ecosia: Remove private mode badge
-        // privateModeBadge.show(visible)
-    }
+        privateModeBadge.show(visible)
+    }*/
 
     func warningMenuBadge(setVisible: Bool) {
         // Disable other menu badges before showing the warning.

--- a/Client/Frontend/Toolbar+URLBar/TabToolbarHelper.swift
+++ b/Client/Frontend/Toolbar+URLBar/TabToolbarHelper.swift
@@ -21,7 +21,8 @@ protocol TabToolbarProtocol: AnyObject {
     func updateMiddleButtonState(_ state: MiddleButtonState)
     func updatePageStatus(_ isWebPage: Bool)
     func updateTabCount(_ count: Int, animated: Bool)
-    func privateModeBadge(visible: Bool)
+    // Ecosia: Remove private mode badge
+    // func privateModeBadge(visible: Bool)
     func warningMenuBadge(setVisible: Bool)
 }
 

--- a/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -232,7 +232,8 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
 
     var profile: Profile
 
-    fileprivate let privateModeBadge = BadgeWithBackdrop(imageName: "privateModeBadge", backdropCircleColor: UIColor.Defaults.MobilePrivatePurple)
+    // Ecosia: Remove private mode badge
+    // fileprivate let privateModeBadge = BadgeWithBackdrop(imageName: "privateModeBadge", backdropCircleColor: UIColor.Defaults.MobilePrivatePurple)
     fileprivate let appMenuBadge = BadgeWithBackdrop(imageName: "menuBadge")
     fileprivate let warningMenuBadge = BadgeWithBackdrop(imageName: "menuWarning", imageMask: "warning-mask")
 
@@ -279,7 +280,8 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
         addSubview(searchIconImageView)
         updateSearchEngineImage()
 
-        privateModeBadge.add(toParent: self)
+        // Ecosia: Remove private mode badge
+        // privateModeBadge.add(toParent: self)
         appMenuBadge.add(toParent: self)
         warningMenuBadge.add(toParent: self)
 
@@ -375,7 +377,8 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
             make.size.equalTo(URLBarViewUX.ButtonHeight).priority(.high)
         }
 
-        privateModeBadge.layout(onButton: tabsButton)
+        // Ecosia: Remove private mode badge
+        // privateModeBadge.layout(onButton: tabsButton)
         appMenuBadge.layout(onButton: appMenuButton)
         warningMenuBadge.layout(onButton: appMenuButton)
     }
@@ -679,8 +682,9 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
         tabsButton.isHidden = !toolbarIsShowing || inOverlayMode || topTabsIsShowing
         multiStateButton.isHidden = true // Ecosia: always multi state button
 
+        // Ecosia: Remove private mode badge
         // badge isHidden is tied to private mode on/off, use alpha to hide in this case
-        [privateModeBadge, appMenuBadge, warningMenuBadge].forEach {
+        [appMenuBadge, warningMenuBadge].forEach {
             $0.badge.alpha = (!toolbarIsShowing || inOverlayMode) ? 0 : 1
             $0.backdrop.alpha = (!toolbarIsShowing || inOverlayMode) ? 0 : BadgeWithBackdrop.backdropAlpha
         }
@@ -726,11 +730,12 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
 }
 
 extension URLBarView: TabToolbarProtocol {
-    func privateModeBadge(visible: Bool) {
+    /* Ecosia: Remove private mode badge
+     func privateModeBadge(visible: Bool) {
         if UIDevice.current.userInterfaceIdiom != .pad {
             privateModeBadge.show(visible)
         }
-    }
+    }*/
 
     func appMenuBadge(setVisible: Bool) {
         // Warning badges should take priority over the standard badge
@@ -916,7 +921,8 @@ extension URLBarView: NotificationThemeable {
 
         locationContainer.backgroundColor = locationView.backgroundColor
 
-        privateModeBadge.badge.tintBackground(color: UIColor.theme.browser.background)
+        // Ecosia: Remove private mode badge
+        // privateModeBadge.badge.tintBackground(color: UIColor.theme.browser.background)
         appMenuBadge.badge.tintBackground(color: UIColor.theme.browser.background)
         warningMenuBadge.badge.tintBackground(color: UIColor.theme.browser.background)
         searchIconImageView.tintColor = isPrivate ? UIColor.theme.ecosia.primaryText : UIColor.theme.ecosia.textfieldIconTint
@@ -940,9 +946,10 @@ extension URLBarView: PrivateModeUI {
     func applyUIMode(isPrivate: Bool) {
         self.isPrivate = isPrivate
 
+        /* Ecosia: Remove private mode badge
         if UIDevice.current.userInterfaceIdiom != .pad {
             privateModeBadge.show(isPrivate)
-        }
+        }*/
         applyTheme()
     }
 }

--- a/Tests/ClientTests/TabToolbarHelperTests.swift
+++ b/Tests/ClientTests/TabToolbarHelperTests.swift
@@ -140,9 +140,10 @@ class MockTabToolbar: TabToolbarProtocol {
 
     }
 
+    /* Ecosia: Remove private mode badge
     func privateModeBadge(visible: Bool) {
 
-    }
+    }*/
 
     func appMenuBadge(setVisible: Bool) {
 


### PR DESCRIPTION
[MOB-1645](https://ecosia.atlassian.net/browse/MOB-1645)

# Context
Follow-up of [the previous PR](https://github.com/ecosia/ios-browser/pull/436) since during QA an error was found where the icon still appears on landscape 🙈

# Approach
This issue happened since I missed that the tab button switched views on landscape (since then the bottom toolbar does not exist and the options are instead in the url bar view).
Therefore, I just removed the `privateModeBadge` from this other view as well. Since those two places are the only ones using the `TabToolbarProtocol`, I was also able to remove the `func privateModeBadge(visible: Bool)` from it.