### PR TITLE
[MOB-2745] Remove looping in Collection View drag item

### DIFF
--- a/Client/Frontend/Browser/TabDisplayManager.swift
+++ b/Client/Frontend/Browser/TabDisplayManager.swift
@@ -690,6 +690,10 @@ extension LegacyTabDisplayManager: UICollectionViewDragDelegate {
         guard tabDisplayType == .TopTabTray || section == .regularTabs else { return [] }
         guard let tab = dataStore.at(indexPath.item) else { return [] }
 
+        /* Ecosia: 
+         This code must be old code from v122 as not present at all in the latest version
+         on top of that, the resulting `url` is not used anywhere in the snippet below
+         
         // Get the tab's current URL. If it is `nil`, check the `sessionData` since
         // it may be a tab that has not been restored yet.
         var url = tab.url
@@ -700,6 +704,7 @@ extension LegacyTabDisplayManager: UICollectionViewDragDelegate {
                 url = urls[index]
             }
         }
+         */
 
         // Don't store the URL in the item as dragging a tab near the screen edge will prompt to open Safari with the URL
         let itemProvider = NSItemProvider()


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the PR title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2745]

## Context

Crash found in organizer when assessing the crashes upon upgrading.

## Approach

- Checked the crash in Xcode organizer
- Pointed to the crash
- Assessed root cause
- Realised the `url` check and assignment was not used anywhere in the function's scope
- Compared with [the current Firefox's implementation](https://github.com/mozilla-mobile/firefox-ios/blob/main/firefox-ios/Client/Frontend/Browser/TabDisplayManager.swift#L734-L752)
- Compared with [the Firefox implementation from v122](https://github.com/mozilla-mobile/firefox-ios/blob/release/v122/Client/Frontend/Browser/TabDisplayManager.swift#L684-L712)
- Added comment and removed the snippet
- Tested the expected behavior remaining unchanged

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I added the `// Ecosia:` helper comments where needed

[MOB-2745]: https://ecosia.atlassian.net/browse/MOB-2745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ