### PR TITLE
MOB-1831 Add app language region header

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -14508,7 +14508,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ecosia/ios-core.git";
 			requirement = {
-				branch = main;
+				branch = "MOB-1831_add_app_language_region_header";
 				kind = branch;
 			};
 		};

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -14508,7 +14508,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ecosia/ios-core.git";
 			requirement = {
-				branch = "MOB-1831_add_app_language_region_header";
+				branch = main;
 				kind = branch;
 			};
 		};

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1143,10 +1143,7 @@ class BrowserViewController: UIViewController {
     func finishEditingAndSubmit(_ url: URL, visitType: VisitType, forTab tab: Tab) {
         urlBar.currentURL = url
         leaveOverlayMode(didCancel: false)
-        // Ecosia: enriching the app with a language region header for market selection options
-        var urlRequest = URLRequest(url: url)
-        urlRequest.addLanguageRegionHeader()
-        if let nav = tab.loadRequest(urlRequest) {
+        if let nav = tab.loadRequest(URLRequest(url: url)) {
             self.recordNavigationInTab(tab, navigation: nav, visitType: visitType)
         }
     }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1143,8 +1143,9 @@ class BrowserViewController: UIViewController {
     func finishEditingAndSubmit(_ url: URL, visitType: VisitType, forTab tab: Tab) {
         urlBar.currentURL = url
         leaveOverlayMode(didCancel: false)
-
-        if let nav = tab.loadRequest(URLRequest(url: url)) {
+        var urlRequest = URLRequest(url: url)
+        urlRequest.addLanguageRegionHeader()
+        if let nav = tab.loadRequest(urlRequest) {
             self.recordNavigationInTab(tab, navigation: nav, visitType: visitType)
         }
     }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1143,6 +1143,7 @@ class BrowserViewController: UIViewController {
     func finishEditingAndSubmit(_ url: URL, visitType: VisitType, forTab tab: Tab) {
         urlBar.currentURL = url
         leaveOverlayMode(didCancel: false)
+        // Ecosia: enriching the app with a language region header for market selection options
         var urlRequest = URLRequest(url: url)
         urlRequest.addLanguageRegionHeader()
         if let nav = tab.loadRequest(urlRequest) {

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -567,13 +567,16 @@ class Tab: NSObject {
                 return webView.loadFileURL(url, allowingReadAccessTo: url)
             }
 
-            // Ecosia: updating the request with cookies and auth parameters if needed
+            // Ecosia: updating the request with cookies, auth parameters and language header if needed
             var ecosiaUpdatedRequest = request
-            // Ecosia: inject analytics id
             ecosiaUpdatedRequest.url = ecosiaUpdatedRequest.url?.ecosified(isIncognitoEnabled: _isPrivate)
             // Ecosia: inject auth parameters if needed
             ecosiaUpdatedRequest = ecosiaUpdatedRequest.withAuthParameters()
-            return webView.load(ecosiaUpdatedRequest)
+            // Ecosia: enriching the search request (showing SERP page) with a language region header for market selection options
+            if request.url?.isEcosiaSearchQuery == true {
+                request.addLanguageRegionHeader()
+            }
+            return webView.load(request)
         }
         return nil
     }

--- a/Client/Frontend/Browser/Tab.swift
+++ b/Client/Frontend/Browser/Tab.swift
@@ -573,10 +573,10 @@ class Tab: NSObject {
             // Ecosia: inject auth parameters if needed
             ecosiaUpdatedRequest = ecosiaUpdatedRequest.withAuthParameters()
             // Ecosia: enriching the search request (showing SERP page) with a language region header for market selection options
-            if request.url?.isEcosiaSearchQuery == true {
-                request.addLanguageRegionHeader()
+            if ecosiaUpdatedRequest.url?.isEcosiaSearchQuery() == true {
+                ecosiaUpdatedRequest.addLanguageRegionHeader()
             }
-            return webView.load(request)
+            return webView.load(ecosiaUpdatedRequest)
         }
         return nil
     }


### PR DESCRIPTION
[MOB-1831](https://ecosia.atlassian.net/browse/MOB-1831)

## Context

The mobile apps need to provide an additional HTTP request header when loading SERP through native UI (i.e. submitting a search), to help SERP decide which market to serve.

## Approach

Enriching the URLRequest with an additional header that loads SERP upon clicking on autocomplete suggestions and/or directly searching via the URL Bar.

🚨SPM commit update to be reverted. Needed to pass tests only 
