### PR TITLE
MOB-1882 Fix png data memory issue

### DIFF
--- a/Client/Ecosia/UI/Ecosia.xcassets/noInternet.imageset/Contents.json
+++ b/Client/Ecosia/UI/Ecosia.xcassets/noInternet.imageset/Contents.json
@@ -2,16 +2,7 @@
   "images" : [
     {
       "filename" : "noInternet.pdf",
-      "idiom" : "universal",
-      "scale" : "1x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "2x"
-    },
-    {
-      "idiom" : "universal",
-      "scale" : "3x"
+      "idiom" : "universal"
     }
   ],
   "info" : {

--- a/Client/Frontend/InternalSchemeHandler/InternalSchemeHandler.swift
+++ b/Client/Frontend/InternalSchemeHandler/InternalSchemeHandler.swift
@@ -17,6 +17,8 @@ protocol InternalSchemeResponse {
 }
 
 class InternalSchemeHandler: NSObject, WKURLSchemeHandler {
+    
+    private static let noInternetPNGData = UIImage(named: "noInternet")?.pngData()
 
     static func response(forUrl url: URL) -> URLResponse {
         return URLResponse(url: url, mimeType: "text/html", expectedContentLength: -1, textEncodingName: "utf-8")
@@ -45,7 +47,7 @@ class InternalSchemeHandler: NSObject, WKURLSchemeHandler {
                 urlSchemeTask.didFinish()
                 return true
             } else if path.hasSuffix("EcosiaErrorPlaceholderPath.png"),
-                      let data = UIImage(named: "noInternet")?.pngData() {
+                      let data = Self.noInternetPNGData {
                 urlSchemeTask.didReceive(URLResponse(url: url, mimeType: nil, expectedContentLength: -1, textEncodingName: nil))
                 urlSchemeTask.didReceive(data)
                 urlSchemeTask.didFinish()


### PR DESCRIPTION
[MOB-1882](https://ecosia.atlassian.net/browse/MOB-1882)

## Context

We identified a crash when showing the `noInternet` image on the "No Internet" screen.
The crash was reported as part of the ticket.

## Preface

Based on the crash log provided, the crash is happening when trying to create a PNG representation of a `UIImage`. Specifically, the crash happens inside the `UIImagePNGRepresentation` method call in the UIKit library (`UIImage(named: "noInternet")?.pngData()`).
This will likely causing memory issues, which results in the termination of the app.

#### Why might this method cause a memory issue?

Multiuple reasons, of course (depending on the device state, background activities etc...).
What we can do it mitigate the risk, handling the memory slightly better.

#### How?

The `UIImagePNGRepresentation` (or `pngData()`) method can be particularly heavy on memory usage, especially for larger images (not likely this scenario, though).
When it's used frequently or in concurrent threads, it can lead to memory issues and crashes (app terminations).
Given the scenario, the representation logic is involved (each time we refresh an URL in case of this specific feature), creating the `UIImage` and then converting it to PNG data using `pngData()` can temporarily increase memory usage, and if memory is already at a high level, it could lead to a crash. Of course the, `UIImage` instance created by `UIImage(named: "noInternet")` will be deallocated at the end of the block, but the process of transforming it to `pngData()` is consuming more resources on demand.

## Approach

Given the entity of the image itself (not a huge one), I ended up storing the PNG data as a static property, so it can help reduce the memory issue event by ensuring the data is only created once, rather than every time the method is called.

## Other

As suggested in the ticket, the `noInternet` image is a PDF one so it should be valid to accept a single scale universally.
In previous versions, the Single Scale was selected by default when adding a PDF. That's not the case anymore. However, as we don't need multiple scales, I've converted the assets to a single scale one for consistency. 