### PR TITLE
[MOB-2167] Add number of search counts to APNConsent analtytics

### DIFF
--- a/Client/Ecosia/Analytics/Analytics.swift
+++ b/Client/Ecosia/Analytics/Analytics.swift
@@ -150,7 +150,7 @@ final class Analytics {
         // When the user sees the APNConsent
         // we add the number of search counts as value of the event
         if action == .view {
-            _ = event.value(NSNumber(integerLiteral: User.shared.searchCount))
+            event.value = NSNumber(integerLiteral: User.shared.searchCount)
         }
         
         // Add context (if any) from current EngagementService enabled

--- a/Client/Ecosia/Analytics/Analytics.swift
+++ b/Client/Ecosia/Analytics/Analytics.swift
@@ -147,6 +147,12 @@ final class Analytics {
             .label("push_notification_consent")
             .property(Property.home.rawValue)
         
+        // When the user sees the APNConsent
+        // we add the number of search counts as value of the event
+        if action == .view {
+            _ = event.value(NSNumber(integerLiteral: User.shared.searchCount))
+        }
+        
         // Add context (if any) from current EngagementService enabled
         if let toggleName = Unleash.Toggle.Name(rawValue: EngagementServiceExperiment.toggleName),
            let context = Self.getTestContext(from: toggleName) {


### PR DESCRIPTION
## **User description**
<!--
Don't forget to add a prefix to the PR title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2167]

## Context

We want to improve the anonymous analytics tracking including the number of searches a User has performed when viewing the APN Consent Screen.
We want to add the `variant` name as part of the event.

## Approach

- Investigate the current state of the Analytics APN Consent Screen
- Realize the APN Consent Screen does already send the variant name as part of the event (verified)
- Catchup with EM to evaluate the best practice to add the User's searches count
- Add the User's searches count as part of the `value` property for the `view` only event.
- Updated tracking overview doc

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I included documentation updates to the coding standards or Confluence doc when needed


[MOB-2167]: https://ecosia.atlassian.net/browse/MOB-2167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

## **Type**
enhancement


___

## **Description**
- Enhanced the APNConsent analytics event to include the user's search count as part of the event value, specifically for the `view` action. This allows for more detailed tracking of user engagement with the APNConsent screen.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Analytics.swift</strong><dd><code>Enhance APNConsent Analytics with User Search Count</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
Client/Ecosia/Analytics/Analytics.swift

<li>Added the user's search count to the analytics event value when <br>viewing the APNConsent screen.<br> <li> Ensured the search count is only added for the <code>view</code> action.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ecosia/ios-browser/pull/627/files#diff-61a41b9c11bd9f793f1ab7bea2dc7122363ebce2ddee3591fbe1ffa2f1428f1d">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

