### PR TITLE
[MOB-1952] Fix impact cell refresh

### DIFF
--- a/Client/Ecosia/UI/NTP/Impact/ClimateImpactInfo.swift
+++ b/Client/Ecosia/UI/NTP/Impact/ClimateImpactInfo.swift
@@ -95,8 +95,21 @@ enum ClimateImpactInfo: Equatable {
             return nil
         }
     }
+    
+    /// Created to be used for comparison without taking the associated types arguments into consideration.
+    var rawValue: Int {
+        switch self {
+        case .personalCounter:
+            return 0
+        case .invites:
+            return 1
+        case .totalTrees:
+            return 2
+        case .totalInvested:
+            return 3
+        }
+    }
 }
-
 
 extension Int {
     fileprivate var spelledOutString: String {

--- a/Client/Ecosia/UI/NTP/Impact/NTPImpactCell.swift
+++ b/Client/Ecosia/UI/NTP/Impact/NTPImpactCell.swift
@@ -12,9 +12,7 @@ final class NTPImpactCell: UICollectionViewCell, NotificationThemeable, Reusable
     
     weak var delegate: NTPImpactCellDelegate? {
         didSet {
-            containerStack.arrangedSubviews
-                .compactMap { $0 as? NTPImpactRowView }
-                .forEach { $0.delegate = delegate }
+            impactRows.forEach { $0.delegate = delegate }
         }
     }
     
@@ -25,6 +23,9 @@ final class NTPImpactCell: UICollectionViewCell, NotificationThemeable, Reusable
         stack.alignment = .fill
         return stack
     }()
+    private var impactRows: [NTPImpactRowView] {
+        containerStack.arrangedSubviews.compactMap { $0 as? NTPImpactRowView }
+    }
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -76,9 +77,9 @@ final class NTPImpactCell: UICollectionViewCell, NotificationThemeable, Reusable
     }
     
     func refresh(items: [ClimateImpactInfo]) {
-        for (index, view) in containerStack.arrangedSubviews.enumerated() {
-            guard let row = view as? NTPImpactRowView else { return }
-            let info = items[index]
+        impactRows.forEach { row in
+            let matchingInfo = items.first { $0.rawValue == row.info.rawValue }
+            guard let info = matchingInfo else { return }
             row.info = info
         }
     }


### PR DESCRIPTION
[MOB-1952](https://ecosia.atlassian.net/browse/MOB-1952)

## Context

Follow-up of #547, where a bug was found that made the first impact cell be refreshed with the second cell's content whenever the whole list was refreshed in a position where only the first cell was visible.

## Approach

After some investigation, found the stored cells (`NTPImpactCellViewModel.cells`) are not that reliable since, for an unknown reason, when the first cell (`indexPath.row == 0`) is configured after both cells have been stored, the `cells` dictionary for the second key (`1`) is updated, even if the code is `cells[indexPath.row] = cell`.

To fix this, `NTPImpactCell.refresh` was updated to guarantee that the cells are only updated with the correct info.

I spent some timeboxed time to also try and change the refreshing logic in general, with some ideas like clearing the stored cells when the cell is hidden, or using some protocol based delegation instead of the stored variable with the public method, but they were either overly complex or not solved the issue.

Given the very specific flow required for the bug to happen, went for the simple solution. Always up to hear some feedback or suggestion on it 🙂 


[MOB-1952]: https://ecosia.atlassian.net/browse/MOB-1952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ