### PR TITLE
[MOB-1917] Add Unleash refreshing rules before starting it.

### DIFF
--- a/Client/Ecosia/FeatureManagement/FeatureManagement.swift
+++ b/Client/Ecosia/FeatureManagement/FeatureManagement.swift
@@ -13,10 +13,18 @@ struct FeatureManagement {
     static func fetchConfiguration() {
         Task {
             do {
+                Self.addRefreshingRules()
                 try await _ = Unleash.start(env: .current, appVersion: AppInfo.ecosiaAppVersion)
             } catch {
                 debugPrint(error)
             }
         }
-    }    
+    }
+    
+    private static func addRefreshingRules() {
+        UnleashRefreshConfigurator()
+                    .withAppUpdateCheckRule(appVersion: AppInfo.ecosiaAppVersion)
+                    .withDeviceRegionUpdateCheckRule()
+                    .withTwentyFourHoursCacheExpirationRule()
+    }
 }


### PR DESCRIPTION
[MOB-1917](https://ecosia.atlassian.net/browse/MOB-1917)

## Context
Unleash refreshing rules were enhanced as part of https://github.com/ecosia/ios-core/pull/109.

The Client-side had not been implemented yet, which caused Unleash to never refresh (not even with a fresh install).

## Approach
Add `UnleashRefreshConfigurator` with the desired rules. Decided to make it private and call within `fetchConfiguration()` so it is guaranteed that it is always called before start and since there is no reason for it to be visible from outside.

## Other
Technical debt to be created regarding forcing Unleash refresh upon fresh installs (and maybe updates?)


[MOB-1917]: https://ecosia.atlassian.net/browse/MOB-1917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ