### PR TITLE
[MOB-2586] Fix URLBar's progressbar background and animation

### DIFF
--- a/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -281,6 +281,10 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
          multiStateButton, locationContainer, searchIconImageView].forEach {
             addSubview($0)
         }
+        
+        // Ecosia: ProgressBar sits at the back of the LocationView
+        locationView.addSubview(progressBar)
+        locationView.sendSubviewToBack(progressBar)
         // Ecosia: Update Search Engine Image
         updateSearchEngineImage()
         
@@ -302,6 +306,11 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
         scrollToTopButton.snp.makeConstraints { make in
             make.top.equalTo(self)
             make.left.right.equalTo(locationContainer)
+        }
+        
+        // Ecosia: ProgressBar fills the entire URL Bar
+        progressBar.snp.makeConstraints { make in
+            make.edges.equalTo(locationView)
         }
 
         locationView.snp.makeConstraints { make in
@@ -1019,17 +1028,14 @@ extension URLBarView: PrivateModeUI {
     }
 }
 
-// Ecosia: Apply Theme in private mode helper
+// Ecosia: Apply Theme via helper
 extension URLBarView {
     
     func updateUIElementsWithTheme(_ theme: Theme) {
-        let gradientStartColor = isPrivate ? theme.colors.borderAccentPrivate : theme.colors.borderAccent
-        let gradientMiddleColor = isPrivate ? nil : theme.colors.iconAccentPink
-        let gradientEndColor = isPrivate ? theme.colors.borderAccentPrivate : theme.colors.iconAccentYellow
-        locationActiveBorderColor = isPrivate ? theme.colors.layerAccentPrivateNonOpaque : theme.colors.layerAccentNonOpaque
-        progressBar.setGradientColors(startColor: gradientStartColor,
-                                      middleColor: gradientMiddleColor,
-                                      endColor: gradientEndColor)
+        progressBar.backgroundColor = .legacyTheme.ecosia.tertiaryBackground
+        progressBar.setGradientColors(startColor: .legacyTheme.ecosia.highlightedBackground,
+                                      middleColor: .legacyTheme.ecosia.highlightedBackground,
+                                      endColor: .legacyTheme.ecosia.highlightedBackground)
         locationTextField?.applyUIMode(isPrivate: isPrivate, theme: theme)
         locationTextField?.applyTheme(theme: theme)
     }


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the PR title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2586]

## Context

When testing one of the latest Firefox 120 builds, we noticed that the loading state of the URL Bar is not showing anymore.
We also when back many versions and realized it’s been like that since ~8.2.0+

## Approach

- Move back to 8.2.0 codebase
- Understand differences
- Apply discrepancies adapting it to the latest codebase

| GIF with progress bar animation |
| ------------ |
| ![Simulator Screen Recording - iPhone 15 - 2024-05-30 at 12 10 04](https://github.com/ecosia/ios-browser/assets/3584008/68d3ea46-3d7e-4255-96a0-86dfeccde915) |

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator

[MOB-2586]: https://ecosia.atlassian.net/browse/MOB-2586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ