### PR TITLE
[MOB-2112] Add Debug setting for EngagementService identifier

### DIFF
--- a/Client/Ecosia/EngagementService/EngagementService.swift
+++ b/Client/Ecosia/EngagementService/EngagementService.swift
@@ -7,10 +7,16 @@ final class ClientEngagementService {
     
     static let shared = ClientEngagementService()
     private let service  = EngagementService(provider: Braze())
+    private var parameters: [String: Any] = [:]
+    
+    var identifier: String? {
+        parameters["id"] as? String
+    }
     
     func initialize(parameters: [String: Any]) {
         do {
             try service.initialize(parameters: parameters)
+            self.parameters = parameters
         } catch {
             debugPrint(error)
         }

--- a/Client/Ecosia/Settings/EcosiaDebugSettings.swift
+++ b/Client/Ecosia/Settings/EcosiaDebugSettings.swift
@@ -191,3 +191,27 @@ final class UnleashDefaultBrowserSetting: HiddenSetting {
         }
     }
 }
+
+final class EngagementServiceIdentifierSetting: HiddenSetting {
+    override var title: NSAttributedString? {
+        return NSAttributedString(string: "Debug: Engagement Service Identifier parameter", attributes: [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText])
+    }
+
+    override var status: NSAttributedString? {
+        
+        let attributes = [NSAttributedString.Key.foregroundColor: UIColor.theme.tableView.rowText]
+        
+        guard let identifier = ClientEngagementService.shared.identifier else {
+            return NSAttributedString(string: "n/a", attributes: attributes)
+        }
+        let variant = Unleash.getVariant(.defaultBrowser).name
+        return NSAttributedString(string: "\(identifier) (Click to copy)", attributes: attributes)
+    }
+
+    override func onClick(_ navigationController: UINavigationController?) {
+        guard let identifier = ClientEngagementService.shared.identifier else { return }
+        let pasteBoard = UIPasteboard.general
+        pasteBoard.string = identifier
+    }
+}
+

--- a/Client/Frontend/Settings/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/AppSettingsTableViewController.swift
@@ -259,7 +259,8 @@ class AppSettingsTableViewController: SettingsTableViewController, FeatureFlagga
                 InactiveTabsExpireEarly(settings: self),
                 ChangeSearchCount(settings: self),
                 ResetSearchCount(settings: self),
-                UnleashDefaultBrowserSetting(settings: self)
+                UnleashDefaultBrowserSetting(settings: self),
+                EngagementServiceIdentifierSetting(settings: self)
             ])]
 
         return settings


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the PR title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2112]

## Context
Throughout the Braze development, we have identified the need of targeting campaigns / push notification to specific users.

Braze associated an identifier to each installation. We match the Braze Identifier with the Analytics Identifier.

By having a way to identify the current Braze Identifier associated with the current installed app, we will be able to easily route Braze campaigns to specific users in both production and staging.

## Approach

- Create a debug hidden setting that allow us to disclose our current Braze Identifier by storing the `parameters` in
- Allow the field to be copied in the clipboard by clicking on it.
- managed empty state in setting providing `n/a` if for some reason the identifier is not retrieved

![Simulator Screenshot - iPhone 15 - 2024-01-05 at 13 16 35](https://github.com/ecosia/ios-browser/assets/3584008/4bc0966e-8811-44cd-92b5-00e1bba9bed0)

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator

[MOB-2112]: https://ecosia.atlassian.net/browse/MOB-2112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ