### PR TITLE
[MOB-2367] Update financial counter subtitle copy in NTP

### DIFF
--- a/Client/Ecosia/L10N/String.swift
+++ b/Client/Ecosia/L10N/String.swift
@@ -161,7 +161,7 @@ extension String {
         case after = "After"
         case treesPlantedByTheCommunity = "trees planted by the Ecosia community"
         case treesPlantedByTheCommunityCapitalized = "Trees planted by the Ecosia community"
-        case investedIntoClimateAction = "invested into climate action"
+        case dedicatedToClimateAction = "dedicted to climate action"
         case activeProjects = "Active projects"
         case countries = "Countries"
         case finishTour = "Start Planting"

--- a/Client/Ecosia/L10N/en.lproj/Ecosia.strings
+++ b/Client/Ecosia/L10N/en.lproj/Ecosia.strings
@@ -155,7 +155,7 @@
 "After" = "After";
 "trees planted by the Ecosia community" = "trees planted by the Ecosia community";
 "Trees planted by the Ecosia community" = "Trees planted by the Ecosia community";
-"dedicted to climate action" = "dedicted to climate action";
+"dedicated to climate action" = "dedicated to climate action";
 "Active projects" = "Active projects";
 "Countries" = "Countries";
 "Real results, transparent finances" = "Real results, transparent finances";

--- a/Client/Ecosia/L10N/en.lproj/Ecosia.strings
+++ b/Client/Ecosia/L10N/en.lproj/Ecosia.strings
@@ -155,7 +155,7 @@
 "After" = "After";
 "trees planted by the Ecosia community" = "trees planted by the Ecosia community";
 "Trees planted by the Ecosia community" = "Trees planted by the Ecosia community";
-"invested into climate action" = "invested into climate action";
+"dedicted to climate action" = "dedicted to climate action";
 "Active projects" = "Active projects";
 "Countries" = "Countries";
 "Real results, transparent finances" = "Real results, transparent finances";

--- a/Client/Ecosia/UI/NTP/Impact/ClimateImpactInfo.swift
+++ b/Client/Ecosia/UI/NTP/Impact/ClimateImpactInfo.swift
@@ -35,7 +35,7 @@ enum ClimateImpactInfo: Equatable {
         case .totalTrees:
             return .localized(.treesPlantedByTheCommunity)
         case .totalInvested:
-            return .localized(.investedIntoClimateAction)
+            return .localized(.dedicatedToClimateAction)
         }
     }
     
@@ -48,7 +48,7 @@ enum ClimateImpactInfo: Equatable {
         case .totalTrees(let value):
             return value.spelledOutString + " " + .localized(.treesPlantedByTheCommunity)
         case .totalInvested(let value):
-            return value.spelledOutString + " " + .localized(.investedIntoClimateAction)
+            return value.spelledOutString + " " + .localized(.dedicatedToClimateAction)
         }
     }
     


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the PR title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2367]

## Context

In order to have a product that consistently sounds the same across all platforms 
We want to align the copy of financial counter to web.

## Approach

Despite che change could have been done purely via Transifex, for consistency, I'm proposing to align the codebase and let Transifex automation do the rest for us, keeping the flow as is.

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator

[MOB-2367]: https://ecosia.atlassian.net/browse/MOB-2367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ