### PR TITLE
AG-51 Group NewsCell accessibility children and add link indicator

### DIFF
--- a/Client/Ecosia/UI/NTP/News/NewsCell.swift
+++ b/Client/Ecosia/UI/NTP/News/NewsCell.swift
@@ -183,8 +183,10 @@ final class NewsCell: UICollectionViewCell, NotificationThemeable, ReusableCell 
     }
     
     func configure(_ model: NewsModel, images: Images, positions: Positions) {
-        title.text = model.text.replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
-        bottomLabel.text = RelativeDateTimeFormatter().localizedString(for: model.publishDate, relativeTo: .init())
+        let titleString = model.text.replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
+        title.text = titleString
+        let publishDateString = RelativeDateTimeFormatter().localizedString(for: model.publishDate, relativeTo: .init())
+        bottomLabel.text = publishDateString
         bottomIcon.isHidden = true
         highlightLabel.isHidden = true
 
@@ -210,6 +212,11 @@ final class NewsCell: UICollectionViewCell, NotificationThemeable, ReusableCell 
         }
         background.layer.maskedCorners = masked
         applyTheme()
+            
+        isAccessibilityElement = true
+        accessibilityLabel = "\(titleString); \(publishDateString)"
+        accessibilityTraits = .link
+        shouldGroupAccessibilityChildren = true
     }
 
     private func updateImage(_ data: Data) {


### PR DESCRIPTION
[AG-51](https://ecosia.atlassian.net/browse/AG-51)

## Context
Accessibility ticket created during [Engineering Offsite Core Journey Accessibility Review](https://ecosia.atlassian.net/wiki/spaces/DEV/pages/2627502081/Engineering+Offsite+April+18th-21st+2023+Spring+Cleaning#%E2%99%BF%EF%B8%8F%E2%9C%8A-Core-Journey-Accessibility-Review-(proposed-by-%40Zac-Colley-%26-%40sofiya.tepikin)).

The NTP News items had no indicator they were links.

## Approach
Grouped the `NewsCell` accessibility children, making it act as a link, as well as added the title and published date texts to the accessibility label.
