### PR TITLE
MOB-1637 Inner spacing url bar

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -130,6 +130,7 @@
 		2CB3BEDA29E03ED700C1951F /* MozillaAppServices in Frameworks */ = {isa = PBXBuildFile; productRef = 2CB3BED929E03ED700C1951F /* MozillaAppServices */; };
 		2CB56E3F1E926BFB00AF7586 /* ToolbarTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CB56E3E1E926BFB00AF7586 /* ToolbarTest.swift */; };
 		2CC1B3F01E9B861400814EEC /* DomainAutocompleteTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC1B3EF1E9B861400814EEC /* DomainAutocompleteTest.swift */; };
+		2CC9E08C2A30AED2003420E1 /* URL+Ecosia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC9E08B2A30AED2003420E1 /* URL+Ecosia.swift */; };
 		2CCB296720A99C9500121DD8 /* SaveLoginsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CCB296620A99C9500121DD8 /* SaveLoginsTests.swift */; };
 		2CCF17532105E4FD00705AE5 /* DisplaySettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CCF17522105E4FD00705AE5 /* DisplaySettingsTests.swift */; };
 		2CE63B2829C8DA8200047121 /* ErrorPageHandler+Ecosia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE63B2729C8DA8200047121 /* ErrorPageHandler+Ecosia.swift */; };
@@ -1729,6 +1730,7 @@
 		2CB1A6591FDEA8B60084E96D /* NewTabSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabSettings.swift; sourceTree = "<group>"; };
 		2CB56E3E1E926BFB00AF7586 /* ToolbarTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToolbarTest.swift; sourceTree = "<group>"; };
 		2CC1B3EF1E9B861400814EEC /* DomainAutocompleteTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DomainAutocompleteTest.swift; sourceTree = "<group>"; };
+		2CC9E08B2A30AED2003420E1 /* URL+Ecosia.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+Ecosia.swift"; sourceTree = "<group>"; };
 		2CCB296620A99C9500121DD8 /* SaveLoginsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveLoginsTests.swift; sourceTree = "<group>"; };
 		2CCF17522105E4FD00705AE5 /* DisplaySettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplaySettingsTests.swift; sourceTree = "<group>"; };
 		2CE63B2729C8DA8200047121 /* ErrorPageHandler+Ecosia.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ErrorPageHandler+Ecosia.swift"; sourceTree = "<group>"; };
@@ -6635,6 +6637,7 @@
 				CA8BCC3F28D340AF0020BC50 /* TabCell+Ecosia.swift */,
 				2CE63B2729C8DA8200047121 /* ErrorPageHandler+Ecosia.swift */,
 				2C1AF2622A27A7D9003970E0 /* Toolbar+URLBar */,
+				2CC9E08B2A30AED2003420E1 /* URL+Ecosia.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -9634,6 +9637,7 @@
 				96EB6C3C27D82AEA00A9D159 /* HistoryPanel+ContextMenuExtensions.swift in Sources */,
 				CA4D9CF328C8D801006AFB5D /* FilterController.swift in Sources */,
 				43DDB96A240994370058A068 /* ETPCoverSheetViewController.swift in Sources */,
+				2CC9E08C2A30AED2003420E1 /* URL+Ecosia.swift in Sources */,
 				217AEF7828480844004EED37 /* ResizableButton.swift in Sources */,
 				CA220A6C28D070FE000E66E6 /* FeatureFlagsManager.swift in Sources */,
 				CAEB316728D0B38900ADC9DB /* HomepageViewController+Ecosia.swift in Sources */,

--- a/Client/Ecosia/Extensions/URL+Ecosia.swift
+++ b/Client/Ecosia/Extensions/URL+Ecosia.swift
@@ -10,7 +10,7 @@ extension URL {
         scheme == "https"
     }
     
-    /// This computer var is utilized to determine whether a Website is considered secure from the Ecosia's perspective
+    /// This computed var is utilized to determine whether a Website is considered secure from the Ecosia's perspective
     /// We use it mainly to define the UI that tells the user that the currently visited website is secure
     public var isSecure: Bool {
         isHTTPS || isReaderModeURL

--- a/Client/Ecosia/Extensions/URL+Ecosia.swift
+++ b/Client/Ecosia/Extensions/URL+Ecosia.swift
@@ -1,0 +1,18 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Shared
+
+extension URL {
+
+    public var isHTTPS: Bool {
+        scheme == "https"
+    }
+    
+    /// This computer var is utilized to determine whether a Website is considered secure from the Ecosia's perspective
+    /// We use it mainly to define the UI that tells the user that the currently visited website is secure
+    public var isSecure: Bool {
+        isHTTPS || isReaderModeURL
+    }
+}

--- a/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
+++ b/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
@@ -67,8 +67,8 @@ class TabLocationView: UIView {
 
     lazy var urlTextField: URLTextField = .build { urlTextField in
         /* Ecosia: removing obsolete implementation as we don't support 4S anymore
-        // Prevent the field from compressing the toolbar buttons on the 4S in landscape.
-        urlTextField.setContentCompressionResistancePriority(UILayoutPriority(rawValue: 250), for: .horizontal)
+         Original reason: Prevent the field from compressing the toolbar buttons on the 4S in landscape.
+         urlTextField.setContentCompressionResistancePriority(UILayoutPriority(rawValue: 250), for: .horizontal)
          */
         urlTextField.accessibilityIdentifier = "url"
         urlTextField.accessibilityActionsSource = self

--- a/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
+++ b/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
@@ -334,7 +334,7 @@ extension TabLocationView: TabEventHandler {
         guard url.isWebPage() else {
             return
         }
-        let status: WebsiteConnectionTypeStatus = url.isHTTPS ? .secure : .unsecure
+        let status: WebsiteConnectionTypeStatus = url.isSecure ? .secure : .unsecure
         trackingProtectionButton.updateAppearanceForStatus(status)
     }
 }

--- a/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
+++ b/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
@@ -24,8 +24,10 @@ struct TabLocationViewUX {
     static let BaseURLFontColor = UIColor.Photon.Grey50
     static let Spacing: CGFloat = 8
     static let StatusIconSize: CGFloat = 18
+    /* Ecosia: Updating icons with same size numbers
     static let TPIconSize: CGFloat = 44
-    static let ReaderModeButtonWidth: CGFloat = 34
+    static let ReaderModeButtonWidth: CGFloat = 44
+     */
     static let ButtonSize: CGFloat = 44
     static let URLBarPadding = 4
 }
@@ -111,6 +113,7 @@ class TabLocationView: UIView {
             UILongPressGestureRecognizer(target: self, action: #selector(longPressReloadButton)))
         reloadButton.imageView?.contentMode = .scaleAspectFit
         reloadButton.contentHorizontalAlignment = .left
+        reloadButton.imageEdgeInsets = .init(top: 0, left: 5, bottom: 0, right: 0)
         reloadButton.accessibilityLabel = .TabLocationReloadAccessibilityLabel
         reloadButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.reloadButton
         reloadButton.isAccessibilityElement = true
@@ -145,12 +148,13 @@ class TabLocationView: UIView {
 
         contentView.edges(equalTo: self)
 
+        // Ecosia: Updating icons with same size numbers
         NSLayoutConstraint.activate([
-            trackingProtectionButton.widthAnchor.constraint(equalToConstant: TabLocationViewUX.TPIconSize),
+            trackingProtectionButton.widthAnchor.constraint(equalToConstant: TabLocationViewUX.ButtonSize),
             trackingProtectionButton.heightAnchor.constraint(equalToConstant: TabLocationViewUX.ButtonSize),
-            readerModeButton.widthAnchor.constraint(equalToConstant: TabLocationViewUX.ReaderModeButtonWidth),
+            readerModeButton.widthAnchor.constraint(equalToConstant: TabLocationViewUX.ButtonSize),
             readerModeButton.heightAnchor.constraint(equalToConstant: TabLocationViewUX.ButtonSize),
-            reloadButton.widthAnchor.constraint(equalToConstant: TabLocationViewUX.ReaderModeButtonWidth),
+            reloadButton.widthAnchor.constraint(equalToConstant: TabLocationViewUX.ButtonSize),
             reloadButton.heightAnchor.constraint(equalToConstant: TabLocationViewUX.ButtonSize),
         ])
 

--- a/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
+++ b/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
@@ -24,10 +24,8 @@ struct TabLocationViewUX {
     static let BaseURLFontColor = UIColor.Photon.Grey50
     static let Spacing: CGFloat = 8
     static let StatusIconSize: CGFloat = 18
-    /* Ecosia: Updating icons with same size numbers
     static let TPIconSize: CGFloat = 44
-    static let ReaderModeButtonWidth: CGFloat = 44
-     */
+    static let ReaderModeButtonWidth: CGFloat = 34
     static let ButtonSize: CGFloat = 44
     static let URLBarPadding = 4
 }
@@ -99,6 +97,7 @@ class TabLocationView: UIView {
                                          action: #selector(self.longPressReaderModeButton)))
         readerModeButton.isAccessibilityElement = true
         readerModeButton.isHidden = true
+        readerModeButton.contentHorizontalAlignment = .right
         readerModeButton.accessibilityLabel = .TabLocationReaderModeAccessibilityLabel
         readerModeButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.readerModeButton
         readerModeButton.accessibilityCustomActions = [
@@ -152,9 +151,9 @@ class TabLocationView: UIView {
 
         // Ecosia: Updating icons with same size numbers
         NSLayoutConstraint.activate([
-            trackingProtectionButton.widthAnchor.constraint(equalToConstant: TabLocationViewUX.ButtonSize),
+            trackingProtectionButton.widthAnchor.constraint(equalToConstant: TabLocationViewUX.TPIconSize),
             trackingProtectionButton.heightAnchor.constraint(equalToConstant: TabLocationViewUX.ButtonSize),
-            readerModeButton.widthAnchor.constraint(equalToConstant: TabLocationViewUX.ButtonSize),
+            readerModeButton.widthAnchor.constraint(equalToConstant: TabLocationViewUX.ReaderModeButtonWidth),
             readerModeButton.heightAnchor.constraint(equalToConstant: TabLocationViewUX.ButtonSize),
             reloadButton.widthAnchor.constraint(equalToConstant: TabLocationViewUX.ButtonSize),
             reloadButton.heightAnchor.constraint(equalToConstant: TabLocationViewUX.ButtonSize),

--- a/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
+++ b/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
@@ -68,8 +68,10 @@ class TabLocationView: UIView {
     }
 
     lazy var urlTextField: URLTextField = .build { urlTextField in
+        /* Ecosia: removing obsolete implementation as we don't support 4S anymore
         // Prevent the field from compressing the toolbar buttons on the 4S in landscape.
         urlTextField.setContentCompressionResistancePriority(UILayoutPriority(rawValue: 250), for: .horizontal)
+         */
         urlTextField.accessibilityIdentifier = "url"
         urlTextField.accessibilityActionsSource = self
         urlTextField.backgroundColor = .clear

--- a/Shared/Extensions/URLExtensions.swift
+++ b/Shared/Extensions/URLExtensions.swift
@@ -378,10 +378,6 @@ extension URL {
         return scheme.map { schemes.contains($0) } ?? false
     }
     
-    public var isHTTPS: Bool {
-        scheme == "https"
-    }
-
     public var isIPv6: Bool {
         return host?.contains(":") ?? false
     }


### PR DESCRIPTION
[MOB-1637](https://ecosia.atlassian.net/browse/MOB-1637)

## Context

There is a misalignment in spacing between the right and left-hand sides of the URL Bar.
Both should be equally aligned.

## Approach

After a quick review of how the `TabLocationView` is made, I've come to the realization that a refactor would take too much time in order to simplify the architecture of the URL Bar as well as bring the fix in.
So I did come up with a compromise, leveraging the minimum impact as well as achieving the expected behavior.

## Other

- This UX alignment also fixes an issue when the reading mode gets triggered. Because of the URL being `localhost../reader-mode` the business logic treated it as not secure, hence showing the ⚠️ icon.
- Also moved our previous computer var URL extension into the Ecosia's domain for simplifying upgrades.
 
![Simulator Screen Recording - iPhone 14 - 2023-06-07 at 14 33 01](https://github.com/ecosia/ios-browser/assets/3584008/18b08292-55e9-4893-8199-765acd001746)
