### PR TITLE
[MOB-1938] Add missing english translations for shortcuts widget

### DIFF
--- a/Shared/en-US.lproj/Today.strings
+++ b/Shared/en-US.lproj/Today.strings
@@ -88,6 +88,9 @@ Link";
 /* Quick Actions title when widget enters edit mode */
 "TodayWidget.QuickActionsGalleryTitle" = "Quick Actions";
 
+/* Firefox shortcuts title when widget enters edit mode. Do not translate the word Firefox. */
+"TodayWidget.QuickActionsGalleryTitleV2" = "Ecosia Shortcuts";
+
 /* Sub label for medium size quick action widget */
 "TodayWidget.QuickActionsSubLabel" = "Ecosia - Quick Actions";
 

--- a/Shared/en.lproj/Today.strings
+++ b/Shared/en.lproj/Today.strings
@@ -88,6 +88,9 @@ Link";
 /* Quick Actions title when widget enters edit mode */
 "TodayWidget.QuickActionsGalleryTitle" = "Quick Actions";
 
+/* Firefox shortcuts title when widget enters edit mode. Do not translate the word Firefox. */
+"TodayWidget.QuickActionsGalleryTitleV2" = "Ecosia Shortcuts";
+
 /* Sub label for medium size quick action widget */
 "TodayWidget.QuickActionsSubLabel" = "Ecosia - Quick Actions";
 


### PR DESCRIPTION
[MOB-1938](https://ecosia.atlassian.net/browse/MOB-1938)

## Context
It was found that one of our widgets shows "Firefox" in the english translation insted of "Ecosia.

We use [ecosify-strings.py](https://github.com/ecosia/ios-browser/blob/main/ecosify-strings.py) script to update all values once we fetch them from FF. 

## Approach
Found this was due to some missing translation strings which resulted in it using the default value set inside `Shared/Strings.swift`. Added those respective strings.

Also noticed this is the case on the original repo, which for them is not a problem since the english translation is the default value 🤷 As a follow up, I have created a [technical debt](https://ecosia.atlassian.net/wiki/spaces/MOB/pages/2614362130/Technical+Debt) for checking if we can add this file to the script as well (at the moment it only works with `.strings` files and it will not be straightforward to support other non key-value based files imo, but might be worth a try.

## Other
💡As you can see in this PR FFs string file changes are visible 🤩 I believe this is due to some file level configurations they have set (which even interfered with my current attempt setup using `gitconfig` (WIP in #516). Will take that as inspiration to try and apply for our files as well 🚀 



[MOB-1938]: https://ecosia.atlassian.net/browse/MOB-1938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ