### PR TITLE
Add search engine experiment mimicking current production

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -341,6 +341,8 @@
 		2CE294472B7CDD56006C22B2 /* Core in Frameworks */ = {isa = PBXBuildFile; productRef = 2CE294462B7CDD56006C22B2 /* Core */; };
 		2CE294492B7CDD78006C22B2 /* Core in Frameworks */ = {isa = PBXBuildFile; productRef = 2CE294482B7CDD78006C22B2 /* Core */; };
 		2CE2E24D2B9B1FCB00973C16 /* Core in Frameworks */ = {isa = PBXBuildFile; productRef = 2CE2E24C2B9B1FCB00973C16 /* Core */; };
+		2CF4DA612BB31909001C340A /* EngineShortcutsExperiment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C6188F72B7A8A22006B70D7 /* EngineShortcutsExperiment.swift */; };
+		2CF4DA632BB31970001C340A /* Core in Frameworks */ = {isa = PBXBuildFile; productRef = 2CF4DA622BB31970001C340A /* Core */; };
 		2F13E79B1AC0C02700D75081 /* StringExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F13E79A1AC0C02700D75081 /* StringExtensionsTests.swift */; };
 		2F44FA1B1A9D426A00FD20CC /* TestHashExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F44FA1A1A9D426A00FD20CC /* TestHashExtensions.swift */; };
 		2F44FB2C1A9D5D8500FD20CC /* Library.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F84B22261A09127C00AAB793 /* Library.xcassets */; };
@@ -7828,6 +7830,7 @@
 				5A8FD0EE293A7D6D00333AA7 /* SnapKit in Frameworks */,
 				C82043AF2523DC9600740B71 /* Sync.framework in Frameworks */,
 				5A70EF14295DFD7C00790249 /* Common in Frameworks */,
+				2CF4DA632BB31970001C340A /* Core in Frameworks */,
 				C877039625222FDC006E38EB /* Shared.framework in Frameworks */,
 				0B75AEA91AC20FB20015E5DC /* ImageIO.framework in Frameworks */,
 			);
@@ -12502,6 +12505,7 @@
 				5A87148D292EA3270039A5BD /* Fuzi */,
 				5A8FD0ED293A7D6D00333AA7 /* SnapKit */,
 				5A70EF13295DFD7C00790249 /* Common */,
+				2CF4DA622BB31970001C340A /* Core */,
 			);
 			productName = ShareToFirefox;
 			productReference = F84B22491A0920C600AAB793 /* ShareTo.appex */;
@@ -14544,6 +14548,7 @@
 				D38B2D8A1A8D98D00040E6B5 /* SearchEngines.swift in Sources */,
 				EB6E0C60207E6C3100FBFF7E /* SendToDevice.swift in Sources */,
 				D3C744CF1A687D6C004CE85D /* URIFixup.swift in Sources */,
+				2CF4DA612BB31909001C340A /* EngineShortcutsExperiment.swift in Sources */,
 				EB94075320850C9F00702E05 /* photon-colors.swift in Sources */,
 				210E0EB9298D9D4B00BB4F33 /* DefaultSearchEngineProvider.swift in Sources */,
 				D38B2D8C1A8D98D90040E6B5 /* OpenSearchParser.swift in Sources */,
@@ -21009,6 +21014,11 @@
 			productName = Core;
 		};
 		2CE2E24C2B9B1FCB00973C16 /* Core */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2C61887D2B7A89E4006B70D7 /* XCRemoteSwiftPackageReference "ios-core" */;
+			productName = Core;
+		};
+		2CF4DA622BB31970001C340A /* Core */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 2C61887D2B7A89E4006B70D7 /* XCRemoteSwiftPackageReference "ios-core" */;
 			productName = Core;

--- a/Client/Frontend/Browser/SearchEngines/OpenSearchEngine.swift
+++ b/Client/Frontend/Browser/SearchEngines/OpenSearchEngine.swift
@@ -84,7 +84,23 @@ class OpenSearchEngine: NSObject, NSSecureCoding {
 
     /// Returns the search URL for the given query.
     func searchURLForQuery(_ query: String) -> URL? {
-        return getURLFromTemplate(searchTemplate, query: query)
+        /* Ecosia: Quick Search Shortcuts Experiment
+         If the search is performed via Ecosia, we want to follow the standard flow
+         which is now environment-dependant.
+         the function `getURLFromTemplate(::)` takes into account the ecosia search engine
+         which contains only the production URL.
+         Once this experiment is considered finished and the logic needs fallback,
+         leave only the following line of code for the whole function's body
+         
+         return getURLFromTemplate(searchTemplate, query: query)
+         */
+        if EngineShortcutsExperiment.isEnabled,
+           let fromTemplateURL = getURLFromTemplate(searchTemplate, query: query),
+           fromTemplateURL.baseDomain != "ecosia.org" {
+            return fromTemplateURL
+        } else {
+            return URL.ecosiaSearchWithQuery(query)
+        }
     }
 
     /// Returns the search suggestion URL for the given query.

--- a/Client/Frontend/Browser/SearchEngines/OpenSearchParser.swift
+++ b/Client/Frontend/Browser/SearchEngines/OpenSearchParser.swift
@@ -83,6 +83,9 @@ class OpenSearchParser {
                         if name == nil || value == nil {
                             return nil
                         }
+                        // Ecosia: Quick Search Shortcuts Experiment
+                        if EngineShortcutsExperiment.isEnabled,
+                           let value, value.isMozillaFirefoxParamValue { continue }
 
                         // Ref: FXIOS-4547 required us to change partner code (pc) for Bing search on iPad 
                         if name == "pc", shortName == "Bing", userInterfaceIdiom == .pad {
@@ -138,5 +141,19 @@ class OpenSearchParser {
         }
 
         return OpenSearchEngine(engineID: engineID, shortName: shortName, image: uiImage, searchTemplate: searchTemplate, suggestTemplate: suggestTemplate, isCustomEngine: false)
+    }
+}
+
+// Ecosia: Quick Search Shortcuts Experiment
+extension String {
+    
+    fileprivate var isMozillaFirefoxParamValue: Bool {
+        let values = [
+            "Mozilla-search",
+            "firefox-b-m",
+            "MOZW",
+            "MOZWSB"
+        ]
+        return values.contains(self)
     }
 }

--- a/Client/Frontend/Browser/SearchViewController.swift
+++ b/Client/Frontend/Browser/SearchViewController.swift
@@ -286,6 +286,15 @@ class SearchViewController: SiteTableViewController,
             reloadData()
         }
     }
+    
+    // Ecosia: Quick Search Shortcuts Experiment
+    var tableViewBottomEqualToAnchor: NSLayoutYAxisAnchor {
+        if EngineShortcutsExperiment.isEnabled {
+            return searchEngineScrollView.topAnchor
+        } else {
+            return view.bottomAnchor
+        }
+    }
 
     override func reloadData() {
         querySuggestClient()
@@ -300,7 +309,9 @@ class SearchViewController: SiteTableViewController,
             tableView.topAnchor.constraint(equalTo: view.topAnchor),
             tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: searchEngineScrollView.topAnchor)
+            // Ecosia: Quick Search Shortcuts Experiment
+            // tableView.bottomAnchor.constraint(equalTo: searchEngineScrollView.topAnchor)
+            tableView.bottomAnchor.constraint(equalTo: tableViewBottomEqualToAnchor)
         ])
     }
 


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the PR title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

## Context

We need to add the Search Engine Shortcut Experiment as per it now behaves in production. The porting wasn't 💯 concluded.

## Approach

- Compared with production and applied the same changes.

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator