### PR TITLE
[MOB-1971] Show Debug Settings for all beta and debug builds.

### DIFF
--- a/Client/Frontend/Settings/AppSettingsOptions.swift
+++ b/Client/Frontend/Settings/AppSettingsOptions.swift
@@ -9,7 +9,7 @@ import LocalAuthentication
 import Core
 
 // This file contains all of the settings available in the main settings screen of the app.
-#if MOZ_CHANNEL_FENNEC
+#if MOZ_CHANNEL_FENNEC || MOZ_CHANNEL_BETA
 private var ShowDebugSettings: Bool = true
 #else
 private var ShowDebugSettings: Bool = false


### PR DESCRIPTION
[MOB-1971]

## Context

Throughout testing the upcoming RCs, we realized the debug settings weren’t showing up for the App Center builds.

We (as internal developers and testers) would like to be able to perform the test and play with the debug settings either by having a product built out of the Xcode (hence the debug environment) or the product shared via our beta/internal channels.

## Approach

Enable the debug settings by adding the preprocessor flag `MOZ_CHANNEL_BETA` to the condition that evaluates `ShowDebugSettings` to `true` in `AppSettingsOptions` swift file.

[MOB-1971]: https://ecosia.atlassian.net/browse/MOB-1971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ