### PR TITLE
[MOB-1923] Fix whats new page user storage

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -14692,7 +14692,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ecosia/ios-core.git";
 			requirement = {
-				branch = main;
+				branch = "MOB-1923_refactor_whats_new_versions_shown";
 				kind = branch;
 			};
 		};

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -14692,7 +14692,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ecosia/ios-core.git";
 			requirement = {
-				branch = "MOB-1923_refactor_whats_new_versions_shown";
+				branch = main;
 				kind = branch;
 			};
 		};

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -49,8 +49,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
-        "branch" : "MOB-1923_refactor_whats_new_versions_shown",
-        "revision" : "0bb9c774abbe26b7644368a091a32372cac8aa71"
+        "branch" : "main",
+        "revision" : "40757353e00ba46e1fbb807d56a6002b7e9ed7a6"
       }
     },
     {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -49,8 +49,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "a0c8ae86fc95d12b3513ed019e8b66591596db62"
+        "branch" : "MOB-1923_refactor_whats_new_versions_shown",
+        "revision" : "0bb9c774abbe26b7644368a091a32372cac8aa71"
       }
     },
     {

--- a/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
+++ b/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
@@ -22,7 +22,7 @@ extension BrowserViewController: DefaultBrowserDelegate {
 
 extension BrowserViewController: WhatsNewViewDelegate {
     func whatsNewViewDidShow(_ viewController: WhatsNewViewController) {
-        User.shared.updateWhatsNewItemsVersionsAppending(whatsNewDataProvider.getVersionRange().map { $0.description })
+        whatsNewDataProvider.markPreviousVersionsAsSeen()
         homepageViewController?.reloadTooltip()
     }
 }

--- a/Client/Ecosia/Helpers/EcosiaInstallType/EcosiaInstallType+Extensions.swift
+++ b/Client/Ecosia/Helpers/EcosiaInstallType/EcosiaInstallType+Extensions.swift
@@ -11,16 +11,14 @@ extension EcosiaInstallType {
     ///
     /// - Parameters:
     ///   - versionProvider: An instance of `AppVersionInfoProvider` used to obtain the current app version. Defaults to `DefaultAppVersionProvider`.`
-    ///   - user: An instance of the `User` object to improve reliability on tests. Defaults to its shared instance `.shared`.
     ///
     /// - Note: This function checks if it's not the user's first time and the current Ecosia installation type is unknown. If so, it sets the type to fresh and updates the current version. Additionally, it checks if the persisted version differs from the provided version and sets the type to upgrade while updating the current version.
     ///
     /// - Warning: Ensure that `User.shared.firstTime` and `versionProvider.version` are correctly initialized before calling this function.
     ///
-    static func evaluateCurrentEcosiaInstallType(withVersionProvider versionProvider: AppVersionInfoProvider = DefaultAppVersionInfoProvider(),
-                                                 user: User = .shared) {
+    static func evaluateCurrentEcosiaInstallType(withVersionProvider versionProvider: AppVersionInfoProvider = DefaultAppVersionInfoProvider()) {
         
-        if user.firstTime &&
+        if User.shared.firstTime &&
             EcosiaInstallType.get() == .unknown {
             EcosiaInstallType.set(type: .fresh)
             EcosiaInstallType.updateCurrentVersion(version: versionProvider.version)

--- a/Client/Ecosia/Helpers/EcosiaInstallType/EcosiaInstallType.swift
+++ b/Client/Ecosia/Helpers/EcosiaInstallType/EcosiaInstallType.swift
@@ -12,7 +12,7 @@ enum EcosiaInstallType: String {
     
     /// Represents an upgrade from a previous version of Ecosia.
     case upgrade
-        
+    
     /// Represents an unknown installation type.
     case unknown
 

--- a/Client/Ecosia/UI/WhatsNew/DataProvider/WhatsNewDataProvider.swift
+++ b/Client/Ecosia/UI/WhatsNew/DataProvider/WhatsNewDataProvider.swift
@@ -21,7 +21,7 @@ protocol WhatsNewDataProvider {
     ///
     /// - Returns: An array of `WhatsNewItem` objects that encapsulate individual features or updates.
     /// - Throws: An error if data retrieval or generation fails.
-    func getData() throws -> [WhatsNewItem]
+    func getWhatsNewItemsInRange() throws -> [WhatsNewItem]
     
     /// A Boolean value indicating whether the What's New page should be shown.
     ///

--- a/Client/Ecosia/UI/WhatsNew/DataProvider/WhatsNewLocalDataProvider.swift
+++ b/Client/Ecosia/UI/WhatsNew/DataProvider/WhatsNewLocalDataProvider.swift
@@ -28,7 +28,7 @@ final class WhatsNewLocalDataProvider: WhatsNewDataProvider {
         }
         
         // Are there items to be shown in the range?
-        guard let items = try? getData(), !items.isEmpty else { return false }
+        guard let items = try? getWhatsNewItemsInRange(), !items.isEmpty else { return false }
         
         let shownVersions = User.shared.whatsNewItemsVersionsShown
         let versionsInRange = getVersionRange().map { $0.description }
@@ -66,7 +66,7 @@ final class WhatsNewLocalDataProvider: WhatsNewDataProvider {
     /// - Throws: An error if fetching fails.
     ///
     /// - Returns: An array of `WhatsNewItem` to display.
-    func getData() throws -> [WhatsNewItem] {
+    func getWhatsNewItemsInRange() throws -> [WhatsNewItem] {
         // Get the version range and corresponding What's New items.
         let versionRange = getVersionRange()
         var items: [WhatsNewItem] = []

--- a/Client/Ecosia/UI/WhatsNew/DataProvider/WhatsNewLocalDataProvider.swift
+++ b/Client/Ecosia/UI/WhatsNew/DataProvider/WhatsNewLocalDataProvider.swift
@@ -33,7 +33,7 @@ final class WhatsNewLocalDataProvider: WhatsNewDataProvider {
         let dataProviderVersionsString = getVersionRange().map { $0.description }
         
         // Check if there are saved "What's New" item versions in the user settings.
-        guard let savedWhatsNewItemVersionsString = user.whatsNewItemsVersionsShown else { return true }
+        guard let savedWhatsNewItemVersionsString = User.shared.whatsNewItemsVersionsShown else { return true }
         
         // Determine if there are any new items to show based on saved versions.
         let isNeedingItemsToShow = savedWhatsNewItemVersionsString.allSatisfy { dataProviderVersionsString.contains($0) } == false
@@ -44,17 +44,12 @@ final class WhatsNewLocalDataProvider: WhatsNewDataProvider {
 
     /// The current app version provider from which the Ecosia App Version is retrieved
     private(set) var versionProvider: AppVersionInfoProvider
-    /// The `User` instance. Mainly utilized to pass the correct instance in tests. Production code rely on its `.shared` instance.
-    private(set) var user: User
 
     /// Default initializer.
     /// - Parameters:
     ///   - versionProvider: The current app version provider. Defaults to `DefaultAppVersionInfoProvider`
-    ///   - user: An instance of the `User` object to improve reliability on tests. Defaults to its shared instance `.shared`
-    init(versionProvider: AppVersionInfoProvider = DefaultAppVersionInfoProvider(),
-         user: User = .shared) {
+    init(versionProvider: AppVersionInfoProvider = DefaultAppVersionInfoProvider()) {
         self.versionProvider = versionProvider
-        self.user = user
     }
     
     /// The items we would like to attempt to show in the update sheet
@@ -120,7 +115,7 @@ extension WhatsNewLocalDataProvider {
         let previousVersions = whatsNewItems.keys
             .filter { $0 <= toVersion }
             .map { $0.description }
-        user.updateWhatsNewItemsVersionsAppending(previousVersions)
+        User.shared.updateWhatsNewItemsVersionsAppending(previousVersions)
     }
     
 }

--- a/Client/Ecosia/UI/WhatsNew/DataProvider/WhatsNewLocalDataProvider.swift
+++ b/Client/Ecosia/UI/WhatsNew/DataProvider/WhatsNewLocalDataProvider.swift
@@ -22,20 +22,15 @@ final class WhatsNewLocalDataProvider: WhatsNewDataProvider {
     /// A computed property to determine whether the "What's New" page should be displayed.
     /// - Returns: `true` if the What's New page should be shown; otherwise, `false`.
     var shouldShowWhatsNewPage: Bool {
-        
-        // Check if we are in the upgrade scenario
         guard EcosiaInstallType.get() == .upgrade else {
-            markAllPreviousVersionsAsSeen()
+            markPreviousVersionsAsSeen()
             return false
         }
         
         // Are there items to be shown in the range?
         guard let items = try? getData(), !items.isEmpty else { return false }
         
-        // Was there already shown items in the past?
-        // TODO: Mock it! (it is always empty on tests atm)
-        let shownVersions = User.shared.whatsNewItemsVersionsShown ?? []
-        
+        let shownVersions = User.shared.whatsNewItemsVersionsShown
         let versionsInRange = getVersionRange().map { $0.description }
         
         // Are all versions in the range contained in the shown versions?
@@ -109,15 +104,11 @@ final class WhatsNewLocalDataProvider: WhatsNewDataProvider {
         // Return the range.
         return Array(allVersions[fromIndex...toIndex])
     }
-}
-
-extension WhatsNewLocalDataProvider {
     
-    private func markAllPreviousVersionsAsSeen() {
+    func markPreviousVersionsAsSeen() {
         let previousVersions = whatsNewItems.keys
             .filter { $0 <= toVersion }
             .map { $0.description }
-        User.shared.updateWhatsNewItemsVersionsAppending(previousVersions)
+        User.shared.whatsNewItemsVersionsShown.formUnion(previousVersions)
     }
-    
 }

--- a/Client/Ecosia/UI/WhatsNew/WhatsNewViewModel.swift
+++ b/Client/Ecosia/UI/WhatsNew/WhatsNewViewModel.swift
@@ -8,7 +8,7 @@ final class WhatsNewViewModel {
     var items: [WhatsNewItem]
     
     init(provider: WhatsNewDataProvider) {
-        let providerItems = try? provider.getData()
+        let providerItems = try? provider.getWhatsNewItemsInRange()
         self.items = providerItems ?? []
     }
 }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2291,16 +2291,9 @@ extension BrowserViewController {
     @discardableResult
     private func presentWhatsNewPageIfNeeded() -> Bool {
         guard shouldShowWhatsNewPageScreen else { return false }
-
-        let viewModel = WhatsNewViewModel(provider: whatsNewDataProvider)
-
-        guard !viewModel.items.isEmpty else {
-            return false
-        }
         
-        WhatsNewViewController.presentOn(self,
-                                         viewModel: viewModel)
-
+        let viewModel = WhatsNewViewModel(provider: whatsNewDataProvider)
+        WhatsNewViewController.presentOn(self, viewModel: viewModel)
         return true
     }
 

--- a/Tests/ClientTests/Ecosia/EcosiaInstallTypeTests.swift
+++ b/Tests/ClientTests/Ecosia/EcosiaInstallTypeTests.swift
@@ -8,11 +8,11 @@ import XCTest
 
 final class EcosiaInstallTypeTests: XCTestCase {
     
-    private var user: User!
+    private var user: User = .shared
     
     override func setUpWithError() throws {
         try? FileManager.default.removeItem(at: FileManager.user)
-        user = .init()
+        User.shared = .init()
         UserDefaults.standard.removeObject(forKey: EcosiaInstallType.installTypeKey)
         UserDefaults.standard.removeObject(forKey: EcosiaInstallType.currentInstalledVersionKey)
     }
@@ -42,8 +42,7 @@ final class EcosiaInstallTypeTests: XCTestCase {
     
     func testEvaluateCurrentEcosiaInstallType_WhenUnknown_ShouldSetToFresh() {
         let mockVersion = MockAppVersion(version: "1.0.0")
-        EcosiaInstallType.evaluateCurrentEcosiaInstallType(withVersionProvider: mockVersion, 
-                                                                              user: user)
+        EcosiaInstallType.evaluateCurrentEcosiaInstallType(withVersionProvider: mockVersion)
         let type = EcosiaInstallType.get()
         XCTAssertEqual(type, .fresh)
     }
@@ -53,8 +52,7 @@ final class EcosiaInstallTypeTests: XCTestCase {
         EcosiaInstallType.set(type: .fresh)
         EcosiaInstallType.updateCurrentVersion(version: "0.9.0")
         
-        EcosiaInstallType.evaluateCurrentEcosiaInstallType(withVersionProvider: mockVersion, 
-                                                                              user: user)
+        EcosiaInstallType.evaluateCurrentEcosiaInstallType(withVersionProvider: mockVersion)
         let type = EcosiaInstallType.get()
         XCTAssertEqual(type, .upgrade)
     }
@@ -64,8 +62,7 @@ final class EcosiaInstallTypeTests: XCTestCase {
         EcosiaInstallType.set(type: .fresh)
         EcosiaInstallType.updateCurrentVersion(version: "1.0.0")
         
-        EcosiaInstallType.evaluateCurrentEcosiaInstallType(withVersionProvider: mockVersion, 
-                                                                              user: user)
+        EcosiaInstallType.evaluateCurrentEcosiaInstallType(withVersionProvider: mockVersion)
         let type = EcosiaInstallType.get()
         XCTAssertEqual(type, .fresh)
     }
@@ -77,8 +74,7 @@ extension EcosiaInstallTypeTests {
     func testEvaluateFreshInstallType_WithFirstTime_And_VersionProvider() {
         user.firstTime = true
         let versionProvider = MockAppVersionInfoProvider(mockedAppVersion: "1.0.0")
-        EcosiaInstallType.evaluateCurrentEcosiaInstallType(withVersionProvider: versionProvider,
-                                                                              user: user)
+        EcosiaInstallType.evaluateCurrentEcosiaInstallType(withVersionProvider: versionProvider)
         
         XCTAssertEqual(EcosiaInstallType.get(), .fresh)
         XCTAssertEqual(EcosiaInstallType.persistedCurrentVersion(), "1.0.0")
@@ -90,8 +86,7 @@ extension EcosiaInstallTypeTests {
         UserDefaults.standard.set("0.9.0", forKey: EcosiaInstallType.currentInstalledVersionKey)
         
         let versionProvider = MockAppVersionInfoProvider(mockedAppVersion: "1.0.0")
-        EcosiaInstallType.evaluateCurrentEcosiaInstallType(withVersionProvider: versionProvider,
-                                                                              user: user)
+        EcosiaInstallType.evaluateCurrentEcosiaInstallType(withVersionProvider: versionProvider)
         
         XCTAssertEqual(EcosiaInstallType.get(), .upgrade)
         XCTAssertEqual(EcosiaInstallType.persistedCurrentVersion(), "1.0.0")

--- a/Tests/ClientTests/Ecosia/EcosiaInstallTypeTests.swift
+++ b/Tests/ClientTests/Ecosia/EcosiaInstallTypeTests.swift
@@ -8,11 +8,7 @@ import XCTest
 
 final class EcosiaInstallTypeTests: XCTestCase {
     
-    private var user: User = .shared
-    
     override func setUpWithError() throws {
-        try? FileManager.default.removeItem(at: FileManager.user)
-        User.shared = .init()
         UserDefaults.standard.removeObject(forKey: EcosiaInstallType.installTypeKey)
         UserDefaults.standard.removeObject(forKey: EcosiaInstallType.currentInstalledVersionKey)
     }
@@ -41,6 +37,7 @@ final class EcosiaInstallTypeTests: XCTestCase {
     }
     
     func testEvaluateCurrentEcosiaInstallType_WhenUnknown_ShouldSetToFresh() {
+        User.shared.firstTime = true
         let mockVersion = MockAppVersion(version: "1.0.0")
         EcosiaInstallType.evaluateCurrentEcosiaInstallType(withVersionProvider: mockVersion)
         let type = EcosiaInstallType.get()
@@ -72,7 +69,7 @@ extension EcosiaInstallTypeTests {
     
     // Test evaluating install type and version for a fresh install with firstTime=true
     func testEvaluateFreshInstallType_WithFirstTime_And_VersionProvider() {
-        user.firstTime = true
+        User.shared.firstTime = true
         let versionProvider = MockAppVersionInfoProvider(mockedAppVersion: "1.0.0")
         EcosiaInstallType.evaluateCurrentEcosiaInstallType(withVersionProvider: versionProvider)
         
@@ -82,7 +79,7 @@ extension EcosiaInstallTypeTests {
 
     // Test evaluating install type and version for an upgrade with firstTime=true
     func testEvaluateUpgradeInstallType_WithFirstTimeFalse_And_VersionProvider() {
-        user.firstTime = false
+        User.shared.firstTime = false
         UserDefaults.standard.set("0.9.0", forKey: EcosiaInstallType.currentInstalledVersionKey)
         
         let versionProvider = MockAppVersionInfoProvider(mockedAppVersion: "1.0.0")

--- a/Tests/ClientTests/Ecosia/VersionTests.swift
+++ b/Tests/ClientTests/Ecosia/VersionTests.swift
@@ -78,6 +78,7 @@ final class VersionTests: XCTestCase {
     }
 }
 
+// Integration tests for Version + WhatsNewLocalDataProvider
 extension VersionTests {
     
     func testUpgradeFromVersionWithoutLogic() {
@@ -106,7 +107,7 @@ extension VersionTests {
                                   provider: appVersionInfoProvider)
         
         // When: We retrieve the What's New items after this "fake" update
-        let items = try? dataProvider.getData()
+        let items = try? dataProvider.getWhatsNewItemsInRange()
         
         // Then: We should not have items for versions beyond 8.3.0 (like 9.0.0)
         XCTAssertTrue(items?.isEmpty == true, "WhatsNewItem list should be empty for fake update to same version")
@@ -127,7 +128,7 @@ extension VersionTests {
         Version.updateFromCurrent(forKey: Self.appVersionUpdateTestKey, provider: appVersionInfoProvider)
         
         // And: We retrieve the What's New items after this update
-        let items = try? dataProvider.getData()
+        let items = try? dataProvider.getWhatsNewItemsInRange()
         
         // Then: We should not have items for versions beyond 8.3.1 (like 9.0.0)
         XCTAssertTrue(items?.isEmpty == true, "WhatsNewItem list should be empty for an update to minor version when there are items for upper versions")

--- a/Tests/ClientTests/Ecosia/WhatsNewLocalDataProviderTests.swift
+++ b/Tests/ClientTests/Ecosia/WhatsNewLocalDataProviderTests.swift
@@ -6,74 +6,44 @@ import XCTest
 @testable import Client
 @testable import Core
 
+// This tests are dependant on WhatsNewLocalDataProvider.whatsNewItems hardcoded implementation
 final class WhatsNewLocalDataProviderTests: XCTestCase {
     
     override func setUpWithError() throws {
+        User.shared.whatsNewItemsVersionsShown = []
         UserDefaults.standard.removeObject(forKey: EcosiaInstallType.installTypeKey)
         UserDefaults.standard.removeObject(forKey: EcosiaInstallType.currentInstalledVersionKey)
     }
     
-    // MARK: - Fresh Install Tests
-    
-    func testFreshInstallShouldNotShowWhatsNew() {
+    // MARK: Fresh Install Tests
+    func testFreshInstallShouldNotShowWhatsNewAndMarkPreviousVersionsAsSeen() {
         // Given
+        EcosiaInstallType.set(type: .fresh)
+        let dataProvider = WhatsNewLocalDataProvider(versionProvider: MockAppVersionInfoProvider(mockedAppVersion: "9.0.2"))
+        
+        // When
+        let shouldShowWhatsNew = dataProvider.shouldShowWhatsNewPage
+        
+        // Then
+        XCTAssertFalse(shouldShowWhatsNew, "Fresh install should not show what's new")
+        XCTAssertEqual(User.shared.whatsNewItemsVersionsShown, ["9.0.0"])
+    }
+    
+    // MARK: Unknown Install Tests
+    func testUnkownInstallShouldNotShowWhatsNewAndMarkPreviousVersionsAsSeen() {
+        // Given
+        EcosiaInstallType.set(type: .unknown)
         let dataProvider = WhatsNewLocalDataProvider(versionProvider: MockAppVersionInfoProvider(mockedAppVersion: "1.0.0"))
         
         // When
         let shouldShowWhatsNew = dataProvider.shouldShowWhatsNewPage
         
         // Then
-        XCTAssertFalse(shouldShowWhatsNew, "Fresh install should not show What's New")
+        XCTAssertFalse(shouldShowWhatsNew, "Unknown install should not show what's new")
+        XCTAssertEqual(User.shared.whatsNewItemsVersionsShown, [], "No previous versions shoul be marked since 1.0.0 < 9.0.0")
     }
     
-    func testFreshInstallShouldNotGetWhatsNewItems() {
-        // Given
-        let dataProvider = WhatsNewLocalDataProvider(versionProvider: MockAppVersionInfoProvider(mockedAppVersion: "1.0.0"))
-        
-        // When
-        do {
-            let whatsNewItems = try dataProvider.getData()
-            
-            // Then
-            XCTAssertTrue(whatsNewItems.isEmpty, "Fresh install should not get What's New items")
-        } catch {
-            XCTFail("Unexpected error: \(error)")
-        }
-    }
-    
-    // MARK: - Unknown Install Tests
-    
-    func testUnkownInstallShouldNotShowWhatsNew() {
-        // Given
-        EcosiaInstallType.set(type: .unknown)
-        let dataProvider = WhatsNewLocalDataProvider(versionProvider: MockAppVersionInfoProvider(mockedAppVersion: "9.0.0"))
-        
-        // When
-        let shouldShowWhatsNew = dataProvider.shouldShowWhatsNewPage
-        
-        // Then
-        XCTAssertFalse(shouldShowWhatsNew, "Upgrade to the same version should not show What's New")
-    }
-    
-    func testUnknownInstallShouldNotGetWhatsNewItems() {
-        // Given
-        EcosiaInstallType.set(type: .unknown)
-        let dataProvider = WhatsNewLocalDataProvider(versionProvider: MockAppVersionInfoProvider(mockedAppVersion: "9.0.0"))
-        
-        // When
-        do {
-            let whatsNewItems = try dataProvider.getData()
-            
-            // Then
-            XCTAssertTrue(whatsNewItems.isEmpty, "Upgrade to the same version should not get What's New items")
-        } catch {
-            XCTFail("Unexpected error: \(error)")
-        }
-    }
-    
-    // MARK: - Upgrade Install Tests
-    
-    // TODO: Make the test independent of WhatsNewLocalDataProvider.whatsNewItems
+    // MARK: Upgrade Install Tests
     func testUpgradeToVersionWithItemsShouldShowWhatsNew() {
         // Given
         EcosiaInstallType.updateCurrentVersion(version: "8.0.0")
@@ -84,38 +54,60 @@ final class WhatsNewLocalDataProviderTests: XCTestCase {
         let shouldShowWhatsNew = dataProvider.shouldShowWhatsNewPage
         
         // Then
-        XCTAssertTrue(shouldShowWhatsNew, "Upgrade to a different version should show What's New. Got items to be shown: \(User.shared.whatsNewItemsVersionsShown ?? []), for version range: \(dataProvider.getVersionRange().map { $0.description })")
+        XCTAssertTrue(shouldShowWhatsNew, "Upgrade to a version with items should show whats new")
     }
     
-    // TODO: In this case ☝️, don't we also need to test `getData()`?
-    
-    func testUpgradeToLowerVersionShouldNotShowWhatsNew() {
+    func testUpgradeToVersionWithoutItemsShouldNotShowWhatsNew() {
         // Given
+        EcosiaInstallType.updateCurrentVersion(version: "8.2.1")
         EcosiaInstallType.set(type: .upgrade)
-        EcosiaInstallType.updateCurrentVersion(version: "9.0.0")
-        let dataProvider = WhatsNewLocalDataProvider(versionProvider: MockAppVersionInfoProvider(mockedAppVersion: "8.0.0"))
+        let dataProvider = WhatsNewLocalDataProvider(versionProvider: MockAppVersionInfoProvider(mockedAppVersion: "8.3.0"))
         
         // When
         let shouldShowWhatsNew = dataProvider.shouldShowWhatsNewPage
         
         // Then
-        XCTAssertFalse(shouldShowWhatsNew, "Upgrade to a lower version should not show What's New")
+        XCTAssertFalse(shouldShowWhatsNew, "Upgrade to a version without items should not show whats new")
     }
     
-    // TODO: Is this repetitive with the ☝️?
-    func testUpgradeToLowerVersionShouldNotGetWhatsNewItems() {
+    func testDowngradeShouldNotShowWhatsNew() {
         // Given
-        let dataProvider = WhatsNewLocalDataProvider(versionProvider: MockAppVersionInfoProvider(mockedAppVersion: "8.0.0"))
+        User.shared.whatsNewItemsVersionsShown = ["9.0.0"]
+        EcosiaInstallType.set(type: .upgrade)
+        EcosiaInstallType.updateCurrentVersion(version: "9.3.0")
+        let dataProvider = WhatsNewLocalDataProvider(versionProvider: MockAppVersionInfoProvider(mockedAppVersion: "9.0.0"))
         
         // When
-        do {
-            EcosiaInstallType.evaluateCurrentEcosiaInstallType(withVersionProvider: dataProvider.versionProvider)
-            let whatsNewItems = try dataProvider.getData()
-            
-            // Then
-            XCTAssertTrue(whatsNewItems.isEmpty, "Upgrade to a lower version should not get What's New items")
-        } catch {
-            XCTFail("Unexpected error: \(error)")
-        }
+        let shouldShowWhatsNew = dataProvider.shouldShowWhatsNewPage
+        
+        // Then
+        XCTAssertFalse(shouldShowWhatsNew, "Downgrade should not show what's new")
+    }
+    
+    func testUpgradeToGreaterVersionThanTheOneWithItemsShouldShowWhatsNew() {
+        // Given
+        EcosiaInstallType.set(type: .upgrade)
+        EcosiaInstallType.updateCurrentVersion(version: "8.0.0")
+        let dataProvider = WhatsNewLocalDataProvider(versionProvider: MockAppVersionInfoProvider(mockedAppVersion: "9.0.2"))
+        
+        // When
+        let shouldShowWhatsNew = dataProvider.shouldShowWhatsNewPage
+        
+        // Then
+        XCTAssertTrue(shouldShowWhatsNew, "Upgrade to greater version than the one with items should show what's new")
+    }
+    
+    func testUpgradeWithAlreadyShownItemsShouldNotShow() {
+        // Given
+        User.shared.whatsNewItemsVersionsShown = ["9.0.0"]
+        EcosiaInstallType.set(type: .upgrade)
+        EcosiaInstallType.updateCurrentVersion(version: "8.0.0")
+        let dataProvider = WhatsNewLocalDataProvider(versionProvider: MockAppVersionInfoProvider(mockedAppVersion: "9.0.2"))
+        
+        // When
+        let shouldShowWhatsNew = dataProvider.shouldShowWhatsNewPage
+        
+        // Then
+        XCTAssertFalse(shouldShowWhatsNew, "Upgrade with already shown items should show not show what's new")
     }
 }

--- a/Tests/ClientTests/Ecosia/WhatsNewLocalDataProviderTests.swift
+++ b/Tests/ClientTests/Ecosia/WhatsNewLocalDataProviderTests.swift
@@ -8,11 +8,11 @@ import XCTest
 
 final class WhatsNewLocalDataProviderTests: XCTestCase {
     
-    private var user: User!
+    private var user: User = .shared
         
     override func setUpWithError() throws {
         try? FileManager.default.removeItem(at: FileManager.user)
-        user = .init()
+        User.shared = .init()
         UserDefaults.standard.removeObject(forKey: EcosiaInstallType.installTypeKey)
         UserDefaults.standard.removeObject(forKey: EcosiaInstallType.currentInstalledVersionKey)
     }
@@ -21,8 +21,7 @@ final class WhatsNewLocalDataProviderTests: XCTestCase {
     
     func testFreshInstallShouldNotShowWhatsNew() {
         // Given
-        let dataProvider = WhatsNewLocalDataProvider(versionProvider: MockAppVersionInfoProvider(mockedAppVersion: "1.0.0"),
-                                                     user: user)
+        let dataProvider = WhatsNewLocalDataProvider(versionProvider: MockAppVersionInfoProvider(mockedAppVersion: "1.0.0"))
         
         // When
         let shouldShowWhatsNew = dataProvider.shouldShowWhatsNewPage
@@ -33,8 +32,7 @@ final class WhatsNewLocalDataProviderTests: XCTestCase {
     
     func testFreshInstallShouldNotGetWhatsNewItems() {
         // Given
-        let dataProvider = WhatsNewLocalDataProvider(versionProvider: MockAppVersionInfoProvider(mockedAppVersion: "1.0.0"),
-                                                     user: user)
+        let dataProvider = WhatsNewLocalDataProvider(versionProvider: MockAppVersionInfoProvider(mockedAppVersion: "1.0.0"))
         
         // When
         do {
@@ -53,29 +51,25 @@ final class WhatsNewLocalDataProviderTests: XCTestCase {
         // Given
         user.firstTime = false
         UserDefaults.standard.set("8.3.0", forKey: EcosiaInstallType.currentInstalledVersionKey)
-        let dataProvider = WhatsNewLocalDataProvider(versionProvider: MockAppVersionInfoProvider(mockedAppVersion: "10.0.0"),
-                                                     user: user)
+        let dataProvider = WhatsNewLocalDataProvider(versionProvider: MockAppVersionInfoProvider(mockedAppVersion: "10.0.0"))
         
         // When
-        EcosiaInstallType.evaluateCurrentEcosiaInstallType(withVersionProvider: dataProvider.versionProvider, 
-                                                                              user: user)
+        EcosiaInstallType.evaluateCurrentEcosiaInstallType(withVersionProvider: dataProvider.versionProvider)
         let shouldShowWhatsNew = dataProvider.shouldShowWhatsNewPage
         
         // Then
         XCTAssertEqual(EcosiaInstallType.get(), .upgrade)
-        XCTAssertTrue(shouldShowWhatsNew, "Upgrade to a different version should show What's New. Got items to be shown: \(user.whatsNewItemsVersionsShown), for version range: \(dataProvider.getVersionRange().map { $0.description })")
+        XCTAssertTrue(shouldShowWhatsNew, "Upgrade to a different version should show What's New. Got items to be shown: \(User.shared.whatsNewItemsVersionsShown), for version range: \(dataProvider.getVersionRange().map { $0.description })")
     }
         
     func testUpgradeToSameVersionShouldNotShowWhatsNew() {
         // Given
         user.firstTime = false
         UserDefaults.standard.set("9.0.0", forKey: EcosiaInstallType.currentInstalledVersionKey)
-        let dataProvider = WhatsNewLocalDataProvider(versionProvider: MockAppVersionInfoProvider(mockedAppVersion: "9.0.0"),
-                                                     user: user)
+        let dataProvider = WhatsNewLocalDataProvider(versionProvider: MockAppVersionInfoProvider(mockedAppVersion: "9.0.0"))
         
         // When
-        EcosiaInstallType.evaluateCurrentEcosiaInstallType(withVersionProvider: dataProvider.versionProvider, 
-                                                                              user: user)
+        EcosiaInstallType.evaluateCurrentEcosiaInstallType(withVersionProvider: dataProvider.versionProvider)
         let shouldShowWhatsNew = dataProvider.shouldShowWhatsNewPage
         
         // Then
@@ -87,13 +81,11 @@ final class WhatsNewLocalDataProviderTests: XCTestCase {
         // Given
         user.firstTime = false
         UserDefaults.standard.set("9.0.0", forKey: EcosiaInstallType.currentInstalledVersionKey)
-        let dataProvider = WhatsNewLocalDataProvider(versionProvider: MockAppVersionInfoProvider(mockedAppVersion: "9.0.0"),
-                                                     user: user)
+        let dataProvider = WhatsNewLocalDataProvider(versionProvider: MockAppVersionInfoProvider(mockedAppVersion: "9.0.0"))
         
         // When
         do {
-            EcosiaInstallType.evaluateCurrentEcosiaInstallType(withVersionProvider: dataProvider.versionProvider, 
-                                                                                  user: user)
+            EcosiaInstallType.evaluateCurrentEcosiaInstallType(withVersionProvider: dataProvider.versionProvider)
             let whatsNewItems = try dataProvider.getData()
             
             // Then
@@ -109,8 +101,7 @@ final class WhatsNewLocalDataProviderTests: XCTestCase {
         let dataProvider = WhatsNewLocalDataProvider(versionProvider: MockAppVersionInfoProvider(mockedAppVersion: "8.0.0"))
         
         // When
-        EcosiaInstallType.evaluateCurrentEcosiaInstallType(withVersionProvider: dataProvider.versionProvider,
-                                                                              user: user)
+        EcosiaInstallType.evaluateCurrentEcosiaInstallType(withVersionProvider: dataProvider.versionProvider)
         let shouldShowWhatsNew = dataProvider.shouldShowWhatsNewPage
         
         // Then
@@ -123,8 +114,7 @@ final class WhatsNewLocalDataProviderTests: XCTestCase {
         
         // When
         do {
-            EcosiaInstallType.evaluateCurrentEcosiaInstallType(withVersionProvider: dataProvider.versionProvider,
-                                                                                  user: user)
+            EcosiaInstallType.evaluateCurrentEcosiaInstallType(withVersionProvider: dataProvider.versionProvider)
             let whatsNewItems = try dataProvider.getData()
             
             // Then

--- a/Tests/ClientTests/Frontend/Home/FirefoxHomeViewModelTests.swift
+++ b/Tests/ClientTests/Frontend/Home/FirefoxHomeViewModelTests.swift
@@ -5,6 +5,7 @@
 import XCTest
 
 @testable import Client
+@testable import Core
 
 class FirefoxHomeViewModelTests: XCTestCase {
 
@@ -35,9 +36,16 @@ class FirefoxHomeViewModelTests: XCTestCase {
                                           tabManager: MockTabManager(),
                                           urlBar: URLBarView(profile: profile),
                                           referrals: .init())
-        XCTAssertEqual(viewModel.shownSections.count, 5) //Ecosia: Update number of sections
+        // Ecosia: Update shown sections
+        XCTAssertEqual(viewModel.shownSections.count, 6)
         XCTAssertEqual(viewModel.shownSections[0], HomepageSectionType.logoHeader)
-        XCTAssertEqual(viewModel.shownSections[1], HomepageSectionType.libraryShortcuts)
-        XCTAssertEqual(viewModel.shownSections[2], HomepageSectionType.impact)
+        // Bookmark Nudge depends on User.showsBookmarksNTPNudgeCard()
+        XCTAssertEqual(viewModel.shownSections[1], HomepageSectionType.bookmarkNudge)
+        XCTAssertEqual(viewModel.shownSections[2], HomepageSectionType.libraryShortcuts)
+        XCTAssertEqual(viewModel.shownSections[3], HomepageSectionType.impact)
+        // News is not shown without items
+        // XCTAssertEqual(viewModel.shownSections[4], HomepageSectionType.news)
+        XCTAssertEqual(viewModel.shownSections[4], HomepageSectionType.aboutEcosia)
+        XCTAssertEqual(viewModel.shownSections[5], HomepageSectionType.ntpCustomization)
     }
 }


### PR DESCRIPTION
[MOB-1923]

## Context

A [bug was reported on the whats new page](https://ecosia.atlassian.net/browse/MOB-1923?focusedCommentId=83037) where it was being shown every time the NTP appears after the upgrade until the app gets killed and reopened.

Core side implementation for a refactor on the user object here: https://github.com/ecosia/ios-core/pull/119

## Approach

- The main fix was removing `User.shared` from the injected dependencies and the stored property, and instead reading from `User.shared` dynamically wherever needed.

## Other

By updating the way we set given user conditions on our tests, we noticed some false-positive tests existed and that the logic on `WhatsNewLocalDataProvider.shouldShowWhatsNewPage` needed refactor: 
- Make it more compact and readable
- Include a check for empty `getData()` items on the logic, not showing the page in that case
  - Therefore also removing that check from `BrowserViewController.presentWhatsNewPageIfNeeded()`
- Refactor `WhatsNewLocalDataProviderTests`, making `shouldShowWhatsNewPage` as the testable logic and including all foreseen cases.

Additionally:
- Made `FirefoxHomeViewModelTests` more explicitly since it also depends on the `User` and was failing at some point
- Change `WhatsNewLocalDataProvider.getVersionRange()` check to `>=` (used to be only `>`) so it handles updates to the exact version.

[MOB-1923]: https://ecosia.atlassian.net/browse/MOB-1923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ