### PR TITLE
MOB-1910 Fix bookmarks tracking analytics opt out

### DIFF
--- a/Client/Ecosia/Analytics/Analytics.swift
+++ b/Client/Ecosia/Analytics/Analytics.swift
@@ -262,7 +262,7 @@ final class Analytics {
                                action: Action.click.rawValue)
             .label(Label.Bookmarks.importFunctionality.rawValue)
             .property(property.rawValue)
-        tracker.track(event)
+        track(event)
     }
 
     func bookmarksEmptyLearnMoreClicked() {
@@ -270,14 +270,14 @@ final class Analytics {
                                action: Action.click.rawValue)
             .label(Label.Bookmarks.learnMore.rawValue)
             .property(Property.Bookmarks.emptyState.rawValue)
-        tracker.track(event)
+        track(event)
     }
     
     func bookmarksNtp(action: Action.Promo) {
         let event = Structured(category: Category.bookmarks.rawValue,
                                action: action.rawValue)
             .label(Label.Bookmarks.bookmarksPromo.rawValue)
-        tracker.track(event)
+        track(event)
     }
     
     func bookmarksImportEnded(_ property: Property.Bookmarks) {
@@ -285,7 +285,7 @@ final class Analytics {
                                action: Action.Bookmarks.import.rawValue)
             .label(Label.Bookmarks.import.rawValue)
             .property(property.rawValue)
-        tracker.track(event)
+        track(event)
     }
     
     func introClick(_ label: Label.Navigation, at page: Property.OnboardingPage?) {


### PR DESCRIPTION
[MOB-1910](https://ecosia.atlassian.net/browse/MOB-1910)

## Context
The bookmarks feature was in #437 PR for a long time while we waited for it to be tested.

In the meantime, analytics opt out was implemented in #484.

When bookmarks was merged, it was not properly integrated into the analytics opt out and therefore its tracking events were still being sent even after the user decides to opt out.

## Approach
Use the expected helper method on the bookmarks events instead of directly using the tracker.
