### PR TITLE
[MOB-2469] Background tooltip + arrow color fixes

### DIFF
--- a/BrowserKit/Sources/ComponentLibrary/ContextualHintView/ContextualHintView.swift
+++ b/BrowserKit/Sources/ComponentLibrary/ContextualHintView/ContextualHintView.swift
@@ -88,7 +88,8 @@ public class ContextualHintView: UIView, ThemeApplicable {
         closeButton.accessibilityLabel = viewModel.closeButtonA11yLabel
         descriptionLabel.text = viewModel.description
 
-        layer.addSublayer(gradient)
+        // Ecosia: Remove gradient
+        // layer.addSublayer(gradient)
 
         addSubview(scrollView)
         addSubview(closeButton)
@@ -152,6 +153,12 @@ public class ContextualHintView: UIView, ThemeApplicable {
     public func applyTheme(theme: Theme) {
         closeButton.tintColor = theme.colors.textOnDark
         descriptionLabel.textColor = theme.colors.textOnDark
+        // Ecosia: Update custom background theming
+        if theme.type == .light {
+            backgroundColor = UIColor(red: 0.153, green: 0.322, blue: 0.263, alpha: 1)
+        } else {
+            backgroundColor = UIColor(rgb: 0xAFE9B0)
+        }
         gradient.colors = theme.colors.layerGradient.cgColors
 
         if viewModel.isActionType {

--- a/Client/Ecosia/UI/Theme/EcosiaThemeColourPalette.swift
+++ b/Client/Ecosia/UI/Theme/EcosiaThemeColourPalette.swift
@@ -97,8 +97,8 @@ private class EcosiaLightColourPalette: ThemeColourPalette {
     var textDisabled: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.textDisabled }
     var textWarning: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.textWarning }
     var textAccent: UIColor { .legacyTheme.ecosia.primaryButton }
-    var textOnDark: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.textOnDark }
-    var textOnLight: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.textOnLight }
+    var textOnDark: UIColor { .legacyTheme.ecosia.primaryTextInverted }
+    var textOnLight: UIColor { .legacyTheme.ecosia.primaryTextInverted }
     var textInverted: UIColor { .legacyTheme.ecosia.primaryTextInverted }
 
     // MARK: - Icons

--- a/Client/Frontend/Browser/Tabs/Legacy/LegacyInactiveTabs/LegacyInactiveTabCell.swift
+++ b/Client/Frontend/Browser/Tabs/Legacy/LegacyInactiveTabs/LegacyInactiveTabCell.swift
@@ -219,6 +219,10 @@ extension LegacyInactiveTabCell: UITableViewDataSource, UITableViewDelegate {
         switch InactiveTabSection(rawValue: section) {
         case .inactive, .none:
             guard let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: LegacyInactiveTabHeader.cellIdentifier) as? LegacyInactiveTabHeader else { return nil }
+            // Ecosia: add missing ThemeApplicable implementation
+            if let theme = inactiveTabsViewModel?.theme {
+                headerView.applyTheme(theme: theme)
+            }
             headerView.state = hasExpanded ? .down : .trailing
             headerView.title = String.TabsTrayInactiveTabsSectionTitle
             headerView.accessibilityLabel = hasExpanded ?

--- a/Client/Frontend/Browser/Tabs/Legacy/LegacyInactiveTabs/LegacyInactiveTabHeader.swift
+++ b/Client/Frontend/Browser/Tabs/Legacy/LegacyInactiveTabs/LegacyInactiveTabHeader.swift
@@ -6,7 +6,8 @@ import Common
 import Foundation
 import Shared
 
-class LegacyInactiveTabHeader: UITableViewHeaderFooterView, ReusableCell {
+// Ecosia: Add missing ThemeApplicable protocol declaration
+class LegacyInactiveTabHeader: UITableViewHeaderFooterView, ReusableCell, ThemeApplicable {
     var state: ExpandButtonState? {
         willSet(state) {
             moreButton.setImage(state?.image, for: .normal)


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the PR title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2469]

## Context

The majority of time spent on this work has been finding an efficient way to test it and make tabs look inactive.

## Approach

- Testability investigation and Tab's architecture understanding
- Found an efficient way to make the tabs testable
  - Make 50 tabs via the hidden debug option in settings
  - go to `TabData` and mark the `lastUsedTime` in the initialization at least 15 days ago (a Tab is marked as inactive if the last opened time was 14 days ago)
  - remove the logic that marks the tooltip as "seen"
  - run the app
- Fixed the background appropriately. It's been done like that in other places for other older Ecosia versions when there is no 1:1 mapping between a color we have in our Palette and Firefox's provided one.

<details>
<summary>Before</summary>

![File (1)](https://github.com/ecosia/ios-browser/assets/3584008/383448c8-5d8c-453f-bf57-307569b9f9b3)

</details>
<details>
<summary>After</summary>

![Simulator Screenshot - iPhone 15 - 2024-04-26 at 16 50 19](https://github.com/ecosia/ios-browser/assets/3584008/e84d71b3-474e-4099-b219-232086ff8aaf)

</details>


## Other

The arrow disclosure indicator looks like a Firefox bug at least in the v122 codebase. The view doesn't rely on the `ThemeApplicable` protocol but implements its function. However, the flow is not respected and ends up with a non-expected scenario where the theming is not coherent.  

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator

[MOB-2469]: https://ecosia.atlassian.net/browse/MOB-2469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ