### PR TITLE
[MOB-1987] Use refactored referrals requests

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -14684,7 +14684,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ecosia/ios-core.git";
 			requirement = {
-				branch = "MOB-1987_refactor_referrals";
+				branch = main;
 				kind = branch;
 			};
 		};

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -14684,7 +14684,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ecosia/ios-core.git";
 			requirement = {
-				branch = main;
+				branch = "MOB-1987_refactor_referrals";
 				kind = branch;
 			};
 		};

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -49,8 +49,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
-        "branch" : "MOB-1987_refactor_referrals",
-        "revision" : "e8b29e62b42dbe69f22ab0ddfd102454f9f2a20d"
+        "branch" : "main",
+        "revision" : "19ee6dc580da5473088fcc0dec06bccee02b1b90"
       }
     },
     {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -50,7 +50,7 @@
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
         "branch" : "MOB-1987_refactor_referrals",
-        "revision" : "fb3e5f4e745509d39f2669268a995d60f5c3c07b"
+        "revision" : "e8b29e62b42dbe69f22ab0ddfd102454f9f2a20d"
       }
     },
     {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -49,8 +49,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "550a89133b67c0dceca7909a0da0c6d91c2bd168"
+        "branch" : "MOB-1987_refactor_referrals",
+        "revision" : "fb3e5f4e745509d39f2669268a995d60f5c3c07b"
       }
     },
     {

--- a/Client/Ecosia/Migration/LoadingScreen.swift
+++ b/Client/Ecosia/Migration/LoadingScreen.swift
@@ -158,16 +158,15 @@ final class LoadingScreen: UIViewController {
 
     // MARK: Referrals
     private func claimReferral(_ code: String) {
-        referrals.claim(referrer: code) { [weak self] result in
-            User.shared.referrals.pendingClaim = nil
-
-            switch result {
-            case .success:
+        Task { [weak self] in
+            do {
+                try await referrals.claim(referrer: code)
                 self?.loadingGroup.leave()
                 Analytics.shared.inviteClaimSuccess()
-            case .failure(let error):
-                self?.showReferralError(error)
+            } catch {
+                self?.showReferralError(error as? Referrals.Error ?? .genericError)
             }
+            User.shared.referrals.pendingClaim = nil
         }
     }
 

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -192,7 +192,9 @@ class HomepageViewController: UIViewController, HomePanel, FeatureFlaggable {
         viewModel.recordViewAppeared()
         
         // Ecosia: Refresh referral claims
-        referrals.refresh()
+        Task {
+            try? await referrals.refresh()
+        }
     }
 
     func recordHomepageDisappeared() {


### PR DESCRIPTION
[MOB-1987]

## Context

As part of https://github.com/ecosia/ios-core/pull/123 we have refactored `Referrals`.

## Approach

Adapt wherever it was called to support the new `async await` implementation.

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I am using the correct version from [core](https://github.com/ecosia/ios-core), including any necessary changes for this ticket and pointing to `main` instead of a feature branch


[MOB-1987]: https://ecosia.atlassian.net/browse/MOB-1987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ