### PR TITLE
Minor readme formatting and grammar fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,17 +85,15 @@ bundle update
 
 ### Why is the `CURRENT_PROJECT_VERSION` set to `0`?
 
-The `CURRENT_PROJECT_VERSION` is set to `0`, indicates that is not being used for local testing. The outcoming build number is updated by the CI, mathcing the CI run number (e.g. `8023`).
+The `CURRENT_PROJECT_VERSION` being set to `0` indicates that it is not being used for local testing. The outcoming build number is updated by the CI, matching the CI run number (e.g. `8023`).
 
-#### Get certificates and profiles
+### Get certificates and profiles
 
-Our certs and profiles are managed centrally by [fastlane match](https://docs.fastlane.tools/actions/match/).
-
-Find the repo is [here](https://github.com/ecosia/IosSearchSigning)
+Our certs and profiles are managed centrally by [fastlane match](https://docs.fastlane.tools/actions/match/). Find the repo [here](https://github.com/ecosia/IosSearchSigning)
 
 Run `bundle exec fastlane match --readonly` to add certs and profiles to your system. You can append  `-p "keychain password"` to avoid keychain prompts during the process. The passphrase to decrypt the repo can be found in LastPass.
 
-#### Adding your own device
+### Adding your own device
 
 As we use `fastlane match` to hardwire profiles it gets a bit tricky to add a new device and run the app via your machine.
 


### PR DESCRIPTION
## **User description**
Fixes for the readme: 
clarified "current_project_version set to 0" section
normalized two heading sizes 
clarified where "IOS search signing" repo is


___

## **Type**
documentation


___

## **Description**
- Improved explanation for `CURRENT_PROJECT_VERSION` being set to `0`, enhancing understanding for local testing context.
- Fixed a typo in the description of how the build number is updated by the CI.
- Normalized heading sizes for better readability and structure in the README.
- Consolidated information about the certs and profiles management, making it easier to find the relevant repository.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Improvements in README for Clarity and Formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
README.md

<li>Clarified the explanation for <code>CURRENT_PROJECT_VERSION</code> being set to <code>0</code>.<br> <li> Corrected the spelling of "matching" in the CI run number explanation.<br> <li> Normalized heading levels for "Get certificates and profiles" and <br>"Adding your own device".<br> <li> Consolidated the information about where to find the certs and <br>profiles repo.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ecosia/ios-browser/pull/631/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+4/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

