### PR TITLE
MOB-1879 Remove learn more link from usage data setting

### DIFF
--- a/Client/Ecosia/Settings/EcosiaSettings.swift
+++ b/Client/Ecosia/Settings/EcosiaSettings.swift
@@ -176,19 +176,11 @@ final class EcosiaSendAnonymousUsageDataSetting: BoolSetting {
                   prefKey: "",
                   defaultValue: true,
                   titleText: .localized(.sendUsageDataSettingsTitle),
-                  statusText: .localized(.sendUsageDataSettingsDescription) + " " + .localized(.learnMore),
+                  statusText: .localized(.sendUsageDataSettingsDescription),
                   settingDidChange: { value in
             User.shared.sendAnonymousUsageData = value
             Analytics.shared.sendAnonymousUsageDataSetting(enabled: value)
         })
-    }
-    
-    override var url: URL? {
-        return Environment.current.urlProvider.privacy
-    }
-
-    override func onClick(_ navigationController: UINavigationController?) {
-        setUpAndPushSettingsContentViewController(navigationController, self.url)
     }
 
     override func displayBool(_ control: UISwitch) {


### PR DESCRIPTION
[MOB-1879](https://ecosia.atlassian.net/browse/MOB-1879)

## Context
Follow-up of #484.

After implementing the previous solution, some more UX consideration was requested to hyperlink the Learn More text. Given that we do not have a specific link for it (were directing to the privacy page, same as the above setting) and that it was not technically straightforward to implement this solution (investigated in #506), it was decided to instead remove the Learn More text and link.

## Approach
Remove the "Learn More" text that was appended previously and removing click functionality from the item.
