### PR TITLE
MOB-1835 Add current country and ecosia app version to MMP

### DIFF
--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -50,7 +50,7 @@
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
         "branch" : "main",
-        "revision" : "2171c124a7dcb8869759cd763547b6b413c5d51c"
+        "revision" : "7c50574eb22c09eb8371fd79a501ad4593a81251"
       }
     },
     {

--- a/Client/Ecosia/MMP/MMP.swift
+++ b/Client/Ecosia/MMP/MMP.swift
@@ -23,8 +23,9 @@ struct MMP {
                                                   deviceManufacturer: DeviceInfo.manufacturer,
                                                   deviceModel: DeviceInfo.deviceModelName,
                                                   locale: DeviceInfo.currentLocale,
+                                                  country: DeviceInfo.currentCountry,
                                                   deviceBuildVersion: DeviceInfo.osBuildNumber,
-                                                  appVersion: AppInfo.appVersion,
+                                                  appVersion: AppInfo.ecosiaAppVersion,
                                                   installReceipt: AppInfo.installReceipt)
                 
                 let mmpProvider: MMPProvider = Singular(includeSKAN: true)


### PR DESCRIPTION
[MOB-1835](https://ecosia.atlassian.net/browse/MOB-1835)

## Context
From looking at Singular's events logs, we noticed country and app version were not correct on the events (always showed the same `104.0` and `US` respectively).

## Approach
- Country was added to the app device info struct on [ios-core#89](https://github.com/ecosia/ios-core/pull/89) and therefore we are passing it here now.
- Also using `AppInfo.ecosiaAppVersion` since that correctly reflects our app version, instead of `AppInfo.appVersion` which is hardcoded and shows the Firefox version we are basing on.
