### PR TITLE
MOB-1881 Fix insecure connection visible

### DIFF
--- a/Client/Ecosia/Extensions/URL+Ecosia.swift
+++ b/Client/Ecosia/Extensions/URL+Ecosia.swift
@@ -17,8 +17,9 @@ extension URL {
     /// having issues to load
     /// In case at least one of the flags evaluates to `true`, we consider the URL secure.
     public var isSecure: Bool {
-        let isOriginalUrlFromErrorPageSecure = InternalURL(self)?.originalURLFromErrorPage?.isHTTPS ?? false
-        let securityFlags = [isOriginalUrlFromErrorPageSecure, isHTTPS, isReaderModeURL]
+        let isOriginalUrlFromErrorPageSecure = InternalURL(self)?.originalURLFromErrorPage?.isHTTPS == true
+        let internalUrlIsNotErrorPage = InternalURL(self)?.isErrorPage == false
+        let securityFlags = [isOriginalUrlFromErrorPageSecure, internalUrlIsNotErrorPage, isHTTPS, isReaderModeURL]
         return securityFlags.first(where: { $0 == true }) ?? false
     }
 }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -1292,6 +1292,7 @@ class BrowserViewController: UIViewController {
         case .loading:
             guard let loading = change?[.newKey] as? Bool else { break }
             setupMiddleButtonStatus(isLoading: loading)
+            urlBar.locationView.toggleURLProtectionButtonVisibility(loading)
         case .URL:
             // Special case for "about:blank" popups, if the webView.url is nil, keep the tab url as "about:blank"
             if tab.url?.absoluteString == "about:blank" && webView.url == nil {

--- a/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
+++ b/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
@@ -326,6 +326,10 @@ extension TabLocationView {
     private var isTrackingProtectionHidden: Bool {
         trackingProtectionButton.evaluateNeedingVisbilityForURLScheme(url?.scheme)
     }
+    
+    func toggleURLProtectionButtonVisibility(_ isLoading: Bool = false) {
+        trackingProtectionButton.alpha = isLoading ? 0 : 1
+    }
 }
 
 extension TabLocationView: TabEventHandler {


### PR DESCRIPTION
[MOB-1881](https://ecosia.atlassian.net/browse/MOB-1881)

## Context

We have realized that the icon was adding an inconsistent state when visiting websites expositing it to different statuses.

## Approach

We have implemented a fix that not only solves the issue but also improves the UX given the ratio of codebase complexity/time.

## Other

We have explored other solutions like transitioning the icon from the left-hand side to the right, but then realized that not only may be difficult to maintain in the future given the complexity of the codebase and the vastity of edge cases we may need to consider (on top of accessibility and motion).

