### PR TITLE
[MOB-2012] Swap Firefox's SnackBar with iOS Native Alert (tinted)

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -897,6 +897,7 @@ private extension BrowserViewController {
 
     // Use for sms and mailto links, which do not show a confirmation before opening.
     func showSnackbar(forExternalUrl url: URL, tab: Tab, completion: @escaping (Bool) -> Void) {
+        /* Ecosia: Change to native alert controller
         let snackBar = TimerSnackBar(text: .ExternalLinkGenericConfirmation + "\n\(url.absoluteString)", img: nil)
         let ok = SnackButton(title: .OKString, accessibilityIdentifier: "AppOpenExternal.button.ok") { bar in
             tab.removeSnackbar(bar)
@@ -913,6 +914,21 @@ private extension BrowserViewController {
         snackBar.addButton(ok)
         snackBar.addButton(cancel)
         tab.addSnackbar(snackBar)
+         */
+        let alert = UIAlertController(title: .localized(.openExternalLinkTitle),
+                                      message: String.init(format: .localized(.openExternalLinkDescription), url.absoluteString),
+                                      preferredStyle: .alert)
+        alert.view.tintColor = .legacyTheme.ecosia.primaryButton
+        let cancelAction = UIAlertAction(title: .localized(.cancel), style: .default) { _ in
+            completion(false)
+        }
+        alert.addAction(cancelAction)
+        let openAction = UIAlertAction(title: .localized(.open), style: .default) { _ in
+            completion(true)
+        }
+        alert.addAction(openAction)
+        alert.preferredAction = openAction
+        present(alert, animated: true)
     }
 
     func shouldRequestBeOpenedAsPopup(_ request: URLRequest) -> Bool {

--- a/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -499,7 +499,15 @@ extension BrowserViewController: WKNavigationDelegate {
             DispatchQueue.main.asyncAfter(deadline: .now() + tabManager.delaySelectingNewPopupTab + 0.1) {
                 // Show only if no other snack bar
                 guard let tab = self.tabManager.selectedTab, tab.bars.isEmpty else { return }
+                /* Ecosia: Change to native alert controller (showSnackbar() contains the Ecosia change)
                 TimerSnackBar.showAppStoreConfirmationBar(forTab: tab, appStoreURL: url, theme: self.themeManager.currentTheme) { _ in
+                    // If a new window was opened for this URL (it will have no history), close it.
+                    if tab.historyList.isEmpty {
+                        self.tabManager.removeTab(tab)
+                    }
+                }
+                 */
+                self.showSnackbar(forExternalUrl: url, tab: tab) { _ in
                     // If a new window was opened for this URL (it will have no history), close it.
                     if tab.historyList.isEmpty {
                         self.tabManager.removeTab(tab)


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the PR title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2012]

## Context

When testing one of the latest Firefox 120 builds, we noticed that for all links trying to open the app externally, we show the standard Firefox bottom popup.

## Approach

Replace it at the center of its implementation.
Easy to check and update when solving conflicts.

| GIF with fix showing native alert |
| ----------- |
| ![Simulator Screen Recording - iPhone 15 - 2024-05-30 at 13 54 03](https://github.com/ecosia/ios-browser/assets/3584008/b9c72832-79a5-4106-8fc7-5024b67ca411) |

## Other

## Before merging

### Checklist

- [ ] I performed some relevant testing on a real device and/or simulator
- [ ] I wrote Unit Tests that confirm the expected behavior
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [ ] I added the `// Ecosia:` helper comments where needed
- [ ] I included documentation updates to the coding standards or Confluence doc when needed
- [ ] I am using the correct version from [core](https://github.com/ecosia/ios-core), including any necessary changes for this ticket and pointing to `main` instead of a feature branch


[MOB-2012]: https://ecosia.atlassian.net/browse/MOB-2012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ