### PR TITLE
MOB-1936 Silence precondition with warning on Deferred.swift

### DIFF
--- a/ThirdParty/Deferred/Deferred/Deferred.swift
+++ b/ThirdParty/Deferred/Deferred/Deferred.swift
@@ -31,7 +31,11 @@ open class Deferred<T> {
     private func _fill(value: T, assertIfFilled: Bool) {
         let (filledValue, blocks) = protected.withWriteLock { data -> (T, [UponBlock]) in
             if assertIfFilled {
-                // Ecosia: Silencing the precondition and replacing it with a warning
+                // Ecosia: Silencing the precondition and replacing it with a warning.
+                // The issue seem to link back to a process of favicons downloads with a lot of websites in history/bookmarks.
+                // Some downloaded favicons resulted into a "too large" error being thrown at some point in the stacktrace.
+                // The FF codebase currently relies on a different mechanism.
+                // We will review it once we will perform the upgrade.
 //                precondition(data.protectedValue == nil, "Cannot fill an already-filled Deferred")
                 if data.protectedValue != nil {
                     print("Warning: Attempt to fill an already-filled Deferred.")

--- a/ThirdParty/Deferred/Deferred/Deferred.swift
+++ b/ThirdParty/Deferred/Deferred/Deferred.swift
@@ -31,8 +31,13 @@ open class Deferred<T> {
     private func _fill(value: T, assertIfFilled: Bool) {
         let (filledValue, blocks) = protected.withWriteLock { data -> (T, [UponBlock]) in
             if assertIfFilled {
-                precondition(data.protectedValue == nil, "Cannot fill an already-filled Deferred")
-                data.protectedValue = value
+                // Ecosia: Silencing the precondition and replacing it with a warning
+//                precondition(data.protectedValue == nil, "Cannot fill an already-filled Deferred")
+                if data.protectedValue != nil {
+                    print("Warning: Attempt to fill an already-filled Deferred.")
+                } else {
+                    data.protectedValue = value
+                }
             } else if data.protectedValue == nil {
                 data.protectedValue = value
             }


### PR DESCRIPTION
[MOB-1936](https://ecosia.atlassian.net/browse/MOB-1936)

## Context

Found multiple crashes on the Deferred object.
The goal is to leverage a possible silencing of the precondition and raise a simple Warning message 

## Approach

Silencing the precondition and replacing it with a warning.

[MOB-1936]: https://ecosia.atlassian.net/browse/MOB-1936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ