### PR TITLE
[MOB-1959] Expand `ToolBarActionMenuDelegate` to open URL in current Tab

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
@@ -199,6 +199,10 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
 // MARK: - ToolbarActionMenuDelegate
 extension BrowserViewController: ToolBarActionMenuDelegate {
     
+    /* 
+     Ecosia: Add ToolBarActionMenuDelegate additional delegate function
+     to handle the opening of URLs as part of the current tab
+     */
     func openURLInCurrentTab(_ url: URL?) {
         guard let url else { return }
         tabManager.selectedTab?.loadRequest(URLRequest(url: url))

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
@@ -198,6 +198,11 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
 
 // MARK: - ToolbarActionMenuDelegate
 extension BrowserViewController: ToolBarActionMenuDelegate {
+    
+    func openURLInCurrentTab(_ url: URL?) {
+        guard let url else { return }
+        tabManager.selectedTab?.loadRequest(URLRequest(url: url))
+    }
 
     func updateToolbarState() {
         updateToolbarStateForTraitCollection(view.traitCollection)

--- a/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -15,6 +15,8 @@ protocol ToolBarActionMenuDelegate: AnyObject {
     func addBookmark(url: String, title: String?, favicon: Favicon?)
 
     func openURLInNewTab(_ url: URL?, isPrivate: Bool)
+    // Ecosia: Add option to open in same tab
+    func openURLInCurrentTab(_ url: URL?)
     func openBlankNewTab(focusLocationField: Bool, isPrivate: Bool, searchFor searchText: String?)
 
     func showLibrary(panel: LibraryPanelType?)
@@ -378,7 +380,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol, FeatureFlaggable, CanRemo
                 self.delegate?.openURLInNewTab(url, isPrivate: false)
             }
              */
-            self.delegate?.openURLInNewTab(Environment.current.urlProvider.faq, isPrivate: false)
+            self.delegate?.openURLInCurrentTab(Environment.current.urlProvider.faq)
         }.items
     }
 


### PR DESCRIPTION
[MOB-1959]

## Context

We utilized the `getHelpAction` inherited from Firefox to handle the opening of the Help page (our Ecosia FAQ page).
However, our UX requested the Help page be opened as part of the current tab.

## Approach

Expanded the capabilities of `ToolBarActionMenuDelegate` by adding `func openURLInCurrentTab(_ url: URL?)` and delegating the action to the BrowserViewController's TabManager.

![Simulator Screen Recording - iPhone Xs - 2023-10-17 at 15 16 36](https://github.com/ecosia/ios-browser/assets/3584008/1615ae48-f336-4e04-94df-aff63846d03a)


[MOB-1959]: https://ecosia.atlassian.net/browse/MOB-1959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ