### PR TITLE
[MOB-2540] Keep signaling `accountManagerInitialized` to satisfy dependencies

### DIFF
--- a/Client/Application/AppLaunchUtil.swift
+++ b/Client/Application/AppLaunchUtil.swift
@@ -72,12 +72,16 @@ class AppLaunchUtil {
             }
         }
 
-        /* Hide RustFirefoxAccounts
+        /* Ecosia: Hide RustFirefoxAccounts
+           Keep `accountManagerInitialized` signaling right after this commented code👇 active to satifsy tasks dependencies
         RustFirefoxAccounts.startup(prefs: profile.prefs) { _ in
             self.logger.log("RustFirefoxAccounts started", level: .info, category: .sync)
+         
             AppEventQueue.signal(event: .accountManagerInitialized)
         }
          */
+        AppEventQueue.signal(event: .accountManagerInitialized)
+        
         // Add swizzle on UIViewControllers to automatically log when there's a new view showing
         UIViewController.loggerSwizzle()
 


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the PR title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2540]

## Context

Opening an external link when the app is closed (not in the background) does not work.

## Approach

- 🧠 refresh on how the app works on a cold start
- attached the App process via the Xcode option `Debug -> Attach to Process by PID or Name`
- launched app by clicking on a URL saved in the reminder
- verified the flow with appropriate debugging (breakpoints etc...)
- validated the flow against the latest Firefox Production as well

#### Outcome:

The flow as how it is now (and slightly improved in the latest Firefox) requires the app to resolve some tasks before signaling the `startupFlowComplete` event and let it handle the navigation to the intended link/section.
As par with the work done to remove/hide certain features, there is the AccountManager one that we don't need now.
The `accountManagerInitialized`, however, sits among those tasks that needed to be done before triggering the `startupFlowComplete`. The more elegant solution would be to let the app signal the event regardless of its real concrete initialization.
The main reason is better codebase maintenance and overall unified places to (perhaps) uncomment whenever we implement the Accounts.
Moreover, this dependency could sit elsewhere with future upgrades, compromising other flows.

![Simulator Screen Recording - iPhone 15 - 2024-05-10 at 14 51 28](https://github.com/ecosia/ios-browser/assets/3584008/42c786f5-3712-43d6-9078-28f191746212)

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator

[MOB-2540]: https://ecosia.atlassian.net/browse/MOB-2540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ