### PR TITLE
[MOB-2740-2] Update `resume` event

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -254,6 +254,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Ecosia
         Task {
             await FeatureManagement.fetchConfiguration()
+            analytics.activity(.resume)
         }
         MMP.sendSession()
         searchesCounter.subscribe(self) { searchCount in
@@ -302,8 +303,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func applicationWillEnterForeground(_ application: UIApplication) {
-        // Ecosia: lifecycle tracking
-        analytics.activity(.resume)
         handleForegroundEvent()
     }
 

--- a/EcosiaTests/IntegrationTests/AnalyticsFeatureManagementIntegrationTests.swift
+++ b/EcosiaTests/IntegrationTests/AnalyticsFeatureManagementIntegrationTests.swift
@@ -27,18 +27,7 @@ final class AnalyticsFeatureManagementIntegrationTests: XCTestCase {
         XCTAssertEqual(Unleash.model.toggles.count, 0)
         XCTAssertEqual(Unleash.model.updated, Date(timeIntervalSince1970: 0))
     }
-    
-    func testStateAfterInitialForeground_expectsNoModelUpdates() async {
-        let application = await UIApplication.shared
         
-        await appDelegate.applicationWillEnterForeground(application)
-        
-        XCTAssertEqual(mockAnalytics.activityCallCount, 1)
-        XCTAssertEqual(mockAnalytics.lastActivity, .resume)
-        XCTAssertEqual(Unleash.model.toggles.count, 0)
-        XCTAssertEqual(Unleash.model.updated, Date(timeIntervalSince1970: 0))
-    }
-    
     func testStateAfterDidFinishLaunchingWithOptions_expectsModelUpdates() async {
         let application = await UIApplication.shared
         let options: [UIApplication.LaunchOptionsKey: Any]? = nil
@@ -57,7 +46,7 @@ final class AnalyticsFeatureManagementIntegrationTests: XCTestCase {
         XCTAssertNotEqual(Unleash.model.toggles.count, 0)
     }
     
-    func testStateAfterSubsequentForeground_expectesSameModel_AfterDidFinishLaunchingWithOptions() async {
+    func testStateAfterDidBecomeActive_expectesSameModel_AfterDidFinishLaunchingWithOptions() async {
         let application = await UIApplication.shared
         
         // Store an updated model so to not let Unleash perform a call
@@ -75,8 +64,9 @@ final class AnalyticsFeatureManagementIntegrationTests: XCTestCase {
         let modelAfterLaunch = Unleash.model
         
         // Simulate entering background and foreground again
-        await appDelegate.applicationWillEnterForeground(application)
+        await appDelegate.applicationDidBecomeActive(application)
         
+        wait(0.5)
         XCTAssertEqual(mockAnalytics.activityCallCount, 2)
         XCTAssertEqual(mockAnalytics.lastActivity, .resume)
         XCTAssertEqual(Unleash.model.toggles.count, modelAfterLaunch.toggles.count)

--- a/EcosiaTests/IntegrationTests/AnalyticsFeatureManagementIntegrationTests.swift
+++ b/EcosiaTests/IntegrationTests/AnalyticsFeatureManagementIntegrationTests.swift
@@ -39,7 +39,7 @@ final class AnalyticsFeatureManagementIntegrationTests: XCTestCase {
         
         XCTAssertTrue(didFinishLaunching)
         // Let it go thru all the activities, including the Task detached ones
-        wait(0.5)
+        wait(1)
         XCTAssertEqual(mockAnalytics.activityCallCount, 1)
         XCTAssertEqual(mockAnalytics.lastActivity, .launch)
         XCTAssertNotEqual(Unleash.model.updated, Date(timeIntervalSince1970: 0))
@@ -58,7 +58,7 @@ final class AnalyticsFeatureManagementIntegrationTests: XCTestCase {
         
         XCTAssertTrue(didFinishLaunching)
         // Let it go thru all the activities, including the Task detached ones
-        wait(0.5)
+        wait(1)
         XCTAssertEqual(mockAnalytics.activityCallCount, 1)
         XCTAssertEqual(mockAnalytics.lastActivity, .launch)
         let modelAfterLaunch = Unleash.model
@@ -66,7 +66,7 @@ final class AnalyticsFeatureManagementIntegrationTests: XCTestCase {
         // Simulate entering background and foreground again
         await appDelegate.applicationDidBecomeActive(application)
         
-        wait(0.5)
+        wait(1)
         XCTAssertEqual(mockAnalytics.activityCallCount, 2)
         XCTAssertEqual(mockAnalytics.lastActivity, .resume)
         XCTAssertEqual(Unleash.model.toggles.count, modelAfterLaunch.toggles.count)


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the PR title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2740]

## Context

Issue found when double-checking the `resume` event given the wrong specification that it should not be triggered as part of the `didFinishLaunchingWithOption`

## Approach

- Moved the check as part of the `didBecomeActive` event
- Verified it on Snowplo

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I added the `// Ecosia:` helper comments where needed

[MOB-2740]: https://ecosia.atlassian.net/browse/MOB-2745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ