### PR TITLE
[MOB-2526] Apply Ecosia's `tintColor` to `tableView` for Markets

### DIFF
--- a/Client/Ecosia/UI/MarketsController.swift
+++ b/Client/Ecosia/UI/MarketsController.swift
@@ -4,6 +4,7 @@
 
 import Core
 import UIKit
+import Common
 
 final class Markets {
     static private (set) var all: [Market] = {
@@ -73,6 +74,7 @@ final class MarketsController: ThemedTableViewController {
 
     override func applyTheme() {
         super.applyTheme()
+        tableView.tintColor = UIColor.legacyTheme.ecosia.primaryBrand
         view.backgroundColor = UIColor.legacyTheme.tableView.headerBackground
     }
 }


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the PR title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2526]

## Context

As part of a wired testing on the Testflight 10.0.0 (1) build, a few minor cosmetic 💅 discrepancies were found.
Issue 👇 
Search region selection: Wrong key color for arrow (blue)

## Approach

- Compared with production
- Found the common class having this change
- Ported the change on the branched code off the Firefox Upgrade
- Compared the before/after and against production

| Before | After |
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone 15 - 2024-05-10 at 15 45 21](https://github.com/ecosia/ios-browser/assets/3584008/8846539c-6732-46ae-8b06-af11dcd2efdf) | ![Simulator Screenshot - iPhone 15 - 2024-05-10 at 15 44 17](https://github.com/ecosia/ios-browser/assets/3584008/6596c3a5-3113-4ed5-a09d-dbf7f5fe3bfa) |


## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator


[MOB-2526]: https://ecosia.atlassian.net/browse/MOB-2526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ