### PR TITLE
MOB-1885 google market flagger

### DIFF
--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -50,7 +50,7 @@
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
         "branch" : "main",
-        "revision" : "145eae41d16dfe7b77510ae61a546fc905650646"
+        "revision" : "1503a03756fd832de9f2f6ad1817e1ea00b80d67"
       }
     },
     {

--- a/Client/Ecosia/FeatureManagement/FeatureManagement.swift
+++ b/Client/Ecosia/FeatureManagement/FeatureManagement.swift
@@ -13,7 +13,7 @@ struct FeatureManagement {
     static func fetchConfiguration() {
         Task {
             do {
-                try await _ = Unleash.start(env: .current)
+                try await _ = Unleash.start(env: .current, appVersion: AppInfo.ecosiaAppVersion)
             } catch {
                 debugPrint(error)
             }

--- a/Client/Ecosia/Settings/EcosiaDebugSettings.swift
+++ b/Client/Ecosia/Settings/EcosiaDebugSettings.swift
@@ -190,7 +190,7 @@ final class UnleashDefaultBrowserSetting: HiddenSetting {
     override func onClick(_ navigationController: UINavigationController?) {
         Task {
             do {
-                _ = try await Unleash.reset(env: .current)
+                _ = try await Unleash.reset(env: .current, appVersion: AppInfo.ecosiaAppVersion)
             } catch {
                 debugPrint(error)
             }


### PR DESCRIPTION
[MOB-1885](https://ecosia.atlassian.net/browse/MOB-1885)

## Context

We will have different UX for Google and Non-Google Markets. We need a business logic component that tells us which version to use based on the user’s device regional settings.

## Approach

Updated project counterpart with the latest core changes