### PR TITLE
[MOB-2553] Updated show/hide locker logic like latest v128

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -39,6 +39,8 @@ class BrowserViewController: UIViewController,
         .canGoForward,
         .URL,
         .title,
+        // Ecosia: Update show/hide locker icon based on Firefox v128
+        .hasOnlySecureContent
     ]
 
     weak var browserDelegate: BrowserDelegate?
@@ -1417,6 +1419,10 @@ class BrowserViewController: UIViewController,
                   let canGoForward = change?[.newKey] as? Bool
             else { break }
             navigationToolbar.updateForwardStatus(canGoForward)
+        // Ecosia: Update show/hide locker icon based on Firefox v128
+        case .hasOnlySecureContent:
+            urlBar.locationView.hasSecureContent = webView.hasOnlySecureContent
+            urlBar.locationView.showTrackingProtectionButton(for: webView.url)
         default:
             assertionFailure("Unhandled KVO key: \(keyPath ?? "nil")")
         }
@@ -1449,7 +1455,8 @@ class BrowserViewController: UIViewController,
                 isPrivate: tab.isPrivate)
         }
         urlBar.currentURL = tab.url?.displayURL
-        urlBar.locationView.tabDidChangeContentBlocking(tab)
+        // Ecosia: Update show/hide locker icon based on Firefox v128
+        // urlBar.locationView.tabDidChangeContentBlocking(tab)
         urlBar.locationView.updateShoppingButtonVisibility(for: tab)
         let isPage = tab.url?.displayURL?.isWebPage() ?? false
         navigationToolbar.updatePageStatus(isPage)
@@ -1681,9 +1688,11 @@ class BrowserViewController: UIViewController,
         guard let webView = tab.webView else { return }
 
         if let url = webView.url {
+            /* Ecosia: Update show/hide locker icon based on Firefox v128
             if tab === tabManager.selectedTab {
                 urlBar.locationView.tabDidChangeContentBlocking(tab)
             }
+             */
 
             if (!InternalURL.isValid(url: url) || url.isReaderModeURL) && !url.isFileURL {
                 postLocationChangeNotificationForTab(tab, navigation: navigation)

--- a/Client/TabManagement/Tab.swift
+++ b/Client/TabManagement/Tab.swift
@@ -487,6 +487,8 @@ class Tab: NSObject, ThemeApplicable {
             configureEdgeSwipeGestureRecognizers()
             self.webView?.addObserver(self, forKeyPath: KVOConstants.URL.rawValue, options: .new, context: nil)
             self.webView?.addObserver(self, forKeyPath: KVOConstants.title.rawValue, options: .new, context: nil)
+            // Ecosia: Update show/hide locker icon based on Firefox v128
+            self.webView?.addObserver(self, forKeyPath: KVOConstants.hasOnlySecureContent.rawValue, options: .new, context: nil)
             UserScriptManager.shared.injectUserScriptsIntoWebView(webView, nightMode: nightMode, noImageMode: noImageMode)
 
             tabDelegate?.tab(self, didCreateWebView: webView)
@@ -506,6 +508,8 @@ class Tab: NSObject, ThemeApplicable {
     deinit {
         webView?.removeObserver(self, forKeyPath: KVOConstants.URL.rawValue)
         webView?.removeObserver(self, forKeyPath: KVOConstants.title.rawValue)
+        // Ecosia: Update show/hide locker icon based on Firefox v128
+        webView?.removeObserver(self, forKeyPath: KVOConstants.hasOnlySecureContent.rawValue)
         webView?.navigationDelegate = nil
 
         debugTabCount -= 1

--- a/Shared/AppConstants.swift
+++ b/Shared/AppConstants.swift
@@ -47,6 +47,8 @@ public enum KVOConstants: String {
     case canGoBack
     case canGoForward
     case contentSize
+    // Ecosia: Update show/hide locker icon based on Firefox v128
+    case hasOnlySecureContent
 }
 
 public struct KeychainKey {


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the PR title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2553]

## Context

While a page is loading coming from the NTP, an insecure icon shows - especially visible if the page takes a bit to load.

## Approach

- Evaluated current codebase
- Evaluated and validated the behavior against the base Firefox v122 branch
- Evaluated behavior against the latest version of Firefox (v128)
- Picked the desired behavior being the one against the latest version of Firefox (v128)
- Adapted the solution found on the v128 to our codebase
- Testing

| Previous      | Current with fix     |
| ------------- | ------------- |
| ![Simulator Screen Recording - iPhone 15 - 2024-05-15 at 09 18 37](https://github.com/ecosia/ios-browser/assets/3584008/4054e58a-1ece-4747-8d70-b7bcd09402d7) | ![Simulator Screen Recording - iPhone 15 - 2024-05-14 at 23 19 31](https://github.com/ecosia/ios-browser/assets/3584008/9980cd22-2369-42cb-a1d7-4f6878e6d4be) |

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I added the `// Ecosia:` helper comments where needed

[MOB-2553]: https://ecosia.atlassian.net/browse/MOB-2553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ