### PR TITLE
[MOB-2740] `launch` and  `resume` analytics fix

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -345,6 +345,7 @@
 		2C872A642B8CD7E000B318A0 /* EcosiaHomeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C872A562B8CD65100B318A0 /* EcosiaHomeViewModelTests.swift */; };
 		2CABD7162C11C9CC00A0750F /* MozillaAppServices in Frameworks */ = {isa = PBXBuildFile; productRef = 2CABD7152C11C9CC00A0750F /* MozillaAppServices */; };
 		2CABD7282C12EF1E00A0750F /* PrivateModeButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CABD7272C12EF1E00A0750F /* PrivateModeButtonTests.swift */; };
+		2CC8AC342C4F887D000A669A /* MockAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC8AC332C4F887D000A669A /* MockAnalytics.swift */; };
 		2CCFB3D72C0FBEE800BEDCA0 /* TabToolbarHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D815A3A724A53F3200AAB221 /* TabToolbarHelperTests.swift */; };
 		2CE294472B7CDD56006C22B2 /* Core in Frameworks */ = {isa = PBXBuildFile; productRef = 2CE294462B7CDD56006C22B2 /* Core */; };
 		2CE294492B7CDD78006C22B2 /* Core in Frameworks */ = {isa = PBXBuildFile; productRef = 2CE294482B7CDD78006C22B2 /* Core */; };
@@ -2484,6 +2485,7 @@
 		2CBCAB0D2B88EEE40080AD68 /* EcosiaDebug.WidgetKit.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = EcosiaDebug.WidgetKit.xcconfig; sourceTree = "<group>"; };
 		2CBCAB0E2B88EEE40080AD68 /* EcosiaDebug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = EcosiaDebug.xcconfig; sourceTree = "<group>"; };
 		2CC1B3EF1E9B861400814EEC /* DomainAutocompleteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DomainAutocompleteTests.swift; sourceTree = "<group>"; };
+		2CC8AC332C4F887D000A669A /* MockAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAnalytics.swift; sourceTree = "<group>"; };
 		2CCB296620A99C9500121DD8 /* LoginsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginsTests.swift; sourceTree = "<group>"; };
 		2CCF17522105E4FD00705AE5 /* DisplaySettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplaySettingsTests.swift; sourceTree = "<group>"; };
 		2CCFB3D42C0F1EA500BEDCA0 /* LoadingScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoadingScreen.swift; sourceTree = "<group>"; };
@@ -8755,6 +8757,7 @@
 			isa = PBXGroup;
 			children = (
 				2C872A532B8CD47600B318A0 /* MockAppVersionInfoProvider.swift */,
+				2CC8AC332C4F887D000A669A /* MockAnalytics.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -14352,6 +14355,7 @@
 				3943A81D1E9807C700D4F6DC /* FxAPushMessageTest.swift in Sources */,
 				212985E72A72B39D00546684 /* ThemeSettingsControllerTests.swift in Sources */,
 				8A9E46BD2A6599E5003327D4 /* MockStatusBarScrollDelegate.swift in Sources */,
+				2CC8AC342C4F887D000A669A /* MockAnalytics.swift in Sources */,
 				E1463D0629830E4F0074E16E /* MockUserNotificationCenter.swift in Sources */,
 				439B78182A09721600CAAE37 /* CreditCardHelperTests.swift in Sources */,
 				8ADED7F0276A7788009C19E6 /* CumulativeDaysOfUseCounterTests.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -333,6 +333,7 @@
 		2C6189EC2B7B7AB4006B70D7 /* DispatchQueueHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83821FF1FC7961D00303C12 /* DispatchQueueHelper.swift */; };
 		2C6189F12B7B7D5D006B70D7 /* SnowplowTracker in Frameworks */ = {isa = PBXBuildFile; productRef = 2C6189F02B7B7D5D006B70D7 /* SnowplowTracker */; };
 		2C78374B2C1765DF00BBFFEB /* LoadingScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CCFB3D42C0F1EA500BEDCA0 /* LoadingScreen.swift */; };
+		2C7DBABD2C4EA37200BCD03F /* AnalyticsFeatureManagementIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7DBABB2C4EA17200BCD03F /* AnalyticsFeatureManagementIntegrationTests.swift */; };
 		2C872A552B8CD58200B318A0 /* ContileProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A7A93ED2810ADF2005E7E1B /* ContileProviderTests.swift */; };
 		2C872A5A2B8CD7E000B318A0 /* MockAppVersionInfoProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C872A532B8CD47600B318A0 /* MockAppVersionInfoProvider.swift */; };
 		2C872A5B2B8CD7E000B318A0 /* AnalyticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE294692B7FC5A5006C22B2 /* AnalyticsTests.swift */; };
@@ -2451,6 +2452,7 @@
 		2C61892F2B7A8A22006B70D7 /* Analytics+Configuration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Analytics+Configuration.swift"; sourceTree = "<group>"; };
 		2C6189302B7A8A22006B70D7 /* Analytics.Values.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Analytics.Values.swift; sourceTree = "<group>"; };
 		2C6E44099EACF7BE5438CEB6 /* ca */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ca; path = ca.lproj/Today.strings; sourceTree = "<group>"; };
+		2C7DBABB2C4EA17200BCD03F /* AnalyticsFeatureManagementIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsFeatureManagementIntegrationTests.swift; sourceTree = "<group>"; };
 		2C872A532B8CD47600B318A0 /* MockAppVersionInfoProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAppVersionInfoProvider.swift; sourceTree = "<group>"; };
 		2C872A562B8CD65100B318A0 /* EcosiaHomeViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EcosiaHomeViewModelTests.swift; sourceTree = "<group>"; };
 		2C8C07761E7800EA00DC1237 /* FindInPageTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FindInPageTests.swift; sourceTree = "<group>"; };
@@ -8741,6 +8743,14 @@
 			path = Analytics;
 			sourceTree = "<group>";
 		};
+		2C7DBABA2C4EA14C00BCD03F /* IntegrationTests */ = {
+			isa = PBXGroup;
+			children = (
+				2C7DBABB2C4EA17200BCD03F /* AnalyticsFeatureManagementIntegrationTests.swift */,
+			);
+			path = IntegrationTests;
+			sourceTree = "<group>";
+		};
 		2C872A522B8CD45F00B318A0 /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
@@ -8788,6 +8798,7 @@
 		2CE2945C2B7FC51E006C22B2 /* EcosiaTests */ = {
 			isa = PBXGroup;
 			children = (
+				2C7DBABA2C4EA14C00BCD03F /* IntegrationTests */,
 				2C4414432BD7B4D000249464 /* BingDistributionExperimentTests.swift */,
 				2C872A522B8CD45F00B318A0 /* Mocks */,
 				2CE294692B7FC5A5006C22B2 /* AnalyticsTests.swift */,
@@ -14369,6 +14380,7 @@
 				5AF6254728A58AC100A90253 /* MockHistoryHighlightsDataAdaptor.swift in Sources */,
 				8A7A26E329D4ACF300EA76F1 /* SceneCoordinatorTests.swift in Sources */,
 				39C137972655798A003DC662 /* NimbusIntegrationTests.swift in Sources */,
+				2C7DBABD2C4EA37200BCD03F /* AnalyticsFeatureManagementIntegrationTests.swift in Sources */,
 				215B458427DA87FC00E5E800 /* TabMetadataManagerTests.swift in Sources */,
 				2173326A29CCF901007F20C7 /* UIPanGestureRecognizerMock.swift in Sources */,
 				5A9A09D628B01FD500B6F51E /* MockURLBarView.swift in Sources */,

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -191,7 +191,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
          */
         Task {
             await FeatureManagement.fetchConfiguration()
-            // Ecosia: lifecycle tracking
+            // Ecosia: Lifecycle tracking. Needs to happen after Unleash start so that the flags are correctly added to the analytics context.
             analytics.activity(.launch)
             // Ecosia: Engagement Service Initialization helper
             ClientEngagementService.shared.initializeAndUpdateNotificationRegistrationIfNeeded(notificationCenterDelegate: self)

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -48,6 +48,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private var widgetManager: TopSitesWidgetManager?
     private var menuBuilderHelper: MenuBuilderHelper?
     private var metricKitWrapper = MetricKitWrapper()
+    // Ecosia: Add analytics
+    var analytics: AnalyticsProtocol = Analytics.shared
 
     /// Tracking active status of the application.
     private var isActive = false
@@ -190,7 +192,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         Task {
             await FeatureManagement.fetchConfiguration()
             // Ecosia: lifecycle tracking
-            Analytics.shared.activity(.launch)
+            analytics.activity(.launch)
             // Ecosia: Engagement Service Initialization helper
             ClientEngagementService.shared.initializeAndUpdateNotificationRegistrationIfNeeded(notificationCenterDelegate: self)
         }
@@ -301,7 +303,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func applicationWillEnterForeground(_ application: UIApplication) {
         // Ecosia: lifecycle tracking
-        Analytics.shared.activity(.resume)
+        analytics.activity(.resume)
         handleForegroundEvent()
     }
 

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -175,8 +175,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Ecosia: Update EcosiaInstallType if needed
         EcosiaInstallType.evaluateCurrentEcosiaInstallType()
         // Ecosia: Disable BG sync //backgroundSyncUtil = BackgroundSyncUtil(profile: profile, application: application)
-        // Ecosia: lifecycle tracking
-        Analytics.shared.activity(.launch)
         
         /* 
          Ecosia: Feature Management fetch
@@ -191,6 +189,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
          */
         Task {
             await FeatureManagement.fetchConfiguration()
+            // Ecosia: lifecycle tracking
+            Analytics.shared.activity(.launch)
             // Ecosia: Engagement Service Initialization helper
             ClientEngagementService.shared.initializeAndUpdateNotificationRegistrationIfNeeded(notificationCenterDelegate: self)
         }

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -300,6 +300,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func applicationWillEnterForeground(_ application: UIApplication) {
+        // Ecosia: lifecycle tracking
+        Analytics.shared.activity(.resume)
         handleForegroundEvent()
     }
 

--- a/Client/Coordinators/Launch/LaunchCoordinator.swift
+++ b/Client/Coordinators/Launch/LaunchCoordinator.swift
@@ -30,16 +30,7 @@ class LaunchCoordinator: BaseCoordinator,
         let isFullScreen = launchType.isFullScreenAvailable(isIphone: isIphone)
         switch launchType {
         case .intro(let manager):
-            /*
-             Ecosia: Fetch Config before showing onboarding
-             in order to be able to correctly evaluate `SkipOnboardingExperiment.shouldHideSkipButton`
-             
-             presentIntroOnboarding(with: manager, isFullScreen: isFullScreen)
-             */
-            Task {
-                await FeatureManagement.fetchConfiguration()
-                await MainActor.run { presentIntroOnboarding(with: manager, isFullScreen: isFullScreen) }
-            }
+            presentIntroOnboarding(with: manager, isFullScreen: isFullScreen)
         case .update(let viewModel):
             presentUpdateOnboarding(with: viewModel, isFullScreen: isFullScreen)
         case .defaultBrowser:

--- a/Client/Ecosia/Analytics/Analytics.swift
+++ b/Client/Ecosia/Analytics/Analytics.swift
@@ -2,7 +2,11 @@ import Foundation
 import SnowplowTracker
 import Core
 
-final class Analytics {
+protocol AnalyticsProtocol {
+    func activity(_ action: Analytics.Action.Activity)
+}
+
+final class Analytics: AnalyticsProtocol {
     private static let installSchema = "iglu:org.ecosia/ios_install_event/jsonschema/1-0-0"
     private static let abTestSchema = "iglu:org.ecosia/abtest_context/jsonschema/1-0-1"
     private static let consentSchema = "iglu:org.ecosia/eccc_context/jsonschema/1-0-2"

--- a/EcosiaTests/IntegrationTests/AnalyticsFeatureManagementIntegrationTests.swift
+++ b/EcosiaTests/IntegrationTests/AnalyticsFeatureManagementIntegrationTests.swift
@@ -1,0 +1,124 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import Client
+@testable import Core
+
+final class MockAnalytics: AnalyticsProtocol {
+    var activityCallCount = 0
+    var lastActivity: Analytics.Action.Activity?
+    
+    func activity(_ action: Analytics.Action.Activity) {
+        activityCallCount += 1
+        lastActivity = action
+    }
+}
+
+final class AnalyticsFeatureManagementIntegrationTests: XCTestCase {
+    var appDelegate: AppDelegate!
+    var mockAnalytics: MockAnalytics!
+    var initialModel: Unleash.Model!
+    
+    override func setUp() {
+        super.setUp()
+        
+        appDelegate = AppDelegate()
+        mockAnalytics = MockAnalytics()
+        appDelegate.analytics = mockAnalytics
+        
+        initialModel = Unleash.model
+        // Reset Unleash model to initial state
+        Unleash.model = Unleash.Model()
+    }
+    
+    func testInitialStateOfUnleashModel() {
+        XCTAssertEqual(Unleash.model.toggles.count, 0)
+        XCTAssertEqual(Unleash.model.updated, Date(timeIntervalSince1970: 0))
+    }
+    
+    func testStateAfterInitialForeground_expectsNoModelUpdates() async {
+        let application = await UIApplication.shared
+        
+        await appDelegate.applicationWillEnterForeground(application)
+        
+        XCTAssertEqual(mockAnalytics.activityCallCount, 1)
+        XCTAssertEqual(mockAnalytics.lastActivity, .resume)
+        XCTAssertEqual(Unleash.model.toggles.count, 0)
+        XCTAssertEqual(Unleash.model.updated, Date(timeIntervalSince1970: 0))
+    }
+    
+    func testStateAfterDidFinishLaunchingWithOptions_expectsModelUpdates() async {
+        let application = await UIApplication.shared
+        let options: [UIApplication.LaunchOptionsKey: Any]? = nil
+        
+        // Store an updated model so to not let Unleash perform a call
+        await storeUnleashModel()
+        
+        let didFinishLaunching = await appDelegate.application(application, didFinishLaunchingWithOptions: options)
+        
+        XCTAssertTrue(didFinishLaunching)
+        // Let it go thru all the activities, including the Task detached ones
+        wait(0.5)
+        XCTAssertEqual(mockAnalytics.activityCallCount, 1)
+        XCTAssertEqual(mockAnalytics.lastActivity, .launch)
+        XCTAssertNotEqual(Unleash.model.updated, Date(timeIntervalSince1970: 0))
+        XCTAssertNotEqual(Unleash.model.toggles.count, 0)
+    }
+    
+    func testStateAfterSubsequentForeground_expectesSameModel_AfterDidFinishLaunchingWithOptions() async {
+        let application = await UIApplication.shared
+        
+        // Store an updated model so to not let Unleash perform a call
+        await storeUnleashModel()
+
+        // Simulate didFinishLaunchingWithOptions
+        let options: [UIApplication.LaunchOptionsKey: Any]? = nil
+        let didFinishLaunching = await appDelegate.application(application, didFinishLaunchingWithOptions: options)
+        
+        XCTAssertTrue(didFinishLaunching)
+        // Let it go thru all the activities, including the Task detached ones
+        wait(0.5)
+        XCTAssertEqual(mockAnalytics.activityCallCount, 1)
+        XCTAssertEqual(mockAnalytics.lastActivity, .launch)
+        let modelAfterLaunch = Unleash.model
+        
+        // Simulate entering background and foreground again
+        await appDelegate.applicationWillEnterForeground(application)
+        
+        XCTAssertEqual(mockAnalytics.activityCallCount, 2)
+        XCTAssertEqual(mockAnalytics.lastActivity, .resume)
+        XCTAssertEqual(Unleash.model.toggles.count, modelAfterLaunch.toggles.count)
+        XCTAssertEqual(Unleash.model.updated, modelAfterLaunch.updated)
+    }
+}
+
+extension AnalyticsFeatureManagementIntegrationTests {
+    
+    func storeUnleashModel() async {
+        let jsonString =
+        """
+        {
+          "appVersion": "10.0.0",
+          "updated": 743349796.463453,
+          "id": "626C1D87-975E-4CC6-9397-1137AF7F7637",
+          "deviceRegion": "us",
+          "etag": "example-etag",
+          "toggles": [
+            {
+              "variant": {
+                "name": "disabled",
+                "enabled": false
+              },
+              "name": "example_toggle",
+              "enabled": true
+            }
+          ]
+        }
+        """
+        let decoder = JSONDecoder()
+        let model = try! decoder.decode(Unleash.Model.self, from: jsonString.data(using: .utf8)!)
+        try? await Unleash.save(model)
+    }
+}

--- a/EcosiaTests/IntegrationTests/AnalyticsFeatureManagementIntegrationTests.swift
+++ b/EcosiaTests/IntegrationTests/AnalyticsFeatureManagementIntegrationTests.swift
@@ -6,16 +6,6 @@ import XCTest
 @testable import Client
 @testable import Core
 
-final class MockAnalytics: AnalyticsProtocol {
-    var activityCallCount = 0
-    var lastActivity: Analytics.Action.Activity?
-    
-    func activity(_ action: Analytics.Action.Activity) {
-        activityCallCount += 1
-        lastActivity = action
-    }
-}
-
 final class AnalyticsFeatureManagementIntegrationTests: XCTestCase {
     var appDelegate: AppDelegate!
     var mockAnalytics: MockAnalytics!

--- a/EcosiaTests/Mocks/MockAnalytics.swift
+++ b/EcosiaTests/Mocks/MockAnalytics.swift
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+@testable import Client
+
+final class MockAnalytics: AnalyticsProtocol {
+    var activityCallCount = 0
+    var lastActivity: Analytics.Action.Activity?
+    
+    func activity(_ action: Analytics.Action.Activity) {
+        activityCallCount += 1
+        lastActivity = action
+    }
+}


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the PR title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2740]

## Context

While performing an investigation on some of the recent analytics added, we realized that for the launch and resume events, a specific AB Test was not added.

On top, we realized that the `resume` was missing.

## Approach

- Readd `resume` event
- Implemented `launch` event with proper `fetchConfiguration()` correctly, avoiding scenario-based exceptions
- Add integration tests to properly check the intended behaviour
  - The `resume` events despite being called before the `launch` as `applicationWillEnterForeground(:)` executes first, `application(_:didFinishLaunchingWithOptions:)` then, doesn't send any info about the context as the `Unleash.model` has always 0 toggle. That's indeed the intended behaviour, otherwise it would have sent always double context. A good reminder of the why it was there in the first place. 

## Other

- Modified `Analytics` to make it testable in its `activity(::)`
- Proof of the event being sent as part of the ticket. 

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I wrote Unit Tests that confirm the expected behavior
- [x] I added the `// Ecosia:` helper comments where needed
- [x] AB Test contexts are being sent to Snowplow correctly.

[MOB-2740]: https://ecosia.atlassian.net/browse/MOB-2740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ