### PR TITLE
[MOB-2116] Add `Production.xcconfig` to Ecosia setting

### DIFF
--- a/Client/Configuration/Ecosia.xcconfig
+++ b/Client/Configuration/Ecosia.xcconfig
@@ -4,6 +4,7 @@
 
 #include "Common.xcconfig"
 #include "Release.xcconfig"
+#include "Production.xcconfig"
 
 MOZ_BUNDLE_DISPLAY_NAME = Ecosia
 MOZ_BUNDLE_ID = com.ecosia.ecosiaapp


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the PR title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2116]

## Context

When checking the hidden flag to determine the BrazeID/AnalyticsID, I realized the missing of it and went digging.
For some reason, the Ecosia.xcconfig got lost of its Production.xcconfig include reference.

## Approach

Re-add.
Made sure that the Build Setting is showing up the correct Production Api Key.
A new release needs to be pushed with this fix.

As a further action, allocating some time to it, will investigate the implementation of the swift-lint to check those sensitive files.
Will be the occasion to set the foundation for some linting rules for our developments on top of standard safe-checks like this one. 


[MOB-2116]: https://ecosia.atlassian.net/browse/MOB-2116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ