### PR TITLE
Add privacy policy link to send usage data setting

### DIFF
--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -50,7 +50,7 @@
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
         "branch" : "main",
-        "revision" : "7008973ed30a59a616355f821b96952418af69ef"
+        "revision" : "01d304097ceab29517f8a031a52d0c581d9d4329"
       }
     },
     {

--- a/Client/Assets/top_sites.json
+++ b/Client/Assets/top_sites.json
@@ -391,7 +391,7 @@
   },
   {
     "title": "ecosiainfo",
-    "url": "https://info.ecosia.org/privacy",
+    "url": "https://www.ecosia.org/privacy",
     "image_url": "info-ecosia-org.png",
     "background_color": "#fff",
     "domain": "info.ecosia.org/privacy"

--- a/Client/Ecosia/Settings/EcosiaSettings.swift
+++ b/Client/Ecosia/Settings/EcosiaSettings.swift
@@ -176,10 +176,18 @@ final class EcosiaSendAnonymousUsageDataSetting: BoolSetting {
                   prefKey: "",
                   defaultValue: true,
                   titleText: .localized(.sendUsageDataSettingsTitle),
-                  statusText: .localized(.sendUsageDataSettingsDescription),
+                  statusText: .localized(.sendUsageDataSettingsDescription) + " " + .localized(.learnMore),
                   settingDidChange: { value in
                     User.shared.sendAnonymousUsageData = value
                 })
+    }
+    
+    override var url: URL? {
+        return Environment.current.urlProvider.privacy
+    }
+
+    override func onClick(_ navigationController: UINavigationController?) {
+        setUpAndPushSettingsContentViewController(navigationController, self.url)
     }
 
     override func displayBool(_ control: UISwitch) {


### PR DESCRIPTION
[MOB-1838](https://ecosia.atlassian.net/browse/MOB-1838)

## Context
Follow up to #484.

We have decided to add a learn more "button" redirecting to the privacy policy as consequence to reducing the description. We are using the same approach as FF, adding "Learn More" to the description text and making the whole cell clickable. 

## Approach
- Took advantage of the existing `onClick` and `url` functionalities of the settings items to make it clickable.
- Decided to append the already existing `"Learn More"` translation so that no change in the L10N strings is needed given the upcoming release.
- Update ios-core with changes from [ios-core#96](https://github.com/ecosia/ios-core/pull/96) so that the new privacy policy is used