### PR TITLE
[MOB-2605] Update popover height for iPad

### DIFF
--- a/Client/Ecosia/UI/PageAction/PageActionMenu.swift
+++ b/Client/Ecosia/UI/PageAction/PageActionMenu.swift
@@ -68,7 +68,12 @@ final class PageActionMenu: UIViewController, UIGestureRecognizerDelegate, Theme
         checkSwipeDown()
         guard traitCollection.userInterfaceIdiom == .pad else { return }
         contentSizeObserver = tableView.observe(\.contentSize) { [weak self] tableView, _ in
-            self?.preferredContentSize = CGSize(width: 350, height: tableView.contentSize.height)
+            // Ecosia: Update height for iPad
+            var height = tableView.contentSize.height
+            if UIDevice.current.userInterfaceIdiom == .pad {
+                height += PhotonActionSheet.UX.bigSpacing
+            }
+            self?.preferredContentSize = CGSize(width: 350, height: height)
         }
     }
 

--- a/Client/Ecosia/UI/PageAction/PageActionMenu.swift
+++ b/Client/Ecosia/UI/PageAction/PageActionMenu.swift
@@ -69,11 +69,12 @@ final class PageActionMenu: UIViewController, UIGestureRecognizerDelegate, Theme
         guard traitCollection.userInterfaceIdiom == .pad else { return }
         contentSizeObserver = tableView.observe(\.contentSize) { [weak self] tableView, _ in
             // Ecosia: Update height for iPad
+            // self?.preferredContentSize = CGSize(width: 350, height: tableView.contentSize.height)
             var height = tableView.contentSize.height
             if UIDevice.current.userInterfaceIdiom == .pad {
                 height += PhotonActionSheet.UX.bigSpacing
             }
-            self?.preferredContentSize = CGSize(width: 350, height: height)
+            self?.preferredContentSize = CGSize(width: 350, height: tableView.contentSize.height)
         }
     }
 


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the PR title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2605]

## Context

Found a UI cosmetic issue when setting the height on the iPad expected popover size

## Approach

- Realized the issue exists in Production as well
- Investigated through the codebase
- Realized there are too many calculations being done that could potentially affect all other places of the app
- Found the best compromise to achieve that pragmatically and minimize bigger codebase changes 

| GIF with fix |
| ----------- |
| ![Simulator Screen Recording - iPad (10th generation) - 2024-06-07 at 13 53 19](https://github.com/ecosia/ios-browser/assets/3584008/daff4e6e-6ff2-4107-8fce-de145bf5a459) |

## Other

Clunky tests due to the awaiting merge of: https://github.com/ecosia/ios-browser/pull/695

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I added the `// Ecosia:` helper comments where needed


[MOB-2605]: https://ecosia.atlassian.net/browse/MOB-2605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ