### PR TITLE
Quick fix removing `Environment` setup

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -35,6 +35,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         appLaunchUtil = AppLaunchUtil(profile: profile)
         appLaunchUtil?.setUpPreLaunchDependencies()
 
+        // Setup environment
+        Environment.current = AppConstants.BuildChannel == .release ? .production : .staging
+        
         // Set up a web server that serves us static content. Do this early so that it is ready when the UI is presented.
         webServerUtil = WebServerUtil(profile: profile)
         webServerUtil?.setUpWebServer()

--- a/Client/Ecosia/FeatureManagement/FeatureManagement.swift
+++ b/Client/Ecosia/FeatureManagement/FeatureManagement.swift
@@ -13,7 +13,7 @@ struct FeatureManagement {
     static func fetchConfiguration() {
         Task {
             do {
-                try await _ = Unleash.start(env: Environment.current)
+                try await _ = Unleash.start(env: .current)
             } catch {
                 debugPrint(error)
             }

--- a/Client/Ecosia/FeatureManagement/FeatureManagement.swift
+++ b/Client/Ecosia/FeatureManagement/FeatureManagement.swift
@@ -13,8 +13,7 @@ struct FeatureManagement {
     static func fetchConfiguration() {
         Task {
             do {
-                let env: Environment = AppConstants.BuildChannel == .release ? .production : .staging
-                try await _ = Unleash.start(env: env)
+                try await _ = Unleash.start(env: Environment.current)
             } catch {
                 debugPrint(error)
             }

--- a/Client/Ecosia/MMP/MMP.swift
+++ b/Client/Ecosia/MMP/MMP.swift
@@ -24,7 +24,7 @@ struct MMP {
                                                   installReceipt: AppInfo.installReceipt,
                                                   installTime: NSDate().timeIntervalSince1970,
                                                   updateTime: NSDate().timeIntervalSince1970)
-                try await Singular.sendSessionInfo(appDeviceInfo: appDeviceInfo, env: Environment.current)
+                try await Singular.sendSessionInfo(appDeviceInfo: appDeviceInfo, env: .current)
             } catch {
                 debugPrint(error)
             }

--- a/Client/Ecosia/MMP/MMP.swift
+++ b/Client/Ecosia/MMP/MMP.swift
@@ -24,8 +24,7 @@ struct MMP {
                                                   installReceipt: AppInfo.installReceipt,
                                                   installTime: NSDate().timeIntervalSince1970,
                                                   updateTime: NSDate().timeIntervalSince1970)
-                let env: Environment = AppConstants.BuildChannel == .release ? .production : .staging
-                try await Singular.sendSessionInfo(appDeviceInfo: appDeviceInfo, env: env)
+                try await Singular.sendSessionInfo(appDeviceInfo: appDeviceInfo, env: Environment.current)
             } catch {
                 debugPrint(error)
             }

--- a/Client/Ecosia/Settings/EcosiaDebugSettings.swift
+++ b/Client/Ecosia/Settings/EcosiaDebugSettings.swift
@@ -190,7 +190,7 @@ final class UnleashDefaultBrowserSetting: HiddenSetting {
     override func onClick(_ navigationController: UINavigationController?) {
         Task {
             do {
-                _ = try await Unleash.reset(env: .staging)
+                _ = try await Unleash.reset(env: .current)
             } catch {
                 debugPrint(error)
             }


### PR DESCRIPTION
[MOB-1815](https://ecosia.atlassian.net/browse/MOB-1815)

## Context

We have noticed a fragmented approach when setting the environment.
We want to add a quick fix to the browser side, planning a proper fix in the long term.

## Approach

Removed all the occurrences when the `Environment` was passed by checking the build channel.
We aligned other property injections matching the `.current` one.

### Other

Also, as 💭 oud loud, we would need to review when we pass `env` to be `.current` instead of `.production` by default as it would make more sense. That's part of the longer-term review, though.

Longer term ticket:
https://ecosia.atlassian.net/browse/MOB-1817