### PR TITLE
[MOB-2714] Restore Tabs upon upgrading

### DIFF
--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ccgus/fmdb",
       "state" : {
-        "revision" : "4cd6276ee24a1d90fe521b130608858b5a1e36f4",
-        "version" : "2.7.11"
+        "revision" : "1227a3fa2b9916bfd75fe380eb45cd210e69e251",
+        "version" : "2.7.12"
       }
     },
     {
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SDWebImage/SDWebImage.git",
       "state" : {
-        "revision" : "b8523c1642f3c142b06dd98443ea7c48343a4dfd",
-        "version" : "5.19.3"
+        "revision" : "be0bcd7823ce56629948491f2eaeaa19979514f7",
+        "version" : "5.19.4"
       }
     },
     {

--- a/Client/TabManagement/Legacy/LegacySavedTab.swift
+++ b/Client/TabManagement/Legacy/LegacySavedTab.swift
@@ -4,8 +4,13 @@
 
 import Foundation
 import Shared
+// Ecosia: Implement Tabs architecture from ~v112 to ~116
+import TabDataStore
 
-class LegacySavedTab: Codable {
+// Ecosia: Tabs architecture implementation from ~v112 to ~116
+// class LegacySavedTab: Codable {
+class LegacySavedTab: NSObject, Codable, NSCoding {
+    
     var isSelected: Bool
     var title: String?
     var url: URL?
@@ -56,5 +61,65 @@ class LegacySavedTab: Codable {
         self.tabGroupData = tabGroupData
         self.createdAt = createdAt
         self.hasHomeScreenshot = hasHomeScreenshot
+        
+        super.init()
     }
+    
+    // Ecosia: Implement Tabs architecture from ~v112 to ~116
+    
+    required init?(coder: NSCoder) {
+        self.sessionData = coder.decodeObject(forKey: CodingKeys.sessionData.rawValue) as? LegacySessionData
+        self.screenshotUUID = coder.decodeObject(forKey: CodingKeys.screenshotUUID.rawValue) as? UUID
+        self.isSelected = coder.decodeBool(forKey: CodingKeys.isSelected.rawValue)
+        self.title = coder.decodeObject(forKey: CodingKeys.title.rawValue) as? String
+        self.isPrivate = coder.decodeBool(forKey: CodingKeys.isPrivate.rawValue)
+        self.faviconURL = coder.decodeObject(forKey: CodingKeys.faviconURL.rawValue) as? String
+        self.url = coder.decodeObject(forKey: CodingKeys.url.rawValue) as? URL
+        self.UUID = coder.decodeObject(forKey: CodingKeys.UUID.rawValue) as? String
+        self.tabGroupData = coder.decodeObject(forKey: CodingKeys.tabGroupData.rawValue) as? LegacyTabGroupData
+        self.createdAt = coder.decodeObject(forKey: CodingKeys.createdAt.rawValue) as? Timestamp
+        self.hasHomeScreenshot = coder.decodeBool(forKey: CodingKeys.hasHomeScreenshot.rawValue)
+    }
+    
+    func encode(with coder: NSCoder) {
+        coder.encode(sessionData, forKey: CodingKeys.sessionData.rawValue)
+        coder.encode(screenshotUUID, forKey: CodingKeys.screenshotUUID.rawValue)
+        coder.encode(isSelected, forKey: CodingKeys.isSelected.rawValue)
+        coder.encode(title, forKey: CodingKeys.title.rawValue)
+        coder.encode(isPrivate, forKey: CodingKeys.isPrivate.rawValue)
+        coder.encode(faviconURL, forKey: CodingKeys.faviconURL.rawValue)
+        coder.encode(url, forKey: CodingKeys.url.rawValue)
+        coder.encode(UUID, forKey: CodingKeys.UUID.rawValue)
+        coder.encode(tabGroupData, forKey: CodingKeys.tabGroupData.rawValue)
+        coder.encode(createdAt, forKey: CodingKeys.createdAt.rawValue)
+        coder.encode(hasHomeScreenshot, forKey: CodingKeys.hasHomeScreenshot.rawValue)
+    }
+
+    
+    var jsonDictionary: [String: AnyObject] {
+        let title: String = self.title ?? "null"
+        let faviconURL: String = self.faviconURL ?? "null"
+        let uuid: String = self.screenshotUUID?.uuidString ?? "null"
+
+        var json: [String: AnyObject] = [
+            CodingKeys.title.rawValue: title as AnyObject,
+            CodingKeys.isPrivate.rawValue: String(self.isPrivate) as AnyObject,
+            CodingKeys.isSelected.rawValue: String(self.isSelected) as AnyObject,
+            CodingKeys.faviconURL.rawValue: faviconURL as AnyObject,
+            CodingKeys.screenshotUUID.rawValue: uuid as AnyObject,
+            CodingKeys.url.rawValue: url as AnyObject,
+            CodingKeys.UUID.rawValue: self.UUID as AnyObject,
+            CodingKeys.tabGroupData.rawValue: self.tabGroupData as AnyObject,
+            CodingKeys.createdAt.rawValue: self.createdAt as AnyObject,
+            CodingKeys.hasHomeScreenshot.rawValue: String(self.hasHomeScreenshot) as AnyObject
+        ]
+
+        if let sessionDataInfo = self.sessionData?.jsonDictionary {
+            json[CodingKeys.sessionData.rawValue] = sessionDataInfo as AnyObject?
+        }
+
+        return json
+    }
+    
+    // Ecosia: End Tabs architecture implementation from ~v112 to ~116
 }

--- a/Client/TabManagement/Legacy/LegacySessionData.swift
+++ b/Client/TabManagement/Legacy/LegacySessionData.swift
@@ -51,11 +51,6 @@ class LegacySessionData: NSObject, Codable, NSCoding {
         case currentPage
         case lastUsedTime
         case urls
-        
-        // Ecosia: Tabs architecture implementation from ~v112 to ~116
-        // This is temprorary in order to fix a migration error, can be removed after our Ecosia 10.0.0 has been well adopted
-        case legacyCurrentPage = "user_first_name"
-        case legacyLastUsedTime = "user_last_name"
     }
 
     /**
@@ -82,32 +77,11 @@ class LegacySessionData: NSObject, Codable, NSCoding {
             CodingKeys.urls.rawValue: urls.map { $0.absoluteString }
         ]
     }
-    
-    required init(from decoder: Decoder) throws {
-        let values = try decoder.container(keyedBy: CodingKeys.self)
-        do {
-            currentPage = try values.decode(Int.self, forKey: .currentPage)
-        } catch {
-            currentPage = try values.decode(Int.self, forKey: .legacyCurrentPage)
-        }
-
-        do {
-            lastUsedTime = try values.decode(Timestamp.self, forKey: .lastUsedTime)
-        } catch {
-            lastUsedTime = try values.decode(Timestamp.self, forKey: .legacyLastUsedTime)
-        }
-
-        urls = try values.decode([URL].self, forKey: .urls)
-    }
-    
-    func encode(to encoder: any Encoder) throws {
-        
-    }
-    
+            
     required init?(coder: NSCoder) {
-        self.currentPage = coder.decodeObject(forKey: CodingKeys.currentPage.rawValue) as? Int ?? coder.decodeInteger(forKey: CodingKeys.currentPage.rawValue)
+        self.currentPage = coder.decodeInteger(forKey: CodingKeys.currentPage.rawValue)
         self.urls = migrate(urls: coder.decodeObject(forKey: CodingKeys.urls.rawValue) as? [URL] ?? [URL]())
-        self.lastUsedTime = (coder.decodeObject(forKey: CodingKeys.lastUsedTime.rawValue) as? NSNumber)?.uint64Value ?? UInt64(coder.decodeInt64(forKey: CodingKeys.lastUsedTime.rawValue))
+        self.lastUsedTime = UInt64(coder.decodeInt64(forKey: CodingKeys.lastUsedTime.rawValue))
     }
 
     func encode(with coder: NSCoder) {

--- a/Client/TabManagement/Legacy/LegacyTabDataRetriever.swift
+++ b/Client/TabManagement/Legacy/LegacyTabDataRetriever.swift
@@ -15,6 +15,8 @@ struct LegacyTabDataRetrieverImplementation: LegacyTabDataRetriever {
 
     init(fileManager: LegacyTabFileManager = FileManager.default) {
         self.fileManager = fileManager
+        // Ecosia: Tabs architecture implementation from ~v112 to ~116
+        self.tabsStateArchivePath = deprecatedTabsStateArchivePath()
     }
 
     func getTabData() -> Data? {
@@ -24,3 +26,16 @@ struct LegacyTabDataRetrieverImplementation: LegacyTabDataRetriever {
         return try? Data(contentsOf: tabStateArchivePath)
     }
 }
+
+// Ecosia: Tabs architecture implementation from ~v112 to ~116
+// This is temprorary in order to fix a migration error, can be removed after our Ecosia 10.0.0 has been well adopted
+
+extension LegacyTabDataRetrieverImplementation {
+        
+    private func deprecatedTabsStateArchivePath() -> URL? {
+        guard let path = fileManager.tabPath else { return nil }
+        return URL(fileURLWithPath: path).appendingPathComponent("tabsState.archive")
+    }
+}
+
+// Ecosia: End Tabs architecture implementation from ~v112 to ~116

--- a/Client/TabManagement/Legacy/LegacyTabGroupData.swift
+++ b/Client/TabManagement/Legacy/LegacyTabGroupData.swift
@@ -16,7 +16,10 @@ enum LegacyTabGroupTimerState: String, Codable {
     case none
 }
 
-class LegacyTabGroupData: Codable {
+// Ecosia: Tabs architecture implementation from ~v112 to ~116
+// class LegacyTabGroupData: Codable {
+class LegacyTabGroupData: NSObject, Codable, NSCoding {
+    
     var tabAssociatedSearchTerm: String = ""
     var tabAssociatedSearchUrl: String = ""
     var tabAssociatedNextUrl: String = ""
@@ -32,8 +35,10 @@ class LegacyTabGroupData: Codable {
         case tabAssociatedNextUrl
         case tabHistoryCurrentState
     }
-
-    convenience init() {
+    
+    // Ecosia: Tabs architecture implementation from ~v112 to ~116
+    // convenience init() {
+    convenience override init() {
         self.init(searchTerm: "",
                   searchUrl: "",
                   nextReferralUrl: "",
@@ -45,5 +50,31 @@ class LegacyTabGroupData: Codable {
         self.tabAssociatedSearchUrl = searchUrl
         self.tabAssociatedNextUrl = nextReferralUrl
         self.tabHistoryCurrentState = tabHistoryCurrentState
+    }
+    
+    // Ecosia: Tabs architecture implementation from ~v112 to ~116
+    // This is temprorary in order to fix a migration error, can be removed after our Ecosia 10.0.0 has been well adopted
+
+    var jsonDictionary: [String: Any] {
+        return [
+            CodingKeys.tabAssociatedSearchTerm.rawValue: String(self.tabAssociatedSearchTerm),
+            CodingKeys.tabAssociatedSearchUrl.rawValue: String(self.tabAssociatedSearchUrl),
+            CodingKeys.tabAssociatedNextUrl.rawValue: String(self.tabAssociatedNextUrl),
+            CodingKeys.tabHistoryCurrentState.rawValue: String(self.tabHistoryCurrentState),
+        ]
+    }
+
+    required public init?(coder: NSCoder) {
+        self.tabAssociatedSearchTerm = coder.decodeObject(forKey: CodingKeys.tabAssociatedSearchTerm.rawValue) as? String ?? ""
+        self.tabAssociatedSearchUrl = coder.decodeObject(forKey: CodingKeys.tabAssociatedSearchUrl.rawValue) as? String ?? ""
+        self.tabAssociatedNextUrl = coder.decodeObject(forKey: CodingKeys.tabAssociatedNextUrl.rawValue) as? String ?? ""
+        self.tabHistoryCurrentState = coder.decodeObject(forKey: CodingKeys.tabHistoryCurrentState.rawValue) as? String ?? ""
+    }
+
+    public func encode(with coder: NSCoder) {
+        coder.encode(tabAssociatedSearchTerm, forKey: CodingKeys.tabAssociatedSearchTerm.rawValue)
+        coder.encode(tabAssociatedSearchUrl, forKey: CodingKeys.tabAssociatedSearchUrl.rawValue)
+        coder.encode(tabAssociatedNextUrl, forKey: CodingKeys.tabAssociatedNextUrl.rawValue)
+        coder.encode(tabHistoryCurrentState, forKey: CodingKeys.tabHistoryCurrentState.rawValue)
     }
 }

--- a/Client/TabManagement/TabMigrationUtility.swift
+++ b/Client/TabManagement/TabMigrationUtility.swift
@@ -43,7 +43,13 @@ class DefaultTabMigrationUtility: TabMigrationUtility {
         logger.log("Key exists - running migration? \(shouldRunMigration)",
                    level: .debug,
                    category: .tabs)
-        return shouldRunMigration
+        /* 
+         Ecosia: Tabs architecture implementation from ~v112 to ~116
+         This is temprorary in order to fix a migration error, can be removed after our Ecosia 10.0.0 has been well adopted
+         return shouldRunMigration
+         */
+        let hasLegacyTabData = legacyTabDataRetriever.getTabData() != nil
+        return shouldRunMigration || hasLegacyTabData
     }
 
     func getLegacyTabs() -> [LegacySavedTab] {
@@ -118,6 +124,8 @@ class DefaultTabMigrationUtility: TabMigrationUtility {
         // Save migration WindowData
         await tabDataStore.saveWindowData(window: windowData, forced: true)
         prefs.setBool(false, forKey: migrationKey)
+        // Ecosia: Tabs architecture implementation from ~v112 to ~116
+        clearDeprecatedArchive()
         return windowData
     }
 }

--- a/Client/TabManagement/TabMigrationUtility.swift
+++ b/Client/TabManagement/TabMigrationUtility.swift
@@ -130,21 +130,17 @@ extension DefaultTabMigrationUtility {
     func getDeprecatedTabsToMigrate() -> [LegacySavedTab]? {
         guard let tabData = legacyTabDataRetriever.getTabData()
         else { return [LegacySavedTab]() }
-        do {
-            let deprecatedUnarchiver = try NSKeyedUnarchiver(forReadingWith: tabData)
-            deprecatedUnarchiver.setClass(LegacySavedTab.self, forClassName: "Client.SavedTab")
-            deprecatedUnarchiver.setClass(LegacySessionData.self, forClassName: "Client.SessionData")
-            deprecatedUnarchiver.setClass(LegacyTabGroupData.self, forClassName: "Client.TabGroupData")
-            deprecatedUnarchiver.decodingFailurePolicy = .setErrorAndReturn
-            guard let migratedTabs = deprecatedUnarchiver.decodeObject(forKey: tabsKey) as? [LegacySavedTab] else {
-                let error = String(describing: deprecatedUnarchiver.error)
-                logger.log("Deprecated unarchiver could not decode Saved tab with: \(error)", level: .warning, category: .tabs, description: error.localizedDescription)
-                return nil
-            }
-            return migratedTabs
-        } catch {
+        let deprecatedUnarchiver = try NSKeyedUnarchiver(forReadingWith: tabData)
+        deprecatedUnarchiver.setClass(LegacySavedTab.self, forClassName: "Client.SavedTab")
+        deprecatedUnarchiver.setClass(LegacySessionData.self, forClassName: "Client.SessionData")
+        deprecatedUnarchiver.setClass(LegacyTabGroupData.self, forClassName: "Client.TabGroupData")
+        deprecatedUnarchiver.decodingFailurePolicy = .setErrorAndReturn
+        guard let migratedTabs = deprecatedUnarchiver.decodeObject(forKey: tabsKey) as? [LegacySavedTab] else {
+            let error = String(describing: deprecatedUnarchiver.error)
+            logger.log("Deprecated unarchiver could not decode Saved tab with: \(error)", level: .warning, category: .tabs, description: error.localizedDescription)
             return nil
         }
+        return migratedTabs
     }
     
     

--- a/Client/TabManagement/TabMigrationUtility.swift
+++ b/Client/TabManagement/TabMigrationUtility.swift
@@ -131,13 +131,12 @@ extension DefaultTabMigrationUtility {
         guard let tabData = legacyTabDataRetriever.getTabData()
         else { return [LegacySavedTab]() }
         do {
-            let deprecatedUnarchiver = NSKeyedUnarchiver(forReadingWith: tabData)
-            deprecatedUnarchiver.requiresSecureCoding = true
+            let deprecatedUnarchiver = try NSKeyedUnarchiver(forReadingWith: tabData)
             deprecatedUnarchiver.setClass(LegacySavedTab.self, forClassName: "Client.SavedTab")
             deprecatedUnarchiver.setClass(LegacySessionData.self, forClassName: "Client.SessionData")
             deprecatedUnarchiver.setClass(LegacyTabGroupData.self, forClassName: "Client.TabGroupData")
             deprecatedUnarchiver.decodingFailurePolicy = .setErrorAndReturn
-            guard let migratedTabs = try deprecatedUnarchiver.decodeTopLevelObject(forKey: tabsKey) as? [LegacySavedTab] else {
+            guard let migratedTabs = deprecatedUnarchiver.decodeObject(forKey: tabsKey) as? [LegacySavedTab] else {
                 let error = String(describing: deprecatedUnarchiver.error)
                 logger.log("Deprecated unarchiver could not decode Saved tab with: \(error)", level: .warning, category: .tabs, description: error.localizedDescription)
                 return nil

--- a/Client/TabManagement/TabMigrationUtility.swift
+++ b/Client/TabManagement/TabMigrationUtility.swift
@@ -126,6 +126,7 @@ class DefaultTabMigrationUtility: TabMigrationUtility {
         prefs.setBool(false, forKey: migrationKey)
         // Ecosia: Tabs architecture implementation from ~v112 to ~116
         clearDeprecatedArchive()
+        Analytics.shared.migration(true)
         return windowData
     }
 }
@@ -145,7 +146,10 @@ extension DefaultTabMigrationUtility {
         deprecatedUnarchiver.decodingFailurePolicy = .setErrorAndReturn
         guard let migratedTabs = deprecatedUnarchiver.decodeObject(forKey: tabsKey) as? [LegacySavedTab] else {
             let error = String(describing: deprecatedUnarchiver.error)
-            logger.log("Deprecated unarchiver could not decode Saved tab with: \(error)", level: .warning, category: .tabs, description: error.localizedDescription)
+            let message = "Deprecated unarchiver could not decode Saved tab with: \(error)"
+            logger.log(message, level: .warning, category: .tabs, description: error.localizedDescription)
+            Analytics.shared.migration(false)
+            Analytics.shared.migrationError(in: .tabs, message: message)
             return nil
         }
         return migratedTabs


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the PR title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2714]

## Context

Throughout the Firefox Upgrade implementations, I realized that the tabs were not restored upon upgrading as previously thought. Lets not forget we are jumping from v104 to v122.x codebase after all 😅 .

## Approach

- Understood context
- Realized whether something was implemented/removed throughout the EcosiaHistory, Glean, and other frameworks removal...
- Once acknowledged that nothing that was done could have compromised the restoration... 👇 
- Performed a thorough debugging over the tab restoration process between Ecosia's 9.5.0 and 10.0.0
- Found that `tabState.archive` (stored in 9.5.0 with Firefox v104 as codebase) could not be loaded as the newer codebase didn't have the logic in place to read from that `.archive` and populate the Tabs
- Went through thorough research on the PRs and opened issues over the Firefox repo to understand the work done
- Found out that Firefox has essentially applied a product-led approach to the migration between <v106+ and in between v112 and v116
- Acknowledged the _how and why_ that work was done Firefox side comparing v112 and v122.3 (our new Vanilla)
-  Once implemented and adapted the new structure to accommodate a retrieval from the old `tabState.archive` and the migration not only to the new (yet legacy) Tab storage but also to the newest `RustPlaces` (how Firefox now references to Tabs), I realized that the unarchiving logic utilizing  `NSKeyedUnarchiver` was the same, yet it was "failing" after successfully retrieving the fir `LegacySessionData` object.
- Result: only the first Tab was restored successfully.

### Here comes the tricky part

I went deeply understanding what could have changed in the inner `NSKeyedUnarchiver` logic upon decoding the array of `LegacySavedTab` (different deployment target, different archiving methodologies in the first place...nothing rang a bell 🔔).
I then went deeper and started to compare the raw data👇:
- `tabState.archive` in its `Data` object for both versions with different deployment targets gave us as output the same weight of Data in KBs.
- then I tried to print the String output of both `Data` at runtime for both apps utilizing `.ascii` decoding.
- I realized that something was different between the two binary lists and only the output from the newer app mentioned the `Client.TabGroupData` as a class to decode (`TabGroupData` is now `LegacyTabGroupData` and type of `LegacySavedTab.tabGroupData`)
- The current production code (and Firefox's at v112) don't have that `Client.TabGroupData` to set via `unarchiver.setClass(LegacyTabGroupData.self, forClassName: "Client.TabGroupData")`
- Once updated the new unarchiving logic adding `deprecatedUnarchiver.setClass(LegacyTabGroupData.self, forClassName: "Client.TabGroupData")`, all `LegacySessionData`'s were initialized

Ultimately, I adapted the migration logic by modifying the concrete implementation of `DefaultTabMigrationUtility.shouldRunMigration` by adding a `hasLegacyTabData` condition.
At first glance we may think this check wouldn't be needed as we already have our `prefs.boolForKey(migrationKey)` that should take care of that, however, we need to take into account that the key may have already been used by a previous version of our latest App (9.5.0 based on v104) and Users having upgraded multiple times never uninstalling the app could already have that object stored.

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I added the `// Ecosia:` helper comments where needed

[MOB-2714]: https://ecosia.atlassian.net/browse/MOB-2714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ