### PR TITLE
Fix testing when `SharedTests` only needs testing

### DIFF
--- a/.github/actions/perform_tests/action.yml
+++ b/.github/actions/perform_tests/action.yml
@@ -21,7 +21,7 @@ runs:
     - name: Run tests based on file changes
       shell: bash
       run: |
-        bundles_under_testing="$(${{ inputs.needs-shared-tests }} && echo "SharedTests,")$(${{ inputs.needs-storage-tests }} && echo "StorageTests,")$(${{ inputs.needs-client-tests }} && echo "ClientTests,")"
+        bundles_under_testing=$(echo "$(${{ inputs.needs-shared-tests }} && echo "SharedTests,")$(${{ inputs.needs-storage-tests }} && echo "StorageTests,")$(${{ inputs.needs-client-tests }} && echo "ClientTests,")" | sed 's/,$//')
         bundle exec fastlane run run_tests derived_data_path:"BuildDerivedData" only_testing:"$bundles_under_testing"
 
     - name: Publish Test Report


### PR DESCRIPTION
## Context

Tests are failing when the `,` is appended as for the last char of `bundles_under_testing` only when `SharedTests` are being tested.

## Approach

Stripping out comma `,` from `bundles_under_testing`
