### PR TITLE
[MOB-1960] Update Referrals refresh logic

### DIFF
--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -50,7 +50,7 @@
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
         "branch" : "main",
-        "revision" : "80374e155fa59f86ce1cc1ae2072b11a449b98af"
+        "revision" : "a899a972d0f7844217d99447c2aaa833115aa6d9"
       }
     },
     {

--- a/Client/Ecosia/UI/MultiplyImpact/MultiplyImpact.swift
+++ b/Client/Ecosia/UI/MultiplyImpact/MultiplyImpact.swift
@@ -456,7 +456,7 @@ final class MultiplyImpact: UIViewController, NotificationThemeable {
     }
 
     private func updateInviteLink() {
-        copyLink?.text = inviteLink
+        copyLink?.text = inviteLink ?? inviteLinkPlaceholder
     }
     
     private func refreshReferrals() {
@@ -565,8 +565,10 @@ https://ecosia.co/install-ios
 """
     }
     
-    private var inviteLink: String {
-        guard let code = User.shared.referrals.code else { return "-" }
+    private let inviteLinkPlaceholder = "-"
+    
+    private var inviteLink: String? {
+        guard let code = User.shared.referrals.code else { return nil }
         return "ecosia://\(Referrals.host)/" + code
     }
 

--- a/Client/Ecosia/UI/MultiplyImpact/MultiplyImpact.swift
+++ b/Client/Ecosia/UI/MultiplyImpact/MultiplyImpact.swift
@@ -457,7 +457,7 @@ final class MultiplyImpact: UIViewController, NotificationThemeable {
     private func updateInviteLink() {
         guard let inviteLink = inviteLink else {
             copyLink?.text = "-"
-            referrals.refresh(createCode: true) {[weak self] error in
+            referrals.refresh(force: true, createCode: true) {[weak self] error in
                 if let error = error {
                     self?.showObtainingCode(error)
                 } else {

--- a/Client/Ecosia/UI/MultiplyImpact/MultiplyImpact.swift
+++ b/Client/Ecosia/UI/MultiplyImpact/MultiplyImpact.swift
@@ -66,13 +66,15 @@ final class MultiplyImpact: UIViewController, NotificationThemeable {
     private weak var waves: UIImageView?
     private weak var yourInvites: UILabel?
     private lazy var referralImpactRowView: NTPImpactRowView = {
-        let info = ClimateImpactInfo.referral(value: User.shared.referrals.impact,
-                                              invites: User.shared.referrals.count)
-        let view = NTPImpactRowView(info: info)
+        let view = NTPImpactRowView(info: referralInfo)
         view.forceHideActionButton = true
         view.position = (0, 1)
         return view
     }()
+    
+    var referralInfo: ClimateImpactInfo {
+        .referral(value: User.shared.referrals.impact, invites: User.shared.referrals.count)
+    }
     
     private weak var sharingYourLink: UILabel?
     private weak var sharing: UIView?
@@ -462,10 +464,12 @@ final class MultiplyImpact: UIViewController, NotificationThemeable {
     private func refreshReferrals() {
         referrals.refresh(force: true, createCode: true) { [weak self] error in
             guard error == nil else {
-                self?.showObtainingCode(error!)
+                self?.showRefreshReferralsError(error!)
                 return
             }
-            self?.updateInviteLink()
+            guard let self = self else { return }
+            self.updateInviteLink()
+            self.referralImpactRowView.info = self.referralInfo
         }
     }
     
@@ -501,7 +505,7 @@ final class MultiplyImpact: UIViewController, NotificationThemeable {
         guard let message = inviteMessage else {
             referrals.refresh(createCode: true) { error in
                 if let error = error {
-                    self.showReferralError(error)
+                    self.showInviteFriendsError(error)
                 } else {
                     self.share(message: self.inviteMessage!)
                 }
@@ -525,7 +529,7 @@ final class MultiplyImpact: UIViewController, NotificationThemeable {
         Analytics.shared.startInvite()
     }
 
-    private func showReferralError(_ error: Referrals.Error) {
+    private func showInviteFriendsError(_ error: Referrals.Error) {
         let alert = UIAlertController(title: error.title,
                                       message: error.message,
                                       preferredStyle: .alert)
@@ -536,13 +540,13 @@ final class MultiplyImpact: UIViewController, NotificationThemeable {
         present(alert, animated: true)
     }
 
-    private func showObtainingCode(_ error: Referrals.Error) {
+    private func showRefreshReferralsError(_ error: Referrals.Error) {
         let alert = UIAlertController(title: error.title,
                                       message: error.message,
                                       preferredStyle: .alert)
         alert.addAction(.init(title: .localized(.continueMessage), style: .cancel))
         alert.addAction(.init(title: .localized(.retryMessage), style: .default) { [weak self] _ in
-            self?.updateInviteLink()
+            self?.refreshReferrals()
         })
         present(alert, animated: true)
     }

--- a/Client/Ecosia/UI/MultiplyImpact/MultiplyImpact.swift
+++ b/Client/Ecosia/UI/MultiplyImpact/MultiplyImpact.swift
@@ -391,6 +391,7 @@ final class MultiplyImpact: UIViewController, NotificationThemeable {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         updateInviteLink()
+        refreshReferrals()
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -455,18 +456,17 @@ final class MultiplyImpact: UIViewController, NotificationThemeable {
     }
 
     private func updateInviteLink() {
-        guard let inviteLink = inviteLink else {
-            copyLink?.text = "-"
-            referrals.refresh(force: true, createCode: true) {[weak self] error in
-                if let error = error {
-                    self?.showObtainingCode(error)
-                } else {
-                    self?.updateInviteLink()
-                }
-            }
-            return
-        }
         copyLink?.text = inviteLink
+    }
+    
+    private func refreshReferrals() {
+        referrals.refresh(force: true, createCode: true) { [weak self] error in
+            guard error == nil else {
+                self?.showObtainingCode(error!)
+                return
+            }
+            self?.updateInviteLink()
+        }
     }
     
     @objc private func learnMore() {
@@ -565,8 +565,8 @@ https://ecosia.co/install-ios
 """
     }
     
-    private var inviteLink: String? {
-        guard let code = User.shared.referrals.code else { return nil }
+    private var inviteLink: String {
+        guard let code = User.shared.referrals.code else { return "-" }
         return "ecosia://\(Referrals.host)/" + code
     }
 

--- a/Client/Ecosia/UI/NTP/Impact/NTPImpactCellViewModel.swift
+++ b/Client/Ecosia/UI/NTP/Impact/NTPImpactCellViewModel.swift
@@ -147,6 +147,10 @@ extension NTPImpactCellViewModel: HomepageViewModelProtocol {
     var isEnabled: Bool {
         User.shared.showClimateImpact
     }
+    
+    func refreshData(for traitCollection: UITraitCollection, isPortrait: Bool, device: UIUserInterfaceIdiom) {
+        referrals.refresh()
+    }
 }
 
 extension NTPImpactCellViewModel: HomepageSectionHandler {

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -94,6 +94,11 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable {
 
         viewModel.recordViewAppeared()
     }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        referrals.refresh()
+    }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -94,11 +94,6 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable {
 
         viewModel.recordViewAppeared()
     }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        referrals.refresh()
-    }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)


### PR DESCRIPTION
[MOB-1960](https://ecosia.atlassian.net/browse/MOB-####)

## Context

Due to a regression found on G Changes, we take the occasion to review the Referrals update logic.

## Approach

- Make use of `HomepageViewModelProtocol`'s `refreshData(:)` to conform to other cells and delegate its ViewModel to refresh its own data. As the HomePageViewController sits within the `BrowserViewController` domain, `viewWillAppear` won't respond every time the `HomePageViewController` is shown. The `BrowserViewController` creates the object only once and then orchestrates the transitions between views accordingly.
- Update of `referrals.refresh` specifying the `force:true` parameter within the `updateInviteLink()` function called in `viewWillAppear`

[MOB-1960]: https://ecosia.atlassian.net/browse/MOB-1960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ