### PR TITLE
Aligned `MainTestPlan` tests

### DIFF
--- a/Tests/MainTestPlan.xctestplan
+++ b/Tests/MainTestPlan.xctestplan
@@ -14,7 +14,10 @@
   "testTargets" : [
     {
       "skippedTests" : [
+        "DefaultSearchPrefsTests",
         "ETPCoverSheetTests",
+        "EcosiaBookmarkMigrationTests\/testImportBookmarks()",
+        "HistoryDeletionUtilityTests",
         "TabManagerTests\/testDeleteSelectedTab()",
         "TabManagerTests\/testPrivatePreference_togglePBMDeletesPrivate()",
         "TestFavicons\/testFaviconFetcherParse()",


### PR DESCRIPTION
## Context

Realized with @lucaschifino 's help that some tests in the `MainTestPlan` weren't aligned with the domain-specific test plans (e.g. `ClientTestPlan`)

## Approach

Aligned.

## Other

We need to find a way to reflect those changes.
Perhaps removing the `MainTestPlan` itself and running each TestPlan independently when in regression.
Pros: one less test plan to align
