### PR TITLE
MOB-1580 onboarding analytics

### DIFF
--- a/Client/Ecosia/Analytics/Analytics.Values.swift
+++ b/Client/Ecosia/Analytics/Analytics.Values.swift
@@ -62,7 +62,8 @@ extension Analytics {
         send,
         claim,
         click,
-        change
+        change,
+        display
         
         enum Activity: String {
             case

--- a/Client/Ecosia/Analytics/Analytics.Values.swift
+++ b/Client/Ecosia/Analytics/Analytics.Values.swift
@@ -10,6 +10,7 @@ extension Analytics {
         migration,
         navigation,
         onboarding,
+        intro,
         invitations,
         ntp,
         menu,
@@ -28,8 +29,10 @@ extension Analytics {
             shop,
             faq,
             news,
+            next,
             privacy,
             sendFeedback = "send_feedback",
+            skip,
             terms,
             treecard,
             treestore
@@ -84,11 +87,25 @@ extension Analytics {
         }
     }
     
-    enum Property: String {
+    enum Property {
         case
         home,
         menu,
-        toolbar
+        toolbar,
+        screenName(Int)
+        
+        var rawValue: String {
+            switch self {
+            case .home:
+                return "home"
+            case .menu:
+                return "menu"
+            case .toolbar:
+                return "toolbar"
+            case .screenName(let page):
+                return OnboardingPage.allCases[page].rawValue
+            }
+        }
         
         enum TopSite: String {
             case
@@ -96,6 +113,15 @@ extension Analytics {
             privacy,
             financialReports = "financial_reports",
             howEcosiaWorks = "how_ecosia_works"
+        }
+        
+        enum OnboardingPage: String, CaseIterable {
+            case
+            start,
+            search,
+            profits,
+            action,
+            privacy
         }
     }
 

--- a/Client/Ecosia/Analytics/Analytics.swift
+++ b/Client/Ecosia/Analytics/Analytics.swift
@@ -256,11 +256,20 @@ final class Analytics {
         track(event)
     }
     
-    func onbaordingDisplaying(page: Int) {
+    func introDisplaying(page: Int) {
         let event = Structured(category: Category.intro.rawValue,
                                action: Action.display.rawValue)
             .property(Property.screenName(page).rawValue)
+            .value(.init(integerLiteral: page))
         track(event)
     }
-    
+
+    func introClick(_ label: Label.Navigation, at page: Int) {
+        let event = Structured(category: Category.intro.rawValue,
+                               action: Action.click.rawValue)
+            .label(label.rawValue)
+            .property(Property.screenName(page).rawValue)
+            .value(.init(integerLiteral: page))
+        track(event)
+    }
 }

--- a/Client/Ecosia/Analytics/Analytics.swift
+++ b/Client/Ecosia/Analytics/Analytics.swift
@@ -256,20 +256,28 @@ final class Analytics {
         track(event)
     }
     
-    func introDisplaying(page: Int) {
+    func introDisplaying(page: Property.OnboardingPage?) {
+        guard let page,
+              let pageAsInt = Property.OnboardingPage.allCases.firstIndex(of: page) else {
+            return
+        }
         let event = Structured(category: Category.intro.rawValue,
                                action: Action.display.rawValue)
-            .property(Property.screenName(page).rawValue)
-            .value(.init(integerLiteral: page))
+            .property(Property.screenName(pageAsInt).rawValue)
+            .value(.init(integerLiteral: pageAsInt))
         track(event)
     }
 
-    func introClick(_ label: Label.Navigation, at page: Int) {
+    func introClick(_ label: Label.Navigation, at page: Property.OnboardingPage?) {
+        guard let page,
+              let pageAsInt = Property.OnboardingPage.allCases.firstIndex(of: page) else {
+            return
+        }
         let event = Structured(category: Category.intro.rawValue,
                                action: Action.click.rawValue)
             .label(label.rawValue)
-            .property(Property.screenName(page).rawValue)
-            .value(.init(integerLiteral: page))
+            .property(Property.screenName(pageAsInt).rawValue)
+            .value(.init(integerLiteral: pageAsInt))
         track(event)
     }
 }

--- a/Client/Ecosia/Analytics/Analytics.swift
+++ b/Client/Ecosia/Analytics/Analytics.swift
@@ -256,4 +256,11 @@ final class Analytics {
         track(event)
     }
     
+    func onbaordingDisplaying(page: Int) {
+        let event = Structured(category: Category.intro.rawValue,
+                               action: Action.display.rawValue)
+            .property(Property.screenName(page).rawValue)
+        track(event)
+    }
+    
 }

--- a/Client/Ecosia/UI/Onboarding/Welcome.swift
+++ b/Client/Ecosia/UI/Onboarding/Welcome.swift
@@ -62,6 +62,7 @@ final class Welcome: UIViewController {
         addMask()
         fadeIn()
         didAppear = true
+        Analytics.shared.introDisplaying(page: .start)
     }
 
     private func addOverlay() {
@@ -157,16 +158,16 @@ final class Welcome: UIViewController {
         stack.addArrangedSubview(UIView())
         stack.addArrangedSubview(cta)
 
-        let skip = UIButton(type: .system)
-        skip.backgroundColor = .clear
-        skip.titleLabel?.font = .preferredFont(forTextStyle: .callout)
-        skip.titleLabel?.adjustsFontForContentSizeCategory = true
-        skip.setTitleColor(.Dark.Text.secondary, for: .normal)
-        skip.setTitle(.localized(.skipWelcomeTour), for: .normal)
-        skip.heightAnchor.constraint(equalToConstant: 50).isActive = true
-        skip.addTarget(self, action: #selector(skipTour), for: .primaryActionTriggered)
+        let skipButton = UIButton(type: .system)
+        skipButton.backgroundColor = .clear
+        skipButton.titleLabel?.font = .preferredFont(forTextStyle: .callout)
+        skipButton.titleLabel?.adjustsFontForContentSizeCategory = true
+        skipButton.setTitleColor(.Dark.Text.secondary, for: .normal)
+        skipButton.setTitle(.localized(.skipWelcomeTour), for: .normal)
+        skipButton.heightAnchor.constraint(equalToConstant: 50).isActive = true
+        skipButton.addTarget(self, action: #selector(skip), for: .primaryActionTriggered)
 
-        stack.addArrangedSubview(skip)
+        stack.addArrangedSubview(skipButton)
 
         if view.traitCollection.userInterfaceIdiom == .phone {
             stack.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 16).isActive = true
@@ -278,9 +279,11 @@ final class Welcome: UIViewController {
         tour.modalTransitionStyle = .crossDissolve
         tour.modalPresentationStyle = .overCurrentContext
         present(tour, animated: true, completion: nil)
+        Analytics.shared.introClick(.next, at: .start)
     }
 
-    @objc func skipTour() {
+    @objc func skip() {
+        Analytics.shared.introClick(.skip, at: .start)
         delegate?.welcomeDidFinish(self)
     }
 
@@ -292,6 +295,6 @@ final class Welcome: UIViewController {
 
 extension Welcome: WelcomeTourDelegate {
     func welcomeTourDidFinish(_ tour: WelcomeTour) {
-        skipTour()
+        delegate?.welcomeDidFinish(self)
     }
 }

--- a/Client/Ecosia/UI/Onboarding/WelcomeTour.swift
+++ b/Client/Ecosia/UI/Onboarding/WelcomeTour.swift
@@ -258,11 +258,7 @@ final class WelcomeTour: UIViewController,  NotificationThemeable {
             }
         }
         
-        /*
-         Steps needs to be counted starting from 1
-         so we always top up 1 to the current index
-        */
-        Analytics.shared.introDisplaying(page: onboardingAnalyticsPageFromIndex(currentIndex + 1))
+        Analytics.shared.introDisplaying(page: onboardingAnalyticsPageFromCurrentIndex)
     }
 
     private func moveRight() {
@@ -293,7 +289,9 @@ final class WelcomeTour: UIViewController,  NotificationThemeable {
     // MARK: Actions
     @objc func back() {
         guard !isFirstStep() else {
-            dismiss(animated: true, completion: nil)
+            dismiss(animated: true) {
+                Analytics.shared.introDisplaying(page: .start)
+            }
             return
         }
         let displayingStep = currentIndex - 1
@@ -305,7 +303,7 @@ final class WelcomeTour: UIViewController,  NotificationThemeable {
             complete()
             return
         }
-        Analytics.shared.introClick(.next, at: onboardingAnalyticsPageFromIndex(currentIndex))
+        Analytics.shared.introClick(.next, at: onboardingAnalyticsPageFromCurrentIndex)
         let displayingStep = currentIndex + 1
         display(step: steps[displayingStep])
     }
@@ -315,7 +313,7 @@ final class WelcomeTour: UIViewController,  NotificationThemeable {
     }
 
     @objc func skip() {
-        Analytics.shared.introClick(.skip, at: onboardingAnalyticsPageFromIndex(currentIndex))
+        Analytics.shared.introClick(.skip, at: onboardingAnalyticsPageFromCurrentIndex)
         delegate?.welcomeTourDidFinish(self)
     }
 
@@ -360,7 +358,11 @@ final class WelcomeTour: UIViewController,  NotificationThemeable {
 
 extension WelcomeTour {
     
-    private func onboardingAnalyticsPageFromIndex(_ index: Int) -> Analytics.Property.OnboardingPage? {
-        Analytics.Property.OnboardingPage.allCases[index]
+    private var onboardingAnalyticsPageFromCurrentIndex: Analytics.Property.OnboardingPage? {
+        /*
+         Steps needs to be counted starting from 1
+         so we always top up 1 to the current index
+        */
+        Analytics.Property.OnboardingPage.allCases[currentIndex + 1]
     }
 }

--- a/Client/Ecosia/UI/Onboarding/WelcomeTour.swift
+++ b/Client/Ecosia/UI/Onboarding/WelcomeTour.swift
@@ -257,6 +257,12 @@ final class WelcomeTour: UIViewController,  NotificationThemeable {
                 self.view.layoutIfNeeded()
             }
         }
+        
+        /*
+         Steps needs to be counted starting from 1
+         so we always top up 1 to the current index
+        */
+        Analytics.shared.introDisplaying(page: onboardingAnalyticsPageFromIndex(currentIndex + 1))
     }
 
     private func moveRight() {
@@ -290,18 +296,26 @@ final class WelcomeTour: UIViewController,  NotificationThemeable {
             dismiss(animated: true, completion: nil)
             return
         }
-        display(step: steps[currentIndex - 1])
+        let displayingStep = currentIndex - 1
+        display(step: steps[displayingStep])
     }
 
     @objc func forward() {
         guard !isLastStep() else {
-            skip()
+            complete()
             return
         }
-        display(step: steps[currentIndex + 1])
+        Analytics.shared.introClick(.next, at: onboardingAnalyticsPageFromIndex(currentIndex))
+        let displayingStep = currentIndex + 1
+        display(step: steps[displayingStep])
+    }
+    
+    private func complete() {
+        delegate?.welcomeTourDidFinish(self)
     }
 
     @objc func skip() {
+        Analytics.shared.introClick(.skip, at: onboardingAnalyticsPageFromIndex(currentIndex))
         delegate?.welcomeTourDidFinish(self)
     }
 
@@ -341,5 +355,12 @@ final class WelcomeTour: UIViewController,  NotificationThemeable {
 
     @objc func themeChanged() {
         applyTheme()
+    }
+}
+
+extension WelcomeTour {
+    
+    private func onboardingAnalyticsPageFromIndex(_ index: Int) -> Analytics.Property.OnboardingPage? {
+        Analytics.Property.OnboardingPage.allCases[index]
     }
 }


### PR DESCRIPTION
[MOB-1580](https://ecosia.atlassian.net/browse/MOB-1580)

## Context

We have zero tracking on onboarding screens.
We'd like to start gathering events for button clicks (Get started/Nex” & Skip) as well as the steps being viewed.

## Approach

I've been reviewing the codebase a bit, especially as some implementation in the `Welcome` and `WelcomeTour` was implicitly assumed that skipping the onboarding or completing had essentially the same final outcome.
The code expands and separates the concerns introducing a `complete()` function.

Moreover, the way the `Welcome` screen is being presented and loaded in memory, follows an unconventional view lifecycle pattern, prioritizing animations. In order to achieve proper tracking, the event to display the first page (`.start` - step `0`) needed to be placed in two sections.

From the `pageControl` on, we get the `currentIndex` and increment by `1` so to match the counter "started" at the welcome screen.

## Other

- Small objects renaming
- I wish to apply the same logic done on the `screenName(Int)` for the `TopSite` as well. Decided not to as it's off-context and not big value added.
