### PR TITLE
MOB-1929 Updated `appOpenAsDefaultBrowser()`

### DIFF
--- a/Client/Ecosia/Analytics/Analytics.swift
+++ b/Client/Ecosia/Analytics/Analytics.swift
@@ -103,9 +103,16 @@ final class Analytics {
     }
     
     func appOpenAsDefaultBrowser() {
-        track(Structured(category: Category.external.rawValue,
-                         action: Action.receive.rawValue)
-            .label("default_browser_deeplink"))
+        let event = Structured(category: Category.external.rawValue,
+                               action: Action.receive.rawValue)
+            .label("default_browser_deeplink")
+        
+        // add A/B Test context
+        if let context = Self.getTestContext(from: .defaultBrowser) {
+            event.contexts.append(context)
+        }
+        
+        track(event)
     }
     
     func defaultBrowser(_ action: Action.Promo) {


### PR DESCRIPTION
[MOB-1929](https://ecosia.atlassian.net/browse/MOB-1929)

## Context

We have realized that the current acknowledgment of whether Ecosia was set as the default browser isn't organic enough.
We would like to leverage the current test setup for `mob_ios_default_browser` to accommodate the event when the Ecosia App gets opened as a default browser.

## Approach

As per the JIRA ticket description, I've enriched the `appOpenAsDefaultBrowser()` with the context implemented in `defaultBrowser(:)`.

I've also updated our shared sheet with the Structured info of the `appOpenAsDefaultBrowser()` event.


[MOB-1929]: https://ecosia.atlassian.net/browse/MOB-1929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ