### PR TITLE
MOB-1826 Setup attribution reports to be forwarded to Singular

### DIFF
--- a/Client/Info.plist
+++ b/Client/Info.plist
@@ -86,6 +86,8 @@
 	<string>$(MOZ_PUBLIC_URL_SCHEME)</string>
 	<key>MozWallpaperURLScheme</key>
 	<string>$(MOZ_WALLPAPER_ASSET_URL)</string>
+	<key>NSAdvertisingAttributionReportEndpoint</key>
+	<string>https://singular-bi.net</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>


### PR DESCRIPTION
[MOB-1826](https://ecosia.atlassian.net/browse/MOB-1826)

## Context
Singular supports receiving Apple's reports to gather and provide them to us through Exporting Logs.

## Approach
Just by adding the key to Info.plist, Apple will automatically forward to Singular's endpoint -> see [step-by-step guide](https://support.singular.net/hc/en-us/articles/4405749380379-How-to-Send-SKAdNetwork-Postbacks-to-Singular-iOS-15-?navigation_side_bar=true) from Singular
