### PR TITLE
[MOB-2761] Add FasterInactiveTabs to Ecosia debug settings

### DIFF
--- a/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
+++ b/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
@@ -156,7 +156,8 @@ extension AppSettingsTableViewController {
             ChangeSearchCount(settings: self),
             ResetSearchCount(settings: self),
             UnleashBingDistributionSetting(settings: self),
-            EngagementServiceIdentifierSetting(settings: self)
+            EngagementServiceIdentifierSetting(settings: self),
+            FasterInactiveTabs(settings: self, settingsDelegate: self),
         ]
         
         return SettingSection(title: NSAttributedString(string: "Debug"), children: hiddenDebugSettings)


### PR DESCRIPTION
[MOB-2761]

## Context
We've had a couple issues to investigate about inactive tabs.

## Approach
Just adding the new Firefox debug setting that helps get inactive tabs for testing.

[MOB-2761]: https://ecosia.atlassian.net/browse/MOB-2761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ