### PR TITLE
Mob 1825 Prepare Beta Testflight version

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -12988,7 +12988,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = "${inherited}";
+				CURRENT_PROJECT_VERSION = 76;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				"DEBUG_INFORMATION_FORMAT[sdk=iphonesimulator*]" = dwarf;
 				DEVELOPMENT_TEAM = 33YMRSYD2L;
@@ -13000,7 +13000,7 @@
 					"@executable_path/Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
-				MARKETING_VERSION = "${inherited}";
+				MARKETING_VERSION = 8.1.6;
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lxml2",
@@ -13383,7 +13383,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon_Beta;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = "${inherited}";
+				CURRENT_PROJECT_VERSION = 76;
 				DEVELOPMENT_TEAM = 33YMRSYD2L;
 				INFOPLIST_FILE = Client/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -13391,7 +13391,7 @@
 					"@executable_path/Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
-				MARKETING_VERSION = "${inherited}";
+				MARKETING_VERSION = 8.1.6;
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lxml2",
@@ -13755,7 +13755,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = "${inherited}";
+				CURRENT_PROJECT_VERSION = 76;
 				DEVELOPMENT_TEAM = 33YMRSYD2L;
 				INFOPLIST_FILE = Client/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -13763,7 +13763,7 @@
 					"@executable_path/Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
-				MARKETING_VERSION = "${inherited}";
+				MARKETING_VERSION = 8.1.6;
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lxml2",
@@ -13953,7 +13953,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon_Beta;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = "${inherited}";
+				CURRENT_PROJECT_VERSION = 77;
 				DEVELOPMENT_TEAM = 33YMRSYD2L;
 				INFOPLIST_FILE = Client/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -13961,7 +13961,7 @@
 					"@executable_path/Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
-				MARKETING_VERSION = "${inherited}";
+				MARKETING_VERSION = 8.1.7;
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lxml2",
@@ -14083,7 +14083,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = "${inherited}";
+				CURRENT_PROJECT_VERSION = 76;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				"DEBUG_INFORMATION_FORMAT[sdk=iphonesimulator*]" = dwarf;
 				DEVELOPMENT_TEAM = 33YMRSYD2L;
@@ -14093,7 +14093,7 @@
 					"@executable_path/Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
-				MARKETING_VERSION = "${inherited}";
+				MARKETING_VERSION = 8.1.6;
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lxml2",

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -50,7 +50,7 @@
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
         "branch" : "main",
-        "revision" : "6c579bd63ae1a3d6a89d9c37ea86e79bbbe8324a"
+        "revision" : "2171c124a7dcb8869759cd763547b6b413c5d51c"
       }
     },
     {


### PR DESCRIPTION
[MOB-1825](https://ecosia.atlassian.net/browse/MOB-1825)

## Context
A new fix to the SKAN implementation was done in [ios-core#87](https://github.com/ecosia/ios-core/pull/87).
We also want to deploy a Testflight Beta version for receiving testing support from the Paid Growth team.

## Approach
- Update the core package version in the resolved file.
- Bump the version of the Beta configuration (for now manually as discussed with @d4r1091)
     - Obs.: For some reason all versions were `"${inherited}"` and we could not figure out from where. As soon as I updated one of them in the project all were automatically changed back to the "hardcoded" value, even if the only one updated to `8.1.7.77` was the Beta configuration.
     - Obs2.: This will be overwritten as soon as we properly release a live version as per [the documentation](https://ecosia.atlassian.net/wiki/spaces/MOB/pages/2460680288/iOS+How+to+Release). This manual approach is only done since the Beta version bump is not automated.
