### PR TITLE
MOB-1841 Add analytics opt out tracking event

### DIFF
--- a/Client/Ecosia/Analytics/Analytics.swift
+++ b/Client/Ecosia/Analytics/Analytics.swift
@@ -42,7 +42,7 @@ final class Analytics {
     
     private func track(_ event: Event) {
         guard User.shared.sendAnonymousUsageData else { return }
-        tracker.track(event)
+        _ = tracker.track(event)
     }
     
     private static func getTestContext(from toggle: Unleash.Toggle.Name) -> SelfDescribingJson? {
@@ -279,5 +279,14 @@ final class Analytics {
             .property(Property.screenName(pageAsInt).rawValue)
             .value(.init(integerLiteral: pageAsInt))
         track(event)
+    }
+    
+    func sendAnonymousUsageDataSetting(enabled: Bool) {
+        // This is the only place where the tracker should be directly
+        // used since we want to send this just as the user opts out
+        _ = tracker.track(Structured(category: Category.settings.rawValue,
+                                     action: Action.change.rawValue)
+            .label("analytics")
+            .property(enabled ? "enable" : "disable"))
     }
 }

--- a/Client/Ecosia/Settings/EcosiaSettings.swift
+++ b/Client/Ecosia/Settings/EcosiaSettings.swift
@@ -178,8 +178,9 @@ final class EcosiaSendAnonymousUsageDataSetting: BoolSetting {
                   titleText: .localized(.sendUsageDataSettingsTitle),
                   statusText: .localized(.sendUsageDataSettingsDescription) + " " + .localized(.learnMore),
                   settingDidChange: { value in
-                    User.shared.sendAnonymousUsageData = value
-                })
+            User.shared.sendAnonymousUsageData = value
+            Analytics.shared.sendAnonymousUsageDataSetting(enabled: value)
+        })
     }
     
     override var url: URL? {


### PR DESCRIPTION
[MOB-1841](https://ecosia.atlassian.net/browse/MOB-1841)

## Context

We want to track if users are opting out of analytics or not.

We still want to send this last event before the user opts out.

## Approach

Most of it is quite straight forward. The only issue found was guaranteeing that the event was sent even when sending was just disabled. I thought about some approaches listed below:

- If enabled, send event after changing user object and if disabled sending it before.
❌ Found it too cumbersome and not readable

- Adding a force option to the private `track` method that force passes the `guard` condition
❌ Enables other methods to use it, which is not intended

- Directly use `tracker` inside the specific analytics event method with a comment explaining
✅ Is readable and makes it clear this is an exception


## Other

Also added an empty variable declaration (`_ = `) to silence some warnings.
