### PR TITLE
[MOB-2677] Bring back `main` deployment instead of `MOB-2012_firefox_120_upgrade`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ workflows:
           filters:
             branches:
               only:
-                - /^.*MOB-2012_firefox_120_upgrade.*/
+                - /^.*main.*/
           name: Deploy release version over Testflight if MARKETING_VERION file updated
           config-path: .circleci/deploy-release.yml
           mapping: |
@@ -105,4 +105,4 @@ workflows:
           filters:
             branches:
               only: 
-                - /^.*MOB-2012_firefox_120_upgrade.*/
+                - /^.*main.*/

--- a/.github/workflows/merge_tests.yml
+++ b/.github/workflows/merge_tests.yml
@@ -2,7 +2,7 @@ name: Merge Unit Tests
 
 on:
   pull_request:
-    branches: [ MOB-2012_firefox_120_upgrade ]
+    branches: [ main ]
 
 
 jobs:


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the PR title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2677]

## Context

Throughout the firefox upgrade 122.3 work, we modified the CI’s config files to let it build and run tests against the custom upgrade branch. Now it’s time to bring it back to main one.

## Approach

Revert CI's config files to use `main` branch instead of `MOB-2012_firefox_120_upgrade`

[MOB-2677]: https://ecosia.atlassian.net/browse/MOB-2677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ