### PR TITLE
Use empty platform to remove idfv but keep userid

### DIFF
--- a/Client/Ecosia/Analytics/Analytics.swift
+++ b/Client/Ecosia/Analytics/Analytics.swift
@@ -15,10 +15,10 @@ final class Analytics {
             .sessionContext(true)
             .applicationContext(true)
             .platformContext(true)
+            .platformContextProperties([]) // track minimal device properties
             .geoLocationContext(true)
             .deepLinkContext(false)
             .screenContext(false)
-            .userAnonymisation(true)
         
         let subjectConfiguration = SubjectConfiguration()
             .userId(User.shared.analyticsId.uuidString)


### PR DESCRIPTION
[MOB-1738](https://ecosia.atlassian.net/browse/MOB-1738)

Using `.userAnonymisation(true)` has undesired side effects. It does not only remove `idfa` and `idfv` but also zeros the `userId`. We want to keep the `userId`. Therefore we use the approach of using an empty `PlatformContextProperty` array. This results that only the minimal device/platform info is gathered

> The required `osType`, `osVersion`, `deviceManufacturer`, and `deviceModel` properties will be tracked in the entity regardless of this setting.