### PR TITLE
[MOB-2679] Onboarding Skip Button experiment

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -349,7 +349,7 @@
 		2CE294472B7CDD56006C22B2 /* Core in Frameworks */ = {isa = PBXBuildFile; productRef = 2CE294462B7CDD56006C22B2 /* Core */; };
 		2CE294492B7CDD78006C22B2 /* Core in Frameworks */ = {isa = PBXBuildFile; productRef = 2CE294482B7CDD78006C22B2 /* Core */; };
 		2CE2E24D2B9B1FCB00973C16 /* Core in Frameworks */ = {isa = PBXBuildFile; productRef = 2CE2E24C2B9B1FCB00973C16 /* Core */; };
-		2CE5E1202C3C529900FB5FB0 /* HideSkipOnboardingExperiment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE5E11F2C3C529900FB5FB0 /* HideSkipOnboardingExperiment.swift */; };
+		2CE5E1202C3C529900FB5FB0 /* SkipOnboardingExperiment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE5E11F2C3C529900FB5FB0 /* SkipOnboardingExperiment.swift */; };
 		2CF4DA612BB31909001C340A /* EngineShortcutsExperiment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C6188F72B7A8A22006B70D7 /* EngineShortcutsExperiment.swift */; };
 		2CF4DA632BB31970001C340A /* Core in Frameworks */ = {isa = PBXBuildFile; productRef = 2CF4DA622BB31970001C340A /* Core */; };
 		2F13E79B1AC0C02700D75081 /* StringExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F13E79A1AC0C02700D75081 /* StringExtensionsTests.swift */; };
@@ -2494,7 +2494,7 @@
 		2CE2946C2B7FC5A5006C22B2 /* EcosiaNTPTooltipHighlightTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EcosiaNTPTooltipHighlightTests.swift; sourceTree = "<group>"; };
 		2CE2946D2B7FC5A5006C22B2 /* EcosiaPageActionMenuCellTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EcosiaPageActionMenuCellTests.swift; sourceTree = "<group>"; };
 		2CE294702B7FC5A6006C22B2 /* VersionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VersionTests.swift; sourceTree = "<group>"; };
-		2CE5E11F2C3C529900FB5FB0 /* HideSkipOnboardingExperiment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HideSkipOnboardingExperiment.swift; sourceTree = "<group>"; };
+		2CE5E11F2C3C529900FB5FB0 /* SkipOnboardingExperiment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkipOnboardingExperiment.swift; sourceTree = "<group>"; };
 		2CEA6F781E93E3A600D4100E /* SearchSettingsUITest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchSettingsUITest.swift; sourceTree = "<group>"; };
 		2CEB48402BE0EE2600498471 /* Production.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Production.xcconfig; sourceTree = "<group>"; };
 		2CEDADA120207EC400223A89 /* SyncFAUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncFAUITests.swift; sourceTree = "<group>"; };
@@ -8609,7 +8609,7 @@
 				2C6188F72B7A8A22006B70D7 /* EngineShortcutsExperiment.swift */,
 				2C6188F82B7A8A22006B70D7 /* EngagementServiceExperiment.swift */,
 				2C6188F92B7A8A22006B70D7 /* DefaultBrowserExperiment.swift */,
-				2CE5E11F2C3C529900FB5FB0 /* HideSkipOnboardingExperiment.swift */,
+				2CE5E11F2C3C529900FB5FB0 /* SkipOnboardingExperiment.swift */,
 			);
 			path = Unleash;
 			sourceTree = "<group>";
@@ -14183,7 +14183,7 @@
 				F85C7EDD27109241004BDBA4 /* PasswordManagerOnboardingViewController.swift in Sources */,
 				D8FDEB57220CFE970069A582 /* UIImage+ImageEffects.m in Sources */,
 				EBB89506219398E500EB91A0 /* TabContentBlocker.swift in Sources */,
-				2CE5E1202C3C529900FB5FB0 /* HideSkipOnboardingExperiment.swift in Sources */,
+				2CE5E1202C3C529900FB5FB0 /* SkipOnboardingExperiment.swift in Sources */,
 				21F2A2D22B0BC85200626AEC /* InactiveTabsModel.swift in Sources */,
 				D3E8EF101B97BE69001900FB /* ClearPrivateDataTableViewController.swift in Sources */,
 				C8F457AA1F1FDD9B000CB895 /* BrowserViewController+KeyCommands.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -349,6 +349,7 @@
 		2CE294472B7CDD56006C22B2 /* Core in Frameworks */ = {isa = PBXBuildFile; productRef = 2CE294462B7CDD56006C22B2 /* Core */; };
 		2CE294492B7CDD78006C22B2 /* Core in Frameworks */ = {isa = PBXBuildFile; productRef = 2CE294482B7CDD78006C22B2 /* Core */; };
 		2CE2E24D2B9B1FCB00973C16 /* Core in Frameworks */ = {isa = PBXBuildFile; productRef = 2CE2E24C2B9B1FCB00973C16 /* Core */; };
+		2CE5E1202C3C529900FB5FB0 /* HideSkipOnboardingExperiment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE5E11F2C3C529900FB5FB0 /* HideSkipOnboardingExperiment.swift */; };
 		2CF4DA612BB31909001C340A /* EngineShortcutsExperiment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C6188F72B7A8A22006B70D7 /* EngineShortcutsExperiment.swift */; };
 		2CF4DA632BB31970001C340A /* Core in Frameworks */ = {isa = PBXBuildFile; productRef = 2CF4DA622BB31970001C340A /* Core */; };
 		2F13E79B1AC0C02700D75081 /* StringExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F13E79A1AC0C02700D75081 /* StringExtensionsTests.swift */; };
@@ -2493,6 +2494,7 @@
 		2CE2946C2B7FC5A5006C22B2 /* EcosiaNTPTooltipHighlightTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EcosiaNTPTooltipHighlightTests.swift; sourceTree = "<group>"; };
 		2CE2946D2B7FC5A5006C22B2 /* EcosiaPageActionMenuCellTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EcosiaPageActionMenuCellTests.swift; sourceTree = "<group>"; };
 		2CE294702B7FC5A6006C22B2 /* VersionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VersionTests.swift; sourceTree = "<group>"; };
+		2CE5E11F2C3C529900FB5FB0 /* HideSkipOnboardingExperiment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HideSkipOnboardingExperiment.swift; sourceTree = "<group>"; };
 		2CEA6F781E93E3A600D4100E /* SearchSettingsUITest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchSettingsUITest.swift; sourceTree = "<group>"; };
 		2CEB48402BE0EE2600498471 /* Production.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Production.xcconfig; sourceTree = "<group>"; };
 		2CEDADA120207EC400223A89 /* SyncFAUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncFAUITests.swift; sourceTree = "<group>"; };
@@ -8607,6 +8609,7 @@
 				2C6188F72B7A8A22006B70D7 /* EngineShortcutsExperiment.swift */,
 				2C6188F82B7A8A22006B70D7 /* EngagementServiceExperiment.swift */,
 				2C6188F92B7A8A22006B70D7 /* DefaultBrowserExperiment.swift */,
+				2CE5E11F2C3C529900FB5FB0 /* HideSkipOnboardingExperiment.swift */,
 			);
 			path = Unleash;
 			sourceTree = "<group>";
@@ -14180,6 +14183,7 @@
 				F85C7EDD27109241004BDBA4 /* PasswordManagerOnboardingViewController.swift in Sources */,
 				D8FDEB57220CFE970069A582 /* UIImage+ImageEffects.m in Sources */,
 				EBB89506219398E500EB91A0 /* TabContentBlocker.swift in Sources */,
+				2CE5E1202C3C529900FB5FB0 /* HideSkipOnboardingExperiment.swift in Sources */,
 				21F2A2D22B0BC85200626AEC /* InactiveTabsModel.swift in Sources */,
 				D3E8EF101B97BE69001900FB /* ClearPrivateDataTableViewController.swift in Sources */,
 				C8F457AA1F1FDD9B000CB895 /* BrowserViewController+KeyCommands.swift in Sources */,

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -69,7 +69,7 @@
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
         "branch" : "MOB-2498_upgrade_braze",
-        "revision" : "8e9b6bc3d47ddf5c5e7ce33c073691978e5a6cda"
+        "revision" : "c257abdc2c113a95b577b8edcd88de9a150c252e"
       }
     },
     {

--- a/Client/Ecosia/Analytics/Analytics.swift
+++ b/Client/Ecosia/Analytics/Analytics.swift
@@ -54,14 +54,10 @@ final class Analytics {
         tracker = Self.tracker
     }
     
-    func activity(_ action: Action.Activity) {
-        let event = Structured(category: Category.activity.rawValue,
-                               action: action.rawValue)
-            .label(Analytics.Label.Navigation.inapp.rawValue)
-        
+    private func appendTestContextIfNeeded(_ action: Analytics.Action.Activity, _ event: Structured) {
         switch action {
         case .resume, .launch:
-            // add A/B Test context
+            // Add A/B Test context
             let abTestToggles: [Unleash.Toggle.Name] = [.searchShortcuts, .bingDistribution]
             abTestToggles.forEach {
                 if let context = Self.getTestContext(from: $0) {
@@ -74,6 +70,19 @@ final class Analytics {
                                                          andDictionary: ["cookie_consent": consentValue]))
             }
         }
+        
+        // Add Skip onbaording A/B Test context
+        if let context = Self.getTestContext(from: .hideOnboardingSkip) {
+            event.contexts.append(context)
+        }
+    }
+    
+    func activity(_ action: Action.Activity) {
+        let event = Structured(category: Category.activity.rawValue,
+                               action: action.rawValue)
+            .label(Analytics.Label.Navigation.inapp.rawValue)
+        
+        appendTestContextIfNeeded(action, event)
 
         track(event)
     }

--- a/Client/Ecosia/Analytics/Analytics.swift
+++ b/Client/Ecosia/Analytics/Analytics.swift
@@ -53,30 +53,7 @@ final class Analytics {
         User.shared.analyticsId = .init()
         tracker = Self.tracker
     }
-    
-    private func appendTestContextIfNeeded(_ action: Analytics.Action.Activity, _ event: Structured) {
-        switch action {
-        case .resume, .launch:
-            // Add A/B Test context
-            let abTestToggles: [Unleash.Toggle.Name] = [.searchShortcuts, .bingDistribution]
-            abTestToggles.forEach {
-                if let context = Self.getTestContext(from: $0) {
-                    event.contexts.append(context)
-                }
-            }
-            // Cookie consent context
-            if let consentValue = User.shared.cookieConsentValue {
-                event.contexts.append(SelfDescribingJson(schema: Self.consentSchema,
-                                                         andDictionary: ["cookie_consent": consentValue]))
-            }
-        }
         
-        // Add Skip onbaording A/B Test context
-        if let context = Self.getTestContext(from: .hideOnboardingSkip) {
-            event.contexts.append(context)
-        }
-    }
-    
     func activity(_ action: Action.Activity) {
         let event = Structured(category: Category.activity.rawValue,
                                action: action.rawValue)
@@ -374,5 +351,31 @@ final class Analytics {
                                      action: Action.change.rawValue)
             .label("analytics")
             .property(enabled ? "enable" : "disable"))
+    }
+}
+
+extension Analytics {
+    private func appendTestContextIfNeeded(_ action: Analytics.Action.Activity, _ event: Structured) {
+        switch action {
+        case .resume, .launch:
+            addABTestContexts(to: event, toggles: [.searchShortcuts, .bingDistribution, .hideOnboardingSkip])
+            addCookieConsentContext(to: event)
+        }
+    }
+
+    private func addABTestContexts(to event: Structured, toggles: [Unleash.Toggle.Name]) {
+        toggles.forEach { toggle in
+            if let context = Self.getTestContext(from: toggle) {
+                event.contexts.append(context)
+            }
+        }
+    }
+
+    private func addCookieConsentContext(to event: Structured) {
+        if let consentValue = User.shared.cookieConsentValue {
+            let consentContext = SelfDescribingJson(schema: Self.consentSchema,
+                                                    andDictionary: ["cookie_consent": consentValue])
+            event.contexts.append(consentContext)
+        }
     }
 }

--- a/Client/Ecosia/Experiments/Unleash/HideSkipOnboardingExperiment.swift
+++ b/Client/Ecosia/Experiments/Unleash/HideSkipOnboardingExperiment.swift
@@ -1,0 +1,16 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Core
+
+struct HideSkipOnboardingExperiment {
+    
+    private init() {}
+    
+    static var isEnabled: Bool {
+        Unleash.isEnabled(.hideOnboardingSkip) &&
+        Unleash.getVariant(.hideOnboardingSkip).name == "test"
+    }
+}

--- a/Client/Ecosia/Experiments/Unleash/SkipOnboardingExperiment.swift
+++ b/Client/Ecosia/Experiments/Unleash/SkipOnboardingExperiment.swift
@@ -5,12 +5,15 @@
 import Foundation
 import Core
 
-struct HideSkipOnboardingExperiment {
+struct SkipOnboardingExperiment {
     
     private init() {}
     
-    static var isEnabled: Bool {
-        Unleash.isEnabled(.hideOnboardingSkip) &&
-        Unleash.getVariant(.hideOnboardingSkip).name == "test"
+    private static var isEnabled: Bool {
+        Unleash.isEnabled(.hideOnboardingSkip)
+    }
+    
+    static var shouldHideSkipButton: Bool {
+        Self.isEnabled && Unleash.getVariant(.hideOnboardingSkip).name == "test"
     }
 }

--- a/Client/Ecosia/UI/Onboarding/Welcome.swift
+++ b/Client/Ecosia/UI/Onboarding/Welcome.swift
@@ -162,7 +162,7 @@ final class Welcome: UIViewController {
         stack.addArrangedSubview(UIView())
         stack.addArrangedSubview(cta)
 
-        if !Unleash.isEnabled(.hideOnboardingSkip) {
+        if !HideSkipOnboardingExperiment.isEnabled {
             let skipButton = UIButton(type: .system)
             skipButton.backgroundColor = .clear
             skipButton.titleLabel?.font = .preferredFont(forTextStyle: .callout)

--- a/Client/Ecosia/UI/Onboarding/Welcome.swift
+++ b/Client/Ecosia/UI/Onboarding/Welcome.swift
@@ -162,7 +162,7 @@ final class Welcome: UIViewController {
         stack.addArrangedSubview(UIView())
         stack.addArrangedSubview(cta)
 
-        if !HideSkipOnboardingExperiment.isEnabled {
+        if !SkipOnboardingExperiment.shouldHideSkipButton {
             let skipButton = UIButton(type: .system)
             skipButton.backgroundColor = .clear
             skipButton.titleLabel?.font = .preferredFont(forTextStyle: .callout)

--- a/Client/Ecosia/UI/Onboarding/Welcome.swift
+++ b/Client/Ecosia/UI/Onboarding/Welcome.swift
@@ -162,16 +162,18 @@ final class Welcome: UIViewController {
         stack.addArrangedSubview(UIView())
         stack.addArrangedSubview(cta)
 
-        let skipButton = UIButton(type: .system)
-        skipButton.backgroundColor = .clear
-        skipButton.titleLabel?.font = .preferredFont(forTextStyle: .callout)
-        skipButton.titleLabel?.adjustsFontForContentSizeCategory = true
-        skipButton.setTitleColor(.Dark.Text.secondary, for: .normal)
-        skipButton.setTitle(.localized(.skipWelcomeTour), for: .normal)
-        skipButton.heightAnchor.constraint(equalToConstant: 50).isActive = true
-        skipButton.addTarget(self, action: #selector(skip), for: .primaryActionTriggered)
+        if !Unleash.isEnabled(.hideOnboardingSkip) {
+            let skipButton = UIButton(type: .system)
+            skipButton.backgroundColor = .clear
+            skipButton.titleLabel?.font = .preferredFont(forTextStyle: .callout)
+            skipButton.titleLabel?.adjustsFontForContentSizeCategory = true
+            skipButton.setTitleColor(.Dark.Text.secondary, for: .normal)
+            skipButton.setTitle(.localized(.skipWelcomeTour), for: .normal)
+            skipButton.heightAnchor.constraint(equalToConstant: 50).isActive = true
+            skipButton.addTarget(self, action: #selector(skip), for: .primaryActionTriggered)
 
-        stack.addArrangedSubview(skipButton)
+            stack.addArrangedSubview(skipButton)
+        }
 
         if view.traitCollection.userInterfaceIdiom == .phone {
             stack.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 16).isActive = true

--- a/Client/Ecosia/UI/Onboarding/WelcomeTour.swift
+++ b/Client/Ecosia/UI/Onboarding/WelcomeTour.swift
@@ -96,7 +96,13 @@ final class WelcomeTour: UIViewController,  Themeable {
         let centerControl = pageControl.centerXAnchor.constraint(equalTo: navStack.centerXAnchor)
         centerControl.priority = .defaultHigh
         centerControl.isActive = true
-        if !Unleash.isEnabled(.hideOnboardingSkip) {
+        if HideSkipOnboardingExperiment.isEnabled {
+            let placeholderView = UIButton(type: .system)
+            placeholderView.widthAnchor.constraint(greaterThanOrEqualToConstant: 74).isActive = true
+            placeholderView.setContentCompressionResistancePriority(.required, for: .horizontal)
+            placeholderView.isAccessibilityElement = false
+            navStack.addArrangedSubview(placeholderView)
+        } else {
             let skipButton = UIButton(type: .system)
             skipButton.widthAnchor.constraint(greaterThanOrEqualToConstant: 74).isActive = true
             skipButton.addTarget(self, action: #selector(skip), for: .primaryActionTriggered)
@@ -108,12 +114,6 @@ final class WelcomeTour: UIViewController,  Themeable {
             skipButton.titleLabel?.adjustsFontForContentSizeCategory = true
             
             self.skipButton = skipButton
-        } else {
-            let placeholderView = UIButton(type: .system)
-            placeholderView.widthAnchor.constraint(greaterThanOrEqualToConstant: 74).isActive = true
-            placeholderView.setContentCompressionResistancePriority(.required, for: .horizontal)
-            placeholderView.isAccessibilityElement = false
-            navStack.addArrangedSubview(placeholderView)
         }
 
         let waves = UIImageView(image: .init(named: "onboardingWaves"))

--- a/Client/Ecosia/UI/Onboarding/WelcomeTour.swift
+++ b/Client/Ecosia/UI/Onboarding/WelcomeTour.swift
@@ -96,7 +96,7 @@ final class WelcomeTour: UIViewController,  Themeable {
         let centerControl = pageControl.centerXAnchor.constraint(equalTo: navStack.centerXAnchor)
         centerControl.priority = .defaultHigh
         centerControl.isActive = true
-        if HideSkipOnboardingExperiment.isEnabled {
+        if SkipOnboardingExperiment.shouldHideSkipButton {
             let placeholderView = UIButton(type: .system)
             placeholderView.widthAnchor.constraint(greaterThanOrEqualToConstant: 74).isActive = true
             placeholderView.setContentCompressionResistancePriority(.required, for: .horizontal)

--- a/Client/Ecosia/UI/Onboarding/WelcomeTour.swift
+++ b/Client/Ecosia/UI/Onboarding/WelcomeTour.swift
@@ -17,7 +17,7 @@ final class WelcomeTour: UIViewController,  Themeable {
     private weak var titleLabel: UILabel!
     private weak var subtitleLabel: UILabel!
     private weak var backButton: UIButton!
-    private weak var skipButton: UIButton!
+    private weak var skipButton: UIButton?
     private weak var pageControl: UIPageControl!
     private weak var ctaButton: UIButton!
     private weak var waves: UIImageView!
@@ -96,18 +96,25 @@ final class WelcomeTour: UIViewController,  Themeable {
         let centerControl = pageControl.centerXAnchor.constraint(equalTo: navStack.centerXAnchor)
         centerControl.priority = .defaultHigh
         centerControl.isActive = true
-
-        let skipButton = UIButton(type: .system)
-        skipButton.widthAnchor.constraint(greaterThanOrEqualToConstant: 74).isActive = true
-        skipButton.addTarget(self, action: #selector(skip), for: .primaryActionTriggered)
-        skipButton.setContentCompressionResistancePriority(.required, for: .horizontal)
-        navStack.addArrangedSubview(skipButton)
-        skipButton.setTitle(.localized(.skip), for: .normal)
-        skipButton.accessibilityLabel = .localized(.onboardingSkipTourButtonAccessibility)
-        skipButton.titleLabel?.font = .preferredFont(forTextStyle: .body)
-        skipButton.titleLabel?.adjustsFontForContentSizeCategory = true
-
-        self.skipButton = skipButton
+        if !Unleash.isEnabled(.hideOnboardingSkip) {
+            let skipButton = UIButton(type: .system)
+            skipButton.widthAnchor.constraint(greaterThanOrEqualToConstant: 74).isActive = true
+            skipButton.addTarget(self, action: #selector(skip), for: .primaryActionTriggered)
+            skipButton.setContentCompressionResistancePriority(.required, for: .horizontal)
+            navStack.addArrangedSubview(skipButton)
+            skipButton.setTitle(.localized(.skip), for: .normal)
+            skipButton.accessibilityLabel = .localized(.onboardingSkipTourButtonAccessibility)
+            skipButton.titleLabel?.font = .preferredFont(forTextStyle: .body)
+            skipButton.titleLabel?.adjustsFontForContentSizeCategory = true
+            
+            self.skipButton = skipButton
+        } else {
+            let placeholderView = UIButton(type: .system)
+            placeholderView.widthAnchor.constraint(greaterThanOrEqualToConstant: 74).isActive = true
+            placeholderView.setContentCompressionResistancePriority(.required, for: .horizontal)
+            placeholderView.isAccessibilityElement = false
+            navStack.addArrangedSubview(placeholderView)
+        }
 
         let waves = UIImageView(image: .init(named: "onboardingWaves"))
         waves.translatesAutoresizingMaskIntoConstraints = false
@@ -358,7 +365,7 @@ final class WelcomeTour: UIViewController,  Themeable {
         waves.tintColor = .legacyTheme.ecosia.welcomeBackground
         titleLabel.textColor = .legacyTheme.ecosia.primaryText
         subtitleLabel.textColor = .legacyTheme.ecosia.secondaryText
-        skipButton.tintColor = .legacyTheme.ecosia.primaryButton
+        skipButton?.tintColor = .legacyTheme.ecosia.primaryButton
         backButton.tintColor = .legacyTheme.ecosia.primaryButton
         pageControl.pageIndicatorTintColor = .legacyTheme.ecosia.disabled
         pageControl.currentPageIndicatorTintColor = .legacyTheme.ecosia.primaryButton


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the PR title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2679]

## Context

We have learned from _the first-day behavior analysis_ that users who complete the onboarding tend to stay longer.
We want to test whether making users go through the onboarding and having them learn more about the brand would impact early retention.

## Approach

- Implement a `struct` that verifies whether the `test` variant is received for the experiment.
- If so, we need to hide the `Skip` button in all Onboarding steps.
- I'm also refactoring a bit the A/B test context analytics addition as well as adding the current experiment being tested.
  - Asked Product if sending the data is needed. To me, it is so to filter the returning users completing the onboarding with the Skip button visible and compare to those without.  Will revert the commit otherwise.

## Other

I am marking it as `Draft` as this codebase relies on the `MOB-2498_upgrade_braze` to make the code compile.
Once merged the Core side will update the `MOB-2498_upgrade_braze` branch and remove this version from Draft to make the code compile successfully.

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [ ] I am using the correct version from [core](https://github.com/ecosia/ios-core), including any necessary changes for this ticket and pointing to `main` instead of a feature branch


[MOB-2679]: https://ecosia.atlassian.net/browse/MOB-2679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ