### PR TITLE
Re-Enable Zoom Feature on Context Menu

### DIFF
--- a/Client/Frontend/Browser/MainMenuActionHelper.swift
+++ b/Client/Frontend/Browser/MainMenuActionHelper.swift
@@ -101,7 +101,8 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
     func getToolbarActions(navigationController: UINavigationController?,
                            completion: @escaping ([[PhotonRowActions]]) -> Void) {
         var actions: [[PhotonRowActions]] = []
-        let firstMiscSection = getFirstMiscSection(navigationController)
+        // Ecosia: Remove unused constant
+        // let firstMiscSection = getFirstMiscSection(navigationController)
 
         if isHomePage {
             actions.append(contentsOf: [
@@ -154,6 +155,11 @@ class MainMenuActionHelper: PhotonActionSheetProtocol,
         append(to: &section, action: copyAction)
 
         if !isHomePage && !isFileURL {
+            
+            // Ecosia: Add Zoom Action
+            let zoomAction = getZoomAction()
+            append(to: &section, action: zoomAction)
+
             let findInPageAction = getFindInPageAction()
             append(to: &section, action: findInPageAction)
 


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the PR title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2012]

## Context

## Approach

Re-enable the Zoom Feature as part of the Ecosia Items ported from current 9.x.x production

| Screenshot | Screenshot | Screenshot |
| ----------- | ----------- | ----------- |
| ![Simulator Screenshot - iPhone 15 - 2024-06-24 at 12 52 23](https://github.com/ecosia/ios-browser/assets/3584008/40e17cd7-c839-4a68-bfb3-7f0f998e9561) | ![Simulator Screenshot - iPhone 15 - 2024-06-24 at 12 52 29](https://github.com/ecosia/ios-browser/assets/3584008/aaab8b46-94a0-4c70-afaf-7f1a4bf01431) | ![Simulator Screenshot - iPhone 15 - 2024-06-24 at 12 52 31](https://github.com/ecosia/ios-browser/assets/3584008/e35392ea-e782-4bd7-800b-be8dfa5b96ed) |

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I added the `// Ecosia:` helper comments where needed

[MOB-2012]: https://ecosia.atlassian.net/browse/MOB-2012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ