### PR TITLE
[MOB-1986] Update PULL_REQUEST_TEMPLATE with `Core` ref

### DIFF
--- a/PULL_REQUEST_TEMPLATE
+++ b/PULL_REQUEST_TEMPLATE
@@ -20,4 +20,4 @@ Don't forget to add a prefix to the PR title in this format
 - [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
 - [ ] I added the `// Ecosia:` helper comments where needed
 - [ ] I included documentation updates to the coding standards or Confluence doc when needed
-- [ ] I updated `Core` back to the `main` reference with a new revision if needed
+- [ ] I am using the correct version from [core](https://github.com/ecosia/ios-core), including any necessary changes for this ticket and pointing to `main` instead of a feature branch

--- a/PULL_REQUEST_TEMPLATE
+++ b/PULL_REQUEST_TEMPLATE
@@ -1,5 +1,5 @@
 <!--
-Don't forget to add a prefix to the pr title in this format
+Don't forget to add a prefix to the PR title in this format
 [MOB-####] PR SHORT DESCRIPTION
 -->
 
@@ -16,7 +16,8 @@ Don't forget to add a prefix to the pr title in this format
 ### Checklist
 
 - [ ] I performed some relevant testing on a real device and/or simulator
-- [ ] I wrote Unit Tests that confirm the expected behaviour
+- [ ] I wrote Unit Tests that confirm the expected behavior
 - [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
 - [ ] I added the `// Ecosia:` helper comments where needed
-- [ ] I included documentation updates to the coding standards or Confluence doc, when needed
+- [ ] I included documentation updates to the coding standards or Confluence doc when needed
+- [ ] I updated `Core` back to the `main` reference with a new revision if needed


### PR DESCRIPTION
[MOB-1986]

## Context

We often need to update the reference of the Core branch with feature branches.
Reverting and/or updating `Core` back to `main` sometimes might be forgotten.

## Approach

Minimize the risk by adding another step in the PR template

## Other

Small adjustments to existing guidelines

[MOB-1986]: https://ecosia.atlassian.net/browse/MOB-1986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ