### PR TITLE
MOB-1878 Updating version retrieval

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -86,12 +86,14 @@ platform :ios do
   desc "Testflight build for Live Channel"
   lane :testflight_live do
 
+    updated_version_number_from_version_file = File.read("VERSION").gsub!(/\s+/, '')
+
     # udpated_version_number = increment_version_number(
     #   xcodeproj: project,
-    #   version_number: File.read("VERSION")
+    #   version_number: updated_version_number_from_version_file
     # )
 
-    udpated_version_number = File.read("VERSION").gsub!(/\s+/, '')
+    udpated_version_number = updated_version_number_from_version_file
 
     udpated_build_number = increment_build_number(
       build_number: ENV["CIRCLE_BUILD_NUM"]

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -91,7 +91,7 @@ platform :ios do
     #   version_number: File.read("VERSION")
     # )
 
-    udpated_version_number = File.read("VERSION")
+    udpated_version_number = File.read("VERSION").gsub!(/\s+/, '')
 
     udpated_build_number = increment_build_number(
       build_number: ENV["CIRCLE_BUILD_NUM"]


### PR DESCRIPTION
[MOB-1878](https://ecosia.atlassian.net/browse/MOB-1878)

## Context

Throughout some testing, we have noticed that is possible (by mistake 😉) to add either a whitespace/new line before and/or after the version number. 

## Approach

Trimming the retrieved version string before assigning it to the `udpated_version_number` in Fastlane lane