### PR TITLE
[MOB-2376] Revert "[MOB-2283] Add IDFV property to Analytics tracking."

### DIFF
--- a/Client/Ecosia/Analytics/Analytics+Configuration.swift
+++ b/Client/Ecosia/Analytics/Analytics+Configuration.swift
@@ -13,7 +13,7 @@ extension Analytics {
         .sessionContext(true)
         .applicationContext(true)
         .platformContext(true)
-        .platformContextProperties([.appleIdfv]) // track minimal device properties
+        .platformContextProperties([]) // track minimal device properties
         .geoLocationContext(true)
         .deepLinkContext(false)
         .screenContext(false)


### PR DESCRIPTION
## Context

Due to other priorities, we can’t proceed with the release of the already approved version (iOS 9.2.5) that contains the IDFV collection.

Reverts ecosia/ios-browser#625