### PR TITLE
[MOB-2525] Aligned UI adjustment of `ThemedTableViewCell` as done in prod

### DIFF
--- a/Client/Frontend/Theme/ThemedTableViewCells/ThemedTableViewCell.swift
+++ b/Client/Frontend/Theme/ThemedTableViewCells/ThemedTableViewCell.swift
@@ -12,6 +12,8 @@ class ThemedTableViewCell: UITableViewCell, ReusableCell, ThemeApplicable {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         self.cellStyle = style
         super.init(style: style, reuseIdentifier: reuseIdentifier)
+        // Ecosia: adjust layout margins
+        contentView.directionalLayoutMargins.leading = 16
     }
 
     required init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the PR title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2525]

## Context

As part of a wired testing on the Testflight 10.0.0 (1) build, a few minor cosmetic 💅 discrepancies were found.
Issue 👇 
Settings Cell: Margin on the left seems too low

## Approach

- Compared with production
- Found the common class having this change
- Ported the change on the branched code off the Firefox Upgrade
- Compared the before/after and against production

| Before | After |
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone 15 - 2024-05-10 at 15 17 42](https://github.com/ecosia/ios-browser/assets/3584008/205eb15c-398d-4ce3-97af-607e3e7246b7) | ![Simulator Screenshot - iPhone 15 - 2024-05-10 at 15 14 39](https://github.com/ecosia/ios-browser/assets/3584008/0fac4d67-42ef-4e64-8968-0d51c449e474) |


## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator


[MOB-2525]: https://ecosia.atlassian.net/browse/MOB-2525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ