### PR TITLE
[MOB-2169 implement apn consent screen reminder

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -14732,7 +14732,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ecosia/ios-core.git";
 			requirement = {
-				branch = main;
+				branch = "MOB-2169_implement_apn_consent_screen_reminder";
 				kind = branch;
 			};
 		};

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -14732,7 +14732,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ecosia/ios-core.git";
 			requirement = {
-				branch = "MOB-2169_implement_apn_consent_screen_reminder";
+				branch = main;
 				kind = branch;
 			};
 		};

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/braze-inc/braze-swift-sdk",
       "state" : {
-        "revision" : "a3d83be34c5e3f32d91391544b2c18f707cd27eb",
-        "version" : "7.5.0"
+        "revision" : "dee5204a3f92ca48b58284327c32053c0a379460",
+        "version" : "7.6.0"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ccgus/fmdb",
       "state" : {
-        "revision" : "61e51fde7f7aab6554f30ab061cc588b28a97d04",
-        "version" : "2.7.7"
+        "revision" : "47a2fa12a242b5a2fe13b916c22f2212e426055c",
+        "version" : "2.7.9"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/onevcat/Kingfisher.git",
       "state" : {
-        "revision" : "b6f62758f21a8c03cd64f4009c037cfa580a256e",
-        "version" : "7.9.1"
+        "revision" : "5b92f029fab2cce44386d28588098b5be0824ef5",
+        "version" : "7.11.0"
       }
     },
     {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -60,7 +60,7 @@
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
         "branch" : "MOB-2169_implement_apn_consent_screen_reminder",
-        "revision" : "b6acb804e62d207e1937ee6576c4ad3325bc1eb1"
+        "revision" : "c317a69c19f778801e83007044c7eb33da9f213c"
       }
     },
     {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -58,8 +58,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "5c1244ad583289bc1777a45613287845bf478983"
+        "branch" : "MOB-2169_implement_apn_consent_screen_reminder",
+        "revision" : "d6f0ce409a58592f2271869fa493dd18dc9ef555"
       }
     },
     {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "dd737c8479c7c03d60cc0d5580d88f95ec42a221f5b1dbdb30acb0c67d7c5f4b",
   "pins" : [
     {
       "identity" : "a-star",
@@ -59,7 +60,7 @@
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
         "branch" : "MOB-2169_implement_apn_consent_screen_reminder",
-        "revision" : "d6f0ce409a58592f2271869fa493dd18dc9ef555"
+        "revision" : "b6acb804e62d207e1937ee6576c4ad3325bc1eb1"
       }
     },
     {
@@ -162,5 +163,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
-        "branch" : "MOB-2169_implement_apn_consent_screen_reminder",
-        "revision" : "c317a69c19f778801e83007044c7eb33da9f213c"
+        "branch" : "main",
+        "revision" : "5043e4211bb4e48cb491c9736742edfd5f131903"
       }
     },
     {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -163,5 +163,5 @@
       }
     }
   ],
-  "version" : 3
+  "version" : 2
 }

--- a/Client/Ecosia/Analytics/Analytics.Values.swift
+++ b/Client/Ecosia/Analytics/Analytics.Values.swift
@@ -115,7 +115,8 @@ extension Analytics {
             view,
             skip,
             deny,
-            allow
+            allow,
+            dismiss
         }
         
         enum Bookmarks: String {

--- a/Client/Ecosia/Experiments/Unleash/EngagementServiceExperiment.swift
+++ b/Client/Ecosia/Experiments/Unleash/EngagementServiceExperiment.swift
@@ -10,7 +10,7 @@ struct EngagementServiceExperiment {
     private init() {}
     
     static let minSearches = 3
-    static let searchesUntilOptInRedisplay = 10
+    static let searchesBetweenOptIns = 10
     static let maxOptInShowingAttempts = 3
 
     static var toggleName: String {

--- a/Client/Ecosia/Experiments/Unleash/EngagementServiceExperiment.swift
+++ b/Client/Ecosia/Experiments/Unleash/EngagementServiceExperiment.swift
@@ -10,7 +10,8 @@ struct EngagementServiceExperiment {
     private init() {}
     
     static let minSearches = 3
-    static let maxOptInShowingAttempts = 10
+    static let searchesUntilOptInRedisplay = 10
+    static let maxOptInShowingAttempts = 3
 
     static var toggleName: String {
         Unleash.Toggle.Name.braze.rawValue

--- a/Client/Ecosia/Experiments/Unleash/EngagementServiceExperiment.swift
+++ b/Client/Ecosia/Experiments/Unleash/EngagementServiceExperiment.swift
@@ -9,6 +9,9 @@ struct EngagementServiceExperiment {
     
     private init() {}
     
+    static let minSearches = 3
+    static let maxOptInShowingAttempts = 10
+
     static var toggleName: String {
         Unleash.Toggle.Name.braze.rawValue
     }
@@ -17,16 +20,7 @@ struct EngagementServiceExperiment {
         Unleash.isEnabled(.braze)
     }
 
-    static func minSearches() -> Int {
-        let variant = Unleash.getVariant(.braze)
-        return minSearches(for: variant)
-    }
-    
     static var variantName: String {
         return Unleash.getVariant(.braze).name
-    }
-
-    private static func minSearches(for variant: Unleash.Variant) -> Int {
-        3
     }
 }

--- a/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
+++ b/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
@@ -12,12 +12,6 @@ extension BrowserViewController: HomepageViewControllerDelegate {
     }
 }
 
-extension BrowserViewController: APNConsentViewDelegate {
-    func apnConsentViewDidShow(_ viewController: APNConsentViewController) {
-
-    }
-}
-
 extension BrowserViewController: DefaultBrowserDelegate {
     @available(iOS 14, *)
     func defaultBrowserDidShow(_ defaultBrowser: DefaultBrowser) {

--- a/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
+++ b/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
@@ -14,7 +14,7 @@ extension BrowserViewController: HomepageViewControllerDelegate {
 
 extension BrowserViewController: APNConsentViewDelegate {
     func apnConsentViewDidShow(_ viewController: APNConsentViewController) {
-        User.shared.markAPNConsentScreenAsShown()
+
     }
 }
 

--- a/Client/Ecosia/L10N/String.swift
+++ b/Client/Ecosia/L10N/String.swift
@@ -250,5 +250,6 @@ extension String {
         case apnConsentVariantNameTest1SecondItemTitle = "Get tips on how to be climate active every day"
         case apnConsentCTAAllowButtonTitle = "Allow push notifications"
         case apnConsentSkipButtonTitle = "Not now"
+        case apnConsentLastReminderSkipButtonTitle = "No thanks"
     }
 }

--- a/Client/Ecosia/UI/APNConsent/APNConsentViewController.swift
+++ b/Client/Ecosia/UI/APNConsent/APNConsentViewController.swift
@@ -258,13 +258,13 @@ extension APNConsentViewController {
             guard granted else {
                 Analytics.shared.apnConsent(.deny)
                 self?.optInManager?.recordOptInAttempt()
-                self?.ensureMainThread { [weak self] in
+                DispatchQueue.main.async { [weak self] in
                     self?.dismissVC()
                 }
                 return
             }
             Analytics.shared.apnConsent(.allow)
-            self?.ensureMainThread { [weak self] in
+            DispatchQueue.main.async { [weak self] in
                 self?.dismissVC()
             }
         }

--- a/Client/Ecosia/UI/APNConsent/APNConsentViewController.swift
+++ b/Client/Ecosia/UI/APNConsent/APNConsentViewController.swift
@@ -5,10 +5,6 @@
 import UIKit
 import Core
 
-protocol APNConsentViewDelegate: AnyObject {
-    func apnConsentViewDidShow(_ viewController: APNConsentViewController)
-}
-
 final class APNConsentViewController: UIViewController {
     
     // MARK: - UX
@@ -47,7 +43,6 @@ final class APNConsentViewController: UIViewController {
     private let ctaButton = UIButton()
     private let skipButton = UIButton()
     private var optInManager: OptInReminderManager?
-    weak var delegate: APNConsentViewDelegate?
     var shouldShow: Bool {
         EngagementServiceExperiment.isEnabled &&
         ClientEngagementService.shared.notificationAuthorizationStatus == .notDetermined &&
@@ -57,11 +52,9 @@ final class APNConsentViewController: UIViewController {
     // MARK: - Init
 
     init(viewModel: APNConsentViewModelProtocol,
-         optInManager: OptInReminderManager?,
-         delegate: APNConsentViewDelegate?) {
+         optInManager: OptInReminderManager?) {
         super.init(nibName: nil, bundle: nil)
         self.viewModel = viewModel
-        self.delegate = delegate
         self.optInManager = optInManager
     }
     
@@ -83,7 +76,6 @@ final class APNConsentViewController: UIViewController {
         super.viewDidAppear(animated)
         modalTransitionStyle = .crossDissolve
         Analytics.shared.apnConsent(.view)
-        self.delegate?.apnConsentViewDidShow(self)
     }
     
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
@@ -314,8 +306,6 @@ extension APNConsentViewController: NotificationThemeable {
 extension APNConsentViewController {
     
     func presentAsSheetFrom(_ viewController: UIViewController) {
-        
-        guard viewController as? APNConsentViewDelegate != nil else { return }
 
         modalPresentationStyle = .automatic
         

--- a/Client/Ecosia/UI/APNConsent/UnleashAPNConsentViewModel.swift
+++ b/Client/Ecosia/UI/APNConsent/UnleashAPNConsentViewModel.swift
@@ -42,7 +42,11 @@ final class UnleashAPNConsentViewModel: APNConsentViewModelProtocol {
     
     /// Skip button title.
     var skipButtonTitle: String {
-        .localized(.apnConsentSkipButtonTitle)
+        if User.shared.apnConsentReminderManager?.isLastReminder == true {
+            return .localized(.apnConsentLastReminderSkipButtonTitle)
+        } else {
+            return .localized(.apnConsentSkipButtonTitle)
+        }
     }
 }
 

--- a/Client/Ecosia/UI/APNConsent/UnleashAPNConsentViewModel.swift
+++ b/Client/Ecosia/UI/APNConsent/UnleashAPNConsentViewModel.swift
@@ -42,11 +42,23 @@ final class UnleashAPNConsentViewModel: APNConsentViewModelProtocol {
     
     /// Skip button title.
     var skipButtonTitle: String {
-        if User.shared.apnConsentReminderManager?.isLastReminder == true {
+        if optInManager?.isLastReminder == true {
             return .localized(.apnConsentLastReminderSkipButtonTitle)
         } else {
             return .localized(.apnConsentSkipButtonTitle)
         }
+    }
+    
+    /// The `OptInManager` to optionally initialize the Model with
+    private var optInManager: OptInReminderManager?
+    
+    // MARK: Convienence Init
+    
+    /// Initializes an `UnleashAPNConsentViewModel` with the provided `optInManager`.
+    /// - Parameter optInManager: The opt-in reminder manager to be associated with the view model.
+    convenience init(optInManager: OptInReminderManager) {
+        self.init()
+        self.optInManager = optInManager
     }
 }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -167,11 +167,6 @@ class BrowserViewController: UIViewController {
         DefaultBrowserExperiment.minPromoSearches() <= User.shared.searchCount
     }
     fileprivate var shouldShowWhatsNewPageScreen: Bool { whatsNewDataProvider.shouldShowWhatsNewPage }
-    fileprivate var shouldShowAPNConsentScreen: Bool {
-        EngagementServiceExperiment.isEnabled &&
-        EngagementServiceExperiment.minSearches() <= User.shared.searchCount &&
-        User.shared.shouldShowAPNConsentScreen
-    }
 
     let whatsNewDataProvider = WhatsNewLocalDataProvider()
     
@@ -2309,8 +2304,9 @@ extension BrowserViewController {
     
     @discardableResult
     private func presentAPNConsentIfNeeded() -> Bool {
-        guard shouldShowAPNConsentScreen else { return false }
-        APNConsentViewController.presentOn(self, viewModel: UnleashAPNConsentViewModel())
+        let vc = APNConsentViewController(viewModel: UnleashAPNConsentViewModel(), delegate: self)
+        guard vc.shouldShow else { return false }
+        vc.presentAsSheetFrom(self)
         return true
     }
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -172,6 +172,13 @@ class BrowserViewController: UIViewController {
     
     let referrals = Referrals()
     var menuHelper: MainMenuActionHelper?
+    
+    // Ecosia: Initialize the OptInReminderManager that handles the APNConsent showing
+    private let apnConsentOptInReminderManager = OptInReminderManager(currentSearchesCount: User.shared.searchCount,
+                                                                      maxOptInScreenCount: EngagementServiceExperiment.maxOptInShowingAttempts,
+                                                                      searchesForOptInDisplay: EngagementServiceExperiment.minSearches,
+                                                                      searchesUntilOptInRedisplay: EngagementServiceExperiment.searchesUntilOptInRedisplay,
+                                                                      model: User.shared.apnConsentReminderModel ?? OptInModel())
 
     init(profile: Profile, tabManager: TabManager) {
         self.profile = profile
@@ -2304,8 +2311,9 @@ extension BrowserViewController {
     
     @discardableResult
     private func presentAPNConsentIfNeeded() -> Bool {
-        let vc = APNConsentViewController(viewModel: UnleashAPNConsentViewModel(), delegate: self)
-        guard vc.shouldShow else { return false }
+        let vc = APNConsentViewController(viewModel: UnleashAPNConsentViewModel(optInManager: apnConsentOptInReminderManager),
+                                          optInManager: apnConsentOptInReminderManager,
+                                          delegate: self)
         vc.presentAsSheetFrom(self)
         return true
     }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -183,8 +183,8 @@ class BrowserViewController: UIViewController {
     }
     private let apnConsentOptInReminderManager = OptInReminderManager(currentSearchesCount: User.shared.searchCount,
                                                                       maxOptInScreenCount: EngagementServiceExperiment.maxOptInShowingAttempts,
-                                                                      searchesForOptInDisplay: EngagementServiceExperiment.minSearches,
-                                                                      searchesUntilOptInRedisplay: EngagementServiceExperiment.searchesUntilOptInRedisplay,
+                                                                      minSearchesForFirstOptIn: EngagementServiceExperiment.minSearches,
+                                                                      searchesBetweenOptIns: EngagementServiceExperiment.searchesBetweenOptIns,
                                                                       model: userApnConsentOptInReminderManager)
 
     init(profile: Profile, tabManager: TabManager) {

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -174,10 +174,10 @@ class BrowserViewController: UIViewController {
     var menuHelper: MainMenuActionHelper?
     
     // Ecosia: Initialize the OptInReminderManager that handles the APNConsent showing
-    private static var userApnConsentOptInReminderManager = User.shared.apnConsentReminderModel ?? OptInModel() {
+    private static var userApnConsentOptInModel = User.shared.apnConsentReminderModel ?? OptInModel() {
         didSet {
             if User.shared.apnConsentReminderModel == nil {
-                User.shared.apnConsentReminderModel = userApnConsentOptInReminderManager
+                User.shared.apnConsentReminderModel = userApnConsentOptInModel
             }
         }
     }
@@ -185,7 +185,7 @@ class BrowserViewController: UIViewController {
                                                                       maxOptInScreenCount: EngagementServiceExperiment.maxOptInShowingAttempts,
                                                                       minSearchesForFirstOptIn: EngagementServiceExperiment.minSearches,
                                                                       searchesBetweenOptIns: EngagementServiceExperiment.searchesBetweenOptIns,
-                                                                      model: userApnConsentOptInReminderManager)
+                                                                      model: userApnConsentOptInModel)
 
     init(profile: Profile, tabManager: TabManager) {
         self.profile = profile

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -174,11 +174,18 @@ class BrowserViewController: UIViewController {
     var menuHelper: MainMenuActionHelper?
     
     // Ecosia: Initialize the OptInReminderManager that handles the APNConsent showing
+    private static var userApnConsentOptInReminderManager = User.shared.apnConsentReminderModel ?? OptInModel() {
+        didSet {
+            if User.shared.apnConsentReminderModel == nil {
+                User.shared.apnConsentReminderModel = userApnConsentOptInReminderManager
+            }
+        }
+    }
     private let apnConsentOptInReminderManager = OptInReminderManager(currentSearchesCount: User.shared.searchCount,
                                                                       maxOptInScreenCount: EngagementServiceExperiment.maxOptInShowingAttempts,
                                                                       searchesForOptInDisplay: EngagementServiceExperiment.minSearches,
                                                                       searchesUntilOptInRedisplay: EngagementServiceExperiment.searchesUntilOptInRedisplay,
-                                                                      model: User.shared.apnConsentReminderModel ?? OptInModel())
+                                                                      model: userApnConsentOptInReminderManager)
 
     init(profile: Profile, tabManager: TabManager) {
         self.profile = profile

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -2318,9 +2318,7 @@ extension BrowserViewController {
     
     @discardableResult
     private func presentAPNConsentIfNeeded() -> Bool {
-        let vc = APNConsentViewController(viewModel: UnleashAPNConsentViewModel(optInManager: apnConsentOptInReminderManager),
-                                          optInManager: apnConsentOptInReminderManager,
-                                          delegate: self)
+        let vc = APNConsentViewController(viewModel: UnleashAPNConsentViewModel(optInManager: apnConsentOptInReminderManager), optInManager: apnConsentOptInReminderManager)
         vc.presentAsSheetFrom(self)
         return true
     }


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the PR title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2169]

## Context

As part of the work needed to improve our analytics mechanism, we want to try another iteration of the consent screen, equipped with a reminder logic to it. The main logic resides in Core.

## Approach

- Only the inner logic has changed hence the changes here are minimal 👍 
- Move the logic that determines whether the APNConsent screen needs to be shown as part of the view controller
- Enriched the analytics with a `dismiss` event now that will be called when the user drags down the screen without clicking any of the CTA buttons
- Initialized an instance of the OptInReminderManager  for the APNConsent as part of the BrowserViewController as it is responsible to the logic cards shown
   - its related stored model is also initialized only in case there is no stored reference in the User

## Other

- Minor codebase refinement

## Before merging

### Do not merge before cutting 9.2.6

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I added the `// Ecosia:` helper comments where needed
- [x] I am using the correct version from [core](https://github.com/ecosia/ios-core), including any necessary changes for this ticket and pointing to `main` instead of a feature branch


[MOB-2169]: https://ecosia.atlassian.net/browse/MOB-2169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ