### PR TITLE
[MOB-1960] Refresh referrals on NTP

### DIFF
--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -50,7 +50,7 @@
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
         "branch" : "main",
-        "revision" : "a899a972d0f7844217d99447c2aaa833115aa6d9"
+        "revision" : "a0c8ae86fc95d12b3513ed019e8b66591596db62"
       }
     },
     {

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -190,6 +190,9 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable {
     func recordHomepageAppeared(isZeroSearch: Bool) {
         viewModel.isZeroSearch = isZeroSearch
         viewModel.recordViewAppeared()
+        
+        // Ecosia: Refresh referral claims
+        referrals.refresh()
     }
 
     func recordHomepageDisappeared() {


### PR DESCRIPTION
[MOB-1960](https://ecosia.atlassian.net/browse/MOB-1960)

## Context

As part of #573 we have reviewed the way we refresh referrals on the NTP and referrals page.

During QA [it was reported](https://ecosia.atlassian.net/browse/MOB-1960?focusedCommentId=82976) an issue where referrals got refresh multiple times at once on NTP. This also resulted on a temporary quick fix of removing that refresh from NTP on #577.

## Approach

- Find an appropriate place to refresh referrals whenever NTP appears
  - We found `HomepageViewController.recordHomepageAppeared` was the best candidate for now, as it already belongs to a logic from `BrowserViewController` that checks when the homepage is shown gievn that it was not showing previously.

## Other

Some other improvements to make our implementation safer now that it is refresh much more often are planned on core side:
- Ensure no request is made if there is already a refresh happening: https://github.com/ecosia/ios-core/pull/117
- Update the cooldown date also if there is an api error, so that no extra request are made on every NTP appearance in this case: https://github.com/ecosia/ios-core/pull/118

[MOB-1960]: https://ecosia.atlassian.net/browse/MOB-1960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ