### PR TITLE
[MOB-2476] NTPImpactRowView Action Button's fix

### DIFF
--- a/Client/Ecosia/UI/NTP/Impact/NTPImpactRowView.swift
+++ b/Client/Ecosia/UI/NTP/Impact/NTPImpactRowView.swift
@@ -149,7 +149,9 @@ final class NTPImpactRowView: UIView, Themeable {
             dividerView.bottomAnchor.constraint(equalTo: bottomAnchor),
             dividerView.heightAnchor.constraint(equalToConstant: 1),
             imageContainer.heightAnchor.constraint(equalToConstant: UX.imageHeight),
-            imageContainer.widthAnchor.constraint(equalTo: imageContainer.heightAnchor)
+            imageContainer.widthAnchor.constraint(equalTo: imageContainer.heightAnchor),
+            actionButton.topAnchor.constraint(lessThanOrEqualTo: imageContainer.topAnchor),
+            actionButton.bottomAnchor.constraint(lessThanOrEqualTo: imageContainer.bottomAnchor)
         ])
         
         if info.progressIndicatorValue != nil {


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the PR title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2476]

## Context

Well-known UI issue long waiting for a fix.
The calculation of the Layout somehow differs from this codebase version and our current production one.
Not sure what the real root cause is (might even be related to the Deployment Target?) but it represents a UI glitch on the NTP.

## Approach

There have been multiple tests, code comparisons as well as testing in different scenarios (1/2 rows per section).
The goal was to make sure that whatever code amendment would take place, it shouldn't have been a workaround.
The aim was of course subject to limitations in case there would have been no clear way to fix it.

After a proper investigation of how the view is designed (as well as its hierarchy) and what constraints apply to each specific view, I realized that the root cause of this calculation was a misinterpretation of the default constraints that the OS assigns to the `actionButton` in the `NTPImpactRowView`. The `actionButton` is not contained to its top and bottom anchor to any specific parameter, thus, making it follow the vertical stack view anchors. By doing so, though, the `actionButton` becomes the larger item of the `UIStackView` to expand till possible, thus, making the `UIStackView` to stretch as well.

Found out a validated the root cause, a simple approach would have been setting its height equal to the `imageContainer` for instance, but then we would have had issues when localizing its title label, showing a larger text as a result of different translated content for the same title.

The most efficient approach resulted in assigning to the `actionButton` a top and bottom constraint, keeping the `imageContainer` as a reference, without strict boundaries.

| Issue | Fixed original title |  Fixed custom longer title |
| ------------- | ------------- | ------------- |
| ![IMG_3711](https://github.com/ecosia/ios-browser/assets/3584008/aedc56a8-6279-4340-8267-0fa2f0e62866)|![Simulator Screenshot - iPhone 15 - 2024-04-29 at 16 19 52](https://github.com/ecosia/ios-browser/assets/3584008/1edf1f37-29dc-48bf-bd0f-2ccd9e7aeb94) | ![Simulator Screenshot - iPhone 15 - 2024-04-29 at 16 23 01](https://github.com/ecosia/ios-browser/assets/3584008/26f58f10-7df2-4999-8f2d-959da6c3c03e) |

## Other

This solution works regardless of the number of section's rows, as the calculation is done within each of the rows indipendently.

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator

[MOB-2476]: https://ecosia.atlassian.net/browse/MOB-2476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ