### PR TITLE
[MOB-2621] Cookie injection improvements

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -20828,7 +20828,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ecosia/ios-core.git";
 			requirement = {
-				branch = "MOB-2498_upgrade_braze";
+				branch = "MOB-2621_cookie_injection_improvements";
 				kind = branch;
 			};
 		};

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -20828,7 +20828,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ecosia/ios-core.git";
 			requirement = {
-				branch = "MOB-2621_cookie_injection_improvements";
+				branch = "MOB-2498_upgrade_braze";
 				kind = branch;
 			};
 		};

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/braze-inc/braze-swift-sdk",
       "state" : {
-        "revision" : "2973b623ab2c270bfa5acf3142397b0e1f4806af",
-        "version" : "7.7.0"
+        "revision" : "f893978502a08b02124d2d15c6117eb1a06b7f6f",
+        "version" : "8.4.0"
       }
     },
     {
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
-        "branch" : "MOB-2621_cookie_injection_improvements",
-        "revision" : "dec428fc1dbc74d5c69736af6c2eabe0675230f6"
+        "branch" : "MOB-2498_upgrade_braze",
+        "revision" : "076d04ebd481c7562f1dd8e05024a3860d5842f1"
       }
     },
     {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/braze-inc/braze-swift-sdk",
       "state" : {
-        "revision" : "f893978502a08b02124d2d15c6117eb1a06b7f6f",
-        "version" : "8.4.0"
+        "revision" : "2973b623ab2c270bfa5acf3142397b0e1f4806af",
+        "version" : "7.7.0"
       }
     },
     {
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
-        "branch" : "MOB-2498_upgrade_braze",
-        "revision" : "076d04ebd481c7562f1dd8e05024a3860d5842f1"
+        "branch" : "MOB-2621_cookie_injection_improvements",
+        "revision" : "dec428fc1dbc74d5c69736af6c2eabe0675230f6"
       }
     },
     {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -69,7 +69,7 @@
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
         "branch" : "MOB-2498_upgrade_braze",
-        "revision" : "076d04ebd481c7562f1dd8e05024a3860d5842f1"
+        "revision" : "8e9b6bc3d47ddf5c5e7ce33c073691978e5a6cda"
       }
     },
     {

--- a/Client/Ecosia/UI/LoadingScreen.swift
+++ b/Client/Ecosia/UI/LoadingScreen.swift
@@ -85,6 +85,7 @@ final class LoadingScreen: UIViewController {
     }
 
     private func showReferralError(_ error: Referrals.Error) {
+        guard !error.title.isEmpty else { return }
         let alert = UIAlertController(title: error.title,
                                       message: error.message,
                                       preferredStyle: .alert)
@@ -108,6 +109,8 @@ extension Referrals.Error {
             return .localized(.linkAlreadyUsedTitle)
         case .noConnection:
             return .localized(.networkError)
+        case .notFound:
+            return ""
         }
     }
 
@@ -119,6 +122,8 @@ extension Referrals.Error {
             return .localized(.linkAlreadyUsedMessage)
         case .noConnection:
             return .localized(.noConnectionMessage)
+        case .notFound:
+            return ""
         }
     }
 }

--- a/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1212,6 +1212,7 @@ class BrowserViewController: UIViewController,
         overlayManager.finishEditing(shouldCancelLoading: false)
 
         // Ecosia: Update url with currentURL (ecosified)
+        // if let nav = tab.loadRequest(URLRequest(url: url)) {
         if let nav = tab.loadRequest(URLRequest(url: urlBar.currentURL!)) {
             self.recordNavigationInTab(tab, navigation: nav, visitType: visitType)
         }

--- a/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1211,7 +1211,8 @@ class BrowserViewController: UIViewController,
         urlBar.currentURL = url
         overlayManager.finishEditing(shouldCancelLoading: false)
 
-        if let nav = tab.loadRequest(URLRequest(url: url)) {
+        // Ecosia: Update url with currentURL (ecosified)
+        if let nav = tab.loadRequest(URLRequest(url: urlBar.currentURL!)) {
             self.recordNavigationInTab(tab, navigation: nav, visitType: visitType)
         }
     }

--- a/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -236,7 +236,13 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
         }
 
         set(newURL) {
-            locationView.url = newURL
+            // Ecosia: Update URL accordingly
+            var updatedUrl = newURL
+            if updatedUrl?.isEcosiaSearchQuery() == true {
+                updatedUrl = newURL?.ecosified(isIncognitoEnabled: isPrivate)
+            }
+            locationView.url = updatedUrl
+            // locationView.url = newURL
             
             // Ecosia: update visibility of reload/multi-state button
             if !inOverlayMode {

--- a/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -237,12 +237,12 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
 
         set(newURL) {
             // Ecosia: Update URL accordingly
+            // locationView.url = newURL
             var updatedUrl = newURL
             if updatedUrl?.isEcosiaSearchQuery() == true {
                 updatedUrl = newURL?.ecosified(isIncognitoEnabled: isPrivate)
             }
             locationView.url = updatedUrl
-            // locationView.url = newURL
             
             // Ecosia: update visibility of reload/multi-state button
             if !inOverlayMode {

--- a/Client/TabManagement/Tab.swift
+++ b/Client/TabManagement/Tab.swift
@@ -586,10 +586,9 @@ class Tab: NSObject, ThemeApplicable {
             if let url = request.url, url.isFileURL, request.isPrivileged {
                 return webView.loadFileURL(url, allowingReadAccessTo: url)
             }
-            // Ecosia: updating the request with cookies, auth parameters and language header if needed
+            // Ecosia: updating the request with auth parameters and language header if needed
             // return webView.load(request)
             var ecosiaUpdatedRequest = request
-            ecosiaUpdatedRequest.url = ecosiaUpdatedRequest.url?.ecosified(isIncognitoEnabled: _isPrivate)
             // Inject auth parameters if needed
             ecosiaUpdatedRequest = ecosiaUpdatedRequest.withAuthParameters()
             // Enriching the search request (showing SERP page) with a language region header for market selection options


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the PR title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2621]

## Context

In order to be able to intercept the cookies changes correctly from both SERP search bar and Native search Bar, some updates to the codebase were needed.

## Approach

- Ecosyfing the URL from the central point is called by both the native URL bar and the SERP search page.
- Loading the request with the `currentURL` bar instead of the injected `url` in the `func finishEditingAndSubmit(_ url: URL, visitType: VisitType, forTab tab: Tab)` Tab.

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I added the `// Ecosia:` helper comments where needed
- [ ] I am using the correct version from [core](https://github.com/ecosia/ios-core), including any necessary changes for this ticket and pointing to `main` instead of a feature branch


[MOB-2621]: https://ecosia.atlassian.net/browse/MOB-2621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ