### PR TITLE
[MOB-1970] Fix bookmarks badge existing users only

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -14684,7 +14684,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ecosia/ios-core.git";
 			requirement = {
-				branch = main;
+				branch = "MOB-1970_fix_bookmarks_badge_existing_users_only";
 				kind = branch;
 			};
 		};

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -14684,7 +14684,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ecosia/ios-core.git";
 			requirement = {
-				branch = "MOB-1970_fix_bookmarks_badge_existing_users_only";
+				branch = main;
 				kind = branch;
 			};
 		};

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -49,8 +49,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
-        "branch" : "MOB-1970_fix_bookmarks_badge_existing_users_only",
-        "revision" : "eb8ce7f505c3aff8b639843a849e17ec540f23ba"
+        "branch" : "main",
+        "revision" : "deb7cf5aeb85c861b10f988557ec2cad73611b71"
       }
     },
     {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -49,8 +49,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "19ee6dc580da5473088fcc0dec06bccee02b1b90"
+        "branch" : "MOB-1970_fix_bookmarks_badge_existing_users_only",
+        "revision" : "eb8ce7f505c3aff8b639843a849e17ec540f23ba"
       }
     },
     {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2256,6 +2256,8 @@ extension BrowserViewController {
         User.shared.firstTime = false
         User.shared.migrated = true
         User.shared.hideRebrandIntro()
+        User.shared.hideBookmarksNewBadge()
+        User.shared.hideBookmarksImportExportTooltip()
         // deactivate searchbar hint for new users
         contextHintVC.viewModel.markContextualHintPresented()
     }

--- a/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -629,7 +629,7 @@ class MainMenuActionHelper: PhotonActionSheetProtocol, FeatureFlaggable, CanRemo
     private func getBookmarkLibraryAction() -> SingleActionViewModel {
         return SingleActionViewModel(title: .AppMenu.Bookmarks,
                                      iconString: ImageIdentifiers.bookmarks,
-                                     isNew: User.shared.showsBookmarksNewBadge) { _ in
+                                     isNew: EcosiaInstallType.get() == .upgrade && User.shared.showsBookmarksNewBadge) { _ in
             self.delegate?.showLibrary(panel: .bookmarks)
             Analytics.shared.menuClick("bookmarks")
         }

--- a/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
+++ b/Client/Frontend/Library/Bookmarks/BookmarksPanel.swift
@@ -133,7 +133,7 @@ class BookmarksPanel: SiteTableViewController, LibraryPanel, CanRemoveQuickActio
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
-        if User.shared.showsBookmarksImportExportTooltip {
+        if EcosiaInstallType.get() == .upgrade && User.shared.showsBookmarksImportExportTooltip {
             showBookmarksTooltip()
         }
     }


### PR DESCRIPTION
[MOB-1970]

## Context

Either for fresh installs or app updates, the New badge on Bookmark is displayed.
The expectation from design is to show it for users updating the app only.
The `User.shared.firstTime` was added core side as part of the `User.shared. showsBookmarksNewBadge` condition to hopefully address the new user check, though given the App's flow, the evaluation of that `firstTime`'s flag is set to `false` prior to the showing of the Settings list. 

## Approach

Improved the `isNew` parameter being injected into the `SingleActionViewModel` of the `getBookmarkLibraryAction()`.
Adding the handy `EcosiaInstallType.get() == .upgrade` alongside the updated `User.shared.showsBookmarksNewBadge` to verify whether the new badge needs showing.

Verified the behavior for both fresh install and simulating an update.

## Other

### Some considerations

I understand that our goal is to maximize the acknowledgment from the users to see and explore the new Bookmarks feature. To my understanding though, this badging system might need an improvement instead of relying on hardcoded, function's function-specific conditions as we really need to understand when (product-wise) a feature is still considered as "New".
With the current logic in place, an unrealistic yet potential scenario would be a Version 12.0.4 would still treat the Bookmarks as "New".
Having said that, I went through the simplest implementation needed to solely fix the News issue, also considering the fact that users might upgrade from App Version without the `EcosiaInstallType` implementation before. The "issue" itself would lead the user to see the `New` badge and perhaps engage them into Bookmarks feature discovery anyway.

The ticket also mentioned the tooltip within the Bookmarks view that would suggest the import shown to existing users only. I challenged the decision by sharing that even _as a new user installing the app for the first time, I would still find it insightful the first time opening the bookmarks to know more about the button’s scope via the tooltip_.

I'm awaiting new info and in case apply the same check for the tooltip as well.

EDIT: The same has been applied to the tooltip. @yannsoraru raised a good point design-wise, highlighting the fact that the empty state in the bookmarks page keeps the goal of maximising the feature discoverability. 

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I updated `Core` back to the `main` reference with a new revision

[MOB-1970]: https://ecosia.atlassian.net/browse/MOB-1970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ