### PR TITLE
MOB-1718 `_sp` parameter in incognito replaces to 0

### DIFF
--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -50,7 +50,7 @@
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
         "branch" : "main",
-        "revision" : "7c50574eb22c09eb8371fd79a501ad4593a81251"
+        "revision" : "2b087aa6a5e7955cb92e4af24eb8da58cafc0db9"
       }
     },
     {
@@ -67,8 +67,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/onevcat/Kingfisher.git",
       "state" : {
-        "revision" : "af4be924ad984cf4d16f4ae4df424e79a443d435",
-        "version" : "7.6.2"
+        "revision" : "c1f60c63f356d364f4284ba82961acbe7de79bcc",
+        "version" : "7.8.1"
       }
     },
     {

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -568,7 +568,7 @@ class Tab: NSObject {
 
             // Ecosia: inject analytics id
             var request = request
-            request.url = request.url?.ecosified
+            request.url = request.url?.ecosified(isIncognitoEnabled: _isPrivate)
             return webView.load(request)
         }
         return nil


### PR DESCRIPTION
[MOB-1718](https://ecosia.atlassian.net/browse/MOB-1718)

## Context

To bridge the gap in analytics between our native user ids and the web JS tracker, we append all /search urls with _sp - query parameter.

## Approach

Modified the `ecosified` var matching the updates done on `Core`.