### PR TITLE
MOB-1940 Add check to show WhatsNewPage only to existing users

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -151,6 +151,8 @@
 		2C8C07771E7800EA00DC1237 /* FindInPageTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C8C07761E7800EA00DC1237 /* FindInPageTest.swift */; };
 		2C97EC711E72C80E0092EC18 /* TopTabsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C97EC701E72C80E0092EC18 /* TopTabsTest.swift */; };
 		2C9C9FF72A03C7CF0038A3DD /* UnleashBingExperimentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9C9FF62A03C7CF0038A3DD /* UnleashBingExperimentTests.swift */; };
+		2C9F8CB92AC30F6F00678514 /* EcosiaInstallType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F8CB82AC30F6E00678514 /* EcosiaInstallType.swift */; };
+		2C9F8CBC2AC3106300678514 /* EcosiaInstallTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F8CBA2AC3104800678514 /* EcosiaInstallTypeTests.swift */; };
 		2CA16FDE1E5F089100332277 /* SearchTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA16FDD1E5F089100332277 /* SearchTest.swift */; };
 		2CA2040629D4954F006848DE /* EcosiaPageActionMenuCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA2040529D4954F006848DE /* EcosiaPageActionMenuCellTests.swift */; };
 		2CAD6D992A7A96C000C2E96D /* Analytics+Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CAD6D982A7A96C000C2E96D /* Analytics+Configuration.swift */; };
@@ -1774,6 +1776,8 @@
 		2C9144B0B15218D8A0FCD538 /* es-AR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-AR"; path = "es-AR.lproj/ClearPrivateData.strings"; sourceTree = "<group>"; };
 		2C97EC701E72C80E0092EC18 /* TopTabsTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopTabsTest.swift; sourceTree = "<group>"; };
 		2C9C9FF62A03C7CF0038A3DD /* UnleashBingExperimentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnleashBingExperimentTests.swift; sourceTree = "<group>"; };
+		2C9F8CB82AC30F6E00678514 /* EcosiaInstallType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EcosiaInstallType.swift; sourceTree = "<group>"; };
+		2C9F8CBA2AC3104800678514 /* EcosiaInstallTypeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EcosiaInstallTypeTests.swift; sourceTree = "<group>"; };
 		2CA16FDD1E5F089100332277 /* SearchTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchTest.swift; sourceTree = "<group>"; };
 		2CA2040529D4954F006848DE /* EcosiaPageActionMenuCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EcosiaPageActionMenuCellTests.swift; sourceTree = "<group>"; };
 		2CAD6D982A7A96C000C2E96D /* Analytics+Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Analytics+Configuration.swift"; sourceTree = "<group>"; };
@@ -5317,6 +5321,7 @@
 		2CDABC732AB1C7C1009F6D98 /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
+				2C9F8CB82AC30F6E00678514 /* EcosiaInstallType.swift */,
 				2CDABC762AB1C7D6009F6D98 /* Version */,
 				2CDABC7B2AB1E8CF009F6D98 /* AppInfoProvider */,
 			);
@@ -6750,6 +6755,7 @@
 		CAA6AC4628E470C500A13DE9 /* Ecosia */ = {
 			isa = PBXGroup;
 			children = (
+				2C9F8CBA2AC3104800678514 /* EcosiaInstallTypeTests.swift */,
 				2C9C9FF52A03C7950038A3DD /* ExperimentsTests */,
 				CAA6AC4228E4709F00A13DE9 /* EcosiaHistoryMigrationTests.swift */,
 				CAA6AC4428E470BB00A13DE9 /* EcosiaBookmarkMigrationTests.swift */,
@@ -9317,6 +9323,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5FC276552894AEFF00AF2721 /* LibraryPanelHelper.swift in Sources */,
+				2C9F8CB92AC30F6F00678514 /* EcosiaInstallType.swift in Sources */,
 				2CDABC7E2AB1EAA2009F6D98 /* DefaultAppVersionInfoProvider.swift in Sources */,
 				5A47CFF52860FB8900B2B7BF /* AppLaunchUtil.swift in Sources */,
 				D04CD74A216CF86B004FF5B0 /* SiriShortcuts.swift in Sources */,
@@ -9844,6 +9851,7 @@
 			files = (
 				E4CD9F1D1A6D9C2800318571 /* WebServerTests.swift in Sources */,
 				C869916528918C8E007ACC5C /* WallpaperURLSessionMock.swift in Sources */,
+				2C9F8CBC2AC3106300678514 /* EcosiaInstallTypeTests.swift in Sources */,
 				2CE2F21D2AA87B8B00623F26 /* VersionTests.swift in Sources */,
 				431C0D1E25C9DC4D00395CE4 /* DefaultBrowserOnboardingTests.swift in Sources */,
 				E1AEC17A286E0CF500062E29 /* WebViewNavigationHandlerTests.swift in Sources */,

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -68,6 +68,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         window!.makeKeyAndVisible()
         // Ecosia: pushNotificationSetup()
         appLaunchUtil?.setUpPostLaunchDependencies()
+        // Ecosia: Update EcosiaInstallType if needed
+        EcosiaInstallType.evaluateCurrentEcosiaInstallTypeWithVersionProvider(DefaultAppVersionInfoProvider())
         // Ecosia: Disable BG sync //backgroundSyncUtil = BackgroundSyncUtil(profile: profile, application: application)
         // Ecosia: lifecycle tracking
         Analytics.shared.activity(.launch)

--- a/Client/Ecosia/Helpers/EcosiaInstallType.swift
+++ b/Client/Ecosia/Helpers/EcosiaInstallType.swift
@@ -1,0 +1,85 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// Represents the type of Ecosia installation.
+enum EcosiaInstallType: String {
+    
+    /// Represents a fresh installation of Ecosia.
+    case fresh
+    
+    /// Represents an upgrade from a previous version of Ecosia.
+    case upgrade
+    
+    /// Represents an unknown installation type.
+    case unknown
+
+    // MARK: - Private Properties
+    
+    /// The key used to store and retrieve the install type from UserDefaults.
+    static let installTypeKey = "installTypeKey"
+    
+    /// The key used to store and retrieve the current installed version from UserDefaults.
+    static let currentInstalledVersionKey = "currentInstalledVersionKey"
+    
+    // MARK: - Public Methods
+    
+    /// Retrieves the current Ecosia install type from UserDefaults.
+    ///
+    /// - Returns: The current Ecosia install type. If not found, returns `.unknown`.
+    static func get() -> EcosiaInstallType {
+        guard let rawValue = UserDefaults.standard.string(forKey: Self.installTypeKey),
+              let type = EcosiaInstallType(rawValue: rawValue)
+        else { return unknown }
+
+        return type
+    }
+
+    /// Sets the Ecosia install type in UserDefaults.
+    ///
+    /// - Parameter type: The Ecosia install type to be set.
+    static func set(type: EcosiaInstallType) {
+        UserDefaults.standard.set(type.rawValue, forKey: Self.installTypeKey)
+    }
+
+    /// Retrieves the persisted current version of Ecosia from UserDefaults.
+    ///
+    /// - Returns: The persisted current version. If not found, returns an empty string.
+    static func persistedCurrentVersion() -> String {
+        guard let currentVersion = UserDefaults.standard.string(forKey: Self.currentInstalledVersionKey) else { return "" }
+
+        return currentVersion
+    }
+
+    /// Updates the persisted current version of Ecosia in UserDefaults.
+    ///
+    /// - Parameter version: The version to be persisted.
+    static func updateCurrentVersion(version: String) {
+        UserDefaults.standard.set(version, forKey: Self.currentInstalledVersionKey)
+    }
+}
+
+extension EcosiaInstallType: Equatable {}
+
+extension EcosiaInstallType {
+    
+    /// Evaluates and updates the current Ecosia install type based on the persisted data and the provided app version.
+    ///
+    /// If the current install type is `.unknown`, it sets the install type to `.fresh` and updates the current version.
+    /// If the persisted version is different from the provided app version, it sets the install type to `.upgrade` and updates the current version.
+    ///
+    /// - Parameter versionProvider: An object conforming to `AppVersionInfoProvider` that provides the current app version.
+    static func evaluateCurrentEcosiaInstallTypeWithVersionProvider(_ versionProvider: AppVersionInfoProvider) {
+        if EcosiaInstallType.get() == .unknown {
+            EcosiaInstallType.set(type: .fresh)
+            EcosiaInstallType.updateCurrentVersion(version: versionProvider.version)
+        }
+        
+        if EcosiaInstallType.persistedCurrentVersion() != versionProvider.version {
+            EcosiaInstallType.set(type: .upgrade)
+            EcosiaInstallType.updateCurrentVersion(version: versionProvider.version)
+        }
+    }
+}

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -163,7 +163,7 @@ class BrowserViewController: UIViewController {
     }
 
     fileprivate var shouldShowDefaultBrowserPromo: Bool { profile.prefs.intForKey(PrefsKeys.IntroSeen) == nil }
-    fileprivate var shouldShowWhatsNewPageScreen: Bool { whatsNewDataProvider.shouldShowWhatsNewPage }
+    fileprivate var shouldShowWhatsNewPageScreen: Bool { whatsNewDataProvider.shouldShowWhatsNewPage && !User.shared.firstTime }
     
     let whatsNewDataProvider = WhatsNewLocalDataProvider()
     

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -163,7 +163,7 @@ class BrowserViewController: UIViewController {
     }
 
     fileprivate var shouldShowDefaultBrowserPromo: Bool { profile.prefs.intForKey(PrefsKeys.IntroSeen) == nil }
-    fileprivate var shouldShowWhatsNewPageScreen: Bool { whatsNewDataProvider.shouldShowWhatsNewPage && !User.shared.firstTime }
+    fileprivate var shouldShowWhatsNewPageScreen: Bool { !User.shared.firstTime && whatsNewDataProvider.shouldShowWhatsNewPage }
     
     let whatsNewDataProvider = WhatsNewLocalDataProvider()
     

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -163,7 +163,7 @@ class BrowserViewController: UIViewController {
     }
 
     fileprivate var shouldShowDefaultBrowserPromo: Bool { profile.prefs.intForKey(PrefsKeys.IntroSeen) == nil }
-    fileprivate var shouldShowWhatsNewPageScreen: Bool { InstallType.get() == .upgrade && whatsNewDataProvider.shouldShowWhatsNewPage }
+    fileprivate var shouldShowWhatsNewPageScreen: Bool { EcosiaInstallType.get() == .upgrade && whatsNewDataProvider.shouldShowWhatsNewPage }
     
     let whatsNewDataProvider = WhatsNewLocalDataProvider()
     

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -163,7 +163,7 @@ class BrowserViewController: UIViewController {
     }
 
     fileprivate var shouldShowDefaultBrowserPromo: Bool { profile.prefs.intForKey(PrefsKeys.IntroSeen) == nil }
-    fileprivate var shouldShowWhatsNewPageScreen: Bool { !User.shared.firstTime && whatsNewDataProvider.shouldShowWhatsNewPage }
+    fileprivate var shouldShowWhatsNewPageScreen: Bool { InstallType.get() == .upgrade && whatsNewDataProvider.shouldShowWhatsNewPage }
     
     let whatsNewDataProvider = WhatsNewLocalDataProvider()
     

--- a/Tests/ClientTests/Ecosia/EcosiaInstallTypeTests.swift
+++ b/Tests/ClientTests/Ecosia/EcosiaInstallTypeTests.swift
@@ -1,0 +1,72 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import Client
+
+final class EcosiaInstallTypeTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        // Reset UserDefaults for a clean state before each test
+        UserDefaults.standard.removeObject(forKey: EcosiaInstallType.installTypeKey)
+        UserDefaults.standard.removeObject(forKey: EcosiaInstallType.currentInstalledVersionKey)
+    }
+    
+    func testGetInstallType_WhenUnknown_ShouldReturnUnknown() {
+        let type = EcosiaInstallType.get()
+        XCTAssertEqual(type, .unknown)
+    }
+    
+    func testSetInstallType_ShouldPersistType() {
+        EcosiaInstallType.set(type: .fresh)
+        let persistedType = EcosiaInstallType.get()
+        XCTAssertEqual(persistedType, .fresh)
+    }
+    
+    func testPersistedCurrentVersion_WhenNotSet_ShouldReturnEmptyString() {
+        let version = EcosiaInstallType.persistedCurrentVersion()
+        XCTAssertEqual(version, "")
+    }
+    
+    func testUpdateCurrentVersion_ShouldPersistVersion() {
+        let testVersion = "1.0.0"
+        EcosiaInstallType.updateCurrentVersion(version: testVersion)
+        let persistedVersion = EcosiaInstallType.persistedCurrentVersion()
+        XCTAssertEqual(persistedVersion, testVersion)
+    }
+    
+    func testEvaluateCurrentEcosiaInstallType_WhenUnknown_ShouldSetToFresh() {
+        let mockVersion = MockAppVersion(version: "1.0.0")
+        EcosiaInstallType.evaluateCurrentEcosiaInstallTypeWithVersionProvider(mockVersion)
+        let type = EcosiaInstallType.get()
+        XCTAssertEqual(type, .fresh)
+    }
+
+    func testEvaluateCurrentEcosiaInstallType_WhenVersionDiffers_ShouldSetToUpgrade() {
+        let mockVersion = MockAppVersion(version: "1.0.0")
+        EcosiaInstallType.set(type: .fresh)
+        EcosiaInstallType.updateCurrentVersion(version: "0.9.0")
+        
+        EcosiaInstallType.evaluateCurrentEcosiaInstallTypeWithVersionProvider(mockVersion)
+        let type = EcosiaInstallType.get()
+        XCTAssertEqual(type, .upgrade)
+    }
+
+    func testEvaluateCurrentEcosiaInstallType_WhenVersionSame_ShouldNotChangeType() {
+        let mockVersion = MockAppVersion(version: "1.0.0")
+        EcosiaInstallType.set(type: .fresh)
+        EcosiaInstallType.updateCurrentVersion(version: "1.0.0")
+        
+        EcosiaInstallType.evaluateCurrentEcosiaInstallTypeWithVersionProvider(mockVersion)
+        let type = EcosiaInstallType.get()
+        XCTAssertEqual(type, .fresh)
+    }
+}
+
+extension EcosiaInstallTypeTests {
+    struct MockAppVersion: AppVersionInfoProvider {
+        var version: String
+    }
+}


### PR DESCRIPTION
[MOB-1940](https://ecosia.atlassian.net/browse/MOB-1940)

## **Context:**
The app's user experience (such as the WhatsNewPage showing) can vary based on whether the user is installing the app for the first time, upgrading from a previous version, or in cases where the installation type is unknown. To comply to these different scenarios, we need a mechanism to determine the type of installation currently in place.

## **Approach:**
To address this, we've introduced the `EcosiaInstallType` enum. This enum provides three distinct cases: `fresh`, `upgrade`, and `unknown`.  The  `EcosiaInstallType` is intendently inspired by the `InstallType` enum owned in the current version of the FF codebase. 

- `fresh`: Represents a new installation of the app.
- `upgrade`: Indicates that the app has been upgraded from a previous version.
- `unknown`: Used as a fallback when the installation type cannot be determined.

The enum also provides utility methods to interact with `UserDefaults`, allowing us to persist and retrieve the installation type and the current app version. This ensures that we can determine the installation type across app launches.

By using this enum, we can tailor the user experience based on the installation type, ensuring that users get the most relevant onboarding or update information.

[MOB-1940]: https://ecosia.atlassian.net/browse/MOB-1940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ