### PR TITLE
MOB-1814 Fix ci content blocker cache

### DIFF
--- a/.github/actions/prepare_environment/action.yml
+++ b/.github/actions/prepare_environment/action.yml
@@ -39,7 +39,7 @@ runs:
     - name: Install SPM if cache not found
       shell: bash
       if: steps.restore-spm-cache.outputs.cache-hit != 'true'
-      run: bundle exec fastlane run run_tests skip_build:true
+      run: xcodebuild -resolvePackageDependencies -clonedSourcePackagesDirPath "SourcePackages/"
 
     - name: Save SPM Cache if needed
       if: steps.restore-spm-cache.outputs.cache-hit != 'true'

--- a/.github/actions/prepare_environment/action.yml
+++ b/.github/actions/prepare_environment/action.yml
@@ -38,11 +38,11 @@ runs:
 
     - name: Install SPM if cache not found
       shell: bash
-      if: steps.restore-spm-cache.outputs.cache-hit == 'false'
+      if: steps.restore-spm-cache.outputs.cache-hit != 'true'
       run: bundle exec fastlane spm build_path:"SourcePackages/"
 
     - name: Save SPM Cache if needed
-      if: steps.restore-spm-cache.outputs.cache-hit == 'false'
+      if: steps.restore-spm-cache.outputs.cache-hit != 'true'
       uses: actions/cache/save@v3
       with:
         path: SourcePackages/
@@ -62,7 +62,7 @@ runs:
 
     - name: Run content blocker scripts if cache not found
       shell: bash
-      if: steps.restore-content-blocker-cache.outputs.cache-hit == 'false'
+      if: steps.restore-content-blocker-cache.outputs.cache-hit != 'true'
       run: ./content_blocker_update.sh
 
     - name: Save Content Blocker Cache if new

--- a/.github/actions/prepare_environment/action.yml
+++ b/.github/actions/prepare_environment/action.yml
@@ -39,7 +39,7 @@ runs:
     - name: Install SPM if cache not found
       shell: bash
       if: steps.restore-spm-cache.outputs.cache-hit != 'true'
-      run: bundle exec fastlane spm build_path:"SourcePackages/"
+      run: bundle exec fastlane run spm build_path:"SourcePackages/"
 
     - name: Save SPM Cache if needed
       if: steps.restore-spm-cache.outputs.cache-hit != 'true'

--- a/.github/actions/prepare_environment/action.yml
+++ b/.github/actions/prepare_environment/action.yml
@@ -39,7 +39,7 @@ runs:
     - name: Install SPM if cache not found
       shell: bash
       if: steps.restore-spm-cache.outputs.cache-hit != 'true'
-      run: bundle exec fastlane run spm build_path:"SourcePackages/"
+      run: bundle exec fastlane run run_tests skip_build:true
 
     - name: Save SPM Cache if needed
       if: steps.restore-spm-cache.outputs.cache-hit != 'true'

--- a/Shared/Accessibility.swift
+++ b/Shared/Accessibility.swift
@@ -4,7 +4,6 @@
 
 import UIKit
 
-// Test
 
 public protocol AccessibilityActionsSource: AnyObject {
     func accessibilityCustomActionsForView(_ view: UIView) -> [UIAccessibilityCustomAction]?

--- a/Shared/Accessibility.swift
+++ b/Shared/Accessibility.swift
@@ -4,6 +4,7 @@
 
 import UIKit
 
+// Test
 
 public protocol AccessibilityActionsSource: AnyObject {
     func accessibilityCustomActionsForView(_ view: UIView) -> [UIAccessibilityCustomAction]?


### PR DESCRIPTION
[MOB-1814](https://ecosia.atlassian.net/browse/MOB-1814)

## Context

Builds started to fail because of missing content blocker scripts.

## Approach

Investigation started. Looked at possible solutions.
Everything appeared to be in place, so I started questioning the (what should be) unquestionable.
It appears that the `if` statement within actions' steps are evaluated correctly only if passing `!= true` as provided in the [`cache`](https://github.com/actions/cache#skipping-steps-based-on-cache-hit) action examples.

I took the occasion to also improve the spm execution in case of missing cache for packages.