### PR TITLE
[MOB-2110] Consent Cookie storage

### DIFF
--- a/Client/Ecosia/Analytics/Analytics.swift
+++ b/Client/Ecosia/Analytics/Analytics.swift
@@ -66,11 +66,12 @@ final class Analytics {
             abTestToggles.forEach {
                 if let context = Self.getTestContext(from: $0) {
                     event.contexts.append(context)
-                    if let consentValue = User.shared.cookieConsentValue {
-                        event.contexts.append(SelfDescribingJson(schema: Self.consentSchema,
-                                                                 andDictionary: ["cookie_consent": consentValue]))
-                    }
                 }
+            }
+            // Cookie consent context
+            if let consentValue = User.shared.cookieConsentValue {
+                event.contexts.append(SelfDescribingJson(schema: Self.consentSchema,
+                                                         andDictionary: ["cookie_consent": consentValue]))
             }
         }
 

--- a/Client/Ecosia/Analytics/Analytics.swift
+++ b/Client/Ecosia/Analytics/Analytics.swift
@@ -5,6 +5,7 @@ import Core
 final class Analytics {
     private static let installSchema = "iglu:org.ecosia/ios_install_event/jsonschema/1-0-0"
     private static let abTestSchema = "iglu:org.ecosia/abtest_context/jsonschema/1-0-1"
+    private static let consentSchema = "iglu:org.ecosia/eccc_context/jsonschema/1-0-2"
     private static let abTestRoot = "ab_tests"
     private static let namespace = "ios_sp"
     
@@ -66,7 +67,7 @@ final class Analytics {
                 if let context = Self.getTestContext(from: $0) {
                     event.contexts.append(context)
                     if let consentValue = User.shared.cookieConsentValue {
-                        event.contexts.append(SelfDescribingJson(schema: "iglu:org.ecosia/eccc_context/jsonschema/1-0-2",
+                        event.contexts.append(SelfDescribingJson(schema: Self.consentSchema,
                                                                  andDictionary: ["cookie_consent": consentValue]))
                     }
                 }

--- a/Client/Ecosia/Analytics/Analytics.swift
+++ b/Client/Ecosia/Analytics/Analytics.swift
@@ -65,6 +65,10 @@ final class Analytics {
             abTestToggles.forEach {
                 if let context = Self.getTestContext(from: $0) {
                     event.contexts.append(context)
+                    if let consentValue = User.shared.cookieConsentValue {
+                        event.contexts.append(SelfDescribingJson(schema: "iglu:org.ecosia/eccc_context/jsonschema/1-0-2",
+                                                                 andDictionary: ["cookie_consent": consentValue]))
+                    }
                 }
             }
         }

--- a/Client/Frontend/Browser/MetadataParserHelper.swift
+++ b/Client/Frontend/Browser/MetadataParserHelper.swift
@@ -6,6 +6,8 @@ import Foundation
 import Shared
 import Storage
 import WebKit
+// Ecosia:
+import Core
 
 class MetadataParserHelper: TabEventHandler {
     init() {
@@ -45,6 +47,14 @@ class MetadataParserHelper: TabEventHandler {
                 "tabURL": pageURL
             ]
             NotificationCenter.default.post(name: .OnPageMetadataFetched, object: nil, userInfo: userInfo)
+        }
+        
+        // Ecosia: read local storage value for cookie consent
+        if url.normalizedHost?.hasPrefix("ecosia.org") == true, !tab.isPrivate {
+            webView.evaluateJavascriptInDefaultContentWorld("localStorage.getItem(\"\(Cookie.consentKey)\")") { result, error in
+                guard error == nil, let consentValue = result as? String else { return }
+                User.shared.cookieConsentValue = consentValue
+            }
         }
     }
 }

--- a/Client/Frontend/TabContentsScripts/UserScriptManager.swift
+++ b/Client/Frontend/TabContentsScripts/UserScriptManager.swift
@@ -3,6 +3,8 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import WebKit
+// Ecosia
+import Core
 
 class UserScriptManager: FeatureFlaggable {
     // Scripts can use this to verify the *app* (not JS on the web) is calling into them.
@@ -108,6 +110,15 @@ class UserScriptManager: FeatureFlaggable {
         // that it gets enabled immediately when the DOM loads.
         if noImageMode {
             webView?.configuration.userContentController.addUserScript(noImageModeUserScript)
+        }
+        
+        // Ecosia: Inject Cookie banner consent
+        if let cookieConsentValue = User.shared.cookieConsentValue {
+            let cookieConsentScript = WKUserScript.createInDefaultContentWorld(
+                source: "localStorage.setItem(\"\(Cookie.consentKey)\", \"\(cookieConsentValue)\")",
+                injectionTime: .atDocumentStart,
+                forMainFrameOnly: true)
+            webView?.configuration.userContentController.addUserScript(cookieConsentScript)
         }
     }
 }


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the PR title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2110]

## Context

When users visit SERP for the first time, they are presented our cookie banner.
In this they can decide which cookies and attached functionalities they want to use. 
We want to store the consent given internally, so that we can configure the expected analytics services appropriately. 

## Approach

- Analyse what's done on iOS production
- ACK the snippet saving the consent cookies was not ported into our upgrade branch
- Bring it as part for this PR
- Add the cookie consent value to Snowplow context 

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I added supporting comment in the ticket with link to Snowplow event

[MOB-2110]: https://ecosia.atlassian.net/browse/MOB-2110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ