### PR TITLE
[MOB-2121] Braze initialization logic behind flag

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -158,7 +158,7 @@
 		2C9165432B20DE5700BE390E /* APNConsentViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9165422B20DE5700BE390E /* APNConsentViewModelProtocol.swift */; };
 		2C9165452B20DEF800BE390E /* APNConsentItemCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9165442B20DEF800BE390E /* APNConsentItemCell.swift */; };
 		2C9165472B20DF0C00BE390E /* APNConsentListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9165462B20DF0C00BE390E /* APNConsentListItem.swift */; };
-		2C9165492B20E55200BE390E /* APNConsentUIExperiment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9165482B20E55200BE390E /* APNConsentUIExperiment.swift */; };
+		2C9165492B20E55200BE390E /* EngagementServiceFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9165482B20E55200BE390E /* EngagementServiceFeature.swift */; };
 		2C91654B2B20E64100BE390E /* UnleashAPNConsentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C91654A2B20E64100BE390E /* UnleashAPNConsentViewModel.swift */; };
 		2C97EC711E72C80E0092EC18 /* TopTabsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C97EC701E72C80E0092EC18 /* TopTabsTest.swift */; };
 		2C9F8CB92AC30F6F00678514 /* EcosiaInstallType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F8CB82AC30F6E00678514 /* EcosiaInstallType.swift */; };
@@ -1796,7 +1796,7 @@
 		2C9165422B20DE5700BE390E /* APNConsentViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APNConsentViewModelProtocol.swift; sourceTree = "<group>"; };
 		2C9165442B20DEF800BE390E /* APNConsentItemCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APNConsentItemCell.swift; sourceTree = "<group>"; };
 		2C9165462B20DF0C00BE390E /* APNConsentListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APNConsentListItem.swift; sourceTree = "<group>"; };
-		2C9165482B20E55200BE390E /* APNConsentUIExperiment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APNConsentUIExperiment.swift; sourceTree = "<group>"; };
+		2C9165482B20E55200BE390E /* EngagementServiceFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EngagementServiceFeature.swift; sourceTree = "<group>"; };
 		2C91654A2B20E64100BE390E /* UnleashAPNConsentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnleashAPNConsentViewModel.swift; sourceTree = "<group>"; };
 		2C97EC701E72C80E0092EC18 /* TopTabsTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopTabsTest.swift; sourceTree = "<group>"; };
 		2C9F8CB82AC30F6E00678514 /* EcosiaInstallType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EcosiaInstallType.swift; sourceTree = "<group>"; };
@@ -5285,7 +5285,7 @@
 			children = (
 				2C50B3DC2AF3EE930037AA90 /* EngineShortcutsExperiment.swift */,
 				2C31ECAA2A2E13410058BC31 /* DefaultBrowserExperiment.swift */,
-				2C9165482B20E55200BE390E /* APNConsentUIExperiment.swift */,
+				2C9165482B20E55200BE390E /* EngagementServiceFeature.swift */,
 			);
 			path = Unleash;
 			sourceTree = "<group>";
@@ -9457,7 +9457,7 @@
 				C45F44691D087DB600CB7EF0 /* TopTabsViewController.swift in Sources */,
 				DFACDFAF274D4D6D00A94EEC /* ReusableCell.swift in Sources */,
 				1D0BA05C24F46A0400D731B5 /* TopSitesProvider.swift in Sources */,
-				2C9165492B20E55200BE390E /* APNConsentUIExperiment.swift in Sources */,
+				2C9165492B20E55200BE390E /* EngagementServiceFeature.swift in Sources */,
 				0BF0DB941A8545800039F300 /* URLBarView.swift in Sources */,
 				D01017F5219CB6BD009CBB5A /* DownloadContentScript.swift in Sources */,
 				D5D052EF2645ACBF00759F85 /* View.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -14732,7 +14732,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ecosia/ios-core.git";
 			requirement = {
-				branch = main;
+				branch = "MOB-2121_braze_initialization_logic_behind_flag";
 				kind = branch;
 			};
 		};

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -14732,7 +14732,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ecosia/ios-core.git";
 			requirement = {
-				branch = "MOB-2121_braze_initialization_logic_behind_flag";
+				branch = main;
 				kind = branch;
 			};
 		};

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -58,8 +58,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
-        "branch" : "MOB-2121_braze_initialization_logic_behind_flag",
-        "revision" : "08588954a50952e4a4c0cde191a038d50f1cb380"
+        "branch" : "main",
+        "revision" : "9692f7ecc6ce80083574ec37428bc9aeef6bb9a4"
       }
     },
     {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/braze-inc/braze-swift-sdk",
       "state" : {
-        "revision" : "d3963492b9ae0dd2c28a41201707b1723a7d7c94",
-        "version" : "7.3.0"
+        "revision" : "a3d83be34c5e3f32d91391544b2c18f707cd27eb",
+        "version" : "7.5.0"
       }
     },
     {
@@ -58,8 +58,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "583171cfb66fba22825910646b685093fd9c1a98"
+        "branch" : "MOB-2121_braze_initialization_logic_behind_flag",
+        "revision" : "08588954a50952e4a4c0cde191a038d50f1cb380"
       }
     },
     {

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -74,12 +74,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Ecosia: lifecycle tracking
         Analytics.shared.activity(.launch)
         
-        // Ecosia: Engagement Service Initialization with AnalyticsId binding
-        ClientEngagementService.shared.initialize(parameters: ["id": User.shared.analyticsId.uuidString])
-        // Ecosia: Refresh push registration if APN permission granted
-        Task.detached {
-            await ClientEngagementService.shared.refreshAPNRegistrationIfNeeded(notificationCenterDelegate: self)
-        }
+        // Ecosia: Engagement Service Initialization helper
+        ClientEngagementService.shared.initializeAndUpdateNotificationRegistrationIfNeeded(notificationCenterDelegate: self)
         
         // Ecosia: fetching statistics before they are used
         Task.detached {
@@ -314,6 +310,22 @@ extension AppDelegate {
 extension AppDelegate: WelcomeDelegate {
     func welcomeDidFinish(_ welcome: Welcome) {
         rootViewController.setViewControllers([browserViewController], animated: true)
+    }
+}
+
+/* 
+ 
+ and
+ Refresh push registration if APN permission granted
+ */
+extension AppDelegate {
+    
+    func initializeEngagementServiceAndUpdateRemoteNotificationRegistrationIfNeeded() {
+        guard EngagementServiceFeature.isEnabled else { return }
+        ClientEngagementService.shared.initialize(parameters: ["id": User.shared.analyticsId.uuidString])
+        Task.detached {
+            await ClientEngagementService.shared.refreshAPNRegistrationIfNeeded(notificationCenterDelegate: self)
+        }
     }
 }
 

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -313,22 +313,6 @@ extension AppDelegate: WelcomeDelegate {
     }
 }
 
-/* 
- 
- and
- Refresh push registration if APN permission granted
- */
-extension AppDelegate {
-    
-    func initializeEngagementServiceAndUpdateRemoteNotificationRegistrationIfNeeded() {
-        guard EngagementServiceFeature.isEnabled else { return }
-        ClientEngagementService.shared.initialize(parameters: ["id": User.shared.analyticsId.uuidString])
-        Task.detached {
-            await ClientEngagementService.shared.refreshAPNRegistrationIfNeeded(notificationCenterDelegate: self)
-        }
-    }
-}
-
 // Ecosia: Conformance to UNUserNotificationCenterDelegate to enable APN
 
 extension AppDelegate: UNUserNotificationCenterDelegate {}

--- a/Client/Ecosia/Analytics/Analytics.swift
+++ b/Client/Ecosia/Analytics/Analytics.swift
@@ -148,7 +148,7 @@ final class Analytics {
             .property(Property.home.rawValue)
         
         // Add context (if any) from current EngagementService enabled
-        if let toggleName = Unleash.Toggle.Name(rawValue: APNConsentUIExperiment.toggleName),
+        if let toggleName = Unleash.Toggle.Name(rawValue: EngagementServiceFeature.toggleName),
            let context = Self.getTestContext(from: toggleName) {
             event.contexts.append(context)
         }

--- a/Client/Ecosia/EngagementService/EngagementService.swift
+++ b/Client/Ecosia/EngagementService/EngagementService.swift
@@ -40,3 +40,16 @@ final class ClientEngagementService {
         await service.refreshAPNRegistrationIfNeeded(notificationCenterDelegate: notificationCenterDelegate)
     }
 }
+
+// MARK: - Helpers
+
+extension ClientEngagementService {
+    
+    func initializeAndUpdateNotificationRegistrationIfNeeded(notificationCenterDelegate: UNUserNotificationCenterDelegate) {
+        guard EngagementServiceFeature.isEnabled else { return }
+        initialize(parameters: ["id": User.shared.analyticsId.uuidString])
+        Task.detached {
+            await self.refreshAPNRegistrationIfNeeded(notificationCenterDelegate: notificationCenterDelegate)
+        }
+    }
+}

--- a/Client/Ecosia/Experiments/Unleash/EngagementServiceFeature.swift
+++ b/Client/Ecosia/Experiments/Unleash/EngagementServiceFeature.swift
@@ -5,25 +5,25 @@
 import Foundation
 import Core
 
-struct APNConsentUIExperiment {
+struct EngagementServiceFeature {
     
     private init() {}
     
     static var toggleName: String {
-        Unleash.Toggle.Name.brazeAPNConsentUI.rawValue
+        Unleash.Toggle.Name.braze.rawValue
     }
 
     static var isEnabled: Bool {
-        Unleash.isEnabled(.brazeAPNConsentUI)
+        Unleash.isEnabled(.braze)
     }
 
     static func minSearches() -> Int {
-        let variant = Unleash.getVariant(.brazeAPNConsentUI)
+        let variant = Unleash.getVariant(.braze)
         return minSearches(for: variant)
     }
     
     static var variantName: String {
-        return Unleash.getVariant(.brazeAPNConsentUI).name
+        return Unleash.getVariant(.braze).name
     }
 
     private static func minSearches(for variant: Unleash.Variant) -> Int {

--- a/Client/Ecosia/UI/APNConsent/UnleashAPNConsentViewModel.swift
+++ b/Client/Ecosia/UI/APNConsent/UnleashAPNConsentViewModel.swift
@@ -13,7 +13,7 @@ final class UnleashAPNConsentViewModel: APNConsentViewModelProtocol {
     
     /// Title for the APN consent view, currently based on the Unleash variant.
     var title: String {
-        switch APNConsentUIExperiment.variantName {
+        switch EngagementServiceFeature.variantName {
         case "test1": return .localized(.apnConsentVariantNameTest1HeaderTitle)
         default: return .localized(.apnConsentVariantNameControlHeaderTitle)
         }
@@ -21,7 +21,7 @@ final class UnleashAPNConsentViewModel: APNConsentViewModelProtocol {
     
     /// Image for the APN consent view, currently based on the Unleash variant.
     var image: UIImage? {
-        switch APNConsentUIExperiment.variantName {
+        switch EngagementServiceFeature.variantName {
         case "test1": return .init(named: "apnConsentImageTest1")
         default: return .init(named: "apnConsentImageControl")
         }
@@ -29,7 +29,7 @@ final class UnleashAPNConsentViewModel: APNConsentViewModelProtocol {
     
     /// List items for the APN consent view, currently based on the Unleash variant.
     var listItems: [APNConsentListItem] {
-        switch APNConsentUIExperiment.variantName {
+        switch EngagementServiceFeature.variantName {
         case "test1": return listItemsVariantNameTest1
         default: return listItemsVariantNameControl
         }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -168,8 +168,8 @@ class BrowserViewController: UIViewController {
     }
     fileprivate var shouldShowWhatsNewPageScreen: Bool { whatsNewDataProvider.shouldShowWhatsNewPage }
     fileprivate var shouldShowAPNConsentScreen: Bool {
-        APNConsentUIExperiment.isEnabled &&
-        APNConsentUIExperiment.minSearches() <= User.shared.searchCount &&
+        EngagementServiceFeature.isEnabled &&
+        EngagementServiceFeature.minSearches() <= User.shared.searchCount &&
         User.shared.shouldShowAPNConsentScreen
     }
 


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2121]

## Context

Throughout the implementation of Braze there have been a couple of follow up to determine whether Braze needed initialisation for all users regardless of its App Consent UI showing up.

Originally, the implementation grouped the whole Braze Engagement Service enablement behind a feature flag.

The follow up conversation made us believe that Braze should be instead initialised every time, which could sound unnecessary from the Engineering perspective but perhaps a different need product-wise was in place. 

Upon drafting the release and highlighting the steps needed to bring the Braze release live, a new clarification came up, surfacing the per-user subscription plan we have with Braze.

As Braze will be rolled out to Core Market only, it is essential to make sure the initialisation happens for those users only.

## Approach

- Update the codebase following the new Unleash flag.
- Rename the classes to removed the swap the meaning of "APN consent" flag in favour of the whole service implementation.
- Remove the concept of "Experiment" as this has become, in fact, a Feature.
- Add a "helper" function as part of the `ClientEngagementService` to initialize and register the notification only if the flag is enabled

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I added the `// Ecosia:` helper comments where needed
- [x] I included documentation updates to the coding standards or Confluence doc when needed
- [x] I am using the correct version from [core](https://github.com/ecosia/ios-core), including any necessary changes for this ticket and pointing to `main` instead of a feature branch


[MOB-2121]: https://ecosia.atlassian.net/browse/MOB-2121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ