### PR TITLE
[MOB-2377] Revert the revert: Add `appleIdfv` to Analytics properties

### DIFF
--- a/Client/Ecosia/Analytics/Analytics+Configuration.swift
+++ b/Client/Ecosia/Analytics/Analytics+Configuration.swift
@@ -13,7 +13,7 @@ extension Analytics {
         .sessionContext(true)
         .applicationContext(true)
         .platformContext(true)
-        .platformContextProperties([]) // track minimal device properties
+        .platformContextProperties([.appleIdfv]) // track minimal device properties
         .geoLocationContext(true)
         .deepLinkContext(false)
         .screenContext(false)


### PR DESCRIPTION
## **User description**
[MOB-2377]

## Context

We had reverted this to remove from a past release. This reverts the revert done in #637, essentially re-adding exactly what was done in #625.

[MOB-2377]: https://ecosia.atlassian.net/browse/MOB-2377

___

## **Type**
enhancement


___

## **Description**
- Re-introduces the tracking of the Apple ID for Vendor (`appleIdfv`) in analytics properties, which was previously reverted.
- This enhancement aims to improve the tracking capabilities by including minimal device properties.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Analytics+Configuration.swift</strong><dd><code>Enhance Analytics Configuration with Apple ID for Vendor</code>&nbsp; </dd></summary>
<hr>
      
Client/Ecosia/Analytics/Analytics+Configuration.swift

<li>Added <code>.appleIdfv</code> to <code>platformContextProperties</code> for tracking device <br>properties.<br>


</details>
    

  </td>
  <td><a href="https://github.com/ecosia/ios-browser/pull/651/files#diff-080f5405406772cbb662ff48c5e974da3562e2643d36bcbfd7814f67d379664e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

