### PR TITLE
[MOB-1976] Fix customization button highlight state icon color

### DIFF
--- a/Client/Ecosia/UI/NTP/Customization/NTPCustomizationCell.swift
+++ b/Client/Ecosia/UI/NTP/Customization/NTPCustomizationCell.swift
@@ -21,6 +21,7 @@ final class NTPCustomizationCell: UICollectionViewCell, NotificationThemeable, R
         button.titleLabel?.font = .preferredFont(forTextStyle: .callout)
         button.titleLabel?.adjustsFontSizeToFitWidth = true
         button.setImage(.init(named: ImageIdentifiers.settings)?.withRenderingMode(.alwaysTemplate), for: .normal)
+        button.setImage(.init(named: ImageIdentifiers.settings)?.withRenderingMode(.alwaysTemplate), for: .highlighted)
         button.imageView?.contentMode = .scaleAspectFit
         button.setInsets(forContentPadding: .init(top: UX.verticalInset, left: UX.horizontalInset, bottom: UX.verticalInset, right: UX.horizontalInset),
                          imageTitlePadding: UX.imageTitlePadding)


### PR DESCRIPTION
[MOB-1976]

## Context
As [reported](https://ecosia.atlassian.net/browse/MOB-1848?focusedCommentId=83094), only the background color of the button should change when highlighted, not the icon color.

## Approach
Set the button's highlight image rendering mode also to always template so that it can use the expected color.

### Checklist
- [x] I performed some relevant testing on a real device and/or simulator

[MOB-1976]: https://ecosia.atlassian.net/browse/MOB-1976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ