### PR TITLE
[MOB-2698] Remove Logic showing the Push Notification Consent screen

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -193,11 +193,6 @@ class BrowserViewController: UIViewController,
         DefaultBrowserExperiment.minPromoSearches() <= User.shared.searchCount
     }
     fileprivate var shouldShowWhatsNewPageScreen: Bool { whatsNewDataProvider.shouldShowWhatsNewPage }
-    fileprivate var shouldShowAPNConsentScreen: Bool {
-        EngagementServiceExperiment.isEnabled &&
-        ClientEngagementService.shared.notificationAuthorizationStatus == .notDetermined &&
-        apnConsentOptInReminderManager.shouldDisplayOptInScreen == true
-    }
 
     let whatsNewDataProvider = WhatsNewLocalDataProvider()
     let referrals = Referrals()
@@ -205,12 +200,6 @@ class BrowserViewController: UIViewController,
     // Ecosia: Make `menuHelper` available at class level
     var menuHelper: MainMenuActionHelper?
     
-    // Ecosia: Initialize the OptInReminderManager that handles the APNConsent showing
-    private let apnConsentOptInReminderManager = OptInReminderManager(currentSearchesCount: User.shared.searchCount,
-                                                                      maxOptInScreenCount: EngagementServiceExperiment.maxOptInShowingAttempts,
-                                                                      minSearchesForFirstOptIn: EngagementServiceExperiment.minSearches,
-                                                                      searchesBetweenOptIns: EngagementServiceExperiment.searchesBetweenOptIns,
-                                                                      model: User.shared.apnConsentReminderModel)
     // Ecosia: Add init to separate from Ecosia Properties
     // MARK: - Init
     
@@ -2576,8 +2565,7 @@ extension BrowserViewController {
          */
         let presentationFunctions: [() -> Bool] = [
             presentDefaultBrowserPromoIfNeeded,
-            presentWhatsNewPageIfNeeded,
-            presentAPNConsentIfNeeded
+            presentWhatsNewPageIfNeeded
         ]
 
         _ = presentationFunctions.first(where: { $0() })
@@ -2595,14 +2583,6 @@ extension BrowserViewController {
         return true
     }
     
-    @discardableResult
-    private func presentAPNConsentIfNeeded() -> Bool {
-        guard shouldShowAPNConsentScreen else { return false }
-        let vc = APNConsentViewController(viewModel: UnleashAPNConsentViewModel(optInManager: apnConsentOptInReminderManager), optInManager: apnConsentOptInReminderManager)
-        vc.presentAsSheetFrom(self)
-        return true
-    }
-
     @discardableResult
     private func presentDefaultBrowserPromoIfNeeded() -> Bool {
         guard shouldShowDefaultBrowserPromo else { return false }


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the PR title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2698]

## Context

As part of the Personal Counter Removal, we want to remove all logic that strictly depends on the personal counter. The reminder logic for the Push Notification Consent was made upon the search count.

## Approach

- Remove the logic inherent to showing the Push Notification Consent Screen only.

As mentioned in https://github.com/ecosia/ios-browser/pull/713 , we may want to revisit the Consent Screen so to implement a rule-based showing instead of tightly coupling it with the User's search count.
So would rather keep all the view controllers, copies etc (as already translated anyway) and do revisit the work on the `Core` side at some point. Created a follow-up [ticket](https://ecosia.atlassian.net/browse/MOB-2699) for it.

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I added the `// Ecosia:` helper comments where needed

[MOB-2698]: https://ecosia.atlassian.net/browse/MOB-2698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ