### PR TITLE
Update release notes source file for 8.3.0

### DIFF
--- a/fastlane/metadata/de-DE/release_notes.txt
+++ b/fastlane/metadata/de-DE/release_notes.txt
@@ -1,7 +1,1 @@
-Neue Funktionen:
-- Du kannst jetzt Lesezeichen aus anderen Browsern importieren, die das Exportieren von Lesezeichen als HTML-Datei unterstützen (wie z. B. Chrome, Firefox, oder Safari)
-- Du kannst jetzt Lesezeichen als HTML-Datei exportieren
-- Fehlerbehebung für Apple Wallet-Karten
-
-Wir arbeiten immer hart daran, Ecosia für Dich zu verbessern. Schicke uns gerne Fragen oder Feedback an iosapp@ecosia.org. Wir freuen uns, von dir zu hören!
 

--- a/fastlane/metadata/en-US/release_notes.txt
+++ b/fastlane/metadata/en-US/release_notes.txt
@@ -1,7 +1,4 @@
-New features:
-- You can now import your bookmarks from other browsers that support bookmark export to a html file (like Chrome, Firefox, Safari and more)
-- You can now export your bookmarks into a html file
-- Bugfix for Apple wallet passes
+Bug fixes and general improvements, most notably addressing a bug that caused slow loading when checking whether the page is secure.
+
 
 We are always working hard to make Ecosia better for you. Send any questions or feedback to our team at iosapp@ecosia.org, we love hearing from you!
-

--- a/fastlane/metadata/es-ES/release_notes.txt
+++ b/fastlane/metadata/es-ES/release_notes.txt
@@ -1,7 +1,1 @@
-Nuevaas funciones:
-- Ahora puedes importar tus marcadores desde otros navegadores que permitan la exportación de marcadores a un archivo html (como Chrome, Firefox, Safari y muchos más)
-- Ahora puedes exportar marcadores a un archivo html
-- Corrección de errores en los pases de monedero de Apple
-
-Siempre trabajamos para que Ecosia sea mejor para ti. Envía cualquier duda o comentarios a nuestro equipo a la dirección iosapp@ecosia.org, ¡nos encanta escucharte!
 

--- a/fastlane/metadata/fr-FR/release_notes.txt
+++ b/fastlane/metadata/fr-FR/release_notes.txt
@@ -1,7 +1,1 @@
-Nouvelles fonctionnalités :
-- Vous pouvez désormais importer vos marque-pages depuis d'autres navigateurs compatibles avec l'exportation de marque-pages vers un fichier html (comme Chrome, Firefox, Safari et d'autres)
-- Vous pouvez désormais exporter vos marque-pages vers un fichier html
-- Réparation de bugs pour les pass Wallet d'Apple
-
-Nous travaillons sans relâche pour améliorer Ecosia pour vous. Si vous avez des questions ou des remarques, n'hésitez pas à les communiquer à notre équipe à l'adresse iosapp@ecosia.org. Nous serons ravis d'avoir de vos nouvelles !
 

--- a/fastlane/metadata/it/release_notes.txt
+++ b/fastlane/metadata/it/release_notes.txt
@@ -1,7 +1,1 @@
-Nuove funzioni:
-- Ora puoi importare i tuoi segnalibri da altri browser che supportano l’esportazione di segnalibri in html (come Chrome, Firefox, Safari e altri ancora)
-- Ora puoi esportare i tuoi segnalibri in html
-- Risoluzione di problemi per i pass di Apple Wallet
-
-Siamo sempre al lavoro per migliorare la tua esperienza con Ecosia. Puoi inviare domande o osservazioni al nostro team a iosapp@ecosia.org. Saremo felici di ascoltare la tua opinione!
 

--- a/fastlane/metadata/nl-NL/release_notes.txt
+++ b/fastlane/metadata/nl-NL/release_notes.txt
@@ -1,7 +1,1 @@
-Nieuwe functies:
-- Je kunt nu bladwijzers importeren vanuit andere browsers die het exporteren van bladwijzers naar een *.html-bestand ondersteunen (bijvoorbeeld Chrome, Firefox, Safari en meer)
-- Je kunt nu je bladwijzers exporteren naar een *.html-bestand
-- Bugfix voor Apple Wallet-pasjes
-
-We werken er altijd hard aan om Ecosia voor jou beter te maken. Stuur ons team vragen of feedback via iosapp@ecosia.org. We horen graag van je!
 


### PR DESCRIPTION
## Context
We have created a release candidate 8.3.0 that needs new release notes.

## Approach
Updated the release notes source file with a suggested text, as described [here](https://github.com/ecosia/ios-browser#add-source-release-notes-to-transifex-en-us).

Tried to keep the pattern of how we commonly write release notes, also describing any highlight such as the Cloudflare endless loading fix.

## Other
@ecotopian it is my first time doing it, but if I understood correctly there is no extra review from anyone besides ourselves for those texts, let me know if that is not the case and I should reach out to someone 🙂 
