### PR TITLE
[MOB-2069] Fix wrong default search engine during experiment

### DIFF
--- a/Client.xcodeproj/xcshareddata/xcschemes/Ecosia.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/Ecosia.xcscheme
@@ -128,9 +128,6 @@
                   Identifier = "CustomSearchEnginesTest">
                </Test>
                <Test
-                  Identifier = "DefaultSearchPrefsTests">
-               </Test>
-               <Test
                   Identifier = "EcosiaBookmarkMigrationTests">
                </Test>
                <Test

--- a/Client/Frontend/Browser/DefaultSearchPrefs.swift
+++ b/Client/Frontend/Browser/DefaultSearchPrefs.swift
@@ -70,6 +70,8 @@ final class DefaultSearchPrefs {
             usersEngineList = usersEngineList.map({ overrides[$0] as? String ?? $0 })
         }
         
+        // Ecosia: Guarantee the global default engine is included
+        // This enables ecosia to be set as default even in locales where it normally is not listed
         if !usersEngineList.contains(globalDefaultEngine) {
             usersEngineList.append(globalDefaultEngine)
         }

--- a/Client/Frontend/Browser/DefaultSearchPrefs.swift
+++ b/Client/Frontend/Browser/DefaultSearchPrefs.swift
@@ -69,6 +69,11 @@ final class DefaultSearchPrefs {
         if let overrides = regionOverrides?[region] as? [String: Any] {
             usersEngineList = usersEngineList.map({ overrides[$0] as? String ?? $0 })
         }
+        
+        if !usersEngineList.contains(globalDefaultEngine) {
+            usersEngineList.append(globalDefaultEngine)
+        }
+        
         return usersEngineList
     }
 

--- a/Client/Frontend/Browser/OpenSearch.swift
+++ b/Client/Frontend/Browser/OpenSearch.swift
@@ -77,7 +77,7 @@ class OpenSearchEngine: NSObject, NSCoding {
          `URL.search(query: query)`
          */
         if EngineShortcutsExperiment.isEnabled,
-        let fromTemplateURL = getURLFromTemplate(searchTemplate, query: query),
+           let fromTemplateURL = getURLFromTemplate(searchTemplate, query: query),
            fromTemplateURL.baseDomain != "ecosia.org" {
             return fromTemplateURL
         } else {

--- a/Client/Frontend/Browser/SearchEngines.swift
+++ b/Client/Frontend/Browser/SearchEngines.swift
@@ -201,6 +201,7 @@ class SearchEngines {
             }).compactMap({
                 parser.parse($0.path, engineID: $0.name)
             }).sorted { e, _ in
+                // Ecosia: Add lowercased to ensure equality
                 e.shortName.lowercased() == defaultEngineName.lowercased()
             }
     }

--- a/Client/Frontend/Browser/SearchEngines.swift
+++ b/Client/Frontend/Browser/SearchEngines.swift
@@ -201,7 +201,7 @@ class SearchEngines {
             }).compactMap({
                 parser.parse($0.path, engineID: $0.name)
             }).sorted { e, _ in
-                e.shortName == defaultEngineName
+                e.shortName.lowercased() == defaultEngineName.lowercased()
             }
     }
 

--- a/Tests/ClientTests/DefaultSearchPrefsTests.swift
+++ b/Tests/ClientTests/DefaultSearchPrefsTests.swift
@@ -15,16 +15,16 @@ class DefaultSearchPrefsTests: XCTestCase {
         let searchPrefs = DefaultSearchPrefs(with: Bundle.main.resourceURL!.appendingPathComponent("SearchPlugins").appendingPathComponent("list.json"))!
 
         // setup the most popular locales
-        let us = (lang: ["en-US", "en"], region: "US", resultList: ["google-b-1-m", "amazondotcom", "bing", "ddg", "wikipedia"], resultDefault: "Google")
-        let england = (lang: ["en-GB", "en"], region: "GB", resultList: ["google-b-m", "amazon-co-uk", "bing", "ddg", "wikipedia"], resultDefault: "Google")
-        let france = (lang: ["fr-FR", "fr"], region: "FR", resultList: ["google-b-m", "bing", "ddg", "wikipedia-fr"], resultDefault: "Google")
-        let japan = (lang: ["ja-JP", "ja"], region: "JP", resultList: ["google-b-m", "amazon-jp", "bing", "wikipedia-ja"], resultDefault: "Google")
-        let canada = (lang: ["en-CA", "en"], region: "CA", resultList: ["google-b-m", "amazondotcom", "bing", "ddg", "wikipedia"], resultDefault: "Google")
-        let russia = (lang: ["ru-RU", "ru"], region: "RU", resultList: ["google-com-nocodes", "wikipedia-ru"], resultDefault: "Google")
-        let taiwan = (lang: ["zh-TW", "zh"], region: "TW", resultList: ["google-b-m", "bing", "ddg", "wikipedia-zh-TW"], resultDefault: "Google")
-        let china = (lang: ["zh-hans-CN", "zh-CN", "zh"], region: "CN", resultList: ["google-b-m", "baidu", "bing", "wikipedia-zh-CN"], resultDefault: "百度")
-        let germany = (lang: ["de-DE", "de"], region: "DE", resultList: ["google-b-m", "amazon-de", "bing", "ddg", "ecosia", "wikipedia-de"], resultDefault: "Google")
-        let southAfrica = (lang: ["en-SA", "en"], region: "SA", resultList: ["google-b-m", "amazondotcom", "bing", "ddg", "wikipedia"], resultDefault: "Google")
+        let us = (lang: ["en-US", "en"], region: "US", resultList: ["google-b-1-m", "bing", "ddg", "wikipedia", "ecosia"], resultDefault: "ecosia")
+        let england = (lang: ["en-GB", "en"], region: "GB", resultList: ["google-b-m", "bing", "ddg", "wikipedia", "ecosia"], resultDefault: "ecosia")
+        let france = (lang: ["fr-FR", "fr"], region: "FR", resultList: ["google-b-m", "bing", "ddg", "wikipedia-fr", "ecosia"], resultDefault: "ecosia")
+        let japan = (lang: ["ja-JP", "ja"], region: "JP", resultList: ["google-b-m", "bing", "wikipedia-ja", "ecosia"], resultDefault: "ecosia")
+        let canada = (lang: ["en-CA", "en"], region: "CA", resultList: ["ecosia", "wikipedia", "google-b-m", "bing", "ddg"], resultDefault: "ecosia") // default engines
+        let russia = (lang: ["ru-RU", "ru"], region: "RU", resultList: ["google-com-nocodes", "wikipedia-ru", "ecosia"], resultDefault: "ecosia")
+        let taiwan = (lang: ["zh-TW", "zh"], region: "TW", resultList: ["google-b-m", "bing", "ddg", "wikipedia-zh-TW", "ecosia"], resultDefault: "ecosia")
+        let china = (lang: ["zh-hans-CN", "zh-CN", "zh"], region: "CN", resultList: ["google-b-m", "bing", "wikipedia-zh-CN", "ecosia"], resultDefault: "百度")
+        let germany = (lang: ["de-DE", "de"], region: "DE", resultList: ["google-b-m", "bing", "ddg", "ecosia", "wikipedia-de"], resultDefault: "ecosia")
+        let southAfrica = (lang: ["en-SA", "en"], region: "SA", resultList: ["ecosia", "wikipedia", "google-b-m", "bing", "ddg"], resultDefault: "ecosia") // default engines
         let testLocales = [us, england, france, japan, canada, russia, taiwan, china, germany, southAfrica]
 
         // run tests

--- a/Tests/ClientTests/DefaultSearchPrefsTests.swift
+++ b/Tests/ClientTests/DefaultSearchPrefsTests.swift
@@ -15,6 +15,7 @@ class DefaultSearchPrefsTests: XCTestCase {
         let searchPrefs = DefaultSearchPrefs(with: Bundle.main.resourceURL!.appendingPathComponent("SearchPlugins").appendingPathComponent("list.json"))!
 
         // setup the most popular locales
+        // Ecosia: update values to include ecosia
         let us = (lang: ["en-US", "en"], region: "US", resultList: ["google-b-1-m", "bing", "ddg", "wikipedia", "ecosia"], resultDefault: "ecosia")
         let england = (lang: ["en-GB", "en"], region: "GB", resultList: ["google-b-m", "bing", "ddg", "wikipedia", "ecosia"], resultDefault: "ecosia")
         let france = (lang: ["fr-FR", "fr"], region: "FR", resultList: ["google-b-m", "bing", "ddg", "wikipedia-fr", "ecosia"], resultDefault: "ecosia")


### PR DESCRIPTION
[MOB-2069]

## Context

We have implemented an alternative search shortcuts experiment on https://github.com/ecosia/ios-browser/pull/596.

This caused an unintended issue where Google was being used on default searches for some users.

## Problem

Upon investigation I found that the issue was on `DefaultSearchPrefs.visibleDefaultEngines` returning a list that did not contain "ecosia". This happened because our [search plugins list json](https://github.com/ecosia/ios-browser/blob/main/Client/Assets/Search/SearchPlugins/list.json) does not contain "ecosia" on `visibleDefaultEngines` for some locales entries (even if it is on the default entry), which means it is not included in the list if a matching locale is found.

This seems to be an intended behaviour from firefox since in their case the default search engine was configurable and always present on the locale lists. In our case though, we want ecosia regardless of the country.
 
## Approach

The simplest fix I could find was guaranteeing that the `globalDefaultEngine` - which is `"defaul.searchDefault"` in the json and is already set to `"ecosia"` - is included in the array always, even if not present in the json.

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I wrote Unit Tests that confirm the expected behavior
- [x] Timebox investigating a more foolproof fix than the simplest one -> Did not find good alternatives that wouldn't over-complicate other parts of the flow or that wouldn't require a bigger refactor of firefox's logic
- [x] I added the `// Ecosia:` helper comments where needed


[MOB-2069]: https://ecosia.atlassian.net/browse/MOB-2069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ