### PR TITLE
[MOB-2521] Update `getVersionRange()` and improved tests

### DIFF
--- a/EcosiaTests/WhatsNewLocalDataProviderTests.swift
+++ b/EcosiaTests/WhatsNewLocalDataProviderTests.swift
@@ -19,7 +19,9 @@ final class WhatsNewLocalDataProviderTests: XCTestCase {
     func testFreshInstallShouldNotShowWhatsNewAndMarkPreviousVersionsAsSeen() {
         // Given
         EcosiaInstallType.set(type: .fresh)
-        let dataProvider = WhatsNewLocalDataProvider(versionProvider: MockAppVersionInfoProvider(mockedAppVersion: "9.0.2"))
+        let items: [Version: [WhatsNewItem]] = [Version("9.0.0")!: [.emptyItem()]]
+        let dataProvider = WhatsNewLocalDataProvider(versionProvider: MockAppVersionInfoProvider(mockedAppVersion: "9.0.2"),
+                                                     whatsNewItems: items)
         
         // When
         let shouldShowWhatsNew = dataProvider.shouldShowWhatsNewPage
@@ -48,12 +50,18 @@ final class WhatsNewLocalDataProviderTests: XCTestCase {
         // Given
         EcosiaInstallType.updateCurrentVersion(version: "8.0.0")
         EcosiaInstallType.set(type: .upgrade)
-        let dataProvider = WhatsNewLocalDataProvider(versionProvider: MockAppVersionInfoProvider(mockedAppVersion: "9.0.0"))
+        let items: [Version: [WhatsNewItem]] = [Version("8.0.0")!: [.emptyItem()],
+                                                Version("9.0.0")!: [.emptyItem()],
+                                                Version("9.0.1")!: [.emptyItem()],
+                                                Version("9.0.2")!: [.emptyItem()]
+        ]
+        let dataProvider = WhatsNewLocalDataProvider(versionProvider: MockAppVersionInfoProvider(mockedAppVersion: "9.0.0"), whatsNewItems: items)
         
         // When
         let shouldShowWhatsNew = dataProvider.shouldShowWhatsNewPage
         
         // Then
+        XCTAssertTrue(dataProvider.getVersionRange() == [Version("9.0.0")!], "The version 9.0.0 should be the only the only version returned, got \(dataProvider.getVersionRange()) instead")
         XCTAssertTrue(shouldShowWhatsNew, "Upgrade to a version with items should show whats new")
     }
     
@@ -61,7 +69,12 @@ final class WhatsNewLocalDataProviderTests: XCTestCase {
         // Given
         EcosiaInstallType.updateCurrentVersion(version: "8.2.1")
         EcosiaInstallType.set(type: .upgrade)
-        let dataProvider = WhatsNewLocalDataProvider(versionProvider: MockAppVersionInfoProvider(mockedAppVersion: "8.3.0"))
+        let items: [Version: [WhatsNewItem]] = [Version("8.2.0")!: [.emptyItem()],
+                                                Version("8.2.6")!: [.emptyItem()]
+        ]
+        let dataProvider = WhatsNewLocalDataProvider(versionProvider:
+                                                        MockAppVersionInfoProvider(mockedAppVersion: "8.2.5"),
+                                                     whatsNewItems: items)
         
         // When
         let shouldShowWhatsNew = dataProvider.shouldShowWhatsNewPage
@@ -84,16 +97,23 @@ final class WhatsNewLocalDataProviderTests: XCTestCase {
         XCTAssertFalse(shouldShowWhatsNew, "Downgrade should not show what's new")
     }
     
-    func testUpgradeToGreaterVersionThanTheOneWithItemsShouldShowWhatsNew() {
+    func testUpgradeToGreaterVersionThanAnyInBetweenWithItemsShouldShowWhatsNew() {
         // Given
         EcosiaInstallType.set(type: .upgrade)
         EcosiaInstallType.updateCurrentVersion(version: "8.0.0")
-        let dataProvider = WhatsNewLocalDataProvider(versionProvider: MockAppVersionInfoProvider(mockedAppVersion: "9.0.2"))
+        let items: [Version: [WhatsNewItem]] = [Version("8.0.0")!: [.emptyItem()],
+                                                Version("9.0.0")!: [.emptyItem()],
+                                                Version("9.0.1")!: [.emptyItem()],
+                                                Version("9.0.2")!: [.emptyItem()]
+        ]
+        let dataProvider = WhatsNewLocalDataProvider(versionProvider: MockAppVersionInfoProvider(mockedAppVersion: "9.0.2"), whatsNewItems: items)
         
         // When
         let shouldShowWhatsNew = dataProvider.shouldShowWhatsNewPage
         
         // Then
+        XCTAssertFalse(dataProvider.getVersionRange().contains(Version("8.0.0")!), "The version 8.0.0 should not be among the picked version range, got \(dataProvider.getVersionRange()) instead")
+        XCTAssertTrue(dataProvider.getVersionRange() == [Version("9.0.0")!, Version("9.0.1")!, Version("9.0.2")!], "The versions 9.0.0 and 9.0.1 should be among the picked version range. Resulting version range \(dataProvider.getVersionRange()).")
         XCTAssertTrue(shouldShowWhatsNew, "Upgrade to greater version than the one with items should show what's new")
     }
     
@@ -102,12 +122,39 @@ final class WhatsNewLocalDataProviderTests: XCTestCase {
         User.shared.whatsNewItemsVersionsShown = ["9.0.0"]
         EcosiaInstallType.set(type: .upgrade)
         EcosiaInstallType.updateCurrentVersion(version: "8.0.0")
+        let items: [Version: [WhatsNewItem]] = [
+            Version("8.2.0")!: [.emptyItem()],
+            Version("9.0.0")!: [.emptyItem()]
+        ]
         let dataProvider = WhatsNewLocalDataProvider(versionProvider: MockAppVersionInfoProvider(mockedAppVersion: "9.0.2"))
         
         // When
         let shouldShowWhatsNew = dataProvider.shouldShowWhatsNewPage
         
         // Then
+        XCTAssertFalse(dataProvider.getVersionRange() == [Version("8.2.0")!], "The version 8.2.0 should not be among the picked version range. Resulting version range: \(dataProvider.getVersionRange())")
         XCTAssertFalse(shouldShowWhatsNew, "Upgrade with already shown items should show not show what's new")
+    }
+    
+    func testUpgradeToVersionWithoutItemsLike940ShouldNotShowWhatsNew() {
+        // Given
+        EcosiaInstallType.updateCurrentVersion(version: "9.4.0")
+        EcosiaInstallType.set(type: .upgrade)
+        let dataProvider = WhatsNewLocalDataProvider(versionProvider: MockAppVersionInfoProvider(mockedAppVersion: "10.0.0"))
+        
+        // When
+        let shouldShowWhatsNew = dataProvider.shouldShowWhatsNewPage
+        
+        // Then
+        XCTAssertFalse(shouldShowWhatsNew, "Upgrade to a version without items should not show whats new")
+    }
+}
+
+extension WhatsNewItem {
+    
+    fileprivate static func emptyItem() -> WhatsNewItem {
+        WhatsNewItem(image: .init(),
+                     title: .init(),
+                     subtitle: .init())
     }
 }


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the PR title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2521]

## Context

As part of the update test, we set our version number to an expected major upgrade (10.0.0).
Throughout the tests, we realized that the What's New Page appeared.

## Approach

Assessed the logic with a TDD-like approach.
Realized the missing tests, amended some, and implemented the new ones.
Improved the testability of the `WhatsNewLocalDataProvider` class, providing a way to set the `whatsNewItems`.
Update the logic ended up simplifying it as follows:
Goal:  _ Provide me with all the versions between the "fromVersion" (excluded) and `toVersion` (included)._

## Other

Technically we should be fixing this in the current production, however, my suggestion with this PR is to bring it straight alongside the upgrade as it doesn't have a huge impact on the usability point of view. 

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I wrote Unit Tests that confirm the expected behavior

[MOB-2521]: https://ecosia.atlassian.net/browse/MOB-2521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ