### PR TITLE
Re-mergning workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,24 +70,7 @@ orbs:
   path-filtering: circleci/path-filtering@0.1.1
 
 workflows:
-
-  build-and-upload-for-testing:
-    jobs:
-      - build-testflight-deploy-beta:
-          name: Deploy beta version over Testflight
-          filters:
-            tags:
-              only: /^beta.*/
-            branches:
-              ignore: /.*/
-      - build-appcenter-deploy:
-          name: Deploy ad-hoc version over AppCenter
-          filters:
-            branches:
-              only: 
-                - /^.*main.*/
-
-  build-and-upload-to-testflight-live:
+  build-and-upload-to-delivery-platforms:
     jobs:
       - path-filtering/filter:
           filters:
@@ -98,3 +81,16 @@ workflows:
           config-path: .circleci/deploy-release.yml
           mapping: |
             Client/Configuration/Common.xcconfig deploy-release true
+      - build-and-deploy-testflight-beta:
+          name: Deploy beta version over Testflight
+          filters:
+            tags:
+              only: /^beta.*/
+            branches:
+              ignore: /.*/
+      - build-and-deploy-appcenter:
+          name: Deploy ad-hoc version over AppCenter
+          filters:
+            branches:
+              only: 
+                - /^.*main.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ setup: true
 
 jobs:
 
-  build-testflight-deploy-beta:
+  build-and-deploy-testflight-beta:
     environment:
       CI: true
     macos:
@@ -35,7 +35,7 @@ jobs:
           name: Build and deploy to Testflight
           command: bundle exec fastlane testflight_beta
 
-  build-appcenter-deploy:
+  build-and-deploy-appcenter:
     environment:
       CI: true
     macos:


### PR DESCRIPTION
## Context

The insidious issue `⚠️ Max number of workflows exceeded.` appeared again due to the Workflow's split throughout the release process updates.

## Approach

As eventually we kept the path-filtering orb, there is no need of having two separated workflows.
Re-merging 👍 

## Other

Small renaming for consistency 😉 