### PR TITLE
MOB-2079 Fix CI push release notes and improvement

### DIFF
--- a/.github/workflows/upload_release_notes_to_appstore.yml
+++ b/.github/workflows/upload_release_notes_to_appstore.yml
@@ -1,7 +1,7 @@
 name: Release Notes update
 
 on:
-  pull_request:
+  push:
     paths:
       - 'fastlane/metadata/**'
       - '!fastlane/metadata/en-US/**'

--- a/.github/workflows/upload_release_notes_to_appstore.yml
+++ b/.github/workflows/upload_release_notes_to_appstore.yml
@@ -3,8 +3,8 @@ name: Release Notes update
 on:
   push:
     paths:
-      - 'fastlane/metadata/**'
-      - '!fastlane/metadata/en-US/**'
+      - 'fastlane/metadata/**/release_notes.txt'
+      - '!fastlane/metadata/en-US/**/release_notes.txt'
     branches: [ main ]
 
 jobs:


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the PR title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2079]

## Context

While investigating a temporary issue on GitHub Action, I realized that the trigger for the `Release Notes update` workflow was set to `pull_request` instead of `push`.
This would cause the workflow not to run as the target branch was always `main`.

## Approach

- Replace `pull_request` with `push`
- Make sure the workflows would run for changes to the `release_notes.txt`

The ticket explains exactly why a need of this specification was added.

## Before merging

### Checklist

- [x] I performed some relevant testing (replacing `main` with the current branch)


[MOB-2079]: https://ecosia.atlassian.net/browse/MOB-2079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ