### PR TITLE
Add extract staging config step to build testflight beta job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,9 @@ jobs:
           name: verify github
           command: for ip in $(dig @8.8.8.8 github.com +short); do ssh-keyscan github.com,$ip; ssh-keyscan $ip; done 2>/dev/null >> ~/.ssh/known_hosts
       - run:
+          name: extract Staging XCConfig
+          command: echo "$STAGING_XCCONFIG" | base64 --decode > Client/Configuration/Staging.xcconfig
+      - run:
           name: clean packages
           command: xcodebuild -scheme Ecosia -project Client.xcodeproj clean
       - run:


### PR DESCRIPTION
## Context
After adding the beta tag on the [previous commit](https://github.com/ecosia/ios-browser/commit/4dcfc497a095993ab8771efc99b3ed4075a560c2), the `build-testflight-deploy-beta` CircleCI job was failing.

## Approach
Since our `EcosiaBeta.xcconfig` requires `Staging.xcconfig`, I have added a step to the job that extracts it from the CircleCI environment variables. This is already the approach done in the `build-appcenter-deploy` job.