### PR TITLE
[MOB-2164] Update Push Notification consent OptIn Reminder analytics

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -14732,7 +14732,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ecosia/ios-core.git";
 			requirement = {
-				branch = "MOB-2164_update_optin_analytics";
+				branch = main;
 				kind = branch;
 			};
 		};

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -14732,7 +14732,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ecosia/ios-core.git";
 			requirement = {
-				branch = main;
+				branch = "MOB-2164_update_optin_analytics";
 				kind = branch;
 			};
 		};

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "5043e4211bb4e48cb491c9736742edfd5f131903"
+        "branch" : "MOB-2164_update_optin_analytics",
+        "revision" : "d8015d706129fd00dd275b1021696c9e1d7b5595"
       }
     },
     {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
-        "branch" : "MOB-2164_update_optin_analytics",
-        "revision" : "d8015d706129fd00dd275b1021696c9e1d7b5595"
+        "branch" : "main",
+        "revision" : "87fd05cc88ff9c2d10422b961bebd5e8e645aa9d"
       }
     },
     {

--- a/Client/Ecosia/Analytics/Analytics.Values.swift
+++ b/Client/Ecosia/Analytics/Analytics.Values.swift
@@ -6,7 +6,7 @@ extension Analytics {
         activity,
         abTest = "ab_Test",
         browser,
-        pushNotification = "push_notification",
+        pushNotificationConsent = "push_notification_consent",
         external,
         migration,
         navigation,

--- a/Client/Ecosia/Analytics/Analytics.swift
+++ b/Client/Ecosia/Analytics/Analytics.swift
@@ -142,9 +142,10 @@ final class Analytics {
     /// defined in the `APNConsentUIExperiment`
     /// so to leverage decoupling.
     func apnConsent(_ action: Action.APNConsent) {
-        let event = Structured(category: Category.pushNotification.rawValue,
+        let iterationsCount = User.shared.apnConsentReminderModel != nil ? "\(User.shared.apnConsentReminderModel!.optInScreenCount)" : "n/a"
+        let event = Structured(category: Category.pushNotificationConsent.rawValue,
                                action: action.rawValue)
-            .label("push_notification_consent")
+            .label(iterationsCount)
             .property(Property.home.rawValue)
         
         // When the user sees the APNConsent


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the PR title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2164]

## Context

In order to be able to track the iteration count in our analytics, we need to get the iterations' count from the User's stored model.
We also want to make the Analytics' category more granular.

## Approach

- Update the Analytics tracking for the APNConsentScreen
- Update the category from `push_notification` to `push_notification_consent`
- Update the Analytics' label of the APNConsent to get the iterations count, otherwise send "n/a".
   - sending `n/a` instead of not setting the label will help us on better make queries in case of unexpected value being sent (must be a `"number"`).

## Other

## Before merging

- Point to correct `main`.

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I am using the correct version from [core](https://github.com/ecosia/ios-core), including any necessary changes for this ticket and pointing to `main` instead of a feature branch


[MOB-2164]: https://ecosia.atlassian.net/browse/MOB-2164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ