### PR TITLE
[MOB-2604] Fix private icon on iPad

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -348,6 +348,7 @@
 		2C872A622B8CD7E000B318A0 /* VersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE294702B7FC5A6006C22B2 /* VersionTests.swift */; };
 		2C872A632B8CD7E000B318A0 /* WhatsNewLocalDataProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE2946B2B7FC5A5006C22B2 /* WhatsNewLocalDataProviderTests.swift */; };
 		2C872A642B8CD7E000B318A0 /* EcosiaHomeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C872A562B8CD65100B318A0 /* EcosiaHomeViewModelTests.swift */; };
+		2CABD7282C12EF1E00A0750F /* PrivateModeButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CABD7272C12EF1E00A0750F /* PrivateModeButtonTests.swift */; };
 		2CE294472B7CDD56006C22B2 /* Core in Frameworks */ = {isa = PBXBuildFile; productRef = 2CE294462B7CDD56006C22B2 /* Core */; };
 		2CE294492B7CDD78006C22B2 /* Core in Frameworks */ = {isa = PBXBuildFile; productRef = 2CE294482B7CDD78006C22B2 /* Core */; };
 		2CE2E24D2B9B1FCB00973C16 /* Core in Frameworks */ = {isa = PBXBuildFile; productRef = 2CE2E24C2B9B1FCB00973C16 /* Core */; };
@@ -2473,6 +2474,7 @@
 		2C9144B0B15218D8A0FCD538 /* es-AR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-AR"; path = "es-AR.lproj/ClearPrivateData.strings"; sourceTree = "<group>"; };
 		2C97EC701E72C80E0092EC18 /* TopTabsTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopTabsTest.swift; sourceTree = "<group>"; };
 		2CA16FDD1E5F089100332277 /* SearchTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchTest.swift; sourceTree = "<group>"; };
+		2CABD7272C12EF1E00A0750F /* PrivateModeButtonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateModeButtonTests.swift; sourceTree = "<group>"; };
 		2CAE4511992E91A32AB7D7C7 /* th */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = th; path = th.lproj/Today.strings; sourceTree = "<group>"; };
 		2CB1A6591FDEA8B60084E96D /* NewTabSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabSettings.swift; sourceTree = "<group>"; };
 		2CB56E3E1E926BFB00AF7586 /* ToolbarTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToolbarTest.swift; sourceTree = "<group>"; };
@@ -8823,6 +8825,7 @@
 				2CE2946B2B7FC5A5006C22B2 /* WhatsNewLocalDataProviderTests.swift */,
 				2C872A562B8CD65100B318A0 /* EcosiaHomeViewModelTests.swift */,
 				2C26EA132C04CAD100795552 /* EcosiaTopSitesHelperTests.swift */,
+				2CABD7272C12EF1E00A0750F /* PrivateModeButtonTests.swift */,
 			);
 			path = EcosiaTests;
 			sourceTree = "<group>";
@@ -14340,6 +14343,7 @@
 				8A28C628291028870078A81A /* CanRemoveQuickActionBookmarkTests.swift in Sources */,
 				03CCC9181AF05E7300DBF30D /* RelativeDatesTests.swift in Sources */,
 				F84B21DA1A090F8100AAB793 /* ClientTests.swift in Sources */,
+				2CABD7282C12EF1E00A0750F /* PrivateModeButtonTests.swift in Sources */,
 				219935F12B07DFA200E5966F /* TabDisplayPanelTests.swift in Sources */,
 				DF940A0C2A96352B00C1497D /* FakespotSettingsCardViewModelTests.swift in Sources */,
 				281B2BEA1ADF4D90002917DC /* MockProfile.swift in Sources */,

--- a/Client/Frontend/Browser/TabTrayButtonExtensions.swift
+++ b/Client/Frontend/Browser/TabTrayButtonExtensions.swift
@@ -8,10 +8,6 @@ import Shared
 
 class PrivateModeButton: ToggleButton, PrivateModeUI {
     
-    // Ecosia: Add tints
-    private var offTint = UIColor.black
-    private var onTint = UIColor.black
-    
     override init(frame: CGRect) {
         super.init(frame: frame)
         accessibilityLabel = .TabTrayToggleAccessibilityLabel

--- a/Client/Frontend/Browser/TabTrayButtonExtensions.swift
+++ b/Client/Frontend/Browser/TabTrayButtonExtensions.swift
@@ -7,6 +7,11 @@ import UIKit
 import Shared
 
 class PrivateModeButton: ToggleButton, PrivateModeUI {
+    
+    // Ecosia: Add tints
+    private var offTint = UIColor.black
+    private var onTint = UIColor.black
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         accessibilityLabel = .TabTrayToggleAccessibilityLabel
@@ -27,8 +32,15 @@ class PrivateModeButton: ToggleButton, PrivateModeUI {
     func applyUIMode(isPrivate: Bool, theme: Theme) {
         isSelected = isPrivate
 
-        tintColor = isPrivate ? theme.colors.iconOnColor : theme.colors.iconPrimary
+        // Ecosia: Update tint
+        // tintColor = isPrivate ? theme.colors.iconOnColor : theme.colors.iconPrimary
+        tintColor = isPrivate ? .legacyTheme.ecosia.primaryBackground : .legacyTheme.ecosia.primaryText
         imageView?.tintColor = tintColor
+        
+        // Ecosia: Modify background layer
+        backgroundLayer.backgroundColor = isPrivate
+            ? UIColor.legacyTheme.ecosia.privateButtonBackground.cgColor
+            : UIColor.clear.cgColor
 
         accessibilityValue = isSelected ? .TabTrayToggleAccessibilityValueOn : .TabTrayToggleAccessibilityValueOff
     }

--- a/Client/Frontend/Widgets/ToggleButton.swift
+++ b/Client/Frontend/Widgets/ToggleButton.swift
@@ -5,8 +5,9 @@
 import UIKit
 
 private struct UX {
-    static let BackgroundColor = UIColor.Photon.Purple60
-
+    // Ecosia: Update background color
+    // static let BackgroundColor = UIColor.Photon.Purple60
+    static let BackgroundColor = UIColor.legacyTheme.ecosia.secondaryBrand
     // The amount of pixels the toggle button will expand over the normal size. This results in the larger -> contract animation.
     static let ExpandDelta: CGFloat = 5
     static let ShowDuration: TimeInterval = 0.4

--- a/EcosiaTests/PrivateModeButtonTests.swift
+++ b/EcosiaTests/PrivateModeButtonTests.swift
@@ -1,0 +1,88 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import Client
+
+final class PrivateModeButtonTests: XCTestCase {
+    
+    var button: PrivateModeButton!
+    var lightTheme = EcosiaLightTheme()
+    var darkTheme = EcosiaDarkTheme()
+    
+    override func setUp() {
+        super.setUp()
+        button = PrivateModeButton(frame: .zero)
+    }
+
+    func testApplyUIMode_Private_LightMode() {
+        LegacyThemeManager.instance.current = LegacyNormalTheme()
+        button.applyUIMode(isPrivate: true, theme: lightTheme)
+        
+        XCTAssertEqual(button.tintColor, lightTheme.colors.layer3)
+        XCTAssertEqual(button.imageView?.tintColor, lightTheme.colors.layer3)
+        XCTAssertEqual(button.backgroundLayer.backgroundColor, UIColor.Photon.Grey70.cgColor)
+        XCTAssertEqual(button.accessibilityValue, .TabTrayToggleAccessibilityValueOn)
+    }
+    
+    func testApplyUIMode_NotPrivate_LightMode() {
+        button.applyUIMode(isPrivate: false, theme: lightTheme)
+        
+        XCTAssertEqual(button.tintColor, lightTheme.colors.textPrimary)
+        XCTAssertEqual(button.imageView?.tintColor, lightTheme.colors.textPrimary)
+        XCTAssertEqual(button.backgroundLayer.backgroundColor, UIColor.clear.cgColor)
+        XCTAssertEqual(button.accessibilityValue, .TabTrayToggleAccessibilityValueOff)
+    }
+    
+    func testApplyUIMode_Private_DarkMode() {
+        LegacyThemeManager.instance.current = LegacyDarkTheme()
+        button.applyUIMode(isPrivate: true, theme: darkTheme)
+        
+        XCTAssertEqual(button.tintColor, darkTheme.colors.layer1)
+        XCTAssertEqual(button.imageView?.tintColor, darkTheme.colors.layer1)
+        XCTAssertEqual(button.backgroundLayer.backgroundColor, UIColor.white.cgColor)
+        XCTAssertEqual(button.accessibilityValue, .TabTrayToggleAccessibilityValueOn)
+    }
+    
+    func testApplyUIMode_NotPrivate_DarkMode() {
+        button.applyUIMode(isPrivate: false, theme: darkTheme)
+        
+        XCTAssertEqual(button.tintColor, darkTheme.colors.textPrimary)
+        XCTAssertEqual(button.imageView?.tintColor, darkTheme.colors.textPrimary)
+        XCTAssertEqual(button.backgroundLayer.backgroundColor, UIColor.clear.cgColor)
+        XCTAssertEqual(button.accessibilityValue, .TabTrayToggleAccessibilityValueOff)
+    }
+    
+    func testApplyTheme_Selected_LightMode() {
+        button.isSelected = true
+        button.applyTheme(theme: lightTheme)
+        
+        XCTAssertEqual(button.tintColor, lightTheme.colors.iconOnColor)
+        XCTAssertEqual(button.imageView?.tintColor, lightTheme.colors.iconOnColor)
+    }
+    
+    func testApplyTheme_NotSelected_LightMode() {
+        button.isSelected = false
+        button.applyTheme(theme: lightTheme)
+        
+        XCTAssertEqual(button.tintColor, lightTheme.colors.iconPrimary)
+        XCTAssertEqual(button.imageView?.tintColor, lightTheme.colors.iconPrimary)
+    }
+    
+    func testApplyTheme_Selected_DarkMode() {
+        button.isSelected = true
+        button.applyTheme(theme: darkTheme)
+        
+        XCTAssertEqual(button.tintColor, darkTheme.colors.iconOnColor)
+        XCTAssertEqual(button.imageView?.tintColor, darkTheme.colors.iconOnColor)
+    }
+    
+    func testApplyTheme_NotSelected_DarkMode() {
+        button.isSelected = false
+        button.applyTheme(theme: darkTheme)
+        
+        XCTAssertEqual(button.tintColor, darkTheme.colors.iconPrimary)
+        XCTAssertEqual(button.imageView?.tintColor, darkTheme.colors.iconPrimary)
+    }
+}


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the PR title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2604]

## Context

We found an issue on iPad that applied the purple color to the private button in selected state.

## Approach

Found the root cause and fix it.

| GIF with fix |
| ----------- |
| ![Simulator Screen Recording - iPad (10th generation) - 2024-06-07 at 13 28 58](https://github.com/ecosia/ios-browser/assets/3584008/1f6b89fd-bdf1-45f9-8ec7-4b306131b0a2) |

## Other

Clunky tests due to the awaiting merge of: https://github.com/ecosia/ios-browser/pull/695

Add tests

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I wrote Unit Tests that confirm the expected behavior
- [x] I added the `// Ecosia:` helper comments where needed

[MOB-2604]: https://ecosia.atlassian.net/browse/MOB-2604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ