### PR TITLE
MOB-1807 Ab test adjustments UI fixes

### DIFF
--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -170,12 +170,7 @@ class AppSettingsTableViewController: SettingsTableViewController, FeatureFlagga
             AutoCompleteSettings(prefs: prefs),
             PersonalSearchSettings(prefs: prefs)
         ]
-        
-        // Ecosia: Disable those settings for Bing search experiment when we show the Bing SERP
-        if BingSearchExperiment.shouldShowBingSERP {
-            searchSettings.removeAll()
-        }
-        
+                
         var customization: [Setting] = [HomePageSettingViewController.TopSitesSettings(settings: self)]
         
         if tabTrayGroupsAreBuildActive || inactiveTabsAreBuildActive {
@@ -190,6 +185,11 @@ class AppSettingsTableViewController: SettingsTableViewController, FeatureFlagga
                      .init(title: .init(string: .localized(.customization)), children: customization),
                      .init(title: .init(string: .SettingsGeneralSectionTitle), children: generalSettings)]
         
+        // Ecosia: Disable search settings for Bing search experiment when we show the Bing SERP
+        if BingSearchExperiment.shouldShowBingSERP {
+            settings.removeAll(where: { $0.title?.string == .localized(.search) } )
+        }
+
         var privacySettings = [Setting]()
         privacySettings.append(LoginsSetting(settings: self, delegate: settingsDelegate))
 


### PR DESCRIPTION
[MOB-1807](https://ecosia.atlassian.net/browse/MOB-1807)

## Context

QA found out a UI glitch that was still showing the Search section header after hiding the rows.

## Approach

Removing the section entirely, header included.
Ended up making a cleaner implementation.

## Other

As `children` not accessible as property of `SettingSection` and wanted a concise approach, I thought that the copy would be sufficient, given the nature of the implementation itself (experiment / temporary).
