### PR TITLE
[MOB-1977] Make release notes fully automated via GitHub Action

### DIFF
--- a/.github/workflows/upload_release_notes_to_appstore.yml
+++ b/.github/workflows/upload_release_notes_to_appstore.yml
@@ -23,6 +23,4 @@ jobs:
           bundler-cache: true
     
       - name: Fastlane upload release notes
-        run: |
-            CURRENT_VERSION=$(grep 'MARKETING_VERSION' Client/Configuration/Common.xcconfig | cut -d ' ' -f3)
-            bundle exec fastlane deliver --force true --app-version $CURRENT_VERSION
+        run: bundle exec fastlane upload_release_notes

--- a/.github/workflows/upload_release_notes_to_appstore.yml
+++ b/.github/workflows/upload_release_notes_to_appstore.yml
@@ -1,11 +1,11 @@
 name: Release Notes update
 
 on:
-  push:
+  pull_request:
     paths:
       - 'fastlane/metadata/**'
       - '!fastlane/metadata/en-US/**'
-    branches: [ MOB-1977_fully_automated_release_notes ]
+    branches: [ main ]
 
 jobs:
   upload_release_notes_to_appstore:
@@ -25,5 +25,4 @@ jobs:
       - name: Fastlane upload release notes
         run: |
             CURRENT_VERSION=$(grep 'MARKETING_VERSION' Client/Configuration/Common.xcconfig | cut -d ' ' -f3)
-            echo $CURRENT_VERSION
-            # bundle exec fastlane deliver --force true --app-version $CURRENT_VERSION
+            bundle exec fastlane deliver --force true --app-version $CURRENT_VERSION

--- a/.github/workflows/upload_release_notes_to_appstore.yml
+++ b/.github/workflows/upload_release_notes_to_appstore.yml
@@ -26,4 +26,4 @@ jobs:
         run: |
             CURRENT_VERSION=$(grep 'MARKETING_VERSION' Client/Configuration/Common.xcconfig | cut -d ' ' -f3)
             echo $CURRENT_VERSION
-            # bundle exec fastlane deliver --app-version $CURRENT_VERSION
+            # bundle exec fastlane deliver --force true --app-version $CURRENT_VERSION

--- a/.github/workflows/upload_release_notes_to_appstore.yml
+++ b/.github/workflows/upload_release_notes_to_appstore.yml
@@ -1,11 +1,11 @@
 name: Release Notes update
 
 on:
-  pull_request:
+  push:
     paths:
       - 'fastlane/metadata/**'
       - '!fastlane/metadata/en-US/**'
-    branches: [ main ]
+    branches: [ MOB-1977_fully_automated_release_notes ]
 
 jobs:
   upload_release_notes_to_appstore:
@@ -30,4 +30,5 @@ jobs:
       - name: Fastlane upload release notes
         run: |
             CURRENT_VERSION=$(grep 'MARKETING_VERSION' Client/Configuration/Common.xcconfig | cut -d ' ' -f3)
-            bundle exec fastlane deliver --app-version $CURRENT_VERSION
+            echo $CURRENT_VERSION
+            # bundle exec fastlane deliver --app-version $CURRENT_VERSION

--- a/.github/workflows/upload_release_notes_to_appstore.yml
+++ b/.github/workflows/upload_release_notes_to_appstore.yml
@@ -1,11 +1,11 @@
 name: Release Notes update
 
 on:
-  push:
+  pull_request:
     paths:
       - 'fastlane/metadata/**'
       - '!fastlane/metadata/en-US/**'
-    branches: [ MOB-1977_fully_automated_release_notes  ]
+    branches: [ main ]
 
 jobs:
   upload_release_notes_to_appstore:

--- a/.github/workflows/upload_release_notes_to_appstore.yml
+++ b/.github/workflows/upload_release_notes_to_appstore.yml
@@ -1,11 +1,11 @@
 name: Release Notes update
 
 on:
-  pull_request:
+  push:
     paths:
       - 'fastlane/metadata/**'
       - '!fastlane/metadata/en-US/**'
-    branches: [ main ]
+    branches: [ MOB-1977_fully_automated_release_notes  ]
 
 jobs:
   upload_release_notes_to_appstore:

--- a/.github/workflows/upload_release_notes_to_appstore.yml
+++ b/.github/workflows/upload_release_notes_to_appstore.yml
@@ -1,0 +1,33 @@
+name: Release Notes update
+
+on:
+  pull_request:
+    paths:
+      - 'fastlane/metadata/**'
+      - '!fastlane/metadata/en-US/**'
+    branches: [ main ]
+
+jobs:
+  upload_release_notes_to_appstore:
+    runs-on: ubuntu-latest
+    name: Upload release notes to AppStore
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+  
+      - name: Install gems
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+          bundler-cache: true
+    
+      - name: Fastlane upload release notes
+        run: |
+            CURRENT_VERSION=$(grep 'MARKETING_VERSION' Client/Configuration/Common.xcconfig | cut -d ' ' -f3)
+            bundle exec fastlane deliver --app-version $CURRENT_VERSION

--- a/.github/workflows/upload_release_notes_to_appstore.yml
+++ b/.github/workflows/upload_release_notes_to_appstore.yml
@@ -15,12 +15,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.11'
-          cache: 'pip'
-  
+          
       - name: Install gems
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/upload_release_notes_to_appstore.yml
+++ b/.github/workflows/upload_release_notes_to_appstore.yml
@@ -24,3 +24,7 @@ jobs:
     
       - name: Fastlane upload release notes
         run: bundle exec fastlane upload_release_notes
+        env:
+          FASTLANE_APPSTORE_CONNECT_KEY_ID: ${{ secrets.FASTLANE_APPSTORE_CONNECT_KEY_ID }}
+          FASTLANE_APPSTORE_CONNECT_KEY_ISSUER_ID: ${{ secrets.FASTLANE_APPSTORE_CONNECT_KEY_ISSUER_ID }}
+          FASTLANE_APPSTORE_CONNECT_KEY_CONTENT: ${{ secrets.FASTLANE_APPSTORE_CONNECT_KEY_CONTENT }}

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ python3 ecosify-strings.py Shared
 
 Follow the instructions from our [confluence page](https://ecosia.atlassian.net/wiki/spaces/MOB/pages/2460680288/How+to+release)
 
-## Howto update the release notes (semi-automated)
+## How to update the release notes
 
 Make sure that `fastlane` and `transifex`-cli is installed.
 
@@ -199,6 +199,14 @@ Make sure that `fastlane` and `transifex`-cli is installed.
 ### Add language translations
 
 - Make sure that all languages are translated in the transifex [web interface](https://app.transifex.com/ecosia/ecosia-ios-search-app/release_notestxt/) and found their way to `main`
+
+- Verify the translations in the Transifex-made PR
+
+- Squash and Merge the PR
+
+- The GitHub Action Workflow `Upload release notes to AppStore` will take care of the upload
+
+#### In case you need a manual update
 
 - Push via the update translation via `deliver` to the AppStore
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ Make sure that `fastlane` and `transifex`-cli is installed.
 
 ### Add source release notes to transifex (en-US)
 
+> ℹ️ Updating the source file in the project and merging it into `main` will automatically push it to Transifex as well since the Github integration is in place
+
 - Make sure that an _inflight_ version exists in AppStore Connect. If not, create one.
 - Add English text to release notes in AppStore Connect
 - Download metadata from AppStore specifying the inflight version

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -137,21 +137,23 @@ platform :ios do
   desc 'Upload release notes to the AppStore'
   lane :upload_release_notes do
     
-    app_store_connect_api_key(
-      key_id: ENV["FASTLANE_APPSTORE_CONNECT_KEY_ID"],
-      issuer_id: ENV["FASTLANE_APPSTORE_CONNECT_KEY_ISSUER_ID"],
-      key_content: Base64.decode64(ENV["FASTLANE_APPSTORE_CONNECT_KEY_CONTENT"])
-    )
+    # app_store_connect_api_key(
+    #   key_id: ENV["FASTLANE_APPSTORE_CONNECT_KEY_ID"],
+    #   issuer_id: ENV["FASTLANE_APPSTORE_CONNECT_KEY_ISSUER_ID"],
+    #   key_content: Base64.decode64(ENV["FASTLANE_APPSTORE_CONNECT_KEY_CONTENT"])
+    # )
 
     version_number = get_xcconfig_value(
       path: 'Client/Configuration/Common.xcconfig',
       name: 'MARKETING_VERSION'
     )
 
-    upload_to_app_store(
-      force: true,
-      app_version: version_number
-    )
+    UI.message("Version number: #{version_number}")
+
+    # upload_to_app_store(
+    #   force: true,
+    #   app_version: version_number
+    # )
 
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -86,6 +86,17 @@ platform :ios do
     )
   end
 
+  desc "Creates an API KEY to add as step in other lanes"
+  private_lane :inject_appstore_connect_api do
+
+    app_store_connect_api_key(
+      key_id: ENV["FASTLANE_APPSTORE_CONNECT_KEY_ID"],
+      issuer_id: ENV["FASTLANE_APPSTORE_CONNECT_KEY_ISSUER_ID"],
+      key_content: Base64.decode64(ENV["FASTLANE_APPSTORE_CONNECT_KEY_CONTENT"])
+    )
+
+  end
+
   desc "Testflight build for Live Channel"
   lane :testflight_live do
 
@@ -112,12 +123,8 @@ platform :ios do
       configuration: "Release"
     )
 
-    app_store_connect_api_key(
-      key_id: ENV["FASTLANE_APPSTORE_CONNECT_KEY_ID"],
-      issuer_id: ENV["FASTLANE_APPSTORE_CONNECT_KEY_ISSUER_ID"],
-      key_content: Base64.decode64(ENV["FASTLANE_APPSTORE_CONNECT_KEY_CONTENT"])
-    )
-
+    inject_appstore_connect_api
+    
     pilot(
       apple_id: "670881887",
       itc_provider: "33YMRSYD2L",
@@ -137,11 +144,7 @@ platform :ios do
   desc 'Upload release notes to the AppStore'
   lane :upload_release_notes do
     
-    app_store_connect_api_key(
-      key_id: ENV["FASTLANE_APPSTORE_CONNECT_KEY_ID"],
-      issuer_id: ENV["FASTLANE_APPSTORE_CONNECT_KEY_ISSUER_ID"],
-      key_content: Base64.decode64(ENV["FASTLANE_APPSTORE_CONNECT_KEY_CONTENT"])
-    )
+    inject_appstore_connect_api
 
     version_number = get_xcconfig_value(
       path: 'Client/Configuration/Common.xcconfig',

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -137,23 +137,21 @@ platform :ios do
   desc 'Upload release notes to the AppStore'
   lane :upload_release_notes do
     
-    # app_store_connect_api_key(
-    #   key_id: ENV["FASTLANE_APPSTORE_CONNECT_KEY_ID"],
-    #   issuer_id: ENV["FASTLANE_APPSTORE_CONNECT_KEY_ISSUER_ID"],
-    #   key_content: Base64.decode64(ENV["FASTLANE_APPSTORE_CONNECT_KEY_CONTENT"])
-    # )
+    app_store_connect_api_key(
+      key_id: ENV["FASTLANE_APPSTORE_CONNECT_KEY_ID"],
+      issuer_id: ENV["FASTLANE_APPSTORE_CONNECT_KEY_ISSUER_ID"],
+      key_content: Base64.decode64(ENV["FASTLANE_APPSTORE_CONNECT_KEY_CONTENT"])
+    )
 
     version_number = get_xcconfig_value(
       path: 'Client/Configuration/Common.xcconfig',
       name: 'MARKETING_VERSION'
     )
 
-    UI.message("Version number: #{version_number}")
-
-    # upload_to_app_store(
-    #   force: true,
-    #   app_version: version_number
-    # )
+    upload_to_app_store(
+      force: true,
+      app_version: version_number
+    )
 
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -134,6 +134,27 @@ platform :ios do
 
   end
 
+  desc 'Upload release notes to the AppStore'
+  lane :upload_release_notes do
+    
+    app_store_connect_api_key(
+      key_id: ENV["FASTLANE_APPSTORE_CONNECT_KEY_ID"],
+      issuer_id: ENV["FASTLANE_APPSTORE_CONNECT_KEY_ISSUER_ID"],
+      key_content: Base64.decode64(ENV["FASTLANE_APPSTORE_CONNECT_KEY_CONTENT"])
+    )
+
+    version_number = get_xcconfig_value(
+      path: 'Client/Configuration/Common.xcconfig',
+      name: 'MARKETING_VERSION'
+    )
+
+    upload_to_app_store(
+      force: true,
+      app_version: version_number
+    )
+
+  end
+
   desc 'This lane performs the expected git steps when releasing'
   private_lane :tag_and_push do |options|
     

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -152,7 +152,7 @@ platform :ios do
     )
 
     upload_to_app_store(
-      force: true,
+      force: true, # Set to true to skip the verification via HTML preview file
       app_version: version_number
     )
 

--- a/fastlane/metadata/it/description.txt
+++ b/fastlane/metadata/it/description.txt
@@ -1,4 +1,4 @@
-Con un download puoi aiutare a combattere il cambiamento climatico, tutelando anche la tua privacy. Scarica subito la app Ecosia per piantare alberi effettuando ricerche, è completamente gratuita!
+Csssson un download puoi aiutare a combattere il cambiamento climatico, tutelando anche la tua privacy. Scarica subito la app Ecosia per piantare alberi effettuando ricerche, è completamente gratuita!
 
 Blocco degli annunci pubblicitari e navigazione veloce — La app Ecosia è basata su Firefox di Mozilla e offre un’esperienza di navigazione intuitiva, rapida e sicura con tutto quello che ti serve, come schede, modalità in incognito, segnalibri, download e modalità scura. Visualizziamo anche una foglia verde di fianco ai risultati pro-ambientali, aiutandoti a fare scelte più green mentre effettui ricerche.
 

--- a/fastlane/metadata/it/description.txt
+++ b/fastlane/metadata/it/description.txt
@@ -1,4 +1,4 @@
-Con un download puoi aiutare a combattere il cambiamento climatico, tutelando anche la tua privacy. Scarica subito la app Ecosia per piantare alberi effettuando ricerche, è completamente gratuita!
+Cssson un download puoi aiutare a combattere il cambiamento climatico, tutelando anche la tua privacy. Scarica subito la app Ecosia per piantare alberi effettuando ricerche, è completamente gratuita!
 
 Blocco degli annunci pubblicitari e navigazione veloce — La app Ecosia è basata su Firefox di Mozilla e offre un’esperienza di navigazione intuitiva, rapida e sicura con tutto quello che ti serve, come schede, modalità in incognito, segnalibri, download e modalità scura. Visualizziamo anche una foglia verde di fianco ai risultati pro-ambientali, aiutandoti a fare scelte più green mentre effettui ricerche.
 

--- a/fastlane/metadata/it/description.txt
+++ b/fastlane/metadata/it/description.txt
@@ -1,4 +1,4 @@
-Cssson un download puoi aiutare a combattere il cambiamento climatico, tutelando anche la tua privacy. Scarica subito la app Ecosia per piantare alberi effettuando ricerche, è completamente gratuita!
+Con un download puoi aiutare a combattere il cambiamento climatico, tutelando anche la tua privacy. Scarica subito la app Ecosia per piantare alberi effettuando ricerche, è completamente gratuita!
 
 Blocco degli annunci pubblicitari e navigazione veloce — La app Ecosia è basata su Firefox di Mozilla e offre un’esperienza di navigazione intuitiva, rapida e sicura con tutto quello che ti serve, come schede, modalità in incognito, segnalibri, download e modalità scura. Visualizziamo anche una foglia verde di fianco ai risultati pro-ambientali, aiutandoti a fare scelte più green mentre effettui ricerche.
 

--- a/fastlane/metadata/it/description.txt
+++ b/fastlane/metadata/it/description.txt
@@ -1,4 +1,4 @@
-Csssson un download puoi aiutare a combattere il cambiamento climatico, tutelando anche la tua privacy. Scarica subito la app Ecosia per piantare alberi effettuando ricerche, è completamente gratuita!
+Con un download puoi aiutare a combattere il cambiamento climatico, tutelando anche la tua privacy. Scarica subito la app Ecosia per piantare alberi effettuando ricerche, è completamente gratuita!
 
 Blocco degli annunci pubblicitari e navigazione veloce — La app Ecosia è basata su Firefox di Mozilla e offre un’esperienza di navigazione intuitiva, rapida e sicura con tutto quello che ti serve, come schede, modalità in incognito, segnalibri, download e modalità scura. Visualizziamo anche una foglia verde di fianco ai risultati pro-ambientali, aiutandoti a fare scelte più green mentre effettui ricerche.
 


### PR DESCRIPTION
[MOB-1977]

## Context

The release note is partially automated

## Approach

Create an ad-hoc workflow.

This GitHub Actions workflow is named "Release Notes update" and is designed to automate the process of updating release notes for an app on the AppStore using Fastlane. Here's a breakdown of what each part of the workflow does:

1. **Trigger Condition**:
   - This workflow is triggered when a pull request is opened or updated in the `main` branch.
   - The trigger is further filtered by file paths. It will only run when changes are made in the `fastlane/metadata/` directory and its subdirectories. However, changes in `fastlane/metadata/en-US/` or its subdirectories are excluded as we update those that will trigger Transifex.

2. **Jobs**:
   - This workflow defines a single job called `upload_release_notes_to_appstore` that runs on the latest version of Ubuntu. Thought about not needing a Mac image which is larger for no value added.

3. **Steps**:

   a. **Checkout**: classic step
   b. **Install gems**: minimum requirement to install Fastlane and its plugins
   d. **Fastlane `upload_release_notes` lane**:
      - This step executes the ad-hoc public fastlane's lane that creates the needed AppStoreConnect ApiKey, grabs the version number, and executes `upload_to_app_store` (alias of `deliver`) to upload the metadata skipping the HTML confirmation we usually get when ran locally via the command in the README (without the `force` flag).

### Tests

Tested locally and on GitHub Action making sure that all the necessary info is passed to the action.

## Other

Updated README to accommodate the new process.

Meant to add a specific section that wouldn't necessarily involve any AppStore Connect metadata download as essentially we may need only to update the `en-US/description.txt` file but I thought that given the changes to support and marketing URLs and others expected, we may still want to download the metadata from the AppStore Connect for now.
Adding the wanted README input line as a reference for the future:

```
#### Via Repo update

- Modify the current strings in the `/fastlane/metadata/en-US/**`
- Make a PR with the modified `en-US` files
- Wait for the approval and merge

The job won't be triggered for the files within the `en-US` folder as it's our reference one. No need to trigger an upload for that as it will be picked up as part of the whole update.
```

### Next Steps

@ecotopian I guess I'll need to pass the baton to you with regards to the Secrets to add to this repo.
They need to be the same added to the CircleCI one. 

## Before merging

### Checklist

- [x] I performed some relevant testing on my local and GitHub Action
- [x] I've updated the README file with the new process

[MOB-1977]: https://ecosia.atlassian.net/browse/MOB-1977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ