### PR TITLE
[MOB-2283] Add IDFV property to Analytics tracking.

### DIFF
--- a/Client/Ecosia/Analytics/Analytics+Configuration.swift
+++ b/Client/Ecosia/Analytics/Analytics+Configuration.swift
@@ -13,7 +13,7 @@ extension Analytics {
         .sessionContext(true)
         .applicationContext(true)
         .platformContext(true)
-        .platformContextProperties([]) // track minimal device properties
+        .platformContextProperties([.appleIdfv]) // track minimal device properties
         .geoLocationContext(true)
         .deepLinkContext(false)
         .screenContext(false)


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the PR title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2283]

## Context

We're enhancing Mobile Measurement Partner integration in our apps. However, there's a notable disparity between new user installs reported by our partner and us. An hint is that our use of internal ID "SING" might be the issue. 
To test, we plan to send both "SING + IDFV" to establish a mapping and observe any differences.

## Approach

Add IDFV to our Analytics service.

## Other

The ticket doesn't block the code implementation and merge. Discussed with Product already. However, we might wait full unblock from our Legal dept to make sure our Privacy Policy is up to date by the time we go out with it. 

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I included documentation updates to the coding standards or Confluence doc when needed


[MOB-2283]: https://ecosia.atlassian.net/browse/MOB-2283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ