### PR TITLE
Fix url insecure lock icon appearing on NTP

### DIFF
--- a/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
+++ b/Client/Frontend/Toolbar+URLBar/TabLocationView.swift
@@ -391,7 +391,9 @@ private extension TabLocationView {
 
         readerModeButton.isHidden = shoppingButton.isHidden ? newReaderModeState == .unavailable : true
         // When the user turns on the reader mode we need to hide the trackingProtectionButton (according to 16400), we will hide it once the newReaderModeState == .active
-        self.trackingProtectionButton.isHidden = newReaderModeState == .active
+        if newReaderModeState == .active {
+            self.trackingProtectionButton.isHidden = true
+        }
 
         if wasHidden != readerModeButton.isHidden {
             UIAccessibility.post(notification: UIAccessibility.Notification.layoutChanged, argument: nil)


### PR DESCRIPTION
## **User description**
## Context

A bug where the insecure lock icon appeared if switching from open website to existing NTP was [reported in slack](https://ecosia-team.slack.com/archives/C06LT4FNG7M/p1709742964672139).

## Approach

Found a similar fix on FF's side (https://github.com/mozilla-mobile/firefox-ios/pull/18636) that also resolved this issue.

Turns out that the reader mode was the problem and un-hiding the button.

I also decided not to add a `// Ecosia` comment since this is actually the same logic applied on the latest FF branch (see PR above which was already merged).

<details>
<summary>Video example with the fix</summary>

https://github.com/ecosia/ios-browser/assets/19517744/43b0ab56-c9bd-411e-ac25-4d2463481d4f

</details>

___

## **Type**
bug_fix


___

## **Description**
- Fixed an issue where the insecure lock icon appeared when switching from an open website to an existing New Tab Page (NTP).
- Adjusted the visibility logic of the `readerModeButton` and `trackingProtectionButton` to ensure the lock icon behaves correctly.
- Ensured that accessibility notifications are correctly posted when the visibility of the `readerModeButton` changes.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TabLocationView.swift</strong><dd><code>Fix Insecure Lock Icon by Adjusting Reader Mode Button Visibility</code></dd></summary>
<hr>
      
Client/Frontend/Toolbar+URLBar/TabLocationView.swift

<li>Adjusted visibility logic for <code>readerModeButton</code> and <br><code>trackingProtectionButton</code>.<br> <li> <code>trackingProtectionButton</code> is now hidden when <code>newReaderModeState</code> is <br><code>.active</code>.<br> <li> Ensured accessibility notification is posted when <code>readerModeButton</code> <br>visibility changes.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ecosia/ios-browser/pull/633/files#diff-5d47204e2c1e5500f65829619bc1170fe02adf7d8424af700a5c8bb444bc58cb">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

