### PR TITLE
MOB-1647 fix check inactive lock icon

### DIFF
--- a/Client/Ecosia/Extensions/Toolbar+URLBar/ConnectionStatusImage.swift
+++ b/Client/Ecosia/Extensions/Toolbar+URLBar/ConnectionStatusImage.swift
@@ -6,6 +6,6 @@ import Foundation
 
 struct ConnectionStatusImage {
     
-    static let connectionSecureImage = UIImage.templateImageNamed("secureLock")?.tinted(withColor: .theme.ecosia.primaryButtonActive)
+    static let connectionSecureImage = UIImage.templateImageNamed("secureLock")?.tinted(withColor: .theme.ecosia.secondaryIcon)
     static let connectionUnsecureImage = UIImage.templateImageNamed("problem")?.tinted(withColor: .theme.ecosia.warning)
 }

--- a/Client/Ecosia/Extensions/URL+Ecosia.swift
+++ b/Client/Ecosia/Extensions/URL+Ecosia.swift
@@ -12,7 +12,13 @@ extension URL {
     
     /// This computed var is utilized to determine whether a Website is considered secure from the Ecosia's perspective
     /// We use it mainly to define the UI that tells the user that the currently visited website is secure
+    /// When the URL page isn't loaded properly for some reason, we still lookup the website that is being loaded, and determine its security
+    /// so the end user alway have an idea of the website being loaded shown in the URL bar and avoid any UI misalignment showing the `warning` icon for a secure website
+    /// having issues to load
+    /// In case at least one of the flags evaluates to `true`, we consider the URL secure.
     public var isSecure: Bool {
-        isHTTPS || isReaderModeURL
+        let isOriginalUrlFromErrorPageSecure = InternalURL(self)?.originalURLFromErrorPage?.isHTTPS ?? false
+        let securityFlags = [isOriginalUrlFromErrorPageSecure, isHTTPS, isReaderModeURL]
+        return securityFlags.first(where: { $0 == true }) ?? false
     }
 }

--- a/Client/Ecosia/UI/EcosiaTheme.swift
+++ b/Client/Ecosia/UI/EcosiaTheme.swift
@@ -47,6 +47,7 @@ class EcosiaTheme {
     var navigationBarText: UIColor { .Light.Text.primary }
 
     var primaryIcon: UIColor { .Light.Icon.primary }
+    var secondaryIcon: UIColor { .Light.Icon.secondary }
     var decorativeIcon: UIColor { .Light.Icon.decorative }
     
     var highlightedBackground: UIColor { .Light.Background.highlighted }
@@ -117,6 +118,7 @@ final class DarkEcosiaTheme: EcosiaTheme {
     override var navigationBarText: UIColor { .Dark.Text.primary }
 
     override var primaryIcon: UIColor { .Dark.Icon.primary }
+    override var secondaryIcon: UIColor { .Dark.Icon.secondary }
     override var decorativeIcon: UIColor { .Dark.Icon.decorative }
     
     override var highlightedBackground: UIColor { .Dark.Background.highlighted }

--- a/Client/Ecosia/UI/SemanticColor.swift
+++ b/Client/Ecosia/UI/SemanticColor.swift
@@ -34,6 +34,7 @@ extension UIColor {
         
         struct Icon {
             static let primary = UIColor(red: 0.059, green: 0.059, blue: 0.059, alpha: 1)
+            static let secondary = UIColor(rgb: 0x007508)
             static let decorative = UIColor(red: 0.424, green: 0.424, blue: 0.424, alpha: 1)
         }
         
@@ -76,6 +77,7 @@ extension UIColor {
         
         struct Icon {
             static let primary = UIColor.white
+            static let secondary = UIColor(rgb: 0x5DD25E)
             static let decorative = UIColor(red: 0.871, green: 0.871, blue: 0.871, alpha: 1)
         }
         

--- a/Client/Ecosia/UI/SemanticColor.swift
+++ b/Client/Ecosia/UI/SemanticColor.swift
@@ -27,7 +27,7 @@ extension UIColor {
         }
 
         struct State {
-            static let warning = UIColor(red: 0.992, green: 0.259, blue: 0.337, alpha: 1)
+            static let warning = UIColor(rgb: 0xFD4256)
             static let information = UIColor(red: 0, green: 0.494, blue: 0.659, alpha: 1)
             static let disabled = UIColor(rgb: 0xDEDED9)
         }
@@ -66,7 +66,7 @@ extension UIColor {
         }
 
         struct State {
-            static let warning = UIColor(red: 1.0, green: 0.541, blue: 0.549, alpha: 1)
+            static let warning = UIColor(rgb: 0xFF8A8C)
             static let information = UIColor(red: 0.589, green: 0.839, blue: 0.973, alpha: 1)
             static let disabled = UIColor(rgb: 0x6C6C6C)
         }

--- a/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVM.swift
+++ b/Client/Frontend/Browser/EnhancedTrackingProtection/EnhancedTrackingProtectionVM.swift
@@ -37,7 +37,7 @@ class EnhancedTrackingProtectionMenuVM {
     }
 
     var connectionSecure: Bool {
-        return tab.webView?.url?.isHTTPS == true
+        return tab.webView?.url?.isSecure == true
     }
 
     var isSiteETPEnabled: Bool {

--- a/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
+++ b/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
@@ -331,9 +331,6 @@ extension TabLocationView {
 extension TabLocationView: TabEventHandler {
     
     func tab(_ tab: Tab, didChangeURL url: URL) {
-        guard url.isWebPage() else {
-            return
-        }
         let status: WebsiteConnectionTypeStatus = url.isSecure ? .secure : .unsecure
         trackingProtectionButton.updateAppearanceForStatus(status)
     }


### PR DESCRIPTION
[MOB-1647](https://ecosia.atlassian.net/browse/MOB-1647)

## Context

After a design review, we've discovered that those icons were missing the recently updated colors (bad timing 😛)

## Approach

Reviewed the Figma file and updated colors.
I also took a chance to review the way we define a website "secure" from the UX perspective (also noted by our team designer as well).