### PR TITLE
[MOB-2016] Fix locker image color on theme update

### DIFF
--- a/Client/Ecosia/Extensions/Toolbar+URLBar/ConnectionStatusImage.swift
+++ b/Client/Ecosia/Extensions/Toolbar+URLBar/ConnectionStatusImage.swift
@@ -6,6 +6,10 @@ import Foundation
 
 struct ConnectionStatusImage {
     
-    static let connectionSecureImage = UIImage.templateImageNamed("secureLock")?.tinted(withColor: .theme.ecosia.secondaryIcon)
-    static let connectionUnsecureImage = UIImage.templateImageNamed("problem")?.tinted(withColor: .theme.ecosia.warning)
+    static var connectionSecureImage: UIImage? {
+        UIImage.templateImageNamed("secureLock")?.tinted(withColor: .theme.ecosia.secondaryIcon)
+    }
+    static var connectionUnsecureImage: UIImage? {
+        UIImage.templateImageNamed("problem")?.tinted(withColor: .theme.ecosia.warning)
+    }
 }

--- a/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
+++ b/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
@@ -64,6 +64,8 @@ class TabLocationView: UIView {
     var placeholder: NSAttributedString {
         return NSAttributedString(string: .TabLocationURLPlaceholder, attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.ecosia.secondaryText])
     }
+    
+    var status: WebsiteConnectionTypeStatus?
 
     lazy var urlTextField: URLTextField = .build { urlTextField in
         /* Ecosia: removing obsolete implementation as we don't support 4S anymore
@@ -315,6 +317,7 @@ extension TabLocationView: NotificationThemeable {
 
         let color = LegacyThemeManager.instance.currentName == .dark ? UIColor(white: 0.3, alpha: 0.6): UIColor.theme.textField.background
         menuBadge.badge.tintBackground(color: color)
+        updateProtectionButtonStatusIfNeeded()
     }
 }
 
@@ -325,6 +328,11 @@ extension TabLocationView {
         trackingProtectionButton.evaluateNeedingVisbilityForURLScheme(url?.scheme)
     }
     
+    private func updateProtectionButtonStatusIfNeeded() {
+        guard let status else { return }
+        trackingProtectionButton.updateAppearanceForStatus(status)
+    }
+    
     func toggleURLProtectionButtonVisibility(_ isLoading: Bool = false) {
         trackingProtectionButton.alpha = isLoading ? 0 : 1
     }
@@ -333,7 +341,7 @@ extension TabLocationView {
 extension TabLocationView: TabEventHandler {
     
     func tab(_ tab: Tab, didChangeURL url: URL) {
-        let status: WebsiteConnectionTypeStatus = url.isSecure ? .secure : .unsecure
-        trackingProtectionButton.updateAppearanceForStatus(status)
+        status = url.isSecure ? .secure : .unsecure
+        updateProtectionButtonStatusIfNeeded()
     }
 }


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the PR title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2016]

## Context

The image locker wasn't updating its color upon the device appearance update.

## Approach

Investigated the root cause.
The image locker wasn't updating successfully as the memory kept the original color reference when first initialized.
Attached is the GIF as a reference.
It wasn't really a regression but mostly something that has been noticed and reported. The issue is presented depending on the initial appearance state.

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator

![Simulator Screen Recording - iPhone 15 - 2023-11-22 at 17 15 22](https://github.com/ecosia/ios-browser/assets/3584008/ad1d0dcd-6cca-40a2-922c-66f63149b8a4)


[MOB-2016]: https://ecosia.atlassian.net/browse/MOB-2016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ