### PR TITLE
[MOB-2090] - Register for APN every app launch if needed

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -14732,7 +14732,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ecosia/ios-core.git";
 			requirement = {
-				branch = main;
+				branch = "MOB-2090_register_token_if_granted";
 				kind = branch;
 			};
 		};

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -14732,7 +14732,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ecosia/ios-core.git";
 			requirement = {
-				branch = "MOB-2090_register_token_if_granted";
+				branch = main;
 				kind = branch;
 			};
 		};

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -58,8 +58,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "a21e77d720b1d60d659765eefe2c30677c5d03e2"
+        "branch" : "MOB-2090_register_token_if_granted",
+        "revision" : "fe989c4f874e5f948f78c303df38ed3aa5ca2eec"
       }
     },
     {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -58,8 +58,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
-        "branch" : "MOB-2090_register_token_if_granted",
-        "revision" : "fe989c4f874e5f948f78c303df38ed3aa5ca2eec"
+        "branch" : "main",
+        "revision" : "583171cfb66fba22825910646b685093fd9c1a98"
       }
     },
     {

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -76,6 +76,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         // Ecosia: Engagement Service Initialization with AnalyticsId binding
         ClientEngagementService.shared.initialize(parameters: ["id": User.shared.analyticsId.uuidString])
+        // Ecosia: Refresh push registration if APN permission granted
+        Task.detached {
+            await ClientEngagementService.shared.refreshAPNRegistrationIfNeeded(notificationCenterDelegate: self)
+        }
         
         // Ecosia: fetching statistics before they are used
         Task.detached {

--- a/Client/Ecosia/EngagementService/EngagementService.swift
+++ b/Client/Ecosia/EngagementService/EngagementService.swift
@@ -29,4 +29,8 @@ final class ClientEngagementService {
     func requestAPNConsent(notificationCenterDelegate: UNUserNotificationCenterDelegate) async throws -> Bool {
         try await service.requestAPNConsent(notificationCenterDelegate: notificationCenterDelegate)
     }
+    
+    public func refreshAPNRegistrationIfNeeded(notificationCenterDelegate: UNUserNotificationCenterDelegate) async {
+        await service.refreshAPNRegistrationIfNeeded(notificationCenterDelegate: notificationCenterDelegate)
+    }
 }


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the PR title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2090]

## Context

We want to make sure the token is always up to date.
Apple guarantees that the APN token doesn’t change, however, is good practice to always attempt to register the push notification if granted to guarantee that the User will keep receiving push notifications.
E.g. Users back up their phone and restore on a new one. Same settings, different token.

## Approach

On every app launch, we perform the APN registration if the permission was granted.

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I am using the correct version from [core](https://github.com/ecosia/ios-core), including any necessary changes for this ticket and pointing to `main` instead of a feature branch


[MOB-2090]: https://ecosia.atlassian.net/browse/MOB-2090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ