### PR TITLE
[MOB-2060] Add engagement service analytics

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -158,7 +158,7 @@
 		2C9165432B20DE5700BE390E /* APNConsentViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9165422B20DE5700BE390E /* APNConsentViewModelProtocol.swift */; };
 		2C9165452B20DEF800BE390E /* APNConsentItemCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9165442B20DEF800BE390E /* APNConsentItemCell.swift */; };
 		2C9165472B20DF0C00BE390E /* APNConsentListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9165462B20DF0C00BE390E /* APNConsentListItem.swift */; };
-		2C9165492B20E55200BE390E /* EngagementServiceExperiment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9165482B20E55200BE390E /* EngagementServiceExperiment.swift */; };
+		2C9165492B20E55200BE390E /* APNConsentUIExperiment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9165482B20E55200BE390E /* APNConsentUIExperiment.swift */; };
 		2C91654B2B20E64100BE390E /* UnleashAPNConsentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C91654A2B20E64100BE390E /* UnleashAPNConsentViewModel.swift */; };
 		2C97EC711E72C80E0092EC18 /* TopTabsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C97EC701E72C80E0092EC18 /* TopTabsTest.swift */; };
 		2C9F8CB92AC30F6F00678514 /* EcosiaInstallType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F8CB82AC30F6E00678514 /* EcosiaInstallType.swift */; };
@@ -1796,7 +1796,7 @@
 		2C9165422B20DE5700BE390E /* APNConsentViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APNConsentViewModelProtocol.swift; sourceTree = "<group>"; };
 		2C9165442B20DEF800BE390E /* APNConsentItemCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APNConsentItemCell.swift; sourceTree = "<group>"; };
 		2C9165462B20DF0C00BE390E /* APNConsentListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APNConsentListItem.swift; sourceTree = "<group>"; };
-		2C9165482B20E55200BE390E /* EngagementServiceExperiment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EngagementServiceExperiment.swift; sourceTree = "<group>"; };
+		2C9165482B20E55200BE390E /* APNConsentUIExperiment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APNConsentUIExperiment.swift; sourceTree = "<group>"; };
 		2C91654A2B20E64100BE390E /* UnleashAPNConsentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnleashAPNConsentViewModel.swift; sourceTree = "<group>"; };
 		2C97EC701E72C80E0092EC18 /* TopTabsTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopTabsTest.swift; sourceTree = "<group>"; };
 		2C9F8CB82AC30F6E00678514 /* EcosiaInstallType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EcosiaInstallType.swift; sourceTree = "<group>"; };
@@ -5285,7 +5285,7 @@
 			children = (
 				2C50B3DC2AF3EE930037AA90 /* EngineShortcutsExperiment.swift */,
 				2C31ECAA2A2E13410058BC31 /* DefaultBrowserExperiment.swift */,
-				2C9165482B20E55200BE390E /* EngagementServiceExperiment.swift */,
+				2C9165482B20E55200BE390E /* APNConsentUIExperiment.swift */,
 			);
 			path = Unleash;
 			sourceTree = "<group>";
@@ -9457,7 +9457,7 @@
 				C45F44691D087DB600CB7EF0 /* TopTabsViewController.swift in Sources */,
 				DFACDFAF274D4D6D00A94EEC /* ReusableCell.swift in Sources */,
 				1D0BA05C24F46A0400D731B5 /* TopSitesProvider.swift in Sources */,
-				2C9165492B20E55200BE390E /* EngagementServiceExperiment.swift in Sources */,
+				2C9165492B20E55200BE390E /* APNConsentUIExperiment.swift in Sources */,
 				0BF0DB941A8545800039F300 /* URLBarView.swift in Sources */,
 				D01017F5219CB6BD009CBB5A /* DownloadContentScript.swift in Sources */,
 				D5D052EF2645ACBF00759F85 /* View.swift in Sources */,

--- a/Client/Ecosia/Analytics/Analytics.Values.swift
+++ b/Client/Ecosia/Analytics/Analytics.Values.swift
@@ -111,7 +111,6 @@ extension Analytics {
         enum APNConsent: String {
             case
             view,
-            click,
             skip,
             deny,
             allow

--- a/Client/Ecosia/Analytics/Analytics.Values.swift
+++ b/Client/Ecosia/Analytics/Analytics.Values.swift
@@ -6,6 +6,7 @@ extension Analytics {
         activity,
         abTest = "ab_Test",
         browser,
+        pushNotification = "push_notification",
         external,
         migration,
         navigation,
@@ -82,7 +83,8 @@ extension Analytics {
         change,
         display,
         enable,
-        disable
+        disable,
+        dismiss
         
         enum Activity: String {
             case
@@ -104,6 +106,15 @@ extension Analytics {
             view,
             click,
             close
+        }
+        
+        enum APNConsent: String {
+            case
+            view,
+            click,
+            skip,
+            deny,
+            allow
         }
         
         enum Bookmarks: String {

--- a/Client/Ecosia/Analytics/Analytics.swift
+++ b/Client/Ecosia/Analytics/Analytics.swift
@@ -139,7 +139,7 @@ final class Analytics {
     /// The function is EngagementService agnostic e.g. doesn't have context
     /// of the engagement service being used (i.e. `Braze`)
     /// but it does get the `Toggle.Name` from the one
-    /// defined in the `EngagementServiceExperiment`
+    /// defined in the `APNConsentUIExperiment`
     /// so to leverage decoupling.
     func apnConsent(_ action: Action.APNConsent) {
         let event = Structured(category: Category.pushNotification.rawValue,
@@ -148,7 +148,7 @@ final class Analytics {
             .property(Property.home.rawValue)
         
         // Add context (if any) from current EngagementService enabled
-        if let toggleName = Unleash.Toggle.Name(rawValue: EngagementServiceExperiment.toggleName),
+        if let toggleName = Unleash.Toggle.Name(rawValue: APNConsentUIExperiment.toggleName),
            let context = Self.getTestContext(from: toggleName) {
             event.contexts.append(context)
         }

--- a/Client/Ecosia/Analytics/Analytics.swift
+++ b/Client/Ecosia/Analytics/Analytics.swift
@@ -147,8 +147,8 @@ final class Analytics {
             .label("push_notification_consent")
             .property(Property.home.rawValue)
         
-        // add context from current EngagementService enabled
-        if let toggleName = Unleash.Toggle.Name(rawValue: EngagementServiceExperiment.name),
+        // Add context (if any) from current EngagementService enabled
+        if let toggleName = Unleash.Toggle.Name(rawValue: EngagementServiceExperiment.toggleName),
            let context = Self.getTestContext(from: toggleName) {
             event.contexts.append(context)
         }

--- a/Client/Ecosia/Analytics/Analytics.swift
+++ b/Client/Ecosia/Analytics/Analytics.swift
@@ -135,6 +135,27 @@ final class Analytics {
         track(event)
     }
     
+    /// Sends the analytics event for a given action
+    /// The function is EngagementService agnostic e.g. doesn't have context
+    /// of the engagement service being used (i.e. `Braze`)
+    /// but it does get the `Toggle.Name` from the one
+    /// defined in the `EngagementServiceExperiment`
+    /// so to leverage decoupling.
+    func apnConsent(_ action: Action.APNConsent) {
+        let event = Structured(category: Category.pushNotification.rawValue,
+                               action: action.rawValue)
+            .label("push_notification_consent")
+            .property(Property.home.rawValue)
+        
+        // add context from current EngagementService enabled
+        if let toggleName = Unleash.Toggle.Name(rawValue: EngagementServiceExperiment.name),
+           let context = Self.getTestContext(from: toggleName) {
+            event.contexts.append(context)
+        }
+        
+        track(event)
+    }
+    
     func accessQuickSearchSettingsScreen() {
         let event = Structured(category: Category.browser.rawValue,
                                action: Action.open.rawValue)

--- a/Client/Ecosia/Experiments/Unleash/APNConsentUIExperiment.swift
+++ b/Client/Ecosia/Experiments/Unleash/APNConsentUIExperiment.swift
@@ -5,7 +5,7 @@
 import Foundation
 import Core
 
-struct EngagementServiceExperiment {
+struct APNConsentUIExperiment {
     
     private init() {}
     

--- a/Client/Ecosia/Experiments/Unleash/EngagementServiceExperiment.swift
+++ b/Client/Ecosia/Experiments/Unleash/EngagementServiceExperiment.swift
@@ -8,6 +8,10 @@ import Core
 struct EngagementServiceExperiment {
     
     private init() {}
+    
+    static var toggleName: String {
+        Unleash.Toggle.Name.brazeAPNConsentUI.rawValue
+    }
 
     static var isEnabled: Bool {
         Unleash.isEnabled(.brazeAPNConsentUI)

--- a/Client/Ecosia/UI/APNConsent/APNConsentViewController.swift
+++ b/Client/Ecosia/UI/APNConsent/APNConsentViewController.swift
@@ -69,14 +69,10 @@ final class APNConsentViewController: UIViewController {
         applyTheme()
     }
     
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        Analytics.shared.apnConsent(.view)
-    }
-    
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         modalTransitionStyle = .crossDissolve
+        Analytics.shared.apnConsent(.view)
         self.delegate?.apnConsentViewDidShow(self)
     }
     

--- a/Client/Ecosia/UI/APNConsent/APNConsentViewController.swift
+++ b/Client/Ecosia/UI/APNConsent/APNConsentViewController.swift
@@ -212,7 +212,7 @@ extension APNConsentViewController {
     @objc private func ctaTapped() {
         guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
         ClientEngagementService.shared.requestAPNConsent(notificationCenterDelegate: appDelegate) { granted, error in
-            guard error == nil else {
+            guard granted else {
                 Analytics.shared.apnConsent(.deny)
                 return
             }

--- a/Client/Ecosia/UI/APNConsent/APNConsentViewController.swift
+++ b/Client/Ecosia/UI/APNConsent/APNConsentViewController.swift
@@ -69,6 +69,11 @@ final class APNConsentViewController: UIViewController {
         applyTheme()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        Analytics.shared.apnConsent(.view)
+    }
+    
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         modalTransitionStyle = .crossDissolve
@@ -204,13 +209,18 @@ extension APNConsentViewController {
 extension APNConsentViewController {
 
     @objc private func skipTapped() {
+        Analytics.shared.apnConsent(.skip)
         dismiss(animated: true)
     }
 
     @objc private func ctaTapped() {
         guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
         ClientEngagementService.shared.requestAPNConsent(notificationCenterDelegate: appDelegate) { granted, error in
-            // TODO: Add analytics
+                        guard error == nil else {
+                Analytics.shared.apnConsent(.deny)
+                return
+            }
+            Analytics.shared.apnConsent(.allow)
         }
     }
 }

--- a/Client/Ecosia/UI/APNConsent/APNConsentViewController.swift
+++ b/Client/Ecosia/UI/APNConsent/APNConsentViewController.swift
@@ -212,7 +212,7 @@ extension APNConsentViewController {
     @objc private func ctaTapped() {
         guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
         ClientEngagementService.shared.requestAPNConsent(notificationCenterDelegate: appDelegate) { granted, error in
-                        guard error == nil else {
+            guard error == nil else {
                 Analytics.shared.apnConsent(.deny)
                 return
             }

--- a/Client/Ecosia/UI/APNConsent/UnleashAPNConsentViewModel.swift
+++ b/Client/Ecosia/UI/APNConsent/UnleashAPNConsentViewModel.swift
@@ -13,7 +13,7 @@ final class UnleashAPNConsentViewModel: APNConsentViewModelProtocol {
     
     /// Title for the APN consent view, currently based on the Unleash variant.
     var title: String {
-        switch EngagementServiceExperiment.variantName {
+        switch APNConsentUIExperiment.variantName {
         case "test1": return .localized(.apnConsentVariantNameTest1HeaderTitle)
         default: return .localized(.apnConsentVariantNameControlHeaderTitle)
         }
@@ -21,7 +21,7 @@ final class UnleashAPNConsentViewModel: APNConsentViewModelProtocol {
     
     /// Image for the APN consent view, currently based on the Unleash variant.
     var image: UIImage? {
-        switch EngagementServiceExperiment.variantName {
+        switch APNConsentUIExperiment.variantName {
         case "test1": return .init(named: "apnConsentImageTest1")
         default: return .init(named: "apnConsentImageControl")
         }
@@ -29,7 +29,7 @@ final class UnleashAPNConsentViewModel: APNConsentViewModelProtocol {
     
     /// List items for the APN consent view, currently based on the Unleash variant.
     var listItems: [APNConsentListItem] {
-        switch EngagementServiceExperiment.variantName {
+        switch APNConsentUIExperiment.variantName {
         case "test1": return listItemsVariantNameTest1
         default: return listItemsVariantNameControl
         }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -168,8 +168,8 @@ class BrowserViewController: UIViewController {
     }
     fileprivate var shouldShowWhatsNewPageScreen: Bool { whatsNewDataProvider.shouldShowWhatsNewPage }
     fileprivate var shouldShowAPNConsentScreen: Bool {
-        EngagementServiceExperiment.isEnabled &&
-        EngagementServiceExperiment.minSearches() <= User.shared.searchCount &&
+        APNConsentUIExperiment.isEnabled &&
+        APNConsentUIExperiment.minSearches() <= User.shared.searchCount &&
         User.shared.shouldShowAPNConsentScreen
     }
 


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the PR title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2060]

## Context

We want to measure the interaction of end users with the UI Card in both variants. 

## Approach

Add Analytics for the following scenario:

- User sees the APN consent screen
- User taps on the "not now" button
- User denies push notification registration request
- User allows push notification registration registration

🎅 🎄 

## Other

## Before merging

### Checklist

- [x] I included documentation updates to the coding standards or Confluence doc when needed
- [x] I am using the correct version from [core](https://github.com/ecosia/ios-core), including any necessary changes for this ticket and pointing to `main` instead of a feature branch


[MOB-2060]: https://ecosia.atlassian.net/browse/MOB-2060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ