### PR TITLE
[MOB-1954] UI context menu fixes

### DIFF
--- a/Client/Ecosia/UI/PageAction/PageActionMenu.swift
+++ b/Client/Ecosia/UI/PageAction/PageActionMenu.swift
@@ -166,20 +166,15 @@ extension PageActionMenu: UITableViewDataSource, UITableViewDelegate {
         return cell
     }
 
-    func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
-        return UIView()
-    }
-
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        if section == 0 {
-            return UITableView.automaticDimension
-        } else {
-            return UX.spacing
+        guard section == 0 else {
+            return 0
         }
+        return UITableView.automaticDimension
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        guard section == 0 else { return UIView() }
+        guard section == 0 else { return nil }
 
         let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: UX.shortcuts) as! PageActionsShortcutsHeader
         header.delegate = delegate

--- a/Client/Ecosia/UI/PageAction/PageActionMenu.swift
+++ b/Client/Ecosia/UI/PageAction/PageActionMenu.swift
@@ -167,10 +167,7 @@ extension PageActionMenu: UITableViewDataSource, UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        guard section == 0 else {
-            return 0
-        }
-        return UITableView.automaticDimension
+        return if section == 0 { 0 } else { UITableView.automaticDimension }
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {

--- a/Client/Ecosia/UI/PageAction/PageActionMenu.swift
+++ b/Client/Ecosia/UI/PageAction/PageActionMenu.swift
@@ -167,7 +167,10 @@ extension PageActionMenu: UITableViewDataSource, UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return if section == 0 { 0 } else { UITableView.automaticDimension }
+        guard section == 0 else {
+            return 0
+        }
+        return UITableView.automaticDimension
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {

--- a/Client/Ecosia/UI/PageAction/PageActionMenu.swift
+++ b/Client/Ecosia/UI/PageAction/PageActionMenu.swift
@@ -9,7 +9,6 @@ final class PageActionMenu: UIViewController, UIGestureRecognizerDelegate {
     // MARK: - UX
 
     struct UX {
-        static let spacing: CGFloat = 16
         static let estimatedSectionHeaderHeight: CGFloat = 16
         static let shortcuts = "Shortcuts"
         static let rowHeight: CGFloat = 50

--- a/Client/Ecosia/UI/PageAction/PageActionMenuCell.swift
+++ b/Client/Ecosia/UI/PageAction/PageActionMenuCell.swift
@@ -146,6 +146,7 @@ extension PageActionMenuCell {
         separatorView.backgroundColor = .theme.ecosia.border
         
         contentView.addSubview(separatorView)
+        contentView.bringSubviewToFront(separatorView)
         
         updateSeparatorViewConstraints(separatorView)
     }
@@ -153,7 +154,7 @@ extension PageActionMenuCell {
     private func updateSeparatorViewConstraints(_ separatorView: UIView) {
         separatorView.heightAnchor.constraint(equalToConstant: UX.separatorHeight).isActive = true
         separatorView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -UX.separatorHeight).isActive = true
-        separatorView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -UX.padding).isActive = true
+        separatorView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -UX.padding).isActive = true
         if let imageView {
             separatorView.leadingAnchor.constraint(equalTo: imageView.leadingAnchor).isActive = true
         } else if let textLabel {
@@ -218,8 +219,8 @@ extension PageActionMenuCell {
                 badgeLabel.text = .localized(.new)
                 badge.addSubview(badgeLabel)
                 
-                badgeLabel.topAnchor.constraint(equalTo: badge.topAnchor, constant: 2.5).isActive = true
-                badgeLabel.leftAnchor.constraint(equalTo: badge.leftAnchor, constant: 8).isActive = true
+                badgeLabel.centerXAnchor.constraint(equalTo: badge.centerXAnchor).isActive = true
+                badgeLabel.centerYAnchor.constraint(equalTo: badge.centerYAnchor).isActive = true
                 
                 self.badge = badge
                 self.badgeLabel = badgeLabel

--- a/Client/Ecosia/UI/PageAction/PageActionsShortcutsHeader.swift
+++ b/Client/Ecosia/UI/PageAction/PageActionsShortcutsHeader.swift
@@ -24,16 +24,24 @@ class PageActionsShortcutsHeader: UITableViewHeaderFooterView {
 
     var shortcuts: [NTPLibraryShortcutView] = []
 
-    let home = Panel(title: .localized(.home), image: UIImage(named: "menu-Home"), tag: 0)
-    let newTab = Panel(title: .AppMenu.NewTab, image: UIImage(named: "menu-NewTab"), tag: 1)
-    let share = Panel(title: .AppMenu.Share, image: UIImage(named: "action_share"), tag: 2)
-    let settings = Panel(title: .AppMenu.AppMenuSettingsTitleString, image: UIImage(named: ImageIdentifiers.settings), tag: 3)
+    let home = Panel(title: .localized(.home), 
+                     image: UIImage(named: "menu-Home"),
+                     tag: 0)
+    let newTab = Panel(title: .AppMenu.NewTab, 
+                       image: UIImage(named: "menu-NewTab"),
+                       tag: 1)
+    let share = Panel(title: .AppMenu.Share, 
+                      image: UIImage(named: "action_share"),
+                      tag: 2)
+    let settings = Panel(title: .AppMenu.AppMenuSettingsTitleString, 
+                         image: UIImage(named: ImageIdentifiers.settings),
+                         tag: 3)
 
     override init(reuseIdentifier: String?) {
         super.init(reuseIdentifier: reuseIdentifier)
         mainView.distribution = .fillEqually
-        mainView.alignment = .leading
-        mainView.spacing = 0
+        mainView.alignment = .center
+        mainView.spacing = 8
         mainView.translatesAutoresizingMaskIntoConstraints = false
         contentView.addSubview(mainView)
 
@@ -44,8 +52,8 @@ class PageActionsShortcutsHeader: UITableViewHeaderFooterView {
         NSLayoutConstraint.activate([
             mainView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 22),
             mainView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -8, priority: .defaultHigh),
-            mainView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-            mainView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            mainView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            mainView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
         ])
 
 

--- a/Client/Ecosia/UI/PageAction/PageActionsShortcutsHeader.swift
+++ b/Client/Ecosia/UI/PageAction/PageActionsShortcutsHeader.swift
@@ -50,7 +50,7 @@ class PageActionsShortcutsHeader: UITableViewHeaderFooterView {
         height.isActive = true
 
         NSLayoutConstraint.activate([
-            mainView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 22),
+            mainView.topAnchor.constraint(equalTo: contentView.topAnchor),
             mainView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -8, priority: .defaultHigh),
             mainView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
             mainView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),

--- a/Client/Frontend/Menu/Menu.xcassets/menu-Settings.imageset/Contents.json
+++ b/Client/Frontend/Menu/Menu.xcassets/menu-Settings.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
-    "preserves-vector-representation" : true
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
   }
 }


### PR DESCRIPTION
[MOB-1954](https://ecosia.atlassian.net/browse/MOB-####)

## Context

Throughout our QAing we have identified some UI issues needing attention.

## Approach

Screenshot containing al the fixes but the Help one.

This PR fixes the following:
- Settings Icon in Context Menu not tinted in Dark Mode
- News badge content view prevents the separator to expand
- Menu spacing issues
- Distance from the header quick menu and the knob

![Simulator Screenshot - iPhone 15 Pro - 2023-10-09 at 16 32 54](https://github.com/ecosia/ios-browser/assets/3584008/d81c18d8-a841-4fb9-b14d-3008af347a18)




[MOB-1954]: https://ecosia.atlassian.net/browse/MOB-1954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ