### PR TITLE
[MOB-1848] Impact NTP cell UI fixes

### DIFF
--- a/Client/Ecosia/UI/NTP/AboutEcosia/NTPAboutEcosiaCellViewModel.swift
+++ b/Client/Ecosia/UI/NTP/AboutEcosia/NTPAboutEcosiaCellViewModel.swift
@@ -34,15 +34,13 @@ extension NTPAboutEcosiaCellViewModel: HomepageViewModelProtocol {
     }
     
     func section(for traitCollection: UITraitCollection) -> NSCollectionLayoutSection {
-        let height = NTPAboutEcosiaCell.UX.height
-        let count = CGFloat(numberOfItemsInSection())
         let item = NSCollectionLayoutItem(
             layoutSize: .init(widthDimension: .fractionalWidth(1),
-                              heightDimension: .estimated(height))
+                              heightDimension: .estimated(100))
         )
         let group = NSCollectionLayoutGroup.horizontal(
             layoutSize: .init(widthDimension: .fractionalWidth(1),
-                              heightDimension: .estimated(height*count)),
+                              heightDimension: .estimated(100)),
             subitem: item,
             count: 1
         )

--- a/Client/Ecosia/UI/NTP/Impact/NTPImpactCell.swift
+++ b/Client/Ecosia/UI/NTP/Impact/NTPImpactCell.swift
@@ -7,7 +7,6 @@ import Core
 
 final class NTPImpactCell: UICollectionViewCell, NotificationThemeable, ReusableCell {
     struct UX {
-        static let estimatedHeight: CGFloat = NTPImpactRowView.UX.height*2 + cellsSpacing
         static let cellsSpacing: CGFloat = 12
     }
     
@@ -51,10 +50,10 @@ final class NTPImpactCell: UICollectionViewCell, NotificationThemeable, Reusable
     
     private func setupConstraints() {
         NSLayoutConstraint.activate([
-            containerStack.topAnchor.constraint(equalTo: topAnchor),
-            containerStack.leadingAnchor.constraint(equalTo: leadingAnchor),
-            containerStack.trailingAnchor.constraint(equalTo: trailingAnchor),
-            containerStack.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -UX.cellsSpacing)
+            containerStack.topAnchor.constraint(equalTo: contentView.topAnchor),
+            containerStack.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            containerStack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            containerStack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -UX.cellsSpacing)
         ])
     }
 

--- a/Client/Ecosia/UI/NTP/Impact/NTPImpactCellViewModel.swift
+++ b/Client/Ecosia/UI/NTP/Impact/NTPImpactCellViewModel.swift
@@ -99,20 +99,21 @@ extension NTPImpactCellViewModel: HomepageViewModelProtocol {
     }
 
     func section(for traitCollection: UITraitCollection) -> NSCollectionLayoutSection {
-        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
-                                              heightDimension: .estimated(NTPImpactCell.UX.estimatedHeight))
-        let item = NSCollectionLayoutItem(layoutSize: itemSize)
-
-        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
-                                               heightDimension: .estimated(NTPImpactCell.UX.estimatedHeight))
-        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitem: item, count: 1)
-
+        let item = NSCollectionLayoutItem(
+            layoutSize: .init(widthDimension: .fractionalWidth(1),
+                              heightDimension: .estimated(200))
+        )
+        let group = NSCollectionLayoutGroup.horizontal(
+            layoutSize: .init(widthDimension: .fractionalWidth(1),
+                              heightDimension: .estimated(200)),
+            subitem: item,
+            count: 1
+        )
         let section = NSCollectionLayoutSection(group: group)
 
         section.contentInsets = sectionType.sectionInsets(traitCollection, bottomSpacing: 0)
         
         var supplementaryItems = [NSCollectionLayoutBoundarySupplementaryItem]()
-        
         if NTPTooltip.highlight() != nil {
             supplementaryItems.append(
                 .init(layoutSize: .init(widthDimension: .fractionalWidth(1),

--- a/Client/Ecosia/UI/NTP/Impact/NTPImpactRowView.swift
+++ b/Client/Ecosia/UI/NTP/Impact/NTPImpactRowView.swift
@@ -120,7 +120,7 @@ final class NTPImpactRowView: UIView, NotificationThemeable {
             hStack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -UX.padding),
             hStack.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -UX.padding),
             dividerView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: UX.padding),
-            dividerView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -UX.padding),
+            dividerView.trailingAnchor.constraint(equalTo: trailingAnchor),
             dividerView.bottomAnchor.constraint(equalTo: bottomAnchor),
             dividerView.heightAnchor.constraint(equalToConstant: 1),
             imageContainer.heightAnchor.constraint(equalToConstant: UX.imageHeight),


### PR DESCRIPTION
[MOB-1848](https://ecosia.atlassian.net/browse/MOB-1848)

## Context

Follow up of #547, after a couple UI issues were found.

## Approach

- Make impact cell separator match Figma by removing trailing padding
- Fix impact cell automatic size by setting the constraints to the `contentView` instead of the cell itself

## Other

- Minor refactors on the `section(for traitCollection: UITraitCollection)` methods, updating some estimated heights that do not need to be precise when the automatic sizing is working.


[MOB-1848]: https://ecosia.atlassian.net/browse/MOB-1848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ