### PR TITLE
Use custom ecosia disclosure indicator for FF settings

### DIFF
--- a/Client/Ecosia/Settings/EcosiaSettings.swift
+++ b/Client/Ecosia/Settings/EcosiaSettings.swift
@@ -7,7 +7,7 @@ import Core
 import Shared
 import Common
 
-private var disclosureIndicator: UIImageView {
+var ecosiaDisclosureIndicator: UIImageView {
     let config = UIImage.SymbolConfiguration(pointSize: 16)
     let disclosureIndicator = UIImageView(image: .init(systemName: "chevron.right", withConfiguration: config))
     disclosureIndicator.contentMode = .center
@@ -17,7 +17,7 @@ private var disclosureIndicator: UIImageView {
 }
 
 final class SearchAreaSetting: Setting {
-    override var accessoryView: UIImageView? { return disclosureIndicator }
+    override var accessoryView: UIImageView? { return ecosiaDisclosureIndicator }
 
     override var style: UITableViewCell.CellStyle { return .value1 }
 
@@ -44,7 +44,7 @@ final class SearchAreaSetting: Setting {
 }
 
 final class SafeSearchSettings: Setting {
-    override var accessoryView: UIImageView? { return disclosureIndicator }
+    override var accessoryView: UIImageView? { return ecosiaDisclosureIndicator }
 
     override var style: UITableViewCell.CellStyle { return .value1 }
 
@@ -194,7 +194,7 @@ final class EcosiaSendAnonymousUsageDataSetting: BoolSetting {
 final class HomepageSettings: Setting {
     private var profile: Profile
 
-    override var accessoryView: UIImageView? { disclosureIndicator }
+    override var accessoryView: UIImageView? { ecosiaDisclosureIndicator }
 
     init(settings: SettingsTableViewController, settingsDelegate: SettingsDelegate?) {
         self.profile = settings.profile
@@ -215,7 +215,7 @@ final class HomepageSettings: Setting {
 final class QuickSearchSearchSetting: Setting {
     let profile: Profile
 
-    override var accessoryView: UIImageView? { return disclosureIndicator }
+    override var accessoryView: UIImageView? { return ecosiaDisclosureIndicator }
 
     override var style: UITableViewCell.CellStyle { return .value1 }
 

--- a/Client/Frontend/Settings/Main/SettingDisclosureUtility.swift
+++ b/Client/Frontend/Settings/Main/SettingDisclosureUtility.swift
@@ -8,10 +8,12 @@ import Shared
 
 struct SettingDisclosureUtility {
     static func buildDisclosureIndicator(theme: Theme) -> UIImageView {
-        let disclosureIndicator = UIImageView()
-        disclosureIndicator.image = UIImage(named: StandardImageIdentifiers.Large.chevronRight)?.withRenderingMode(.alwaysTemplate).imageFlippedForRightToLeftLayoutDirection()
-        disclosureIndicator.tintColor = theme.colors.actionSecondary
-        disclosureIndicator.sizeToFit()
-        return disclosureIndicator
+        // Ecosia: Custom chevron disclosure indicator
+        return ecosiaDisclosureIndicator
+//        let disclosureIndicator = UIImageView()
+//        disclosureIndicator.image = UIImage(named: StandardImageIdentifiers.Large.chevronRight)?.withRenderingMode(.alwaysTemplate).imageFlippedForRightToLeftLayoutDirection()
+//        disclosureIndicator.tintColor = theme.colors.actionSecondary
+//        disclosureIndicator.sizeToFit()
+//        return disclosureIndicator
     }
 }

--- a/Client/Frontend/Settings/Main/SettingDisclosureUtility.swift
+++ b/Client/Frontend/Settings/Main/SettingDisclosureUtility.swift
@@ -8,12 +8,13 @@ import Shared
 
 struct SettingDisclosureUtility {
     static func buildDisclosureIndicator(theme: Theme) -> UIImageView {
-        // Ecosia: Custom chevron disclosure indicator
-        return ecosiaDisclosureIndicator
-//        let disclosureIndicator = UIImageView()
-//        disclosureIndicator.image = UIImage(named: StandardImageIdentifiers.Large.chevronRight)?.withRenderingMode(.alwaysTemplate).imageFlippedForRightToLeftLayoutDirection()
-//        disclosureIndicator.tintColor = theme.colors.actionSecondary
-//        disclosureIndicator.sizeToFit()
-//        return disclosureIndicator
+        /* Ecosia: Custom chevron disclosure indicator
+        let disclosureIndicator = UIImageView()
+        disclosureIndicator.image = UIImage(named: StandardImageIdentifiers.Large.chevronRight)?.withRenderingMode(.alwaysTemplate).imageFlippedForRightToLeftLayoutDirection()
+        disclosureIndicator.tintColor = theme.colors.actionSecondary
+        disclosureIndicator.sizeToFit()
+        return disclosureIndicator
+        */
+        ecosiaDisclosureIndicator
     }
 }


### PR DESCRIPTION
## **User description**
## Context

A bug where some chevron images on the settings page have the wrong color was [reported in slack](https://ecosia-team.slack.com/archives/C06LT4FNG7M/p1710686978672219).

## Approach

Noticed this happened for all Firefox settings, so I changed their centralised method to build the disclosure indicator to use the ecosia one instead. Also renamed ecosia's to make it clearer this is custom.

<details>
<summary>Screenshot examples with the fix</summary>
Dark:

![Simulator Screenshot - iPhone 15 - 2024-03-20 at 15 31 00](https://github.com/ecosia/ios-browser/assets/19517744/422c91f6-351c-459c-856a-1c465ef4e4b9)

Light:

![Simulator Screenshot - iPhone 15 - 2024-03-20 at 15 30 46](https://github.com/ecosia/ios-browser/assets/19517744/2103c8fd-011b-4a20-88ad-998bce223f76)
</details>

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I added the `// Ecosia:` helper comments where needed


___

## **Type**
bug_fix, enhancement


___

## **Description**
- Replaced the standard disclosure indicator with a custom Ecosia disclosure indicator across various settings views to ensure consistency and address color mismatch issues.
- Renamed the disclosure indicator variable to `ecosiaDisclosureIndicator` for better clarity and to highlight its customization.
- Updated `SettingDisclosureUtility` to use the new custom Ecosia disclosure indicator, enhancing visual consistency across the app.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>EcosiaSettings.swift</strong><dd><code>Use Ecosia Custom Disclosure Indicator in Settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
Client/Ecosia/Settings/EcosiaSettings.swift

<li>Renamed <code>disclosureIndicator</code> to <code>ecosiaDisclosureIndicator</code> for clarity <br>and customization.<br> <li> Updated all settings classes to use <code>ecosiaDisclosureIndicator</code> instead <br>of the previous <code>disclosureIndicator</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ecosia/ios-browser/pull/635/files#diff-0aa0ad5dd555b8dc4f7845df9ee5a4afa7c3a19057c0ca5839b11a8263a47680">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>SettingDisclosureUtility.swift</strong><dd><code>Replace Standard Disclosure Indicator with Ecosia Custom</code>&nbsp; </dd></summary>
<hr>
      
Client/Frontend/Settings/Main/SettingDisclosureUtility.swift

<li>Replaced the method to build the disclosure indicator with a call to <br>the new <code>ecosiaDisclosureIndicator</code>.<br> <li> Commented out the old implementation for reference.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ecosia/ios-browser/pull/635/files#diff-bbfb4da2596504cb4ee4388cbc00f515b22515995b7025f7f7495a9b17142a01">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

