### PR TITLE
[MOB-1965] Adjust impact cell title and subtitle for a11y category

### DIFF
--- a/Client/Ecosia/UI/NTP/Impact/NTPImpactRowView.swift
+++ b/Client/Ecosia/UI/NTP/Impact/NTPImpactRowView.swift
@@ -39,12 +39,14 @@ final class NTPImpactRowView: UIView, NotificationThemeable {
         let label = UILabel()
         label.font = .preferredFont(forTextStyle: .title2).bold()
         label.adjustsFontSizeToFitWidth = true
+        label.adjustsFontForContentSizeCategory = true
         return label
     }()
     private lazy var subtitleLabel: UILabel = {
         let label = UILabel()
         label.font = .preferredFont(forTextStyle: .footnote)
         label.numberOfLines = 0
+        label.adjustsFontForContentSizeCategory = true
         return label
     }()
     private lazy var actionButton: ResizableButton = {


### PR DESCRIPTION
[MOB-1965](https://ecosia.atlassian.net/browse/MOB-1965)

## Context
Follow up to #570.

## Approach
Add `adjustsFontForContentSizeCategory = true` to the title and subtitle of the impact cell.

![simulator_screenshot_882C62CD-53DE-4C8D-8576-E34391AFB26D](https://github.com/ecosia/ios-browser/assets/19517744/4decb717-0c71-4fd1-a8a6-d3ac082b67f4)


[MOB-1965]: https://ecosia.atlassian.net/browse/MOB-1965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ