### PR TITLE
[MOB 1953] Separate search and referral impact

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -14696,7 +14696,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ecosia/ios-core.git";
 			requirement = {
-				branch = main;
+				branch = "MOB-1953_separate_search_and_referral_impact";
 				kind = branch;
 			};
 		};

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -14696,7 +14696,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ecosia/ios-core.git";
 			requirement = {
-				branch = "MOB-1953_separate_search_and_referral_impact";
+				branch = main;
 				kind = branch;
 			};
 		};

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -49,8 +49,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "e2090e4fa27732f060ae1e2b61fdd64108f53ad4"
+        "branch" : "MOB-1953_separate_search_and_referral_impact",
+        "revision" : "8f0985f217651666aeab4530a3c8b1b353a9a917"
       }
     },
     {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -49,8 +49,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
-        "branch" : "MOB-1953_separate_search_and_referral_impact",
-        "revision" : "e6b2df6c8f9bf5f7e56abcaf19a52b3cbd8f40ac"
+        "branch" : "main",
+        "revision" : "80374e155fa59f86ce1cc1ae2072b11a449b98af"
       }
     },
     {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -50,7 +50,7 @@
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
         "branch" : "MOB-1953_separate_search_and_referral_impact",
-        "revision" : "8f0985f217651666aeab4530a3c8b1b353a9a917"
+        "revision" : "e6b2df6c8f9bf5f7e56abcaf19a52b3cbd8f40ac"
       }
     },
     {

--- a/Client/Ecosia/Extensions/HomepageViewController+Ecosia.swift
+++ b/Client/Ecosia/Extensions/HomepageViewController+Ecosia.swift
@@ -87,11 +87,11 @@ extension HomepageViewController: NTPLibraryDelegate {
 extension HomepageViewController: NTPImpactCellDelegate {
     func impactCellButtonClickedWithInfo(_ info: ClimateImpactInfo) {
         switch info {
-        case .personalCounter:
+        case .search:
             Analytics.shared.navigation(.open, label: .counter)
             let url = Environment.current.urlProvider.aboutCounter
             openLink(url: url)
-        case .invites:
+        case .referral:
             let invite = MultiplyImpact(referrals: referrals)
             invite.delegate = self
             let nav = EcosiaNavigation(rootViewController: invite)

--- a/Client/Ecosia/Settings/EcosiaDebugSettings.swift
+++ b/Client/Ecosia/Settings/EcosiaDebugSettings.swift
@@ -149,11 +149,11 @@ final class ResetSearchCount: HiddenSetting {
     }
 
     override var status: NSAttributedString? {
-        return NSAttributedString(string: "\(User.shared.treeCount)", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        return NSAttributedString(string: "\(User.shared.searchCount)", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
-        User.shared.treeCount = 0
+        User.shared.searchCount = 0
         self.settings.tableView.reloadData()
         NotificationCenter.default.post(name: .HomePanelPrefsChanged, object: nil)
     }
@@ -165,11 +165,11 @@ final class ChangeSearchCount: HiddenSetting {
     }
 
     override var status: NSAttributedString? {
-        return NSAttributedString(string: "\(User.shared.treeCount)", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+        return NSAttributedString(string: "\(User.shared.searchCount)", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
     }
 
     override func onClick(_ navigationController: UINavigationController?) {
-        User.shared.treeCount += 10
+        User.shared.searchCount += 10
         self.settings.tableView.reloadData()
         NotificationCenter.default.post(name: .HomePanelPrefsChanged, object: nil)
     }

--- a/Client/Ecosia/UI/MultiplyImpact/MultiplyImpact.swift
+++ b/Client/Ecosia/UI/MultiplyImpact/MultiplyImpact.swift
@@ -69,7 +69,6 @@ final class MultiplyImpact: UIViewController, NotificationThemeable {
         let info = ClimateImpactInfo.referral(value: User.shared.referrals.impact,
                                               invites: User.shared.referrals.count)
         let view = NTPImpactRowView(info: info)
-        view.info = info // Needed to force info setup after init
         view.forceHideActionButton = true
         view.position = (0, 1)
         return view

--- a/Client/Ecosia/UI/MultiplyImpact/MultiplyImpact.swift
+++ b/Client/Ecosia/UI/MultiplyImpact/MultiplyImpact.swift
@@ -64,12 +64,16 @@ final class MultiplyImpact: UIViewController, NotificationThemeable {
     private weak var topBackground: UIView?
     private weak var forestOverlay: UIView?
     private weak var waves: UIImageView?
-    private weak var card: UIView?
-    private weak var cardIcon: UIImageView?
-    private weak var cardTitle: UILabel?
-    private weak var cardTreeCount: UILabel?
-    private weak var cardTreeIcon: UIImageView?
     private weak var yourInvites: UILabel?
+    private lazy var referralImpactRowView: NTPImpactRowView = {
+        let info = ClimateImpactInfo.referral(value: User.shared.referrals.impact,
+                                              invites: User.shared.referrals.count)
+        let view = NTPImpactRowView(info: info)
+        view.info = info // Needed to force info setup after init
+        view.forceHideActionButton = true
+        view.position = (0, 1)
+        return view
+    }()
     
     private weak var sharingYourLink: UILabel?
     private weak var sharing: UIView?
@@ -152,48 +156,7 @@ final class MultiplyImpact: UIViewController, NotificationThemeable {
         content.addSubview(yourInvites)
         self.yourInvites = yourInvites
         
-        let card = UIView()
-        card.isUserInteractionEnabled = false
-        card.translatesAutoresizingMaskIntoConstraints = false
-        card.layer.cornerRadius = UX.defaultCornerRadius
-        content.addSubview(card)
-        self.card = card
-        
-        let cardIcon = UIImageView(image: .init(named: "impactReferrals"))
-        cardIcon.translatesAutoresizingMaskIntoConstraints = false
-        cardIcon.setContentHuggingPriority(.required, for: .vertical)
-        cardIcon.contentMode = .center
-        card.addSubview(cardIcon)
-        self.cardIcon = cardIcon
-        
-        let cardTitle = UILabel()
-        cardTitle.translatesAutoresizingMaskIntoConstraints = false
-        cardTitle.numberOfLines = 0
-        cardTitle.text = .localizedPlural(.acceptedInvites, num: User.shared.referrals.count)
-        cardTitle.font = .preferredFont(forTextStyle: .body)
-        cardTitle.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-        cardTitle.setContentHuggingPriority(.defaultLow, for: .horizontal)
-        cardTitle.adjustsFontForContentSizeCategory = true
-        card.addSubview(cardTitle)
-        self.cardTitle = cardTitle
-        
-        let cardTreeCount = UILabel()
-        cardTreeCount.translatesAutoresizingMaskIntoConstraints = false
-        cardTreeCount.numberOfLines = 0
-        cardTreeCount.text = "\(User.shared.referrals.impact)"
-        cardTreeCount.font = .preferredFont(forTextStyle: .subheadline).bold()
-        cardTreeCount.setContentCompressionResistancePriority(.required, for: .horizontal)
-        cardTreeCount.setContentCompressionResistancePriority(.required, for: .vertical)
-        cardTreeCount.setContentHuggingPriority(.required, for: .horizontal)
-        cardTreeCount.adjustsFontForContentSizeCategory = true
-        card.addSubview(cardTreeCount)
-        self.cardTreeCount = cardTreeCount
-
-        let cardTreeIcon = UIImageView(image: .init(named: "yourImpact")?.withRenderingMode(.alwaysTemplate))
-        cardTreeIcon.translatesAutoresizingMaskIntoConstraints = false
-        cardTreeIcon.setContentHuggingPriority(.required, for: .horizontal)
-        card.addSubview(cardTreeIcon)
-        self.cardTreeIcon = cardTreeIcon
+        content.addSubview(referralImpactRowView)
 
         let sharingYourLink = UILabel()
         sharingYourLink.text = .localized(.sharingYourLink)
@@ -306,7 +269,7 @@ final class MultiplyImpact: UIViewController, NotificationThemeable {
             $0.setContentHuggingPriority(.defaultLow, for: .horizontal)
         }
         
-        [card, sharing, flowBackground].forEach {
+        [sharing, flowBackground].forEach {
             $0.translatesAutoresizingMaskIntoConstraints = false
             $0.layer.cornerRadius = UX.defaultCornerRadius
             content.addSubview($0)
@@ -381,25 +344,13 @@ final class MultiplyImpact: UIViewController, NotificationThemeable {
         yourInvites.trailingAnchor.constraint(equalTo: content.trailingAnchor, constant: -UX.defaultPadding).isActive = true
         yourInvites.topAnchor.constraint(equalTo: waves.bottomAnchor, constant: UX.defaultPadding).isActive = true
 
-        card.topAnchor.constraint(equalTo: yourInvites.bottomAnchor, constant: UX.defaultPadding).isActive = true
-        card.bottomAnchor.constraint(equalTo: cardIcon.bottomAnchor, constant: UX.Card.cardBottomMargin).isActive = true
-
-        cardIcon.topAnchor.constraint(equalTo: card.topAnchor, constant: UX.Card.cardIconTopMargin).isActive = true
-        cardIcon.leftAnchor.constraint(equalTo: card.leftAnchor, constant: UX.defaultPadding).isActive = true
-
-        cardTitle.centerYAnchor.constraint(equalTo: cardIcon.centerYAnchor).isActive = true
-        cardTitle.leftAnchor.constraint(equalTo: cardIcon.rightAnchor, constant: UX.Card.cardTitleLeftMargin).isActive = true
-
-        cardTreeCount.leftAnchor.constraint(equalTo: cardTitle.rightAnchor, constant: UX.Card.cardTreeCountLeftMargin).isActive = true
-        cardTreeCount.centerYAnchor.constraint(equalTo: cardTitle.centerYAnchor).isActive = true
-
-        cardTreeIcon.leftAnchor.constraint(equalTo: cardTreeCount.rightAnchor, constant: UX.Card.cardTreeIconLeftMargin).isActive = true
-        cardTreeIcon.rightAnchor.constraint(equalTo: card.rightAnchor, constant: -UX.defaultPadding).isActive = true
-        cardTreeIcon.centerYAnchor.constraint(equalTo: cardTreeCount.centerYAnchor).isActive = true
-
+        referralImpactRowView.leftAnchor.constraint(equalTo: content.leftAnchor, constant: UX.defaultPadding).isActive = true
+        referralImpactRowView.rightAnchor.constraint(equalTo: content.rightAnchor, constant: -UX.defaultPadding).isActive = true
+        referralImpactRowView.topAnchor.constraint(equalTo: yourInvites.bottomAnchor, constant: UX.defaultPadding).isActive = true
+        
         sharingYourLink.leadingAnchor.constraint(equalTo: content.leadingAnchor, constant: UX.defaultPadding).isActive = true
         sharingYourLink.trailingAnchor.constraint(equalTo: content.trailingAnchor, constant: -UX.defaultPadding).isActive = true
-        sharingYourLink.topAnchor.constraint(equalTo: card.bottomAnchor, constant: UX.Card.distanceFromCardBottom).isActive = true
+        sharingYourLink.topAnchor.constraint(equalTo: referralImpactRowView.bottomAnchor, constant: UX.Card.distanceFromCardBottom).isActive = true
         
         sharing.topAnchor.constraint(equalTo: sharingYourLink.bottomAnchor, constant: UX.defaultPadding).isActive = true
         
@@ -469,16 +420,12 @@ final class MultiplyImpact: UIViewController, NotificationThemeable {
         moreSharingMethods?.textColor = .theme.ecosia.secondaryText
         copyText?.textColor = .theme.ecosia.primaryBrand
         
-        [yourInvites, sharingYourLink, flowTitle, cardTitle, cardTreeCount, copyLink].forEach {
+        [yourInvites, sharingYourLink, flowTitle, copyLink].forEach {
             $0?.textColor = .theme.ecosia.primaryText
         }
         
-        [card, sharing, flowBackground].forEach {
+        [sharing, flowBackground].forEach {
             $0?.backgroundColor = .theme.ecosia.impactMultiplyCardBackground
-        }
-        
-        [cardIcon, cardTreeIcon].forEach {
-            $0?.tintColor = .theme.ecosia.primaryBrand
         }
         
         [firstStep, secondStep, thirdStep, fourthStep].forEach {
@@ -488,6 +435,9 @@ final class MultiplyImpact: UIViewController, NotificationThemeable {
         [copyDividerLeft, copyDividerRight].forEach {
             $0?.backgroundColor = .theme.ecosia.border
         }
+        
+        referralImpactRowView.customBackgroundColor = .theme.ecosia.impactMultiplyCardBackground
+        referralImpactRowView.applyTheme()
         
         updateBarAppearance()
     }

--- a/Client/Ecosia/UI/NTP/Impact/ClimateImpactInfo.swift
+++ b/Client/Ecosia/UI/NTP/Impact/ClimateImpactInfo.swift
@@ -6,16 +6,16 @@ import Foundation
 import Core
 
 enum ClimateImpactInfo: Equatable {
-    case personalCounter(value: Int, searches: Int)
-    case invites(value: Int)
+    case search(value: Int, searches: Int)
+    case referral(value: Int, invites: Int)
     case totalTrees(value: Int)
     case totalInvested(value: Int)
     
     var title: String {
         switch self {
-        case .personalCounter(let value, _):
+        case .search(let value, _):
             return "\(value)"
-        case .invites(let value):
+        case .referral(let value, _):
             return "\(value)"
         case .totalTrees(let value):
             return NumberFormatter.ecosiaCurrency(withoutEuroSymbol: true)
@@ -28,10 +28,10 @@ enum ClimateImpactInfo: Equatable {
     
     var subtitle: String {
         switch self {
-        case .personalCounter(_, let searches):
+        case .search(_, let searches):
             return .localizedPlural(.searches, num: searches)
-        case .invites(let value):
-            return .localizedPlural(.friendInvitesPlural, num: value)
+        case .referral(_, let invites):
+            return .localizedPlural(.friendInvitesPlural, num: invites)
         case .totalTrees:
             return .localized(.treesPlantedByTheCommunity)
         case .totalInvested:
@@ -41,10 +41,10 @@ enum ClimateImpactInfo: Equatable {
     
     var accessibilityLabel: String {
         switch self {
-        case .personalCounter(let value, let searches):
-            return value.spelledOutString + " " + .localizedPlural(.treesPlanted, num: value) + ";" + .localizedPlural(.searches, num: searches)
-        case .invites(let value):
-            return .localizedPlural(.friendInvitesPlural, num: value)
+        case .search(let value, let searches):
+            return accessiblityLabelTreesPlanted(value: value) + .localizedPlural(.searches, num: searches)
+        case .referral(let value, let invites):
+            return accessiblityLabelTreesPlanted(value: value) + .localizedPlural(.friendInvitesPlural, num: invites)
         case .totalTrees(let value):
             return value.spelledOutString + " " + .localized(.treesPlantedByTheCommunity)
         case .totalInvested(let value):
@@ -54,9 +54,9 @@ enum ClimateImpactInfo: Equatable {
     
     var image: UIImage? {
         switch self {
-        case .personalCounter:
+        case .search:
             return .init(named: "yourImpact")
-        case .invites:
+        case .referral:
             return .init(named: "groupYourImpact")
         case .totalTrees:
             return .init(named: "hand")
@@ -67,9 +67,9 @@ enum ClimateImpactInfo: Equatable {
     
     var buttonTitle: String? {
         switch self {
-        case .personalCounter:
+        case .search:
             return .localized(.howItWorks)
-        case .invites:
+        case .referral:
             return .localized(.inviteFriends)
         case .totalTrees, .totalInvested:
             return nil
@@ -78,9 +78,9 @@ enum ClimateImpactInfo: Equatable {
     
     var accessibilityHint: String? {
         switch self {
-        case .personalCounter:
+        case .search:
             return .localized(.howItWorks)
-        case .invites:
+        case .referral:
             return .localized(.inviteFriends)
         case .totalTrees, .totalInvested:
             return nil
@@ -89,11 +89,15 @@ enum ClimateImpactInfo: Equatable {
     
     var progressIndicatorValue: Double? {
         switch self {
-        case .personalCounter:
+        case .search:
             return User.shared.progress
-        case .invites, .totalInvested, .totalTrees:
+        case .referral, .totalInvested, .totalTrees:
             return nil
         }
+    }
+    
+    private func accessiblityLabelTreesPlanted(value: Int) -> String {
+        value.spelledOutString + " " + .localizedPlural(.treesPlanted, num: value) + ";"
     }
 }
 

--- a/Client/Ecosia/UI/NTP/Impact/ClimateImpactInfo.swift
+++ b/Client/Ecosia/UI/NTP/Impact/ClimateImpactInfo.swift
@@ -99,9 +99,9 @@ enum ClimateImpactInfo: Equatable {
     /// Created to be used for comparison without taking the associated types arguments into consideration.
     var rawValue: Int {
         switch self {
-        case .personalCounter:
+        case .search:
             return 0
-        case .invites:
+        case .referral:
             return 1
         case .totalTrees:
             return 2

--- a/Client/Ecosia/UI/NTP/Impact/NTPImpactCell.swift
+++ b/Client/Ecosia/UI/NTP/Impact/NTPImpactCell.swift
@@ -68,7 +68,6 @@ final class NTPImpactCell: UICollectionViewCell, NotificationThemeable, Reusable
         
         for (index, info) in items.enumerated() {
             let row = NTPImpactRowView(info: info)
-            row.info = info // Needed to force info setup after init
             row.position = (index, items.count)
             row.delegate = delegate
             containerStack.addArrangedSubview(row)

--- a/Client/Ecosia/UI/NTP/Impact/NTPImpactCellViewModel.swift
+++ b/Client/Ecosia/UI/NTP/Impact/NTPImpactCellViewModel.swift
@@ -22,7 +22,7 @@ final class NTPImpactCellViewModel {
         return [firstSection, secondSection]
     }
     var searchInfo: ClimateImpactInfo {
-        .search(value: User.shared.searchImpact, searches: personalCounter.state ?? User.shared.treeCount)
+        .search(value: User.shared.searchImpact, searches: searchesCounter.state ?? User.shared.searchCount)
     }
     var referralInfo: ClimateImpactInfo {
         .referral(value: User.shared.referrals.impact, invites: User.shared.referrals.count)
@@ -34,7 +34,7 @@ final class NTPImpactCellViewModel {
         .totalInvested(value: InvestmentsProjection.shared.totalInvestedAt(.init()))
     }
 
-    private let personalCounter = PersonalCounter()
+    private let searchesCounter = SearchesCounter()
     private var cells = [Int:NTPImpactCell]()
     private let referrals: Referrals
     init(referrals: Referrals) {
@@ -45,7 +45,7 @@ final class NTPImpactCellViewModel {
             self.refreshCell(withInfo: self.referralInfo)
         }
         
-        personalCounter.subscribe(self) { [weak self] _ in
+        searchesCounter.subscribe(self) { [weak self] _ in
             guard let self = self else { return }
             self.refreshCell(withInfo: self.searchInfo)
         }
@@ -53,7 +53,7 @@ final class NTPImpactCellViewModel {
     
     deinit {
         referrals.unsubscribe(self)
-        personalCounter.unsubscribe(self)
+        searchesCounter.unsubscribe(self)
     }
 
     func subscribeToProjections() {

--- a/Client/Ecosia/UI/NTP/Impact/NTPImpactCellViewModel.swift
+++ b/Client/Ecosia/UI/NTP/Impact/NTPImpactCellViewModel.swift
@@ -13,20 +13,19 @@ protocol NTPImpactCellDelegate: AnyObject {
 final class NTPImpactCellViewModel {
     weak var delegate: NTPImpactCellDelegate?
     var infoItemSections: [[ClimateImpactInfo]] {
-        var firstSection: [ClimateImpactInfo] = [invitesInfo]
+        var firstSection: [ClimateImpactInfo] = [referralInfo]
         if !Unleash.isEnabled(.incentiveRestrictedSearch) {
-            firstSection.insert(personalCounterInfo,
+            firstSection.insert(searchInfo,
                                 at: 0)
         }
         let secondSection: [ClimateImpactInfo] = [totalTreesInfo, totalInvestedInfo]
         return [firstSection, secondSection]
     }
-    var invitesInfo: ClimateImpactInfo {
-        .invites(value: User.shared.referrals.count)
+    var searchInfo: ClimateImpactInfo {
+        .search(value: User.shared.searchImpact, searches: personalCounter.state ?? User.shared.treeCount)
     }
-    var personalCounterInfo: ClimateImpactInfo {
-        .personalCounter(value: User.shared.impact,
-                         searches: personalCounter.state ?? User.shared.treeCount)
+    var referralInfo: ClimateImpactInfo {
+        .referral(value: User.shared.referrals.impact, invites: User.shared.referrals.count)
     }
     var totalTreesInfo: ClimateImpactInfo {
         .totalTrees(value: TreesProjection.shared.treesAt(.init()))
@@ -43,12 +42,12 @@ final class NTPImpactCellViewModel {
         
         referrals.subscribe(self) { [weak self] _ in
             guard let self = self else { return }
-            self.refreshCell(withInfo: self.invitesInfo)
+            self.refreshCell(withInfo: self.referralInfo)
         }
         
         personalCounter.subscribe(self) { [weak self] _ in
             guard let self = self else { return }
-            self.refreshCell(withInfo: self.personalCounterInfo)
+            self.refreshCell(withInfo: self.searchInfo)
         }
     }
     

--- a/Client/Ecosia/UI/NTP/Impact/NTPImpactRowView.swift
+++ b/Client/Ecosia/UI/NTP/Impact/NTPImpactRowView.swift
@@ -69,7 +69,7 @@ final class NTPImpactRowView: UIView, NotificationThemeable {
             imageView.image = info.image
             titleLabel.text = info.title
             subtitleLabel.text = info.subtitle
-            actionButton.isHidden = info.buttonTitle == nil
+            actionButton.isHidden = forceHideActionButton ? true : info.buttonTitle == nil
             actionButton.setTitle(info.buttonTitle, for: .normal)
             if let progress = info.progressIndicatorValue {
                 currentProgressView.value = progress
@@ -83,6 +83,12 @@ final class NTPImpactRowView: UIView, NotificationThemeable {
             setMaskedCornersUsingPosition(row: row, totalCount: count)
         }
     }
+    var forceHideActionButton: Bool = false {
+        didSet {
+            actionButton.isHidden = forceHideActionButton
+        }
+    }
+    var customBackgroundColor: UIColor? = nil
     
     init(info: ClimateImpactInfo) {
         self.info = info
@@ -144,7 +150,7 @@ final class NTPImpactRowView: UIView, NotificationThemeable {
     required init?(coder: NSCoder) { nil }
     
     func applyTheme() {
-        backgroundColor = .theme.ecosia.secondaryBackground
+        backgroundColor = customBackgroundColor ?? .theme.ecosia.secondaryBackground
         titleLabel.textColor = .theme.ecosia.primaryText
         subtitleLabel.textColor = .theme.ecosia.secondaryText
         actionButton.setTitleColor(.theme.ecosia.primaryButton, for: .normal)

--- a/Client/Ecosia/UI/NTP/Impact/NTPImpactRowView.swift
+++ b/Client/Ecosia/UI/NTP/Impact/NTPImpactRowView.swift
@@ -93,6 +93,11 @@ final class NTPImpactRowView: UIView, NotificationThemeable {
     init(info: ClimateImpactInfo) {
         self.info = info
         super.init(frame: .zero)
+        defer {
+            // Needed to force info setup after init
+            self.info = info
+        }
+        
         translatesAutoresizingMaskIntoConstraints = false
         layer.cornerRadius = UX.cornerRadius
         

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2307,7 +2307,7 @@ extension BrowserViewController {
     @discardableResult
     private func presentDefaultBrowserPromoIfNeeded() -> Bool {
         guard shouldShowDefaultBrowserPromo, 
-                DefaultBrowserExperiment.minPromoSearches() <= User.shared.treeCount else { return false }
+                DefaultBrowserExperiment.minPromoSearches() <= User.shared.searchCount else { return false }
 
         if #available(iOS 14, *) {
             let defaultPromo = DefaultBrowser(delegate: self)


### PR DESCRIPTION
[MOB-1953](https://ecosia.atlassian.net/browse/MOB-1953)

## Context

We'll no longer have one global counter to rule them all, we'll instead separate into search and referral impact counters.

Core-side counterpart: https://github.com/ecosia/ios-core/pull/115

## Approach

- Use `User.shared.searchImpact` instead of `User.shared.impact`
- Refactor `ClimateImpactInfo` so it is more clear the existence of two separate impact counter
   - Also correctly enabling referrals impact having a different value than invited friends (both were using `User.shared.referrals.count` and none `User.shared.referrals.impact`)
- Update some names to match renamings mad on ios-core
- Update referral page UI to match NTP's referral counter


[MOB-1953]: https://ecosia.atlassian.net/browse/MOB-1953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ