### PR TITLE
AG-49 Refactor and add accessibility to NTP library shortcut views

### DIFF
--- a/Client/Ecosia/UI/NTP/Cells/NTPLibraryCell.swift
+++ b/Client/Ecosia/UI/NTP/Cells/NTPLibraryCell.swift
@@ -97,14 +97,14 @@ class NTPLibraryCell: UICollectionViewCell, NotificationThemeable, ReusableCell 
     }
 
     @objc func tapped(_ sender: UIButton) {
-        switch sender.tag {
-        case 0:
+        switch Item(rawValue: sender.tag) {
+        case .bookmarks:
             delegate?.libraryCellOpenBookmarks()
-        case 1:
+        case .history:
             delegate?.libraryCellOpenHistory()
-        case 2:
+        case .readingList:
             delegate?.libraryCellOpenReadlist()
-        case 3:
+        case .downloads:
             delegate?.libraryCellOpenDownloads()
         default:
             break

--- a/Client/Ecosia/UI/NTP/Cells/NTPLibraryCell.swift
+++ b/Client/Ecosia/UI/NTP/Cells/NTPLibraryCell.swift
@@ -12,18 +12,31 @@ class NTPLibraryCell: UICollectionViewCell, NotificationThemeable, ReusableCell 
     weak var heightConstraint: NSLayoutConstraint!
     weak var delegate: NTPLibraryDelegate?
 
-    struct Panel {
-        let title: String
-        let image: UIImage?
-        let tag: Int
+    enum Item: Int, CaseIterable {
+        case bookmarks
+        case history
+        case readingList
+        case downloads
+        
+        var title: String {
+            switch self {
+            case .bookmarks: return .AppMenu.AppMenuBookmarksTitleString
+            case .history: return .AppMenu.AppMenuHistoryTitleString
+            case .readingList: return .AppMenu.AppMenuReadingListTitleString
+            case .downloads: return .AppMenu.AppMenuDownloadsTitleString
+            }
+        }
+        var image: UIImage? {
+            switch self {
+            case .bookmarks: return UIImage(named: "libraryFavorites")
+            case .history: return UIImage(named: "libraryHistory")
+            case .readingList: return UIImage(named: "libraryReading")
+            case .downloads: return UIImage(named: "libraryDownloads")
+            }
+        }
     }
 
     var shortcuts: [NTPLibraryShortcutView] = []
-
-    let bookmarks = Panel(title: .AppMenu.AppMenuBookmarksTitleString, image: UIImage(named: "libraryFavorites"), tag: 0)
-    let history = Panel(title: .AppMenu.AppMenuHistoryTitleString, image: UIImage(named: "libraryHistory"), tag: 1)
-    let readingList = Panel(title: .AppMenu.AppMenuReadingListTitleString, image: UIImage(named: "libraryReading"), tag: 2)
-    let downloads = Panel(title: .AppMenu.AppMenuDownloadsTitleString, image: UIImage(named: "libraryDownloads"), tag: 3)
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -46,17 +59,20 @@ class NTPLibraryCell: UICollectionViewCell, NotificationThemeable, ReusableCell 
         heightConstraint.isActive = true
         self.heightConstraint = heightConstraint
 
-
         // Ecosia: Show history instead of synced tabs
-        [bookmarks, history, readingList, downloads].forEach { item in
+        Item.allCases.forEach { item in
             let view = NTPLibraryShortcutView()
             view.button.setImage(item.image, for: .normal)
-            view.button.tag = item.tag
+            view.button.tag = item.rawValue
             view.button.addTarget(self, action: #selector(tapped), for: .primaryActionTriggered)
             view.title.text = item.title
             let words = view.title.text?.components(separatedBy: NSCharacterSet.whitespacesAndNewlines).count
             view.title.numberOfLines = words == 1 ? 1 : 2
             view.accessibilityLabel = item.title
+            view.isAccessibilityElement = true
+            view.shouldGroupAccessibilityChildren = true
+            view.accessibilityTraits = .button
+            view.accessibilityRespondsToUserInteraction = true
             mainView.addArrangedSubview(view)
             shortcuts.append(view)
         }

--- a/Client/Ecosia/UI/NTP/Cells/NTPLibraryCell.swift
+++ b/Client/Ecosia/UI/NTP/Cells/NTPLibraryCell.swift
@@ -28,10 +28,10 @@ class NTPLibraryCell: UICollectionViewCell, NotificationThemeable, ReusableCell 
         }
         var image: UIImage? {
             switch self {
-            case .bookmarks: return UIImage(named: "libraryFavorites")
-            case .history: return UIImage(named: "libraryHistory")
-            case .readingList: return UIImage(named: "libraryReading")
-            case .downloads: return UIImage(named: "libraryDownloads")
+            case .bookmarks: return .init(named: "libraryFavorites")
+            case .history: return .init(named: "libraryHistory")
+            case .readingList: return .init(named: "libraryReading")
+            case .downloads: return .init(named: "libraryDownloads")
             }
         }
     }


### PR DESCRIPTION
[AG-49](https://ecosia.atlassian.net/browse/AG-49)

## Context
Accessibility ticket created during [Engineering Offsite Core Journey Accessibility Review](https://ecosia.atlassian.net/wiki/spaces/DEV/pages/2627502081/Engineering+Offsite+April+18th-21st+2023+Spring+Cleaning#%E2%99%BF%EF%B8%8F%E2%9C%8A-Core-Journey-Accessibility-Review-(proposed-by-%40Zac-Colley-%26-%40sofiya.tepikin)).

Testing the app using Voice Over, it was noticed that the NTP shortcut items button and title are read separately and not in sequence, which can be very confusing.

## Approach
Grouped the `NTPLibraryShortcutView` accessibility children and made the whole view act as a button so that the user understands it is clickable. Also took the opportunity to refactor how the `NTPLibraryCell` created the shortcut items, switching to an `enum` approach as it is more readable and less error prone.

## Other
Also took some time to try and add a sort of accessibility header for the NTP shortcuts collection view section since it is still not clear when going through the screen with voice over what they are about. Among other things, I tried to to add a `UIAccessibilityElement` that would be voiced over before the section or as the section header. Even so, this turned out to not be so trivial and I decided on not spending more time in it and going with the simple approach instead.
