### PR TITLE
[MOB-2478] Removes unused theming code

### DIFF
--- a/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
+++ b/BrowserKit/Sources/Common/Theming/DefaultThemeManager.swift
@@ -46,7 +46,8 @@ public final class DefaultThemeManager: ThemeManager, Notifiable {
         self.mainQueue = mainQueue
         self.sharedContainerIdentifier = sharedContainerIdentifier
 
-        migrateDefaultsToUseStandard()
+        // Ecosia: Remove migration as unneded
+        //migrateDefaultsToUseStandard()
 
         self.userDefaults.register(defaults: [
             ThemeKeys.systemThemeIsOn: true,

--- a/Client/Ecosia/UI/Theme/EcosiaThemeManager.swift
+++ b/Client/Ecosia/UI/Theme/EcosiaThemeManager.swift
@@ -45,20 +45,8 @@ public final class EcosiaThemeManager: ThemeManager, Notifiable {
         self.mainQueue = mainQueue
         self.sharedContainerIdentifier = sharedContainerIdentifier
 
-        migrateDefaultsToUseStandard()
-
         self.userDefaults.register(defaults: [ThemeKeys.systemThemeIsOn: true,
                                               ThemeKeys.NightMode.isOn: NSNumber(value: false)])
-
-        /* 
-         Additional check in case the theme changed while the app was closed
-         Within loadInitialStoredThemeType(), a check of a persisted value is made 👇
-         
-         let savedThemeDescription = userDefaults.string(forKey: ThemeKeys.themeName)
-         
-         This check will extract the last saved theme before killing the app, therefore a different one in case we switched at app killed state where no observers were alive.
-         */
-        updateLegacyThemeIfNeeded()
         changeCurrentTheme(loadInitialStoredThemeType())
 
         setupNotifications(forObserver: self,


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the PR title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2748]

## Context

- The User reported that _"There is only one option for System settings"_
- The UX allows to switch dark/light mode manually when toggling OFF the System Setting
- Once toggled off, the issue encountered is the reset of the System Toggle regardless of its previous state

## Approach

- Understand context and compare codebases
- Realised there's unneeded `updateLegacyThemeIfNeeded()` given the latest implementation and theming fixes
- Old unneeded Firefox migration code was causing the issue, always referring to the old parameters 

Info and video in the Jira ticket.

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I added the `// Ecosia:` helper comments where needed
- [x] I performed an upgrade check when mutating system setting and observing the App keeping the state upon upgrade 

[MOB-2748]: https://ecosia.atlassian.net/browse/MOB-2748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ