### PR TITLE
MOB-1879 Add link attribute to send usage setting learn more text

### DIFF
--- a/Client/Ecosia/Settings/EcosiaSettings.swift
+++ b/Client/Ecosia/Settings/EcosiaSettings.swift
@@ -172,11 +172,19 @@ final class EcosiaTermsSetting: Setting {
 
 final class EcosiaSendAnonymousUsageDataSetting: BoolSetting {
     convenience init(prefs: Prefs) {
+        let titleText = NSAttributedString(string: .localized(.sendUsageDataSettingsTitle))
+        
+        let descriptionText: String = .localized(.sendUsageDataSettingsDescription)
+        let learnMoreText: String = .localized(.learnMore)
+        let statusText = NSMutableAttributedString(string: descriptionText + " " + learnMoreText)
+        let privacyLink = Environment.current.urlProvider.privacy
+        statusText.addAttributes([.link: privacyLink], range: .init(location: descriptionText.count + 1, length: learnMoreText.count))
+        
         self.init(prefs: prefs,
                   prefKey: "",
                   defaultValue: true,
-                  titleText: .localized(.sendUsageDataSettingsTitle),
-                  statusText: .localized(.sendUsageDataSettingsDescription) + " " + .localized(.learnMore),
+                  attributedTitleText: titleText,
+                  attributedStatusText: statusText,
                   settingDidChange: { value in
             User.shared.sendAnonymousUsageData = value
             Analytics.shared.sendAnonymousUsageDataSetting(enabled: value)


### PR DESCRIPTION
[MOB-1879](https://ecosia.atlassian.net/browse/MOB-1879)

## Context
Follow-up of #484.

After implementing the previous solution, some more UX consideration was requested to hyperlink the Learn More text.

## Approach
Further elaboration on the attempts bellow, but in the end opted for setting the attributed link parameter to the string, even if that only changes the UI but **does not enable clicking**. Clicking was then kept as the whole cell. 

### Attempts
Tried adding the link attribute to the text and setting the label `isUserInteractionEnabled` to true which should work, but it only sets the UI of the label and does not responds to the click. 

After some research, I did some other attempts like using `UITextView`, using a custom cell instead of the built in `detailTextLabel`, investigating the responder for something blocking the interaction and attempting to disable the whole cell selection. Even so, seems to not be straight forward and even did not work when I tried in a different scope.

Also, the custom `Setting` object (legacy from FF) we use inside the `SettingsTableViewController` has a lot built in and is hard to refactor. Would argue we should move away from it if we intend on customising more the settings screen, but that would take longer. Also seem that this was not updated on FF's repo since our last sync.

## Risk
The built in [detailTextLabel](https://developer.apple.com/documentation/uikit/uitableviewcell/1623273-detailtextlabel) used is deprecated and will be removed in a later iOS version (same for [textLabel](https://developer.apple.com/documentation/uikit/uitableviewcell/1623210-textlabel) and [imageView](https://developer.apple.com/documentation/uikit/uitableviewcell/1623270-imageview)). This means we will need to change it at some point and that FF will at some point update it - which we could take advantage of then.
