### PR TITLE
[MOB-2129] Make sure Unleash is retrieved at app start

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -158,7 +158,7 @@
 		2C9165432B20DE5700BE390E /* APNConsentViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9165422B20DE5700BE390E /* APNConsentViewModelProtocol.swift */; };
 		2C9165452B20DEF800BE390E /* APNConsentItemCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9165442B20DEF800BE390E /* APNConsentItemCell.swift */; };
 		2C9165472B20DF0C00BE390E /* APNConsentListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9165462B20DF0C00BE390E /* APNConsentListItem.swift */; };
-		2C9165492B20E55200BE390E /* EngagementServiceFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9165482B20E55200BE390E /* EngagementServiceFeature.swift */; };
+		2C9165492B20E55200BE390E /* EngagementServiceExperiment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9165482B20E55200BE390E /* EngagementServiceExperiment.swift */; };
 		2C91654B2B20E64100BE390E /* UnleashAPNConsentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C91654A2B20E64100BE390E /* UnleashAPNConsentViewModel.swift */; };
 		2C97EC711E72C80E0092EC18 /* TopTabsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C97EC701E72C80E0092EC18 /* TopTabsTest.swift */; };
 		2C9F8CB92AC30F6F00678514 /* EcosiaInstallType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9F8CB82AC30F6E00678514 /* EcosiaInstallType.swift */; };
@@ -1796,7 +1796,7 @@
 		2C9165422B20DE5700BE390E /* APNConsentViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APNConsentViewModelProtocol.swift; sourceTree = "<group>"; };
 		2C9165442B20DEF800BE390E /* APNConsentItemCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APNConsentItemCell.swift; sourceTree = "<group>"; };
 		2C9165462B20DF0C00BE390E /* APNConsentListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APNConsentListItem.swift; sourceTree = "<group>"; };
-		2C9165482B20E55200BE390E /* EngagementServiceFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EngagementServiceFeature.swift; sourceTree = "<group>"; };
+		2C9165482B20E55200BE390E /* EngagementServiceExperiment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EngagementServiceExperiment.swift; sourceTree = "<group>"; };
 		2C91654A2B20E64100BE390E /* UnleashAPNConsentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnleashAPNConsentViewModel.swift; sourceTree = "<group>"; };
 		2C97EC701E72C80E0092EC18 /* TopTabsTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopTabsTest.swift; sourceTree = "<group>"; };
 		2C9F8CB82AC30F6E00678514 /* EcosiaInstallType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EcosiaInstallType.swift; sourceTree = "<group>"; };
@@ -5285,7 +5285,7 @@
 			children = (
 				2C50B3DC2AF3EE930037AA90 /* EngineShortcutsExperiment.swift */,
 				2C31ECAA2A2E13410058BC31 /* DefaultBrowserExperiment.swift */,
-				2C9165482B20E55200BE390E /* EngagementServiceFeature.swift */,
+				2C9165482B20E55200BE390E /* EngagementServiceExperiment.swift */,
 			);
 			path = Unleash;
 			sourceTree = "<group>";
@@ -9457,7 +9457,7 @@
 				C45F44691D087DB600CB7EF0 /* TopTabsViewController.swift in Sources */,
 				DFACDFAF274D4D6D00A94EEC /* ReusableCell.swift in Sources */,
 				1D0BA05C24F46A0400D731B5 /* TopSitesProvider.swift in Sources */,
-				2C9165492B20E55200BE390E /* EngagementServiceFeature.swift in Sources */,
+				2C9165492B20E55200BE390E /* EngagementServiceExperiment.swift in Sources */,
 				0BF0DB941A8545800039F300 /* URLBarView.swift in Sources */,
 				D01017F5219CB6BD009CBB5A /* DownloadContentScript.swift in Sources */,
 				D5D052EF2645ACBF00759F85 /* View.swift in Sources */,

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -74,8 +74,22 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Ecosia: lifecycle tracking
         Analytics.shared.activity(.launch)
         
-        // Ecosia: Engagement Service Initialization helper
-        ClientEngagementService.shared.initializeAndUpdateNotificationRegistrationIfNeeded(notificationCenterDelegate: self)
+        /* 
+         Ecosia: Feature Management fetch
+         We perform the same configuration retrieval in
+         `applicationDidBecomeActive(:)` and sounds redundant;
+         However we need it here to make sure we retrieve the latest
+         flag state of the EngagementService.
+         Decouple the "loading" only from the filesystem of any
+         previously saved Model from the `Unleash.start(:)` will not
+         make any tangible difference in the process as we check if
+         any cached version of the Model is in place.
+         */
+        Task {
+            await FeatureManagement.fetchConfiguration()
+            // Ecosia: Engagement Service Initialization helper
+            ClientEngagementService.shared.initializeAndUpdateNotificationRegistrationIfNeeded(notificationCenterDelegate: self)
+        }
         
         // Ecosia: fetching statistics before they are used
         Task.detached {
@@ -128,7 +142,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         // Ecosia
-        FeatureManagement.fetchConfiguration()
+        Task {
+            await FeatureManagement.fetchConfiguration()
+        }
         MMP.sendSession()
     }
 

--- a/Client/Ecosia/Analytics/Analytics.swift
+++ b/Client/Ecosia/Analytics/Analytics.swift
@@ -148,7 +148,7 @@ final class Analytics {
             .property(Property.home.rawValue)
         
         // Add context (if any) from current EngagementService enabled
-        if let toggleName = Unleash.Toggle.Name(rawValue: EngagementServiceFeature.toggleName),
+        if let toggleName = Unleash.Toggle.Name(rawValue: EngagementServiceExperiment.toggleName),
            let context = Self.getTestContext(from: toggleName) {
             event.contexts.append(context)
         }

--- a/Client/Ecosia/EngagementService/EngagementService.swift
+++ b/Client/Ecosia/EngagementService/EngagementService.swift
@@ -46,7 +46,7 @@ final class ClientEngagementService {
 extension ClientEngagementService {
     
     func initializeAndUpdateNotificationRegistrationIfNeeded(notificationCenterDelegate: UNUserNotificationCenterDelegate) {
-        guard EngagementServiceFeature.isEnabled else { return }
+        guard EngagementServiceExperiment.isEnabled else { return }
         initialize(parameters: ["id": User.shared.analyticsId.uuidString])
         Task.detached {
             await self.refreshAPNRegistrationIfNeeded(notificationCenterDelegate: notificationCenterDelegate)

--- a/Client/Ecosia/Experiments/Unleash/EngagementServiceExperiment.swift
+++ b/Client/Ecosia/Experiments/Unleash/EngagementServiceExperiment.swift
@@ -5,7 +5,7 @@
 import Foundation
 import Core
 
-struct EngagementServiceFeature {
+struct EngagementServiceExperiment {
     
     private init() {}
     

--- a/Client/Ecosia/FeatureManagement/FeatureManagement.swift
+++ b/Client/Ecosia/FeatureManagement/FeatureManagement.swift
@@ -8,23 +8,41 @@ import Core
 
 struct FeatureManagement {
     
+    // MARK: - Initialization
+    
     private init() {}
     
-    static func fetchConfiguration() {
-        Task {
-            do {
-                Self.addRefreshingRules()
-                try await _ = Unleash.start(env: .current, appVersion: AppInfo.ecosiaAppVersion)
-            } catch {
-                debugPrint(error)
-            }
+    // MARK: - Configuration
+    
+    /// Fetches the feature configuration asynchronously.
+    static func fetchConfiguration() async {
+        do {
+            try await start()
+        } catch {
+            debugPrint(error)
         }
     }
     
+    // MARK: - Private Methods
+    
+    /// Starts the feature management process asynchronously.
+    ///
+    /// - Throws: An error if the feature management process encounters an issue.
+    @MainActor
+    private static func start() async throws {
+        Self.addRefreshingRules()
+        do {
+            try await _ = Unleash.start(env: .current, appVersion: AppInfo.ecosiaAppVersion)
+        } catch {
+            debugPrint(error)
+        }
+    }
+    
+    /// Adds refreshing rules for feature management.
     private static func addRefreshingRules() {
         UnleashRefreshConfigurator()
-                    .withAppUpdateCheckRule(appVersion: AppInfo.ecosiaAppVersion)
-                    .withDeviceRegionUpdateCheckRule()
-                    .withTwentyFourHoursCacheExpirationRule()
+            .withAppUpdateCheckRule(appVersion: AppInfo.ecosiaAppVersion)
+            .withDeviceRegionUpdateCheckRule()
+            .withTwentyFourHoursCacheExpirationRule()
     }
 }

--- a/Client/Ecosia/UI/APNConsent/UnleashAPNConsentViewModel.swift
+++ b/Client/Ecosia/UI/APNConsent/UnleashAPNConsentViewModel.swift
@@ -13,7 +13,7 @@ final class UnleashAPNConsentViewModel: APNConsentViewModelProtocol {
     
     /// Title for the APN consent view, currently based on the Unleash variant.
     var title: String {
-        switch EngagementServiceFeature.variantName {
+        switch EngagementServiceExperiment.variantName {
         case "test1": return .localized(.apnConsentVariantNameTest1HeaderTitle)
         default: return .localized(.apnConsentVariantNameControlHeaderTitle)
         }
@@ -21,7 +21,7 @@ final class UnleashAPNConsentViewModel: APNConsentViewModelProtocol {
     
     /// Image for the APN consent view, currently based on the Unleash variant.
     var image: UIImage? {
-        switch EngagementServiceFeature.variantName {
+        switch EngagementServiceExperiment.variantName {
         case "test1": return .init(named: "apnConsentImageTest1")
         default: return .init(named: "apnConsentImageControl")
         }
@@ -29,7 +29,7 @@ final class UnleashAPNConsentViewModel: APNConsentViewModelProtocol {
     
     /// List items for the APN consent view, currently based on the Unleash variant.
     var listItems: [APNConsentListItem] {
-        switch EngagementServiceFeature.variantName {
+        switch EngagementServiceExperiment.variantName {
         case "test1": return listItemsVariantNameTest1
         default: return listItemsVariantNameControl
         }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -168,8 +168,8 @@ class BrowserViewController: UIViewController {
     }
     fileprivate var shouldShowWhatsNewPageScreen: Bool { whatsNewDataProvider.shouldShowWhatsNewPage }
     fileprivate var shouldShowAPNConsentScreen: Bool {
-        EngagementServiceFeature.isEnabled &&
-        EngagementServiceFeature.minSearches() <= User.shared.searchCount &&
+        EngagementServiceExperiment.isEnabled &&
+        EngagementServiceExperiment.minSearches() <= User.shared.searchCount &&
         User.shared.shouldShowAPNConsentScreen
     }
 


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the PR title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2129]

## Context

Throughout an extensive test performed over the Testflight build 9.2.2, there was a realisation regarding the Unleash model not matching the current flags state on the Unleash remote dashboard.

The configuration was fetched correctly solely in the `applicationDidBecomeActive` hence the correct one could not be retrieved at the app launch.

As Braze has the requirement of being initialized in the `didFinishLaunchingWithOption` , we needed a way to retrieve the config, without compromising the App Flow.

## Approach

Approached to the problem at best effort.
Mentioned in the code the approach taken and the compromises in order to make sure the Feature flagging management configuration gets fetched every time.
We are benefitting of the fact that we have fetching rules + cached model and whilst decoupling the "fetch" and "load" could be the best, the value added would be mostly "academical" and not really adding/improving anything performance wise.
Suggesting to review it once we will hae he upgrade in.

- Due to a previously closed PR where we discussed the possibility of renaming the Experiment into a Feature, I'm reverting it back to the Experiment as the struct itself lives into the Experiment layout. We will review it later on.
- Added a few self-documented comments to `FeatureManagement` struct 

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I added the `// Ecosia:` helper comments where needed

[MOB-2129]: https://ecosia.atlassian.net/browse/MOB-2129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ