### PR TITLE
[MOB-1848] Add interaction state to customize NTP button

### DIFF
--- a/Client/Ecosia/UI/EcosiaTheme.swift
+++ b/Client/Ecosia/UI/EcosiaTheme.swift
@@ -63,6 +63,7 @@ class EcosiaTheme {
     var secondaryButton: UIColor { .Light.Button.secondary }
     var secondaryButtonContent: UIColor { .Light.Button.secondaryContent }
     var secondaryButtonBackground: UIColor { .Light.Button.secondaryBackground }
+    var activeTransparentBackground: UIColor { .Light.Button.activeTransparentBackground }
     
     var textfieldPlaceholder: UIColor { .Light.Text.secondary }
     var textfieldIconTint: UIColor { .Light.Button.primary }
@@ -142,6 +143,7 @@ final class DarkEcosiaTheme: EcosiaTheme {
     override var secondaryButton: UIColor { .Dark.Button.secondary }
     override var secondaryButtonContent: UIColor { .Dark.Button.secondaryContent }
     override var secondaryButtonBackground: UIColor { .Dark.Button.secondaryBackground }
+    override var activeTransparentBackground: UIColor { .Dark.Button.activeTransparentBackground }
 
     override var textfieldPlaceholder: UIColor { .Dark.Text.secondary }
     override var textfieldIconTint: UIColor { .Dark.Button.primary }

--- a/Client/Ecosia/UI/NTP/Customization/NTPCustomizationCell.swift
+++ b/Client/Ecosia/UI/NTP/Customization/NTPCustomizationCell.swift
@@ -25,6 +25,7 @@ final class NTPCustomizationCell: UICollectionViewCell, NotificationThemeable, R
         button.setInsets(forContentPadding: .init(top: UX.verticalInset, left: UX.horizontalInset, bottom: UX.verticalInset, right: UX.horizontalInset),
                          imageTitlePadding: UX.imageTitlePadding)
         button.addTarget(self, action: #selector(touchButtonAction), for: .touchUpInside)
+        button.clipsToBounds = true
         return button
     }()
     
@@ -63,7 +64,8 @@ final class NTPCustomizationCell: UICollectionViewCell, NotificationThemeable, R
     func applyTheme() {
         button.imageView?.tintColor = .theme.ecosia.secondaryButtonContent
         button.setTitleColor(.theme.ecosia.secondaryButtonContent, for: .normal)
-        button.backgroundColor = .theme.ecosia.secondaryButtonBackground
+        button.setBackgroundColor(.theme.ecosia.secondaryButtonBackground, forState: .normal)
+        button.setBackgroundColor(.theme.ecosia.activeTransparentBackground, forState: .highlighted)
     }
     
     @objc func touchButtonAction() {

--- a/Client/Ecosia/UI/SemanticColor.swift
+++ b/Client/Ecosia/UI/SemanticColor.swift
@@ -21,6 +21,7 @@ extension UIColor {
             static let secondaryActive = UIColor(rgb: 0xF8F8F6)
             static let secondaryContent = UIColor(rgb: 0x333333)
             static let secondaryBackground = UIColor(rgb: 0xF8F8F6)
+            static let activeTransparentBackground = UIColor(rgb: 0x333333).withAlphaComponent(0.24)
         }
         
         struct Text {
@@ -63,6 +64,7 @@ extension UIColor {
             static let secondary = UIColor(rgb: 0x333333)
             static let secondaryContent = UIColor.white
             static let secondaryBackground = UIColor(rgb: 0x252525)
+            static let activeTransparentBackground = UIColor(rgb: 0xDEDED9).withAlphaComponent(0.32)
         }
         
         struct Text {


### PR DESCRIPTION
[MOB-1848](https://ecosia.atlassian.net/browse/MOB-1848)

## Context

Follow-up of #547, where [it was reported](https://ecosia.atlassian.net/browse/MOB-1848?focusedCommentId=82800) that our customize NTP button did not have an interaction state.

## Approach

Added a new background color for the highlighted state according to the `Outline` `IconTextButton` shown on the [button global component](https://www.figma.com/file/s1beHaK0d7VU3UpE4YAg11/%F0%9F%A7%AC-Global-Components?type=design&node-id=194-9405&mode=design&t=UOYLO9wf3eruDPeP-11). Used the existing UIButton extension for setting that.

## Other
From what I talked to Yann, this will be standard as described in the Global Components Figma, so when we reuse it, we can think about exporting into a separate reusable component.

[MOB-1848]: https://ecosia.atlassian.net/browse/MOB-1848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ