### PR TITLE
[MOB-2169] Review User's stored optin model init

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -14732,7 +14732,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ecosia/ios-core.git";
 			requirement = {
-				branch = "MOB-2169_optin_model_init_fix";
+				branch = main;
 				kind = branch;
 			};
 		};

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -14732,7 +14732,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ecosia/ios-core.git";
 			requirement = {
-				branch = main;
+				branch = "MOB-2169_optin_model_init_fix";
 				kind = branch;
 			};
 		};

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -60,7 +60,7 @@
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
         "branch" : "MOB-2169_optin_model_init_fix",
-        "revision" : "e85276c6f0e6fda58ad49c2d7cf687393840043a"
+        "revision" : "64171b679438a190ecca87e9ccd352c77fd147ef"
       }
     },
     {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "87fd05cc88ff9c2d10422b961bebd5e8e645aa9d"
+        "branch" : "MOB-2169_optin_model_init_fix",
+        "revision" : "e85276c6f0e6fda58ad49c2d7cf687393840043a"
       }
     },
     {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
-        "branch" : "MOB-2169_optin_model_init_fix",
-        "revision" : "64171b679438a190ecca87e9ccd352c77fd147ef"
+        "branch" : "main",
+        "revision" : "eab4330cff3c0a64e97124576dcc660bd8e63ca8"
       }
     },
     {

--- a/Client/Ecosia/Analytics/Analytics.swift
+++ b/Client/Ecosia/Analytics/Analytics.swift
@@ -142,10 +142,9 @@ final class Analytics {
     /// defined in the `APNConsentUIExperiment`
     /// so to leverage decoupling.
     func apnConsent(_ action: Action.APNConsent) {
-        let iterationsCount = User.shared.apnConsentReminderModel != nil ? "\(User.shared.apnConsentReminderModel!.optInScreenCount)" : "n/a"
         let event = Structured(category: Category.pushNotificationConsent.rawValue,
                                action: action.rawValue)
-            .label(iterationsCount)
+            .label("\(User.shared.apnConsentReminderModel.optInScreenCount)")
             .property(Property.home.rawValue)
         
         // When the user sees the APNConsent

--- a/Client/Ecosia/UI/APNConsent/APNConsentViewController.swift
+++ b/Client/Ecosia/UI/APNConsent/APNConsentViewController.swift
@@ -70,6 +70,7 @@ final class APNConsentViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         modalTransitionStyle = .crossDissolve
+        optInManager?.recordOptInAttempt()
         Analytics.shared.apnConsent(.view)
     }
     
@@ -234,7 +235,6 @@ extension APNConsentViewController {
 extension APNConsentViewController {
 
     @objc private func skipTapped() {
-        optInManager?.recordOptInAttempt()
         Analytics.shared.apnConsent(.skip)
         dismiss(animated: true)
     }
@@ -244,7 +244,6 @@ extension APNConsentViewController {
         ClientEngagementService.shared.requestAPNConsent(notificationCenterDelegate: appDelegate) { [weak self] granted, error in
             guard granted else {
                 Analytics.shared.apnConsent(.deny)
-                self?.optInManager?.recordOptInAttempt()
                 DispatchQueue.main.async { [weak self] in
                     self?.dismissVC()
                 }

--- a/Client/Ecosia/UI/APNConsent/APNConsentViewController.swift
+++ b/Client/Ecosia/UI/APNConsent/APNConsentViewController.swift
@@ -43,11 +43,6 @@ final class APNConsentViewController: UIViewController {
     private let ctaButton = UIButton()
     private let skipButton = UIButton()
     private var optInManager: OptInReminderManager?
-    var shouldShow: Bool {
-        EngagementServiceExperiment.isEnabled &&
-        ClientEngagementService.shared.notificationAuthorizationStatus == .notDetermined &&
-        optInManager?.shouldDisplayOptInScreen == true
-    }
 
     // MARK: - Init
 

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -179,13 +179,11 @@ class BrowserViewController: UIViewController {
     var menuHelper: MainMenuActionHelper?
     
     // Ecosia: Initialize the OptInReminderManager that handles the APNConsent showing
-    private static let userApnConsentOptInModel = User.shared.apnConsentReminderModel ?? OptInModel()
-    
     private let apnConsentOptInReminderManager = OptInReminderManager(currentSearchesCount: User.shared.searchCount,
                                                                       maxOptInScreenCount: EngagementServiceExperiment.maxOptInShowingAttempts,
                                                                       minSearchesForFirstOptIn: EngagementServiceExperiment.minSearches,
                                                                       searchesBetweenOptIns: EngagementServiceExperiment.searchesBetweenOptIns,
-                                                                      model: userApnConsentOptInModel)
+                                                                      model: User.shared.apnConsentReminderModel)
 
     init(profile: Profile, tabManager: TabManager) {
         self.profile = profile
@@ -197,11 +195,6 @@ class BrowserViewController: UIViewController {
                                                        with: profile)
         self.contextHintVC = ContextualHintViewController(with: contextViewModel)
         
-        // Ecosia: User's stored `apnConsentReminderModel` initialization
-        if User.shared.apnConsentReminderModel == nil {
-            User.shared.apnConsentReminderModel = BrowserViewController.userApnConsentOptInModel
-        }
-
         super.init(nibName: nil, bundle: nil)
         didInit()
     }

--- a/Client/Frontend/Browser/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController.swift
@@ -167,6 +167,11 @@ class BrowserViewController: UIViewController {
         DefaultBrowserExperiment.minPromoSearches() <= User.shared.searchCount
     }
     fileprivate var shouldShowWhatsNewPageScreen: Bool { whatsNewDataProvider.shouldShowWhatsNewPage }
+    fileprivate var shouldShowAPNConsentScreen: Bool {
+        EngagementServiceExperiment.isEnabled &&
+        ClientEngagementService.shared.notificationAuthorizationStatus == .notDetermined &&
+        apnConsentOptInReminderManager.shouldDisplayOptInScreen == true
+    }
 
     let whatsNewDataProvider = WhatsNewLocalDataProvider()
     
@@ -174,13 +179,8 @@ class BrowserViewController: UIViewController {
     var menuHelper: MainMenuActionHelper?
     
     // Ecosia: Initialize the OptInReminderManager that handles the APNConsent showing
-    private static var userApnConsentOptInModel = User.shared.apnConsentReminderModel ?? OptInModel() {
-        didSet {
-            if User.shared.apnConsentReminderModel == nil {
-                User.shared.apnConsentReminderModel = userApnConsentOptInModel
-            }
-        }
-    }
+    private static let userApnConsentOptInModel = User.shared.apnConsentReminderModel ?? OptInModel()
+    
     private let apnConsentOptInReminderManager = OptInReminderManager(currentSearchesCount: User.shared.searchCount,
                                                                       maxOptInScreenCount: EngagementServiceExperiment.maxOptInShowingAttempts,
                                                                       minSearchesForFirstOptIn: EngagementServiceExperiment.minSearches,
@@ -196,6 +196,11 @@ class BrowserViewController: UIViewController {
         let contextViewModel = ContextualHintViewModel(forHintType: .toolbarLocation,
                                                        with: profile)
         self.contextHintVC = ContextualHintViewController(with: contextViewModel)
+        
+        // Ecosia: User's stored `apnConsentReminderModel` initialization
+        if User.shared.apnConsentReminderModel == nil {
+            User.shared.apnConsentReminderModel = BrowserViewController.userApnConsentOptInModel
+        }
 
         super.init(nibName: nil, bundle: nil)
         didInit()
@@ -2318,6 +2323,7 @@ extension BrowserViewController {
     
     @discardableResult
     private func presentAPNConsentIfNeeded() -> Bool {
+        guard shouldShowAPNConsentScreen else { return false }
         let vc = APNConsentViewController(viewModel: UnleashAPNConsentViewModel(optInManager: apnConsentOptInReminderManager), optInManager: apnConsentOptInReminderManager)
         vc.presentAsSheetFrom(self)
         return true


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the PR title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2169]

## Context

As part of the QA process, I realised an issue in the current observation of the `User.shared.apnConsentOptInModel`.
This PR addressed its fix, alongside a better separation of responsibilities with regards to the showing of the APN Consent Screen.
I could also test and improve the analytics retrieval by suggesting a better place to make sure we always send the correct iteration count.

## Approach

- Check and initialize the `User.shared.apnConsentOptInModel` at `BrowserViewController.init`
- Re-add the helper var in `BrowserViewController` that aligns with other methodologies to show cards 
   - Thus, removing the need to make the APN Consent's viewcontroller instance in order to check whether it can be shown.
   - Removed the encapsulation of other parameters checking the "showing eligbility"
- Move analytics that records the optin attempt to the `viewDidAppear` event.

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I added the `// Ecosia:` helper comments where needed
- [x] I am using the correct version from [core](https://github.com/ecosia/ios-core), including any necessary changes for this ticket and pointing to `main` instead of a feature branch

[MOB-2169]: https://ecosia.atlassian.net/browse/MOB-2169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ