### PR TITLE
Ag 57 58 onboarding accessibility fixes

### DIFF
--- a/Client/Ecosia/L10N/String.swift
+++ b/Client/Ecosia/L10N/String.swift
@@ -193,8 +193,6 @@ extension String {
         case onboardingSkipTourButtonAccessibilityLabel = "Skip the onboarding"
         case onboardingContinueCTAButtonAccessibilityLabel = "Continue to the next onboarding page"
         case onboardingFinishCTAButtonAccessibilityLabel = "Finish onbaording and start contributing to Ecosia"
-        case onboardingStepTitleAccessibilityLabel = "This is the title of the onboarding step"
-        case onboardingStepSubtitleAccessibilityLabel = "This is the subtitle of the onboarding step"
         case cancel = "Cancel"
         case open = "Open"
         case openExternalLinkTitle = "Open link in external app?"

--- a/Client/Ecosia/UI/Onboarding/Welcome.swift
+++ b/Client/Ecosia/UI/Onboarding/Welcome.swift
@@ -138,6 +138,7 @@ final class Welcome: UIViewController {
         let label = UILabel()
         label.numberOfLines = 0
         label.attributedText = introText
+        label.accessibilityLabel = simplestWayString.replacingOccurrences(of: "\n", with: "")
         label.font = .preferredFont(forTextStyle: .largeTitle).bold()
         label.adjustsFontForContentSizeCategory = true
         label.textColor = .white
@@ -247,8 +248,9 @@ final class Welcome: UIViewController {
     }
 
     // MARK: Helper
+    private let simplestWayString = String.localized(.theSimplestWay)
     private var introText: NSAttributedString {
-        let raw = String.localized(.theSimplestWay)
+        let raw = simplestWayString
         let splits = raw.components(separatedBy: .newlines)
 
         guard splits.count == 3 else { return NSAttributedString(string: raw) }

--- a/Client/Ecosia/UI/Onboarding/WelcomeTour.swift
+++ b/Client/Ecosia/UI/Onboarding/WelcomeTour.swift
@@ -302,6 +302,7 @@ final class WelcomeTour: UIViewController,  NotificationThemeable {
             return
         }
         display(step: steps[currentIndex + 1])
+        UIAccessibility.post(notification: .screenChanged, argument: titleLabel)
     }
 
     @objc func skip() {

--- a/Client/Ecosia/UI/Onboarding/WelcomeTour.swift
+++ b/Client/Ecosia/UI/Onboarding/WelcomeTour.swift
@@ -257,10 +257,8 @@ final class WelcomeTour: UIViewController,  NotificationThemeable {
     }
     
     private func updateAccessibilityLabels(step: Step) {
-        titleLabel.accessibilityValue = step.title
-        titleLabel.accessibilityLabel = .localized(.onboardingStepTitleAccessibilityLabel)
-        subtitleLabel.accessibilityValue = step.text
-        subtitleLabel.accessibilityLabel = .localized(.onboardingStepSubtitleAccessibilityLabel)
+        titleLabel.accessibilityLabel = step.title
+        subtitleLabel.accessibilityLabel = step.text
         ctaButton.accessibilityLabel = .localized(isLastStep() ? .onboardingFinishCTAButtonAccessibilityLabel : .onboardingContinueCTAButtonAccessibilityLabel)
     }
 

--- a/Client/Ecosia/UI/Onboarding/WelcomeTour.swift
+++ b/Client/Ecosia/UI/Onboarding/WelcomeTour.swift
@@ -146,8 +146,6 @@ final class WelcomeTour: UIViewController,  NotificationThemeable {
         titleLabel.adjustsFontForContentSizeCategory = true
         titleLabel.setContentCompressionResistancePriority(.required, for: .vertical)
         titleLabel.setContentHuggingPriority(.required, for: .vertical)
-        titleLabel.accessibilityLabel = .localized(.onboardingStepTitleAccessibilityLabel)
-        titleLabel.accessibilityValue = titleLabel.text
         labelStack.addArrangedSubview(titleLabel)
         self.titleLabel = titleLabel
 
@@ -159,8 +157,6 @@ final class WelcomeTour: UIViewController,  NotificationThemeable {
         subtitleLabel.adjustsFontSizeToFitWidth = true
         subtitleLabel.setContentCompressionResistancePriority(.required, for: .vertical)
         subtitleLabel.setContentHuggingPriority(.required, for: .vertical)
-        subtitleLabel.accessibilityLabel = .localized(.onboardingStepSubtitleAccessibilityLabel)
-        subtitleLabel.accessibilityValue = subtitleLabel.text
 
         labelStack.addArrangedSubview(subtitleLabel)
         self.subtitleLabel = subtitleLabel
@@ -171,7 +167,6 @@ final class WelcomeTour: UIViewController,  NotificationThemeable {
         ctaButton.titleLabel?.adjustsFontForContentSizeCategory = true
         ctaButton.translatesAutoresizingMaskIntoConstraints = false
         ctaButton.addTarget(self, action: #selector(forward), for: .primaryActionTriggered)
-        ctaButton.accessibilityLabel = .localized(isLastStep() ? .onboardingFinishCTAButtonAccessibilityLabel : .onboardingContinueCTAButtonAccessibilityLabel)
         ctaButton.alpha = 0
         view.addSubview(ctaButton)
         self.ctaButton = ctaButton
@@ -257,6 +252,16 @@ final class WelcomeTour: UIViewController,  NotificationThemeable {
                 self.view.layoutIfNeeded()
             }
         }
+        
+        updateAccessibilityLabels(step: step)
+    }
+    
+    private func updateAccessibilityLabels(step: Step) {
+        titleLabel.accessibilityValue = step.title
+        titleLabel.accessibilityLabel = .localized(.onboardingStepTitleAccessibilityLabel)
+        subtitleLabel.accessibilityValue = step.text
+        subtitleLabel.accessibilityLabel = .localized(.onboardingStepSubtitleAccessibilityLabel)
+        ctaButton.accessibilityLabel = .localized(isLastStep() ? .onboardingFinishCTAButtonAccessibilityLabel : .onboardingContinueCTAButtonAccessibilityLabel)
     }
 
     private func moveRight() {


### PR DESCRIPTION
[AG-57](https://ecosia.atlassian.net/browse/AG-57)
[AG-58](https://ecosia.atlassian.net/browse/AG-58)

## Context
Follow-up of #474.

There were a couple issues found with the accessibility improvements made on the onboarding.
1) Welcome page still voices over the images in the text as “attachment png“
2) All onboarding pages are using the first title and subtitle, i.e. accessibility title and subtitle not updating

## Approach
1) Use the localized text before adding the image attachments as accessibility label. Also removing the new lines from it so it does not add pauses when voicing over.
2) Move the update of the accessibility labels from `addDynamicViews()` to `display()`, since the first only happens once, while the latter happens every time the content is updated.

## Additional improvents
- Removed the "This is the onboarding title" and "This is the onboarding subtitle" voice over and left only the actual value, since it makes going over the onboarding faster and less repetitive.
- Since we re-use the same screen for all onboarding steps, it was not jumping back to the top after the user changes steps. That's why I added a `UIAccessibility` notification to force it to change to the title after a new step is displayed.
