### PR TITLE
[MOB-2642] Designs Adjustments

### DIFF
--- a/Client/Ecosia/L10N/String.swift
+++ b/Client/Ecosia/L10N/String.swift
@@ -188,7 +188,7 @@ extension String {
         case buyTrees = "Buy trees in the Ecosia tree store to delight a friend - or treat yourself"
         case plantTreesAndEarn = "Plant trees and earn eco-friendly rewards with Treecard"
         case sponsored = "Sponsored"
-        case inviteYourFriendsToCheck = "Invite your friends to check out Ecosia. When they join, you both plant an extra tree."
+        case inviteYourFriendsToCheck = "Increase your positive impact on the planet by inviting your friends to join Ecosia."
         case sharingYourLink = "Sharing your link"
         case copy = "Copy"
         case moreSharingMethods = "More sharing methods"

--- a/Client/Ecosia/L10N/en.lproj/Ecosia.strings
+++ b/Client/Ecosia/L10N/en.lproj/Ecosia.strings
@@ -113,7 +113,7 @@
 "If you’re using an iPhone or iPad, tap here to confirm you’ve joined:" = "If you’re using an iPhone or iPad, tap here to confirm you’ve joined:";
 "Link already used" = "Link already used";
 "You can only use an invitation link once." = "You can only use an invitation link once.";
-"Invite your friends to check out Ecosia. When they join, you both plant an extra tree." = "Invite your friends to check out Ecosia. When they join, you both plant an extra tree.";
+"Increase your positive impact on the planet by inviting your friends to join Ecosia." = "Increase your positive impact on the planet by inviting your friends to join Ecosia.";
 "Sharing your link" = "Sharing your link";
 "Copy" = "Copy";
 "More sharing methods" = "More sharing methods";

--- a/Client/Ecosia/UI/Theme/EcosiaThemeColourPalette.swift
+++ b/Client/Ecosia/UI/Theme/EcosiaThemeColourPalette.swift
@@ -107,7 +107,7 @@ private class EcosiaLightColourPalette: ThemeColourPalette {
     var iconDisabled: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.iconDisabled }
     var iconAction: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.iconAction }
     var iconOnColor: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.iconOnColor }
-    var iconWarning: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.iconWarning }
+    var iconWarning: UIColor { .legacyTheme.ecosia.warning }
     var iconSpinner: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.iconSpinner }
     var iconAccentViolet: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.iconAccentViolet }
     var iconAccentBlue: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.iconAccentBlue }

--- a/Client/Ecosia/UI/Theme/EcosiaThemeColourPalette.swift
+++ b/Client/Ecosia/UI/Theme/EcosiaThemeColourPalette.swift
@@ -44,7 +44,7 @@ private class EcosiaLightColourPalette: ThemeColourPalette {
     // MARK: - Layers
     var layer1: UIColor { .legacyTheme.ecosia.tertiaryBackground }
     var layer2: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.layer2 }
-    var layer3: UIColor { .legacyTheme.ecosia.primaryBackground }
+    var layer3: UIColor { .legacyTheme.ecosia.ntpBackground }
     var layer4: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.layer4 }
     var layer5: UIColor { .legacyTheme.ecosia.secondaryBackground }
     var layer6: UIColor { .legacyTheme.ecosia.homePanelBackground }

--- a/Client/Frontend/Browser/Tabs/Legacy/LegacyInactiveTabs/LegacyInactiveTabButton.swift
+++ b/Client/Frontend/Browser/Tabs/Legacy/LegacyInactiveTabs/LegacyInactiveTabButton.swift
@@ -96,7 +96,7 @@ class LegacyInactiveTabButton: UITableViewCell, ThemeApplicable, ReusableCell {
     func applyTheme(theme: Theme) {
         backgroundColor = .clear
         selectedView.backgroundColor = theme.colors.layer5Hover
-        // Update button's color
+        // Ecosia: Update button's color
         // roundedButton.setTitleColor(theme.colors.textPrimary, for: .normal)
         roundedButton.setTitleColor(theme.colors.iconWarning, for: .normal)
         roundedButton.backgroundColor = theme.colors.layer3

--- a/Client/Frontend/Browser/Tabs/Legacy/LegacyInactiveTabs/LegacyInactiveTabButton.swift
+++ b/Client/Frontend/Browser/Tabs/Legacy/LegacyInactiveTabs/LegacyInactiveTabButton.swift
@@ -96,7 +96,9 @@ class LegacyInactiveTabButton: UITableViewCell, ThemeApplicable, ReusableCell {
     func applyTheme(theme: Theme) {
         backgroundColor = .clear
         selectedView.backgroundColor = theme.colors.layer5Hover
-        roundedButton.setTitleColor(theme.colors.textPrimary, for: .normal)
+        // Update button's color
+        // roundedButton.setTitleColor(theme.colors.textPrimary, for: .normal)
+        roundedButton.setTitleColor(theme.colors.iconWarning, for: .normal)
         roundedButton.backgroundColor = theme.colors.layer3
         roundedButton.tintColor = theme.colors.textPrimary
         let image = UIImage(named: StandardImageIdentifiers.Large.delete)?.tinted(withColor: theme.colors.iconPrimary)

--- a/Client/Frontend/Browser/Tabs/Views/EmptyPrivateTabsView.swift
+++ b/Client/Frontend/Browser/Tabs/Views/EmptyPrivateTabsView.swift
@@ -35,6 +35,14 @@ class EmptyPrivateTabsView: UIView {
     }
 
     private lazy var containerView: UIView = .build { _ in }
+    
+    // Ecosia: Add StackView to center items without corrupting the containerView as affect the ScrollView and its parent view
+    private lazy var containerStackView: UIStackView = .build { stackView in
+        stackView.spacing = UX.paddingInBetweenItems
+        stackView.axis = .vertical
+        stackView.alignment = .center
+        stackView.distribution = .fill
+    }
 
     private let titleLabel: UILabel = .build { label in
         label.adjustsFontForContentSizeCategory = true
@@ -88,7 +96,12 @@ class EmptyPrivateTabsView: UIView {
                                   for: .touchUpInside)
         containerView.addSubviews(iconImageView, titleLabel, descriptionLabel, learnMoreButton)
          */
-        containerView.addSubviews(iconImageView, titleLabel, descriptionLabel)
+        // Ecosia: Move subviews to stackview
+        // containerView.addSubviews(iconImageView, titleLabel, descriptionLabel)
+        containerStackView.addArrangedSubview(iconImageView)
+        containerStackView.addArrangedSubview(titleLabel)
+        containerStackView.addArrangedSubview(descriptionLabel)
+        containerView.addSubview(containerStackView)
         scrollView.addSubview(containerView)
         addSubview(scrollView)
 
@@ -108,7 +121,17 @@ class EmptyPrivateTabsView: UIView {
             scrollView.contentLayoutGuide.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
             scrollView.contentLayoutGuide.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
             scrollView.contentLayoutGuide.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+            
+            // Ecosia: Update costraints
+            containerStackView.centerXAnchor.constraint(equalTo: scrollView.centerXAnchor),
+            containerStackView.centerYAnchor.constraint(equalTo: scrollView.centerYAnchor,
+                                                        constant: -UX.horizontalPadding*2),
+            containerStackView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+            containerStackView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+            iconImageView.heightAnchor.constraint(equalToConstant: UX.imageSize.height),
+            iconImageView.widthAnchor.constraint(equalToConstant: UX.imageSize.width),
 
+            /* Ecosia: Remove unneded costraints
             iconImageView.topAnchor.constraint(equalTo: containerView.topAnchor,
                                                constant: UX.paddingInBetweenItems),
             iconImageView.centerXAnchor.constraint(equalTo: containerView.centerXAnchor),
@@ -124,7 +147,7 @@ class EmptyPrivateTabsView: UIView {
                                                   constant: UX.paddingInBetweenItems),
             descriptionLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
             descriptionLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
-            /* Ecosia: Remove Learn More button
+            
             learnMoreButton.topAnchor.constraint(equalTo: descriptionLabel.bottomAnchor,
                                                  constant: UX.paddingInBetweenItems),
             learnMoreButton.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),

--- a/Client/Frontend/Browser/Tabs/Views/InactiveTabs/InactiveTabsFooterView.swift
+++ b/Client/Frontend/Browser/Tabs/Views/InactiveTabs/InactiveTabsFooterView.swift
@@ -80,7 +80,7 @@ class InactiveTabsFooterView: UICollectionReusableView, ReusableCell, ThemeAppli
 
     func applyTheme(theme: Theme) {
         backgroundColor = theme.colors.layer2
-        // Update button's color
+        // Ecosia: Update button's color
         // roundedButton.setTitleColor(theme.colors.textPrimary, for: .normal)
         roundedButton.setTitleColor(theme.colors.iconWarning, for: .normal)
         roundedButton.backgroundColor = theme.colors.layer3

--- a/Client/Frontend/Browser/Tabs/Views/InactiveTabs/InactiveTabsFooterView.swift
+++ b/Client/Frontend/Browser/Tabs/Views/InactiveTabs/InactiveTabsFooterView.swift
@@ -80,7 +80,9 @@ class InactiveTabsFooterView: UICollectionReusableView, ReusableCell, ThemeAppli
 
     func applyTheme(theme: Theme) {
         backgroundColor = theme.colors.layer2
-        roundedButton.setTitleColor(theme.colors.textPrimary, for: .normal)
+        // Update button's color
+        // roundedButton.setTitleColor(theme.colors.textPrimary, for: .normal)
+        roundedButton.setTitleColor(theme.colors.iconWarning, for: .normal)
         roundedButton.backgroundColor = theme.colors.layer3
         roundedButton.tintColor = theme.colors.textPrimary
         let image = UIImage(named: StandardImageIdentifiers.Large.delete)?.tinted(withColor: theme.colors.iconPrimary)

--- a/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -74,8 +74,14 @@ class AppSettingsTableViewController: SettingsTableViewController,
         tableView.accessibilityIdentifier = AccessibilityIdentifiers.Settings.tableViewController
     }
 
+    /* Ecosia: Move settings reload to `viewWillAppear`
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        askedToReload()
+    }
+     */
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         askedToReload()
     }
 

--- a/Client/Frontend/Settings/Main/Privacy/ContentBlockerSetting.swift
+++ b/Client/Frontend/Settings/Main/Privacy/ContentBlockerSetting.swift
@@ -16,20 +16,20 @@ class ContentBlockerSetting: Setting {
     override var accessibilityIdentifier: String? {
         return AccessibilityIdentifiers.Settings.ContentBlocker.title
     }
-
-    override var status: NSAttributedString? {
-        let isOn = profile.prefs.boolForKey(ContentBlockingConfig.Prefs.EnabledKey) ?? ContentBlockingConfig.Defaults.NormalBrowsing
-
-        if isOn {
-            let currentBlockingStrength = profile
-                .prefs
-                .stringForKey(ContentBlockingConfig.Prefs.StrengthKey)
-                .flatMap(BlockingStrength.init(rawValue:)) ?? .basic
-            return NSAttributedString(string: currentBlockingStrength.settingStatus)
-        } else {
-            return NSAttributedString(string: .Settings.Homepage.Shortcuts.ToggleOff)
-        }
-    }
+// Ecosia: Remove `status` as there is a UI issue in showing the content in e.g. German
+//    override var status: NSAttributedString? {
+//        let isOn = profile.prefs.boolForKey(ContentBlockingConfig.Prefs.EnabledKey) ?? ContentBlockingConfig.Defaults.NormalBrowsing
+//
+//        if isOn {
+//            let currentBlockingStrength = profile
+//                .prefs
+//                .stringForKey(ContentBlockingConfig.Prefs.StrengthKey)
+//                .flatMap(BlockingStrength.init(rawValue:)) ?? .basic
+//            return NSAttributedString(string: currentBlockingStrength.settingStatus)
+//        } else {
+//            return NSAttributedString(string: .Settings.Homepage.Shortcuts.ToggleOff)
+//        }
+//    }
 
     override var style: UITableViewCell.CellStyle { return .value1 }
 

--- a/Client/Frontend/Settings/Main/Privacy/ContentBlockerSetting.swift
+++ b/Client/Frontend/Settings/Main/Privacy/ContentBlockerSetting.swift
@@ -16,20 +16,21 @@ class ContentBlockerSetting: Setting {
     override var accessibilityIdentifier: String? {
         return AccessibilityIdentifiers.Settings.ContentBlocker.title
     }
-// Ecosia: Remove `status` as there is a UI issue in showing the content in e.g. German
-//    override var status: NSAttributedString? {
-//        let isOn = profile.prefs.boolForKey(ContentBlockingConfig.Prefs.EnabledKey) ?? ContentBlockingConfig.Defaults.NormalBrowsing
-//
-//        if isOn {
-//            let currentBlockingStrength = profile
-//                .prefs
-//                .stringForKey(ContentBlockingConfig.Prefs.StrengthKey)
-//                .flatMap(BlockingStrength.init(rawValue:)) ?? .basic
-//            return NSAttributedString(string: currentBlockingStrength.settingStatus)
-//        } else {
-//            return NSAttributedString(string: .Settings.Homepage.Shortcuts.ToggleOff)
-//        }
-//    }
+/* Ecosia: Remove `status` as there is a UI issue in showing the content in e.g. German
+    override var status: NSAttributedString? {
+        let isOn = profile.prefs.boolForKey(ContentBlockingConfig.Prefs.EnabledKey) ?? ContentBlockingConfig.Defaults.NormalBrowsing
+
+        if isOn {
+            let currentBlockingStrength = profile
+                .prefs
+                .stringForKey(ContentBlockingConfig.Prefs.StrengthKey)
+                .flatMap(BlockingStrength.init(rawValue:)) ?? .basic
+            return NSAttributedString(string: currentBlockingStrength.settingStatus)
+        } else {
+            return NSAttributedString(string: .Settings.Homepage.Shortcuts.ToggleOff)
+        }
+    }
+    */
 
     override var style: UITableViewCell.CellStyle { return .value1 }
 

--- a/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -987,7 +987,7 @@ extension URLBarView: ThemeApplicable {
         // Ecosia: Take into account overlay mode for `locationView` background
         // locationView.backgroundColor = theme.colors.layer3
         // locationContainer.backgroundColor = theme.colors.layer3
-        locationView.backgroundColor = inOverlayMode ? UIColor.legacyTheme.ecosia.primaryBackground : UIColor.legacyTheme.ecosia.tertiaryBackground
+        locationView.backgroundColor = inOverlayMode ? .legacyTheme.ecosia.primaryBackground : .legacyTheme.ecosia.tertiaryBackground
         locationContainer.backgroundColor = locationView.backgroundColor
 
         // Ecosia: Remove private mode badge

--- a/Client/Frontend/Widgets/AutocompleteTextField.swift
+++ b/Client/Frontend/Widgets/AutocompleteTextField.swift
@@ -380,12 +380,13 @@ extension AutocompleteTextField: ThemeApplicable, PrivateModeUI {
         attributedPlaceholder = NSAttributedString(string: .TabLocationURLPlaceholder,
                                                    attributes: attributes)
 
-        backgroundColor = theme.colors.layer3
         /* Ecosia: update color
+        backgroundColor = theme.colors.layer3
         textColor = theme.colors.textPrimary
         tintColor = theme.colors.actionPrimary
          */
         textColor = theme.colors.textSecondary
+        backgroundColor = .clear
 
         // Only refresh if an autocomplete label is presented to the user
         if autocompleteTextLabel?.attributedText != nil {

--- a/Client/Frontend/Widgets/ThemedDefaultNavigationController.swift
+++ b/Client/Frontend/Widgets/ThemedDefaultNavigationController.swift
@@ -42,7 +42,9 @@ class ThemedDefaultNavigationController: DismissableNavigationViewController, Th
         navigationBar.compactAppearance = standardAppearance
         navigationBar.scrollEdgeAppearance = standardAppearance
         navigationBar.compactScrollEdgeAppearance = standardAppearance
-        navigationBar.tintColor = themeManager.currentTheme.colors.textPrimary
+        // Ecosia: Update bar tint
+        // navigationBar.tintColor = themeManager.currentTheme.colors.textPrimary
+        navigationBar.tintColor = themeManager.currentTheme.colors.actionPrimary
     }
 
     private func setupToolBarAppearance() {

--- a/EcosiaTests/PrivateModeButtonTests.swift
+++ b/EcosiaTests/PrivateModeButtonTests.swift
@@ -20,8 +20,8 @@ final class PrivateModeButtonTests: XCTestCase {
         LegacyThemeManager.instance.current = LegacyNormalTheme()
         button.applyUIMode(isPrivate: true, theme: lightTheme)
         
-        XCTAssertEqual(button.tintColor, lightTheme.colors.layer3)
-        XCTAssertEqual(button.imageView?.tintColor, lightTheme.colors.layer3)
+        XCTAssertEqual(button.tintColor, .legacyTheme.ecosia.primaryBackground)
+        XCTAssertEqual(button.imageView?.tintColor, .legacyTheme.ecosia.primaryBackground)
         XCTAssertEqual(button.backgroundLayer.backgroundColor, UIColor.Photon.Grey70.cgColor)
         XCTAssertEqual(button.accessibilityValue, .TabTrayToggleAccessibilityValueOn)
     }


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the PR title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2642]

## Context

This PR solves a few design inconsistencies already validated in 10.0.0 Build 10.

## Approach

- Iterate on the solvable one pragmatically, leaving the UX belonging to the Vanilla Firefox's reference.
- Carry over the copy update for referrals

## Other

### Before merging

The removal of the `status` in the Content Blocker main setting is just temporary and a follow-up ticket to properly update that has been created already.

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I added the `// Ecosia:` helper comments where needed
- [x] I am using the correct version from [core](https://github.com/ecosia/ios-core), including any necessary changes for this ticket and pointing to `main` instead of a feature branch


[MOB-2642]: https://ecosia.atlassian.net/browse/MOB-2642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ