### PR TITLE
[MOB-1848] Fix impact cell line breaking

### DIFF
--- a/Client/Ecosia/UI/NTP/Impact/NTPImpactRowView.swift
+++ b/Client/Ecosia/UI/NTP/Impact/NTPImpactRowView.swift
@@ -120,7 +120,7 @@ final class NTPImpactRowView: UIView, NotificationThemeable {
             hStack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: UX.padding),
             hStack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -UX.padding),
             hStack.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -UX.padding),
-            actionButton.widthAnchor.constraint(lessThanOrEqualToConstant: UX.buttonMaximumWidth),=
+            actionButton.widthAnchor.constraint(lessThanOrEqualToConstant: UX.buttonMaximumWidth),
             dividerView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: UX.padding),
             dividerView.trailingAnchor.constraint(equalTo: trailingAnchor),
             dividerView.bottomAnchor.constraint(equalTo: bottomAnchor),

--- a/Client/Ecosia/UI/NTP/Impact/NTPImpactRowView.swift
+++ b/Client/Ecosia/UI/NTP/Impact/NTPImpactRowView.swift
@@ -9,7 +9,6 @@ final class NTPImpactRowView: UIView, NotificationThemeable {
         static let cornerRadius: CGFloat = 10
         static let horizontalSpacing: CGFloat = 8
         static let padding: CGFloat = 16
-        static let buttonMaximumWidth: CGFloat = 120
         static let imageHeight: CGFloat = 48
         static let imageHeightWithProgress: CGFloat = 26
         static let progressWidth: CGFloat = 48
@@ -48,12 +47,13 @@ final class NTPImpactRowView: UIView, NotificationThemeable {
         label.numberOfLines = 0
         return label
     }()
-    private lazy var actionButton: UIButton = {
-        let button = UIButton()
+    private lazy var actionButton: ResizableButton = {
+        let button = ResizableButton()
         button.translatesAutoresizingMaskIntoConstraints = false
         button.titleLabel?.font = .preferredFont(forTextStyle: .callout)
-        button.titleLabel?.numberOfLines = 0
         button.titleLabel?.textAlignment = .right
+        button.contentHorizontalAlignment = .right
+        button.edgeSpacing = 0
         button.setContentCompressionResistancePriority(.required, for: .horizontal)
         button.addTarget(self, action: #selector(buttonAction), for: .touchUpInside)
         button.clipsToBounds = true
@@ -120,7 +120,7 @@ final class NTPImpactRowView: UIView, NotificationThemeable {
             hStack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: UX.padding),
             hStack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -UX.padding),
             hStack.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -UX.padding),
-            actionButton.widthAnchor.constraint(lessThanOrEqualToConstant: UX.buttonMaximumWidth),
+            actionButton.widthAnchor.constraint(equalTo: hStack.widthAnchor, multiplier: 1/3),
             dividerView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: UX.padding),
             dividerView.trailingAnchor.constraint(equalTo: trailingAnchor),
             dividerView.bottomAnchor.constraint(equalTo: bottomAnchor),

--- a/Client/Ecosia/UI/NTP/Impact/NTPImpactRowView.swift
+++ b/Client/Ecosia/UI/NTP/Impact/NTPImpactRowView.swift
@@ -6,10 +6,10 @@ import Foundation
 
 final class NTPImpactRowView: UIView, NotificationThemeable {
     struct UX {
-        static let height: CGFloat = 80
         static let cornerRadius: CGFloat = 10
         static let horizontalSpacing: CGFloat = 8
         static let padding: CGFloat = 16
+        static let buttonMaximumWidth: CGFloat = 120
         static let imageHeight: CGFloat = 48
         static let imageHeightWithProgress: CGFloat = 26
         static let progressWidth: CGFloat = 48
@@ -45,14 +45,16 @@ final class NTPImpactRowView: UIView, NotificationThemeable {
     private lazy var subtitleLabel: UILabel = {
         let label = UILabel()
         label.font = .preferredFont(forTextStyle: .footnote)
-        label.adjustsFontSizeToFitWidth = true
+        label.numberOfLines = 0
         return label
     }()
     private lazy var actionButton: UIButton = {
         let button = UIButton()
         button.translatesAutoresizingMaskIntoConstraints = false
         button.titleLabel?.font = .preferredFont(forTextStyle: .callout)
-        button.titleLabel?.adjustsFontSizeToFitWidth = true
+        button.titleLabel?.numberOfLines = 0
+        button.titleLabel?.textAlignment = .right
+        button.setContentCompressionResistancePriority(.required, for: .horizontal)
         button.addTarget(self, action: #selector(buttonAction), for: .touchUpInside)
         button.clipsToBounds = true
         return button
@@ -93,7 +95,7 @@ final class NTPImpactRowView: UIView, NotificationThemeable {
         let hStack = UIStackView()
         hStack.translatesAutoresizingMaskIntoConstraints = false
         hStack.axis = .horizontal
-        hStack.alignment = .fill
+        hStack.alignment = .center
         hStack.spacing = UX.horizontalSpacing
         hStack.addArrangedSubview(imageContainer)
         imageContainer.addSubview(imageView)
@@ -106,19 +108,19 @@ final class NTPImpactRowView: UIView, NotificationThemeable {
         vStack.alignment = .leading
         vStack.addArrangedSubview(titleLabel)
         vStack.addArrangedSubview(subtitleLabel)
-        hStack.addArrangedSubview(vStack)
         vStack.isAccessibilityElement = true
         vStack.shouldGroupAccessibilityChildren = true
         vStack.accessibilityLabel = info.accessibilityLabel
-
+        
+        hStack.addArrangedSubview(vStack)
         hStack.addArrangedSubview(actionButton)
         
         NSLayoutConstraint.activate([
-            heightAnchor.constraint(equalToConstant: UX.height),
             hStack.topAnchor.constraint(equalTo: topAnchor, constant: UX.padding),
             hStack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: UX.padding),
             hStack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -UX.padding),
             hStack.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -UX.padding),
+            actionButton.widthAnchor.constraint(lessThanOrEqualToConstant: UX.buttonMaximumWidth),=
             dividerView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: UX.padding),
             dividerView.trailingAnchor.constraint(equalTo: trailingAnchor),
             dividerView.bottomAnchor.constraint(equalTo: bottomAnchor),

--- a/Client/Frontend/Components/ResizableButton.swift
+++ b/Client/Frontend/Components/ResizableButton.swift
@@ -6,8 +6,13 @@ import UIKit
 
 class ResizableButton: UIButton {
 
-    struct UX {
-        static let buttonEdgeSpacing: CGFloat = 8
+    var edgeSpacing: CGFloat = 8 {
+        didSet {
+            contentEdgeInsets = UIEdgeInsets(top: 0,
+                                             left: edgeSpacing,
+                                             bottom: 0,
+                                             right: edgeSpacing)
+        }
     }
 
     override init(frame: CGRect) {
@@ -25,9 +30,9 @@ class ResizableButton: UIButton {
         titleLabel?.adjustsFontForContentSizeCategory = true
         titleLabel?.lineBreakMode = .byWordWrapping
         contentEdgeInsets = UIEdgeInsets(top: 0,
-                                         left: UX.buttonEdgeSpacing,
+                                         left: edgeSpacing,
                                          bottom: 0,
-                                         right: UX.buttonEdgeSpacing)
+                                         right: edgeSpacing)
     }
 
     override var intrinsicContentSize: CGSize {


### PR DESCRIPTION
[MOB-1848](https://ecosia.atlassian.net/browse/MOB-1848)

## Context

Follow-up of #547, where [it was reported](https://ecosia.atlassian.net/browse/MOB-1848?focusedCommentId=82720) that labels with long texts were wrongly adjusting the font size instead of breaking into new lines.

## Approach

After some back and forth with design, it was decided that the button should occupy a third of the space, with both it and the subtitle breaking into more lines if needed.

To achieve that, I first had to change the alignment of the horizontal stack, since with `fill` it does not use the intrinsic content size. After that, set `subtitleLabel.numberOfLines = 0` and used the already implemented `ResizableButton` for the button (though I had refactor it to allow custom edge spacing).

[MOB-1848]: https://ecosia.atlassian.net/browse/MOB-1848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ