### PR TITLE
[MOB-2755] Hide progress bar if in overlay mode

### DIFF
--- a/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -595,7 +595,9 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
 
     func updateProgressBar(_ progress: Float) {
         progressBar.alpha = 1
-        progressBar.isHidden = false
+        // Ecosia: Do not show loading state when user has selected the url bar and is potentially typing
+        // progressBar.isHidden = false
+        progressBar.isHidden = inOverlayMode
         progressBar.setProgress(progress, animated: !isTransitioning)
     }
 


### PR DESCRIPTION
[MOB-2755]

## Context

There is a visual bug after the upgrade where the progress bar is visible while typing (see ticket above).

## Approach

### Root cause

We observe `estimatedProgress` and [update the bar when it changes](https://github.com/ecosia/ios-browser/blob/b2788392f378c09c6dd88d3a00507075be129a3e/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift#L1376-L1384), **independent of wether the overlay is showing** (overlay being what appear once the user clicks on the url bar).

### Solution

The simplest change to fix that was to keep the progress bar hidden if we are in overlay mode.

I investigated whether it could mean this is mistakenly kept hidden once user exits overlay mode, and, though this makes theoretical sense, I believe the change is quite safe give the next time the progress is update it will be shown again (unless it's done in which case we do want to keep it hidden).

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I added the `// Ecosia:` helper comments where needed

[MOB-2755]: https://ecosia.atlassian.net/browse/MOB-2755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ