### PR TITLE
MOB-1912 Returning the Ecosia's Mobile UA as default one

### DIFF
--- a/Shared/UserAgent.swift
+++ b/Shared/UserAgent.swift
@@ -54,7 +54,8 @@ open class UserAgent {
 
 
     public static func mobileUserAgent() -> String {
-        return UserAgentBuilder.defaultMobileUserAgent().userAgent()
+        // Ecosia: Always returns the Ecosia's UA as default one
+        return UserAgentBuilder.ecosiaMobileUserAgent().userAgent()
     }
 
     public static func oppositeUserAgent(domain: String) -> String {
@@ -108,9 +109,7 @@ public struct CustomUserAgentConstant {
     public static let customUAFor = [
         "paypal.com": defaultMobileUA,
         "yahoo.com": defaultMobileUA,
-        "disneyplus.com": customDesktopUA,
-        URLProvider.production.domain: ecosiaMobileUA,
-        URLProvider.staging.domain: ecosiaMobileUA]
+        "disneyplus.com": customDesktopUA]
 
     public static let customDesktopUAFor = [
         URLProvider.production.domain: ecosiaDesktopUA,

--- a/Shared/UserAgent.swift
+++ b/Shared/UserAgent.swift
@@ -102,7 +102,6 @@ public enum UserAgentPlatform {
 public struct CustomUserAgentConstant {
     private static let defaultMobileUA = UserAgentBuilder.defaultMobileUserAgent().userAgent()
     private static let customDesktopUA = UserAgentBuilder.defaultDesktopUserAgent().clone(extensions: "Version/\(AppInfo.appVersion) \(UserAgent.uaBitSafari)")
-    private static let ecosiaMobileUA = UserAgentBuilder.ecosiaMobileUserAgent().userAgent()
     private static let ecosiaDesktopUA = "\(UserAgent.desktopUserAgent) \(UserAgent.uaBitEcosia)"
 
 


### PR DESCRIPTION
[MOB-1912](https://ecosia.atlassian.net/browse/MOB-1912)

## Context

Noticed that Cloudflare triggers an endless challenge on ecosia.org via the Ecosia iOS Mobile app.

## Approach

Investigation via:
- reproducing the issue with the help of Site Reliability engineers
- comparing with FF codebase
- investigating Ecosia’s codebase

### Outcome

The issue is a question regards the Cloudflare challenge being extremely long (potentially endless) on iOS Apps.
On Android, this issue is not happening.
We got back from Cloudflare support confirming that the challenge can't get through when a User Agent isn't the same.
We could verify that, on Android, the User Agent utilized throughout the request always contains the Ecosia App's info.
On iOS, instead, the Ecosia App's Info is only appended for Ecosia's domains (specifically Staging and Production).
After running some tests, we ended up replacing the default app's User Agent with the Ecosia's UA.