### PR TITLE
MOB-1948 Improve and fix WhatsNewPage logic

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -136,6 +136,7 @@
 		2C31ECAB2A2E13410058BC31 /* DefaultBrowserExperiment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C31ECAA2A2E13410058BC31 /* DefaultBrowserExperiment.swift */; };
 		2C3357E22A09227100E76A48 /* AppInfo+Ecosia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3357E02A09227100E76A48 /* AppInfo+Ecosia.swift */; };
 		2C3357E32A09227100E76A48 /* DeviceInfo+Ecosia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3357E12A09227100E76A48 /* DeviceInfo+Ecosia.swift */; };
+		2C3386F02AC6BCA0009F789C /* MockAppVersionInfoProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3386EF2AC6BCA0009F789C /* MockAppVersionInfoProvider.swift */; };
 		2C3406C81E719F00000FD889 /* SettingsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3406C71E719F00000FD889 /* SettingsTest.swift */; };
 		2C3518BB29C34A0500D03ECD /* URLBarViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3518BA29C34A0500D03ECD /* URLBarViewTests.swift */; };
 		2C473BD0209778900008C853 /* DownloadFilesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C473BCF209778900008C853 /* DownloadFilesTests.swift */; };
@@ -1758,6 +1759,7 @@
 		2C33410CB7E921A125379D7C /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
 		2C3357E02A09227100E76A48 /* AppInfo+Ecosia.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AppInfo+Ecosia.swift"; sourceTree = "<group>"; };
 		2C3357E12A09227100E76A48 /* DeviceInfo+Ecosia.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DeviceInfo+Ecosia.swift"; sourceTree = "<group>"; };
+		2C3386EF2AC6BCA0009F789C /* MockAppVersionInfoProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAppVersionInfoProvider.swift; sourceTree = "<group>"; };
 		2C3406C71E719F00000FD889 /* SettingsTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsTest.swift; sourceTree = "<group>"; };
 		2C3518BA29C34A0500D03ECD /* URLBarViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLBarViewTests.swift; sourceTree = "<group>"; };
 		2C473BCF209778900008C853 /* DownloadFilesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadFilesTests.swift; sourceTree = "<group>"; };
@@ -6504,6 +6506,7 @@
 				8A7653C328A2E68B00924ABF /* MockPocketAPI.swift */,
 				8A2366F928A302E500846D1B /* MockSponsoredPocketAPI.swift */,
 				5A9A09D528B01FD500B6F51E /* MockURLBarView.swift */,
+				2C3386EF2AC6BCA0009F789C /* MockAppVersionInfoProvider.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -9913,6 +9916,7 @@
 				2F13E79B1AC0C02700D75081 /* StringExtensionsTests.swift in Sources */,
 				C869915628917803007ACC5C /* WallpaperJSONTestProvider.swift in Sources */,
 				CAA6AC4328E4709F00A13DE9 /* EcosiaHistoryMigrationTests.swift in Sources */,
+				2C3386F02AC6BCA0009F789C /* MockAppVersionInfoProvider.swift in Sources */,
 				8AE1E1DB27B1C1320024C45E /* SearchBarSettingsViewModelTests.swift in Sources */,
 				CA24B53924ABFE250093848C /* LoginsListSelectionHelperTests.swift in Sources */,
 				2FDB10931A9FBEC5006CF312 /* PrefsTests.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -143,6 +143,7 @@
 		2C49854E206173C800893DAE /* photon-colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C49854D206173C800893DAE /* photon-colors.swift */; };
 		2C4A07DC20246EAD0083E320 /* DragAndDropTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4A07DB20246EAD0083E320 /* DragAndDropTests.swift */; };
 		2C4B6BF320349EB800A009C2 /* FirstRunTourTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4B6BF220349EB800A009C2 /* FirstRunTourTests.swift */; };
+		2C50F09A2AC703E500F09803 /* WhatsNewLocalDataProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C50F0992AC703E500F09803 /* WhatsNewLocalDataProviderTests.swift */; };
 		2C5850012A02879A009D7703 /* BingExperiment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C5850002A02879A009D7703 /* BingExperiment.swift */; };
 		2C73A71B2A9E0B7A006EBAAB /* WhatsNewItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C73A71A2A9E0B7A006EBAAB /* WhatsNewItem.swift */; };
 		2C73A71D2A9E0B97006EBAAB /* WhatsNewDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C73A71C2A9E0B97006EBAAB /* WhatsNewDataProvider.swift */; };
@@ -1766,6 +1767,7 @@
 		2C49854D206173C800893DAE /* photon-colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "photon-colors.swift"; sourceTree = "<group>"; };
 		2C4A07DB20246EAD0083E320 /* DragAndDropTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragAndDropTests.swift; sourceTree = "<group>"; };
 		2C4B6BF220349EB800A009C2 /* FirstRunTourTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstRunTourTests.swift; sourceTree = "<group>"; };
+		2C50F0992AC703E500F09803 /* WhatsNewLocalDataProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatsNewLocalDataProviderTests.swift; sourceTree = "<group>"; };
 		2C5850002A02879A009D7703 /* BingExperiment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BingExperiment.swift; sourceTree = "<group>"; };
 		2C6045859589979C43AF09E0 /* jv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = jv; path = jv.lproj/ClearPrivateDataConfirm.strings; sourceTree = "<group>"; };
 		2C6E44099EACF7BE5438CEB6 /* ca */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ca; path = ca.lproj/Today.strings; sourceTree = "<group>"; };
@@ -6767,6 +6769,7 @@
 				2CA2040529D4954F006848DE /* EcosiaPageActionMenuCellTests.swift */,
 				2CAD6D9C2A7AAFC600C2E96D /* AnalyticsTests.swift */,
 				2CE2F21B2AA87B3100623F26 /* VersionTests.swift */,
+				2C50F0992AC703E500F09803 /* WhatsNewLocalDataProviderTests.swift */,
 			);
 			path = Ecosia;
 			sourceTree = "<group>";
@@ -9864,6 +9867,7 @@
 				8AE80BAF2891960300BC12EA /* MockTraitCollection.swift in Sources */,
 				03CCC9181AF05E7300DBF30D /* RelativeDatesTests.swift in Sources */,
 				F84B21DA1A090F8100AAB793 /* ClientTests.swift in Sources */,
+				2C50F09A2AC703E500F09803 /* WhatsNewLocalDataProviderTests.swift in Sources */,
 				E1AEC179286E0CF500062E29 /* FirefoxHomeViewModelTests.swift in Sources */,
 				2197DF8A287624BF00215624 /* LibraryViewModelTests.swift in Sources */,
 				8AF0CFF527A0B0ED00C1A4A2 /* QuickActionsTests.swift in Sources */,

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -50,7 +50,7 @@
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
         "branch" : "main",
-        "revision" : "a56e84871c2810a05bf2834b714ec632cee28371"
+        "revision" : "d18bef84535590c17f0e9f498dee69f5dcd5c940"
       }
     },
     {

--- a/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
+++ b/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
@@ -22,7 +22,6 @@ extension BrowserViewController: DefaultBrowserDelegate {
 
 extension BrowserViewController: WhatsNewViewDelegate {
     func whatsNewViewDidShow(_ viewController: WhatsNewViewController) {
-        User.shared.updateWhatsNewItemsVersionsAppending(whatsNewDataProvider.getVersionRange().map { $0.description })
         homepageViewController?.reloadTooltip()
     }
 }

--- a/Client/Ecosia/Helpers/EcosiaInstallType.swift
+++ b/Client/Ecosia/Helpers/EcosiaInstallType.swift
@@ -13,6 +13,11 @@ enum EcosiaInstallType: String {
     /// Represents an upgrade from a previous version of Ecosia.
     case upgrade
     
+    /// Represents a state where a same version has been installed
+    /// A different build run / build number has replaced the previous installation.
+    /// This scenario won't happen production.
+    case buildUpdate
+    
     /// Represents an unknown installation type.
     case unknown
 
@@ -80,6 +85,8 @@ extension EcosiaInstallType {
         if EcosiaInstallType.persistedCurrentVersion() != versionProvider.version {
             EcosiaInstallType.set(type: .upgrade)
             EcosiaInstallType.updateCurrentVersion(version: versionProvider.version)
+        } else if EcosiaInstallType.persistedCurrentVersion() == versionProvider.version {
+            EcosiaInstallType.set(type: .buildUpdate)
         }
     }
 }

--- a/Client/Ecosia/Helpers/EcosiaInstallType.swift
+++ b/Client/Ecosia/Helpers/EcosiaInstallType.swift
@@ -12,12 +12,7 @@ enum EcosiaInstallType: String {
     
     /// Represents an upgrade from a previous version of Ecosia.
     case upgrade
-    
-    /// Represents a state where a same version has been installed
-    /// A different build run / build number has replaced the previous installation.
-    /// This scenario won't happen production.
-    case buildUpdate
-    
+        
     /// Represents an unknown installation type.
     case unknown
 
@@ -85,8 +80,6 @@ extension EcosiaInstallType {
         if EcosiaInstallType.persistedCurrentVersion() != versionProvider.version {
             EcosiaInstallType.set(type: .upgrade)
             EcosiaInstallType.updateCurrentVersion(version: versionProvider.version)
-        } else if EcosiaInstallType.persistedCurrentVersion() == versionProvider.version {
-            EcosiaInstallType.set(type: .buildUpdate)
         }
     }
 }

--- a/Client/Ecosia/UI/WhatsNew/DataProvider/WhatsNewLocalDataProvider.swift
+++ b/Client/Ecosia/UI/WhatsNew/DataProvider/WhatsNewLocalDataProvider.swift
@@ -13,7 +13,9 @@ final class WhatsNewLocalDataProvider: WhatsNewDataProvider {
     
     /// The version from which the app was last updated. Optional in case this is the first run
     /// or previous upgrading from an implmention that didn't have this one in the first place.
-    private let fromVersion = Version.saved(forKey: WhatsNewLocalDataProvider.appVersionUpdateKey)
+    private var fromVersion: Version? {
+        Version.saved(forKey: WhatsNewLocalDataProvider.appVersionUpdateKey)
+    }
     
     /// The current version of the app.
     private var toVersion: Version {

--- a/Client/Ecosia/UI/WhatsNew/DataProvider/WhatsNewLocalDataProvider.swift
+++ b/Client/Ecosia/UI/WhatsNew/DataProvider/WhatsNewLocalDataProvider.swift
@@ -82,7 +82,7 @@ final class WhatsNewLocalDataProvider: WhatsNewDataProvider {
         // At this point in the logic, we are still in the upgrade scenario
         // however, if the fromVersion and the toVersion will result being the same
         // we will assume that we have upgraded to a version that didn't have this logic in place before
-        // There is no need to enforce the check for `EcosiaInstallType.get() == .buildUpdate`
+        // There is no need to enforce the check for something ideally considered as a build update.
         // As we currently checked the `.upgrade` scenario above.
         if fromVersion == toVersion {
             return allVersions.filter { $0 == toVersion } ?? []

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -163,7 +163,7 @@ class BrowserViewController: UIViewController {
     }
 
     fileprivate var shouldShowDefaultBrowserPromo: Bool { profile.prefs.intForKey(PrefsKeys.IntroSeen) == nil }
-    fileprivate var shouldShowWhatsNewPageScreen: Bool { EcosiaInstallType.get() == .upgrade && whatsNewDataProvider.shouldShowWhatsNewPage }
+    fileprivate var shouldShowWhatsNewPageScreen: Bool { whatsNewDataProvider.shouldShowWhatsNewPage }
     
     let whatsNewDataProvider = WhatsNewLocalDataProvider()
     

--- a/Tests/ClientTests/Ecosia/VersionTests.swift
+++ b/Tests/ClientTests/Ecosia/VersionTests.swift
@@ -80,6 +80,20 @@ final class VersionTests: XCTestCase {
 
 extension VersionTests {
     
+    func testUpgradeFromVersionWithoutLogic() {
+        // Simulate that the app was previously on a version that didn't have the Version struct logic.
+        // We can represent this by not having any version saved in UserDefaults.
+        
+        XCTAssertNil(Version.saved(forKey: Self.appVersionUpdateTestKey), "There should be no version saved initially.")
+        
+        // Simulate the app being updated to the current version which has the Version struct logic.
+        let currentVersion = "9.0.0" // Assuming 9.0.0 is the version with the new logic.
+        Version.updateFromCurrent(forKey: Self.appVersionUpdateTestKey, provider: MockAppVersionInfoProvider(mockedAppVersion: currentVersion))
+        
+        // Check if the version is now saved correctly.
+        XCTAssertEqual(Version.saved(forKey: Self.appVersionUpdateTestKey)?.description, currentVersion, "The version should be updated to \(currentVersion) after the upgrade.")
+    }
+    
     func testFakeUpdateToSameVersionAgainstLocalDataProviderItemsData() {
         
         // Setup

--- a/Tests/ClientTests/Ecosia/VersionTests.swift
+++ b/Tests/ClientTests/Ecosia/VersionTests.swift
@@ -133,19 +133,3 @@ extension VersionTests {
         XCTAssertTrue(items?.isEmpty == true, "WhatsNewItem list should be empty for an update to minor version when there are items for upper versions")
     }
 }
-
-extension VersionTests {
-    
-    struct MockAppVersionInfoProvider: AppVersionInfoProvider {
-        
-        var mockedAppVersion: String
-        
-        init(mockedAppVersion: String) {
-            self.mockedAppVersion = mockedAppVersion
-        }
-        
-        var version: String {
-            mockedAppVersion
-        }
-    }
-}

--- a/Tests/ClientTests/Ecosia/WhatsNewLocalDataProviderTests.swift
+++ b/Tests/ClientTests/Ecosia/WhatsNewLocalDataProviderTests.swift
@@ -1,0 +1,5 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation

--- a/Tests/ClientTests/Ecosia/WhatsNewLocalDataProviderTests.swift
+++ b/Tests/ClientTests/Ecosia/WhatsNewLocalDataProviderTests.swift
@@ -2,4 +2,108 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import Foundation
+import XCTest
+@testable import Client
+
+final class WhatsNewLocalDataProviderTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removeObject(forKey: EcosiaInstallType.installTypeKey)
+        UserDefaults.standard.removeObject(forKey: EcosiaInstallType.currentInstalledVersionKey)
+    }
+    
+    // MARK: - Fresh Install Tests
+    
+    func testFreshInstallShouldNotShowWhatsNew() {
+        // Given
+        let dataProvider = WhatsNewLocalDataProvider(versionProvider: MockAppVersionInfoProvider(mockedAppVersion: "1.0.0"))
+        
+        // When
+        let shouldShowWhatsNew = dataProvider.shouldShowWhatsNewPage
+        
+        // Then
+        XCTAssertFalse(shouldShowWhatsNew, "Fresh install should not show What's New")
+    }
+    
+    func testFreshInstallShouldNotGetWhatsNewItems() {
+        // Given
+        let dataProvider = WhatsNewLocalDataProvider(versionProvider: MockAppVersionInfoProvider(mockedAppVersion: "1.0.0"))
+        
+        // When
+        do {
+            let whatsNewItems = try dataProvider.getData()
+            
+            // Then
+            XCTAssertTrue(whatsNewItems.isEmpty, "Fresh install should not get What's New items")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+    
+    // MARK: - Upgrade Tests
+    
+    func testUpgradeToDifferentVersionShouldShowWhatsNew() {
+        // Given
+        let dataProvider = WhatsNewLocalDataProvider(versionProvider: MockAppVersionInfoProvider(mockedAppVersion: "10.0.0"))
+        EcosiaInstallType.set(type: .upgrade)
+        
+        // When
+        let shouldShowWhatsNew = dataProvider.shouldShowWhatsNewPage
+        
+        // Then
+        XCTAssertTrue(shouldShowWhatsNew, "Upgrade to a different version should show What's New")
+    }
+        
+    func testUpgradeToSameVersionShouldNotShowWhatsNew() {
+        // Given
+        let dataProvider = WhatsNewLocalDataProvider(versionProvider: MockAppVersionInfoProvider(mockedAppVersion: "9.0.0"))
+        
+        // When
+        let shouldShowWhatsNew = dataProvider.shouldShowWhatsNewPage
+        
+        // Then
+        XCTAssertFalse(shouldShowWhatsNew, "Upgrade to the same version should not show What's New")
+    }
+    
+    func testUpgradeToSameVersionShouldNotGetWhatsNewItems() {
+        // Given
+        let dataProvider = WhatsNewLocalDataProvider(versionProvider: MockAppVersionInfoProvider(mockedAppVersion: "9.0.0"))
+        
+        // When
+        do {
+            let whatsNewItems = try dataProvider.getData()
+            
+            // Then
+            XCTAssertTrue(whatsNewItems.isEmpty, "Upgrade to the same version should not get What's New items")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+    
+    func testUpgradeToLowerVersionShouldNotShowWhatsNew() {
+        // Given
+        let dataProvider = WhatsNewLocalDataProvider(versionProvider: MockAppVersionInfoProvider(mockedAppVersion: "8.0.0"))
+        
+        // When
+        let shouldShowWhatsNew = dataProvider.shouldShowWhatsNewPage
+        
+        // Then
+        XCTAssertFalse(shouldShowWhatsNew, "Upgrade to a lower version should not show What's New")
+    }
+    
+    func testUpgradeToLowerVersionShouldNotGetWhatsNewItems() {
+        // Given
+        let dataProvider = WhatsNewLocalDataProvider(versionProvider: MockAppVersionInfoProvider(mockedAppVersion: "8.0.0"))
+        
+        // When
+        do {
+            let whatsNewItems = try dataProvider.getData()
+            
+            // Then
+            XCTAssertTrue(whatsNewItems.isEmpty, "Upgrade to a lower version should not get What's New items")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+}

--- a/Tests/ClientTests/Mocks/MockAppVersionInfoProvider.swift
+++ b/Tests/ClientTests/Mocks/MockAppVersionInfoProvider.swift
@@ -1,0 +1,18 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+@testable import Client
+
+struct MockAppVersionInfoProvider: AppVersionInfoProvider {
+    
+    var mockedAppVersion: String
+    
+    init(mockedAppVersion: String) {
+        self.mockedAppVersion = mockedAppVersion
+    }
+    
+    var version: String {
+        mockedAppVersion
+    }
+}


### PR DESCRIPTION
[MOB-1948](https://ecosia.atlassian.net/browse/MOB-1948)

## Context

Throughout the QA process there was an issue found as part of regression on latest fixes.

## Approach

This PR reviews the logic of deciding whether of not showing the WhatsNewPage relying mostly on the EcosiaInstallType.

Scenarios tested:

- 8.3.0 -> No What's New Page shown
- 8.3.0 -> manually upgrade to 9.0.0 -> Whats New Page shown
- 9.0.0 -> run -> No Whats New Page shown 
- 9.0.0 -> rerun to 9.0.0 -> No Whats New Page shown
- 9.0.0 -> manually downgrade to 8.3.0 -> No Whats New Page shown

## Other

Will make a PR in core that removes the logic of the User


[MOB-1948]: https://ecosia.atlassian.net/browse/MOB-1948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ