### PR TITLE
[MOB-2633] Add `accessibilityIdentfier` to setting sections

### DIFF
--- a/Client/Ecosia/Settings/NTPCustomizationSettingsViewController.swift
+++ b/Client/Ecosia/Settings/NTPCustomizationSettingsViewController.swift
@@ -51,7 +51,8 @@ final class NTPCustomizationSetting: BoolSetting {
     
     convenience init(prefs: Prefs, theme: Theme, config: CustomizableNTPSettingConfig) {
         self.init(prefs: prefs,
-                  theme: theme,
+                  theme: theme, 
+                  accessibilityIdentifier: config.accessibilityIdentifierPrefix,
                   defaultValue: true,
                   titleText: .localized(config.localizedTitleKey))
         self.config = config

--- a/Client/Ecosia/UI/NTP/Customization/CustomizableNTPSettingConfig.swift
+++ b/Client/Ecosia/UI/NTP/Customization/CustomizableNTPSettingConfig.swift
@@ -47,4 +47,13 @@ enum CustomizableNTPSettingConfig: CaseIterable {
         case .aboutEcosia: return .about
         }
     }
+    
+    var accessibilityIdentifierPrefix: String {
+        switch self {
+        case .topSites: "top_sites"
+        case .climateImpact: "climate_impact"
+        case .ecosiaNews: "ecosia_news"
+        case .aboutEcosia: "about_ecosia"
+        }
+    }
 }

--- a/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -244,9 +244,9 @@ extension HomePageSettingViewController {
         var profile: Profile
 
         override var accessoryType: UITableViewCell.AccessoryType { return .disclosureIndicator }
-        // Ecosia: rename to Top Sites
+        // Ecosia: Override accessibilityIdentifier
         // override var accessibilityIdentifier: String? { return AccessibilityIdentifiers.Settings.Homepage.CustomizeFirefox.Shortcuts.settingsPage }
-        override var accessibilityIdentifier: String? { return .localized(.topSites) }
+        override var accessibilityIdentifier: String? { CustomizableNTPSettingConfig.topSites.accessibilityIdentifierPrefix }
         override var style: UITableViewCell.CellStyle { return .value1 }
 
         override var status: NSAttributedString {

--- a/Client/Frontend/Settings/SettingsTableViewController.swift
+++ b/Client/Frontend/Settings/SettingsTableViewController.swift
@@ -83,6 +83,12 @@ class Setting: NSObject {
         cell.selectionStyle = enabled ? .default : .none
         cell.accessibilityIdentifier = accessibilityIdentifier
         cell.imageView?.image = _image
+        // Ecosia: Update identifier
+        if let accessibilityIdentifier {
+            cell.textLabel?.accessibilityIdentifier = "\(accessibilityIdentifier)_title"
+            cell.detailTextLabel?.accessibilityIdentifier = "\(accessibilityIdentifier)_detail"
+            cell.imageView?.accessibilityIdentifier = "\(accessibilityIdentifier)_image"
+        }
         if let title = title?.string {
             if let detailText = cell.detailTextLabel?.text {
                 cell.accessibilityLabel = "\(title), \(detailText)"
@@ -184,6 +190,8 @@ class BoolSetting: Setting, FeatureFlaggable {
     init(
         prefs: Prefs?,
         prefKey: String? = nil,
+        // Ecosia: Add accessibility identifier
+        accessibilityIdentifier: String? = nil,
         defaultValue: Bool?,
         attributedTitleText: NSAttributedString,
         attributedStatusText: NSAttributedString? = nil,
@@ -197,12 +205,16 @@ class BoolSetting: Setting, FeatureFlaggable {
         self.statusText = attributedStatusText
         self.featureFlagName = featureFlagName
         super.init(title: attributedTitleText)
+        // Ecosia: Add accessibility identifier
+        self.accessibilityIdentifier = accessibilityIdentifier
     }
 
     convenience init(
         prefs: Prefs,
         theme: Theme,
         prefKey: String? = nil,
+        // Ecosia: Add accessibility identifier
+        accessibilityIdentifier: String? = nil,
         defaultValue: Bool,
         titleText: String,
         statusText: String? = nil,
@@ -217,6 +229,8 @@ class BoolSetting: Setting, FeatureFlaggable {
         self.init(
             prefs: prefs,
             prefKey: prefKey,
+            // Ecosia: Add accessibility identifier
+            accessibilityIdentifier: accessibilityIdentifier,
             defaultValue: defaultValue,
             attributedTitleText: NSAttributedString(
                 string: titleText,
@@ -265,7 +279,11 @@ class BoolSetting: Setting, FeatureFlaggable {
 
     public lazy var control: UISwitch = {
         let control = UISwitch()
-        control.accessibilityIdentifier = prefKey
+        // Ecosia: Update identifier
+        // control.accessibilityIdentifier = prefKey
+        if let accessibilityIdentifier {
+            control.accessibilityIdentifier = "\(accessibilityIdentifier)_switch"
+        }
         control.addTarget(self, action: #selector(switchValueChanged), for: .valueChanged)
         return control
     }()


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the PR title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2633]

## Context

QA wanted to test the switches' status as well as overall improve the testing of the NTP section.

## Approach

- Investigate codebase
- acknowledge how the `accessibilityIdentifier` gets injected
- Found the best approach to let QA test not only switches but also the title, detail, and image of a setting cell as long as the `accessibilityIdentifier` is evaluated.

ℹ️ all other `accessibilityIdentifier` will keep working except for the switch where `prefsKey` was evaluated, as in most of the scenarios was wrongly evaluated utilizing localized content. QA is testing no other sections with that key.

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I added the `// Ecosia:` helper comments where needed

[MOB-2633]: https://ecosia.atlassian.net/browse/MOB-2633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ