### PR TITLE
MOB-1794 Always sending `iOS` as `platform` for Singular

### DIFF
--- a/Client/Ecosia/MMP/MMP.swift
+++ b/Client/Ecosia/MMP/MMP.swift
@@ -13,7 +13,11 @@ struct MMP {
     static func sendSession() {
         Task {
             do {
-                let appDeviceInfo = AppDeviceInfo(platform: DeviceInfo.platform,
+                
+                /// We are hardcoding `iOS` as per the platform parameter
+                /// as `Singular` MMP doesn't currently support others like `iPadOS`
+                /// We don't want to modify the `DeviceInfo.platform` as other services may need the correct one.
+                let appDeviceInfo = AppDeviceInfo(platform: "iOS",
                                                   bundleId: AppInfo.bundleIdentifier,
                                                   osVersion: DeviceInfo.osVersionNumber,
                                                   deviceManufacturer: DeviceInfo.manufacturer,


### PR DESCRIPTION
[MOB-1794](https://ecosia.atlassian.net/browse/MOB-1794)

## Context

Singular MMP only supports `iOS` as `platform` query item to send as part of any request.

## Approach

Updating hardcoding `iOS` as part for the `AppDeviceInfo` object we inject in the `sendSession` function.
