### PR TITLE
[MOB-1964] Remove the Referral Refresh from the NTPImpactCell context

### DIFF
--- a/Client/Ecosia/UI/NTP/Impact/NTPImpactCellViewModel.swift
+++ b/Client/Ecosia/UI/NTP/Impact/NTPImpactCellViewModel.swift
@@ -147,10 +147,6 @@ extension NTPImpactCellViewModel: HomepageViewModelProtocol {
     var isEnabled: Bool {
         User.shared.showClimateImpact
     }
-    
-    func refreshData(for traitCollection: UITraitCollection, isPortrait: Bool, device: UIUserInterfaceIdiom) {
-        referrals.refresh()
-    }
 }
 
 extension NTPImpactCellViewModel: HomepageSectionHandler {


### PR DESCRIPTION
[MOB-1964](https://ecosia.atlassian.net/browse/MOB-1964)

## Context

Throughout a test in the Staging Environment via AppCenter build in Browserstack, we realized an unexpected behavior we could notice much more evident with the network debugger.
Multiple requests were made, eventually making our Cloudflare proxy think that our device was sending SPAM request.

## Approach

For now, we are going to make the behavior of the section showing the invited friends as it was working before. 
Our goal is to improve this section anyway.

[MOB-1964]: https://ecosia.atlassian.net/browse/MOB-1964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ