### PR TITLE
[MOB-1947] Use WelcomeNavigation so onboarding supports only portrait

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -296,7 +296,7 @@ extension AppDelegate {
             rootVC = browserViewController!
         }
 
-        let navigationController = UINavigationController(rootViewController: rootVC)
+        let navigationController = WelcomeNavigation(rootViewController: rootVC)
         navigationController.isNavigationBarHidden = true
         navigationController.edgesForExtendedLayout = UIRectEdge(rawValue: 0)
         rootViewController = navigationController

--- a/Client/Ecosia/UI/Onboarding/Welcome.swift
+++ b/Client/Ecosia/UI/Onboarding/Welcome.swift
@@ -38,10 +38,6 @@ final class Welcome: UIViewController {
         return zoomedOut ? .lightContent : .darkContent
     }
 
-    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
-        .portrait
-    }
-
     // MARK: Views
     override func viewDidLoad() {
         super.viewDidLoad()


### PR DESCRIPTION
[MOB-1947](https://ecosia.atlassian.net/browse/MOB-1947)

## Context

Our `Welcome` UIViewController layout breaks on landscape and therefore should only support portrait.

## Approach

Since it belongs to a navigation controller, `supportedInterfaceOrientations` needs to be set there instead of the view controller.

Noticed we already had `WelcomeNavigation` which does exactly that:
```
final class WelcomeNavigation: UINavigationController {
    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
        topViewController is Welcome ? .portrait : .all
    }
}
```

So just used it instead of the base `UINavigationController` when presenting onboarding.

## Other

Also removed `supportedInterfaceOrientations` from `Welcome` since it makes no difference.


[MOB-1947]: https://ecosia.atlassian.net/browse/MOB-1947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ