### PR TITLE
[MOB-2286] Add Search Engine Shortcut analytics

### DIFF
--- a/Client/Ecosia/Analytics/Analytics.Values.swift
+++ b/Client/Ecosia/Analytics/Analytics.Values.swift
@@ -56,7 +56,8 @@ extension Analytics {
             settings,
             newTab = "new_tab",
             blockImages = "block_images",
-            searchbar = "searchbar"
+            searchbar = "searchbar",
+            searchEngineShortcut = "shortcut"
         }
         
         enum Bookmarks: String {
@@ -84,7 +85,8 @@ extension Analytics {
         display,
         enable,
         disable,
-        dismiss
+        dismiss,
+        search
         
         enum Activity: String {
             case

--- a/Client/Ecosia/Analytics/Analytics.swift
+++ b/Client/Ecosia/Analytics/Analytics.swift
@@ -336,6 +336,13 @@ final class Analytics {
         track(event)
     }
     
+    func searchEngineShortcutClick(_ engineID: String) {
+        track(Structured(category: Category.browser.rawValue,
+                         action: Action.search.rawValue)
+            .label(Label.Browser.searchEngineShortcut.rawValue)
+            .property(engineID))
+    }
+    
     func sendAnonymousUsageDataSetting(enabled: Bool) {
         // This is the only place where the tracker should be directly
         // used since we want to send this just as the user opts out

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -365,6 +365,8 @@ class SearchViewController: SiteTableViewController, KeyboardHelperDelegate, Loa
         /* Ecosia: remove Glean dependency
         GleanMetrics.Search.counts["\(engine.engineID ?? "custom").\(SearchesMeasurement.SearchLocation.quickSearch.rawValue)"].add()
         */
+        // Ecosia: Add Search Engine Analytics
+        Analytics.shared.searchEngineShortcutClick(engine.engineID ?? "other")
         searchDelegate?.searchViewController(self, didSelectURL: url, searchTerm: "")
     }
 


### PR DESCRIPTION
## **User description**
<!--
Don't forget to add a prefix to the PR title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2286]

## Context

This PR enables tracking of the search engine shortcut click within our analytics engine.

## Approach

Added the tracking event.

## Other

On top of the requested analytics values, I thought about passing which engine the user selected so to have a better understanding of which search engine is "preferred most" as alternative.
If we can't retrieve the "engine Id", `other` is passed (like Firefox does for its Telemetry tracking framework for this event")
There is no value whatsoever related the search itself, so the user privacy is preserved. 

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I added the `// Ecosia:` helper comments where needed
- [x] I included documentation updates to the coding standards or Confluence doc when needed
- [x] I am using the correct version from [core](https://github.com/ecosia/ios-core), including any necessary changes for this ticket and pointing to `main` instead of a feature branch


[MOB-2286]: https://ecosia.atlassian.net/browse/MOB-2286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

## **Type**
enhancement


___

## **Description**
- Added a new label `searchEngineShortcut` in `Analytics.Values.swift` for tracking search engine shortcut clicks.
- Implemented a new function `searchEngineShortcutClick` in `Analytics.swift` to facilitate the tracking of clicks on search engine shortcuts, enhancing analytics capabilities.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Analytics.Values.swift</strong><dd><code>Add Search Engine Shortcut Label for Analytics Tracking</code>&nbsp; &nbsp; </dd></summary>
<hr>
      
Client/Ecosia/Analytics/Analytics.Values.swift

<li>Added <code>searchEngineShortcut</code> to <code>Label.Browser</code> enum for tracking search <br>engine shortcut clicks.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ecosia/ios-browser/pull/624/files#diff-4dcf0cc0c38e60cf1bf8318e762fe7039d0398eaec88242e0115ea16f19a82db">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Analytics.swift</strong><dd><code>Implement Analytics Tracking for Search Engine Shortcut Clicks</code></dd></summary>
<hr>
      
Client/Ecosia/Analytics/Analytics.swift

<li>Implemented <code>searchEngineShortcutClick</code> function to track clicks on <br>search engine shortcuts.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ecosia/ios-browser/pull/624/files#diff-61a41b9c11bd9f793f1ab7bea2dc7122363ebce2ddee3591fbe1ffa2f1428f1d">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

