### PR TITLE
[MOB-2527] Fix Widgets labels' colors

### DIFF
--- a/WidgetKit/ImageButtonWithLabel.swift
+++ b/WidgetKit/ImageButtonWithLabel.swift
@@ -75,12 +75,14 @@ struct ImageButtonWithLabel: View {
                                     .font(.headline)
                                     .minimumScaleFactor(0.75)
                                     .layoutPriority(1000)
+                                    // Ecosia: add color
                                     .foregroundColor(link.textColor)
                             } else {
                                 Text(link.label)
                                     .font(.footnote)
                                     .minimumScaleFactor(0.75)
                                     .layoutPriority(1000)
+                                    // Ecosia: add color
                                     .foregroundColor(link.textColor)
                             }
                         }

--- a/WidgetKit/ImageButtonWithLabel.swift
+++ b/WidgetKit/ImageButtonWithLabel.swift
@@ -75,11 +75,13 @@ struct ImageButtonWithLabel: View {
                                     .font(.headline)
                                     .minimumScaleFactor(0.75)
                                     .layoutPriority(1000)
+                                    .foregroundColor(link.textColor)
                             } else {
                                 Text(link.label)
                                     .font(.footnote)
                                     .minimumScaleFactor(0.75)
                                     .layoutPriority(1000)
+                                    .foregroundColor(link.textColor)
                             }
                         }
                         Spacer()


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the PR title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2527]

## Context

As part of a wired testing on the Testflight 10.0.0 (1) build, a few minor cosmetic 💅 discrepancies were found.
Issue 👇
Widget: wrong color of text on light green background

## Approach

- Compared with production
- Found the common class having this change
- Ported the change on the branched code off the Firefox Upgrade
- Compared the before/after and against production

| Before (mentioned issue) | After |
| ------------- | ------------- |
| ![IMG_2922 (1)](https://github.com/ecosia/ios-browser/assets/3584008/8f194b3a-7e6a-4650-9b70-3bf48d581991) | ![Simulator Screenshot - iPhone 15 - 2024-05-10 at 15 56 26](https://github.com/ecosia/ios-browser/assets/3584008/0b64564d-9cc7-45d9-989f-28d092685f8b) |

### More side-by-side info with fix

| Dark mode | Light mode |
| ------------- | ------------- |
| ![Simulator Screenshot - iPhone 15 - 2024-05-10 at 15 56 26](https://github.com/ecosia/ios-browser/assets/3584008/74a0b18c-1ee1-4f3c-b39d-a9f71e17793e) | ![Simulator Screenshot - iPhone 15 - 2024-05-10 at 15 56 29](https://github.com/ecosia/ios-browser/assets/3584008/fac6e2e2-3a78-46f8-841d-ade864fccefa) |

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator

[MOB-2527]: https://ecosia.atlassian.net/browse/MOB-2527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ