### PR TITLE
[MOB-2673] Fix theming dark/light mode automatic toggle

### DIFF
--- a/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
@@ -69,7 +69,8 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
 
         // overwrite the user interface style on the window attached to our scene
         // once we have multiple scenes we need to update all of them
-        window?.overrideUserInterfaceStyle = currentTheme.type.getInterfaceStyle()
+        // Ecosia: Remove `overrideUserInterfaceStyle` window set
+        // window?.overrideUserInterfaceStyle = currentTheme.type.getInterfaceStyle()
 
         mainQueue.ensureMainThread { [weak self] in
             self?.notificationCenter.post(name: .ThemeDidChange)

--- a/Client/Coordinators/Scene/SceneSetupHelper.swift
+++ b/Client/Coordinators/Scene/SceneSetupHelper.swift
@@ -20,7 +20,8 @@ struct SceneSetupHelper {
         // Setting the initial theme correctly as we don't have a window attached yet to let ThemeManager set it
         var themeManager: ThemeManager = AppContainer.shared.resolve()
         themeManager.window = window
-        window.overrideUserInterfaceStyle = themeManager.currentTheme.type.getInterfaceStyle()
+        // Ecosia: Remove `overrideUserInterfaceStyle` window set
+        // window.overrideUserInterfaceStyle = themeManager.currentTheme.type.getInterfaceStyle()
 
         return window
     }

--- a/Client/Ecosia/UI/PageAction/PageActionMenu.swift
+++ b/Client/Ecosia/UI/PageAction/PageActionMenu.swift
@@ -61,6 +61,7 @@ final class PageActionMenu: UIViewController, UIGestureRecognizerDelegate, Theme
         setupKnob()
         setupConstraints()
         applyTheme()
+        listenForThemeChange(view)
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -74,7 +75,7 @@ final class PageActionMenu: UIViewController, UIGestureRecognizerDelegate, Theme
             if UIDevice.current.userInterfaceIdiom == .pad {
                 height += PhotonActionSheet.UX.bigSpacing
             }
-            self?.preferredContentSize = CGSize(width: 350, height: tableView.contentSize.height)
+            self?.preferredContentSize = CGSize(width: 350, height: height)
         }
     }
 
@@ -136,6 +137,7 @@ extension PageActionMenu {
     }
     
     private func setupKnob() {
+        guard traitCollection.userInterfaceIdiom == .phone else { return }
         view.addSubview(knob)
         knob.translatesAutoresizingMaskIntoConstraints = false
         knob.layer.cornerRadius = 2
@@ -146,7 +148,12 @@ extension PageActionMenu {
             tableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
             tableView.leftAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leftAnchor),
             tableView.rightAnchor.constraint(equalTo: view.safeAreaLayoutGuide.rightAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+        ])
+        
+        guard traitCollection.userInterfaceIdiom == .phone else { return }
+        
+        NSLayoutConstraint.activate([
             knob.topAnchor.constraint(equalTo: view.topAnchor, constant: 8),
             knob.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             knob.widthAnchor.constraint(equalToConstant: 32),

--- a/Client/Ecosia/UI/Theme/EcosiaThemeColourPalette.swift
+++ b/Client/Ecosia/UI/Theme/EcosiaThemeColourPalette.swift
@@ -21,14 +21,18 @@ public struct EcosiaLightTheme: Theme {
     public var type: ThemeType = .light
     public var colors: ThemeColourPalette = EcosiaLightColourPalette()
 
-    public init() {}
+    public init() {
+        (colors as? EcosiaLightColourPalette)?.fallbackDefaultThemeManager.changeCurrentTheme(.light)
+    }
 }
 
 public struct EcosiaDarkTheme: Theme {
     public var type: ThemeType = .dark
     public var colors: ThemeColourPalette = EcosiaDarkColourPalette()
 
-    public init() {}
+    public init() {
+        (colors as? EcosiaLightColourPalette)?.fallbackDefaultThemeManager.changeCurrentTheme(.dark)
+    }
 }
 
 private class EcosiaDarkColourPalette: EcosiaLightColourPalette {
@@ -37,92 +41,90 @@ private class EcosiaDarkColourPalette: EcosiaLightColourPalette {
 
 private class EcosiaLightColourPalette: ThemeColourPalette {
     
-    private static var fallbackDefaultThemeManager: ThemeManager = {
-        DefaultThemeManager(sharedContainerIdentifier: AppInfo.sharedContainerIdentifier)
-    }()
+    let fallbackDefaultThemeManager: ThemeManager = DefaultThemeManager(sharedContainerIdentifier: AppInfo.sharedContainerIdentifier)
         
     // MARK: - Layers
     var layer1: UIColor { .legacyTheme.ecosia.tertiaryBackground }
-    var layer2: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.layer2 }
+    var layer2: UIColor { fallbackDefaultThemeManager.currentTheme.colors.layer2 }
     var layer3: UIColor { .legacyTheme.ecosia.ntpBackground }
-    var layer4: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.layer4 }
+    var layer4: UIColor { fallbackDefaultThemeManager.currentTheme.colors.layer4 }
     var layer5: UIColor { .legacyTheme.ecosia.secondaryBackground }
     var layer6: UIColor { .legacyTheme.ecosia.homePanelBackground }
     var layer5Hover: UIColor { .legacyTheme.ecosia.secondarySelectedBackground }
-    var layerScrim: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.layerScrim }
-    var layerGradient: Common.Gradient { Self.fallbackDefaultThemeManager.currentTheme.colors.layerGradient }
-    var layerGradientOverlay: Common.Gradient { Self.fallbackDefaultThemeManager.currentTheme.colors.layerGradientOverlay }
+    var layerScrim: UIColor { fallbackDefaultThemeManager.currentTheme.colors.layerScrim }
+    var layerGradient: Common.Gradient { fallbackDefaultThemeManager.currentTheme.colors.layerGradient }
+    var layerGradientOverlay: Common.Gradient { fallbackDefaultThemeManager.currentTheme.colors.layerGradientOverlay }
     var layerAccentNonOpaque: UIColor { .legacyTheme.ecosia.primaryButton }
-    var layerAccentPrivate: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.layerAccentPrivate }
+    var layerAccentPrivate: UIColor { fallbackDefaultThemeManager.currentTheme.colors.layerAccentPrivate }
     var layerAccentPrivateNonOpaque: UIColor { .legacyTheme.ecosia.primaryText }
-    var layerLightGrey30: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.layerLightGrey30 }
-    var layerSepia: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.layerSepia }
-    var layerInfo: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.layerInfo }
-    var layerConfirmation: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.layerConfirmation }
+    var layerLightGrey30: UIColor { fallbackDefaultThemeManager.currentTheme.colors.layerLightGrey30 }
+    var layerSepia: UIColor { fallbackDefaultThemeManager.currentTheme.colors.layerSepia }
+    var layerInfo: UIColor { fallbackDefaultThemeManager.currentTheme.colors.layerInfo }
+    var layerConfirmation: UIColor { fallbackDefaultThemeManager.currentTheme.colors.layerConfirmation }
     var layerWarning: UIColor { .legacyTheme.ecosia.warning }
-    var layerError: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.layerError }
-    var layerRatingA: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.layerRatingA }
-    var layerRatingASubdued: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.layerRatingASubdued }
-    var layerRatingB: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.layerRatingB }
-    var layerRatingBSubdued: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.layerRatingBSubdued }
-    var layerRatingC: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.layerRatingC }
-    var layerRatingCSubdued: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.layerRatingCSubdued }
-    var layerRatingD: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.layerRatingD }
-    var layerRatingDSubdued: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.layerRatingDSubdued }
-    var layerRatingF: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.layerRatingF }
-    var layerRatingFSubdued: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.layerRatingFSubdued }
-    var layerHomepage: Common.Gradient { Self.fallbackDefaultThemeManager.currentTheme.colors.layerHomepage }
-    var layerSearch: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.layerSearch }
-    var layerGradientURL: Common.Gradient { Self.fallbackDefaultThemeManager.currentTheme.colors.layerGradientURL }
-    var actionTabActive: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.actionTabActive }
-    var actionTabInactive: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.actionTabInactive }
-    var borderToolbarDivider: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.borderToolbarDivider }
+    var layerError: UIColor { fallbackDefaultThemeManager.currentTheme.colors.layerError }
+    var layerRatingA: UIColor { fallbackDefaultThemeManager.currentTheme.colors.layerRatingA }
+    var layerRatingASubdued: UIColor { fallbackDefaultThemeManager.currentTheme.colors.layerRatingASubdued }
+    var layerRatingB: UIColor { fallbackDefaultThemeManager.currentTheme.colors.layerRatingB }
+    var layerRatingBSubdued: UIColor { fallbackDefaultThemeManager.currentTheme.colors.layerRatingBSubdued }
+    var layerRatingC: UIColor { fallbackDefaultThemeManager.currentTheme.colors.layerRatingC }
+    var layerRatingCSubdued: UIColor { fallbackDefaultThemeManager.currentTheme.colors.layerRatingCSubdued }
+    var layerRatingD: UIColor { fallbackDefaultThemeManager.currentTheme.colors.layerRatingD }
+    var layerRatingDSubdued: UIColor { fallbackDefaultThemeManager.currentTheme.colors.layerRatingDSubdued }
+    var layerRatingF: UIColor { fallbackDefaultThemeManager.currentTheme.colors.layerRatingF }
+    var layerRatingFSubdued: UIColor { fallbackDefaultThemeManager.currentTheme.colors.layerRatingFSubdued }
+    var layerHomepage: Common.Gradient { fallbackDefaultThemeManager.currentTheme.colors.layerHomepage }
+    var layerSearch: UIColor { fallbackDefaultThemeManager.currentTheme.colors.layerSearch }
+    var layerGradientURL: Common.Gradient { fallbackDefaultThemeManager.currentTheme.colors.layerGradientURL }
+    var actionTabActive: UIColor { fallbackDefaultThemeManager.currentTheme.colors.actionTabActive }
+    var actionTabInactive: UIColor { fallbackDefaultThemeManager.currentTheme.colors.actionTabInactive }
+    var borderToolbarDivider: UIColor { fallbackDefaultThemeManager.currentTheme.colors.borderToolbarDivider }
 
     // MARK: - Actions
     var actionPrimary: UIColor { .legacyTheme.ecosia.primaryButton }
     var actionPrimaryHover: UIColor { .legacyTheme.ecosia.primaryButtonActive }
     var actionSecondary: UIColor { .legacyTheme.ecosia.secondaryButton }
-    var actionSecondaryHover: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.actionSecondaryHover }
-    var formSurfaceOff: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.formSurfaceOff }
-    var formKnob: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.formKnob }
-    var indicatorActive: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.indicatorActive }
-    var indicatorInactive: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.indicatorInactive }
-    var actionConfirmation: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.actionConfirmation }
+    var actionSecondaryHover: UIColor { fallbackDefaultThemeManager.currentTheme.colors.actionSecondaryHover }
+    var formSurfaceOff: UIColor { fallbackDefaultThemeManager.currentTheme.colors.formSurfaceOff }
+    var formKnob: UIColor { fallbackDefaultThemeManager.currentTheme.colors.formKnob }
+    var indicatorActive: UIColor { fallbackDefaultThemeManager.currentTheme.colors.indicatorActive }
+    var indicatorInactive: UIColor { fallbackDefaultThemeManager.currentTheme.colors.indicatorInactive }
+    var actionConfirmation: UIColor { fallbackDefaultThemeManager.currentTheme.colors.actionConfirmation }
     var actionWarning: UIColor { .legacyTheme.ecosia.warning }
-    var actionError: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.actionError }
+    var actionError: UIColor { fallbackDefaultThemeManager.currentTheme.colors.actionError }
 
     // MARK: - Text
     var textPrimary: UIColor { .legacyTheme.ecosia.primaryText }
     var textSecondary: UIColor { .legacyTheme.ecosia.secondaryText }
-    var textDisabled: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.textDisabled }
-    var textWarning: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.textWarning }
+    var textDisabled: UIColor { fallbackDefaultThemeManager.currentTheme.colors.textDisabled }
+    var textWarning: UIColor { fallbackDefaultThemeManager.currentTheme.colors.textWarning }
     var textAccent: UIColor { .legacyTheme.ecosia.primaryButton }
-    var textOnDark: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.textOnDark }
-    var textOnLight: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.textOnLight }
+    var textOnDark: UIColor { fallbackDefaultThemeManager.currentTheme.colors.textOnDark }
+    var textOnLight: UIColor { fallbackDefaultThemeManager.currentTheme.colors.textOnLight }
     var textInverted: UIColor { .legacyTheme.ecosia.primaryTextInverted }
 
     // MARK: - Icons
     var iconPrimary: UIColor { .legacyTheme.ecosia.primaryIcon }
     var iconSecondary: UIColor { .legacyTheme.ecosia.secondaryIcon }
-    var iconDisabled: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.iconDisabled }
-    var iconAction: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.iconAction }
-    var iconOnColor: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.iconOnColor }
+    var iconDisabled: UIColor { fallbackDefaultThemeManager.currentTheme.colors.iconDisabled }
+    var iconAction: UIColor { fallbackDefaultThemeManager.currentTheme.colors.iconAction }
+    var iconOnColor: UIColor { fallbackDefaultThemeManager.currentTheme.colors.iconOnColor }
     var iconWarning: UIColor { .legacyTheme.ecosia.warning }
-    var iconSpinner: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.iconSpinner }
-    var iconAccentViolet: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.iconAccentViolet }
-    var iconAccentBlue: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.iconAccentBlue }
-    var iconAccentPink: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.iconAccentPink }
-    var iconAccentGreen: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.iconAccentGreen }
-    var iconAccentYellow: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.iconAccentYellow }
+    var iconSpinner: UIColor { fallbackDefaultThemeManager.currentTheme.colors.iconSpinner }
+    var iconAccentViolet: UIColor { fallbackDefaultThemeManager.currentTheme.colors.iconAccentViolet }
+    var iconAccentBlue: UIColor { fallbackDefaultThemeManager.currentTheme.colors.iconAccentBlue }
+    var iconAccentPink: UIColor { fallbackDefaultThemeManager.currentTheme.colors.iconAccentPink }
+    var iconAccentGreen: UIColor { fallbackDefaultThemeManager.currentTheme.colors.iconAccentGreen }
+    var iconAccentYellow: UIColor { fallbackDefaultThemeManager.currentTheme.colors.iconAccentYellow }
 
     // MARK: - Border
     var borderPrimary: UIColor { .legacyTheme.ecosia.barSeparator }
     var borderAccent: UIColor { actionPrimary }
     var borderAccentNonOpaque: UIColor { actionPrimary }
     var borderAccentPrivate: UIColor { actionPrimary }
-    var borderInverted: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.borderInverted }
+    var borderInverted: UIColor { fallbackDefaultThemeManager.currentTheme.colors.borderInverted }
 
     // MARK: - Shadow
-    var shadowDefault: UIColor { Self.fallbackDefaultThemeManager.currentTheme.colors.shadowDefault }
+    var shadowDefault: UIColor { fallbackDefaultThemeManager.currentTheme.colors.shadowDefault }
 }
 

--- a/Client/Ecosia/UI/Theme/EcosiaThemeManager.swift
+++ b/Client/Ecosia/UI/Theme/EcosiaThemeManager.swift
@@ -58,11 +58,7 @@ public final class EcosiaThemeManager: ThemeManager, Notifiable {
          
          This check will extract the last saved theme before killing the app, therefore a different one in case we switched at app killed state where no observers were alive.
          */
-        if LegacyThemeManager.instance.systemThemeIsOn {
-            let userInterfaceStyle = UIScreen.main.traitCollection.userInterfaceStyle
-            LegacyThemeManager.instance.current = userInterfaceStyle == .dark ? LegacyDarkTheme() : LegacyNormalTheme()
-        }
-
+        updateLegacyThemeIfNeeded()
         changeCurrentTheme(loadInitialStoredThemeType())
 
         setupNotifications(forObserver: self,
@@ -79,10 +75,11 @@ public final class EcosiaThemeManager: ThemeManager, Notifiable {
     public func changeCurrentTheme(_ newTheme: ThemeType) {
         guard currentTheme.type != newTheme else { return }
         currentTheme = newThemeForType(newTheme)
+        updateLegacyThemeIfNeeded()
 
         // overwrite the user interface style on the window attached to our scene
         // once we have multiple scenes we need to update all of them
-        window?.overrideUserInterfaceStyle = currentTheme.type.getInterfaceStyle()
+        // window?.overrideUserInterfaceStyle = currentTheme.type.getInterfaceStyle()
 
         mainQueue.ensureMainThread { [weak self] in
             self?.notificationCenter.post(name: .ThemeDidChange)
@@ -201,6 +198,16 @@ public final class EcosiaThemeManager: ThemeManager, Notifiable {
             }
         default:
             return
+        }
+    }
+}
+
+extension EcosiaThemeManager {
+    
+    func updateLegacyThemeIfNeeded() {
+        if LegacyThemeManager.instance.systemThemeIsOn {
+            let userInterfaceStyle = UIScreen.main.traitCollection.userInterfaceStyle
+            LegacyThemeManager.instance.current = userInterfaceStyle == .dark ? LegacyDarkTheme() : LegacyNormalTheme()
         }
     }
 }

--- a/Client/Ecosia/UI/Theme/EcosiaThemeManager.swift
+++ b/Client/Ecosia/UI/Theme/EcosiaThemeManager.swift
@@ -76,11 +76,6 @@ public final class EcosiaThemeManager: ThemeManager, Notifiable {
         guard currentTheme.type != newTheme else { return }
         currentTheme = newThemeForType(newTheme)
         updateLegacyThemeIfNeeded()
-
-        // overwrite the user interface style on the window attached to our scene
-        // once we have multiple scenes we need to update all of them
-        // window?.overrideUserInterfaceStyle = currentTheme.type.getInterfaceStyle()
-
         mainQueue.ensureMainThread { [weak self] in
             self?.notificationCenter.post(name: .ThemeDidChange)
         }

--- a/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -171,12 +171,12 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
         updateZoomPageBarVisibility(visible: false)
         menuHelper.getToolbarActions(navigationController: navigationController) { actions in
             /* Ecosia: custom UI/UX for main menu
-            let shouldInverse = PhotonActionSheetViewModel.hasInvertedMainMenu(trait: self.traitCollection, isBottomSearchBar: self.isBottomSearchBar)
             let viewModel = PhotonActionSheetViewModel(actions: actions, modalStyle: .popover, isMainMenu: true, isMainMenuInverted: shouldInverse)
             self.presentSheetWith(viewModel: viewModel, on: self, from: button)
              */
+            let shouldInverse = PhotonActionSheetViewModel.hasInvertedMainMenu(trait: self.traitCollection, isBottomSearchBar: self.isBottomSearchBar)
             let isPhone = self.traitCollection.userInterfaceIdiom == .phone
-            let viewModel = PhotonActionSheetViewModel(actions: actions, modalStyle: isPhone ? .pageSheet : .popover, isMainMenu: true, isMainMenuInverted: false)
+            let viewModel = PhotonActionSheetViewModel(actions: actions, modalStyle: isPhone ? .pageSheet : .popover, isMainMenu: true, isMainMenuInverted: shouldInverse)
             self.presentSheetWith(viewModel: viewModel, on: self, from: button)
         }
         // Ecosia: Make `menuHelper` available at class level

--- a/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+TabToolbarDelegate.swift
@@ -170,11 +170,11 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
 
         updateZoomPageBarVisibility(visible: false)
         menuHelper.getToolbarActions(navigationController: navigationController) { actions in
+            let shouldInverse = PhotonActionSheetViewModel.hasInvertedMainMenu(trait: self.traitCollection, isBottomSearchBar: self.isBottomSearchBar)
             /* Ecosia: custom UI/UX for main menu
             let viewModel = PhotonActionSheetViewModel(actions: actions, modalStyle: .popover, isMainMenu: true, isMainMenuInverted: shouldInverse)
             self.presentSheetWith(viewModel: viewModel, on: self, from: button)
              */
-            let shouldInverse = PhotonActionSheetViewModel.hasInvertedMainMenu(trait: self.traitCollection, isBottomSearchBar: self.isBottomSearchBar)
             let isPhone = self.traitCollection.userInterfaceIdiom == .phone
             let viewModel = PhotonActionSheetViewModel(actions: actions, modalStyle: isPhone ? .pageSheet : .popover, isMainMenu: true, isMainMenuInverted: shouldInverse)
             self.presentSheetWith(viewModel: viewModel, on: self, from: button)

--- a/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -796,7 +796,9 @@ class BrowserViewController: UIViewController,
 
         // During split screen launching on iPad, this callback gets fired before viewDidLoad gets a chance to
         // set things up. Make sure to only update the toolbar state if the view is ready for it.
-        if isViewLoaded {
+        // Ecosia: Update check
+        // if isViewLoaded {
+        if isViewLoaded && UIDevice.current.userInterfaceIdiom == .pad {
             updateToolbarStateForTraitCollection(newCollection)
         }
 

--- a/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/Client/Frontend/Browser/TopTabsViewController.swift
@@ -170,7 +170,9 @@ class TopTabsViewController: UIViewController, Themeable, Notifiable {
 
     func applyTheme() {
         let currentTheme = themeManager.currentTheme
-        view.backgroundColor = currentTheme.colors.layer3
+        // Ecosia: update background
+        // view.backgroundColor = currentTheme.colors.layer3
+        view.backgroundColor = currentTheme.type == .dark ? .Dark.Background.primary : .Light.Background.primary
         tabsButton.applyTheme(theme: currentTheme)
         privateModeButton.applyTheme(theme: currentTheme)
         newTab.tintColor = currentTheme.colors.iconPrimary

--- a/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
+++ b/Client/Frontend/Widgets/PhotonActionSheet/PhotonActionSheetProtocol.swift
@@ -44,7 +44,9 @@ extension PhotonActionSheetProtocol {
                     let margins = viewModel.getMainMenuPopOverMargins(trait: trait, view: view, presentedOn: viewController)
                     popoverVC.popoverLayoutMargins = margins
                 }
-                popoverVC.permittedArrowDirections = [.up]
+                // Ecosia: Update permitted arrow dimensions
+                // popoverVC.permittedArrowDirections = [.up]
+                popoverVC.permittedArrowDirections = viewModel.getPossibleArrowDirections(trait: trait)
             }
 
             viewController.present(sheet, animated: true, completion: nil)


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the PR title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2673]

## Context

There is an issue in the Vanilla 122.x (still present in Firefox production code as well) that prevents the theming from toggling dark/light mode automatically when the App is in the foreground state. 

## Approach

- Understand the codebase and the implication upon toggling dark/light mode
- Acknowledge the places where the theming update takes place
- Found that the codebase uses `overrideUserInterfaceStyle` at UIWindow level in both `SceneDelegate` and `ThemeManager`s, therefore making `traitCollectionDidChange` observer not being called when the app is in the foreground state
- Updated the theming business logic according to our current transitioning infrastructure `LegacyThemeManager` + `ThemeManager`, `ThemeApplicable` and `Themable`
- Update the Ecosia classes implementing `ThemeColourPalette` removing the utilization of `static` vars (initialized at launch time and not strictly needed to be `static`)
- Tested on iPad and reviewed some of the iPad-specific setup including minor fixes:
   - No need to show the `knob` on the settings menu on iPad
   - correctly pass the `height` to the menu's preferred size
   - Update the permitted arrows on the menu depending on the presentation (split view, portrait, landscape)
   - count on the URL bar position when showing the menu

## Other

- References from Firefox Repo: https://github.com/mozilla-mobile/firefox-ios/issues/20629
- I'm not sure the same fix could work on Firefox's latest codebase (`main` branch) as they completed the Theming + SceneDelegate transitions removing all legacy architecture.  

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I added the `// Ecosia:` helper comments where needed

[MOB-2673]: https://ecosia.atlassian.net/browse/MOB-2673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ