### PR TITLE
MOB-1939 Fixed version check when updating from the same version or minor

### DIFF
--- a/Client/Ecosia/UI/WhatsNew/DataProvider/WhatsNewLocalDataProvider.swift
+++ b/Client/Ecosia/UI/WhatsNew/DataProvider/WhatsNewLocalDataProvider.swift
@@ -85,9 +85,9 @@ final class WhatsNewLocalDataProvider: WhatsNewDataProvider {
     private func evaluateVersionNeedsUpdate() {
         let isVersionNil = fromVersion == nil
         let isVersionLowerThanCurrent = fromVersion != nil && fromVersion! < toVersion
-        
-        if isVersionNil ||
-            isVersionLowerThanCurrent {
+        let isVersionSameAsCurrent = fromVersion != nil && fromVersion! == toVersion
+                
+        if isVersionNil || (isVersionLowerThanCurrent && !isVersionSameAsCurrent) {
             Version.updateFromCurrent(forKey: Self.appVersionUpdateKey)
         }
     }
@@ -100,11 +100,17 @@ final class WhatsNewLocalDataProvider: WhatsNewDataProvider {
         evaluateVersionNeedsUpdate()
         
         // Ensure fromVersion is available.
-        guard let fromVersion else { return [] }
+        guard let fromVersion = self.fromVersion else { return [] }
+        
+        // If there's no update (i.e., the versions are the same), we shouldn't return any versions.
+        guard fromVersion != toVersion else { return [] }
         
         // Gather all versions
         let allVersions = Array(whatsNewItems.keys).sorted()
         
+        // Ensure the `toVersion` is equal to or bigger than the smallest version in `whatsNewItems`
+        guard toVersion >= allVersions.first! else { return [] }
+
         // Find the closest previous version or use the first one if `from` is older than all versions.
         let fromIndex = allVersions.lastIndex { $0 <= fromVersion } ?? 0
 

--- a/Client/Ecosia/UI/WhatsNew/DataProvider/WhatsNewLocalDataProvider.swift
+++ b/Client/Ecosia/UI/WhatsNew/DataProvider/WhatsNewLocalDataProvider.swift
@@ -108,8 +108,11 @@ final class WhatsNewLocalDataProvider: WhatsNewDataProvider {
         // Gather all versions
         let allVersions = Array(whatsNewItems.keys).sorted()
         
+        // Gather first item in `allVersions` array
+        guard let firstItemInAllVersions = allVersions.first else { return [] }
+        
         // Ensure the `toVersion` is equal to or bigger than the smallest version in `whatsNewItems`
-        guard toVersion >= allVersions.first! else { return [] }
+        guard toVersion >= firstItemInAllVersions else { return [] }
 
         // Find the closest previous version or use the first one if `from` is older than all versions.
         let fromIndex = allVersions.lastIndex { $0 <= fromVersion } ?? 0

--- a/Tests/ClientTests/Ecosia/VersionTests.swift
+++ b/Tests/ClientTests/Ecosia/VersionTests.swift
@@ -80,6 +80,48 @@ final class VersionTests: XCTestCase {
 
 extension VersionTests {
     
+    func testFakeUpdateToSameVersionAgainstLocalDataProviderItemsData() {
+        
+        // Setup
+        let version = Version("8.3.0")!
+        let appVersionInfoProvider = MockAppVersionInfoProvider(mockedAppVersion: version.description)
+        let dataProvider = WhatsNewLocalDataProvider()
+        
+        // Given: An initial version of 8.3.0 and a "toVersion" of 8.3.0
+        Version.updateFromCurrent(forKey: Self.appVersionUpdateTestKey,
+                                  provider: appVersionInfoProvider)
+        
+        // When: We retrieve the What's New items after this "fake" update
+        let items = try? dataProvider.getData()
+        
+        // Then: We should not have items for versions beyond 8.3.0 (like 9.0.0)
+        XCTAssertTrue(items?.isEmpty == true, "WhatsNewItem list should be empty for fake update to same version")
+    }
+    
+    func testFakeUpdateToMinorVersionAgainstLocalDataProviderItemsData() {
+        
+        // Setup
+        let fromVersion = Version("8.3.0")!
+        let toVersion = Version("8.3.1")!
+        let appVersionInfoProvider = MockAppVersionInfoProvider(mockedAppVersion: toVersion.description)
+        let dataProvider = WhatsNewLocalDataProvider()
+
+        // Given: An initial version of 8.3.0 and a "toVersion" of 8.3.1
+        Version.updateFromCurrent(forKey: Self.appVersionUpdateTestKey, provider: MockAppVersionInfoProvider(mockedAppVersion: fromVersion.description))
+        
+        // When: We perform a fake update to 8.3.1
+        Version.updateFromCurrent(forKey: Self.appVersionUpdateTestKey, provider: appVersionInfoProvider)
+        
+        // And: We retrieve the What's New items after this update
+        let items = try? dataProvider.getData()
+        
+        // Then: We should not have items for versions beyond 8.3.1 (like 9.0.0)
+        XCTAssertTrue(items?.isEmpty == true, "WhatsNewItem list should be empty for an update to minor version when there are items for upper versions")
+    }
+}
+
+extension VersionTests {
+    
     struct MockAppVersionInfoProvider: AppVersionInfoProvider {
         
         var mockedAppVersion: String


### PR DESCRIPTION
[MOB-1939](https://ecosia.atlassian.net/browse/MOB-1939)

## Context:
When an app is updated, it's often desirable to show "What's New" items to the user to inform them about changes, improvements, or new features. These items are associated with specific app versions. However, issues arose when:
1. There was a "fake" update to the same version (e.g., from 8.3.0 to 8.3.0) as the build number was different - pointed out by @lucaschifino 🙌 .
2. An update was made to a minor version (e.g., from 8.3.0 to 8.3.1), but the app was incorrectly showing items associated with a higher version (e.g., 9.0.0).

## Approach:
To address these concerns, following adjustments have been made:

1. **Fake Update Check**: Introduced a guard condition in `getVersionRange()`. If `fromVersion` (the original version before update) is equal to `toVersion` (the new version after update), the function immediately returns an empty list of versions. This ensures no "What's New" items are fetched for such "fake" updates.
 
2. **Minor Version Check**: After sorting all available versions in ascending order, I modified the logic to verify if the current version (`toVersion`) is equal to or higher than the smallest version in `whatsNewItems`. If it's not, the function returns an empty list, ensuring items from higher versions aren't incorrectly shown to the user.

3. **Test Scenarios**: Added test scenarios to validate the new logic:
    - `testFakeUpdateToSameVersionAgainstLocalDataProviderItemsData`: Ensures no "What's New" items are returned when there's a fake update to the same version.
    - `testFakeUpdateToMinorVersionAgainstLocalDataProviderItemsData`: Ensures that if the app is updated to a minor version, items associated with higher versions aren't returned.

[MOB-1939]: https://ecosia.atlassian.net/browse/MOB-1939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ