### PR TITLE
[MOB-2775] Fix passwords decryption

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -19384,7 +19384,7 @@
 				CODE_SIGN_ENTITLEMENTS = "$(inherited)";
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				DEVELOPMENT_TEAM = 43AQ936H96;
+				DEVELOPMENT_TEAM = 33YMRSYD2L;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 33YMRSYD2L;
 				EXCLUDED_SOURCE_FILE_NAMES = "Client/Nimbus/TestData/*";
 				INFOPLIST_FILE = Client/Info.plist;
@@ -19897,7 +19897,7 @@
 				CODE_SIGN_ENTITLEMENTS = "$(inherited)";
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				DEVELOPMENT_TEAM = 43AQ936H96;
+				DEVELOPMENT_TEAM = 33YMRSYD2L;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 33YMRSYD2L;
 				EXCLUDED_SOURCE_FILE_NAMES = "Client/Nimbus/TestData/*";
 				INFOPLIST_FILE = Client/Info.plist;
@@ -20147,7 +20147,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 33YMRSYD2L;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 33YMRSYD2L;
 				EXCLUDED_ARCHS = "";
 				EXCLUDED_SOURCE_FILE_NAMES = (
@@ -20381,7 +20381,7 @@
 				CODE_SIGN_ENTITLEMENTS = "$(inherited)";
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				DEVELOPMENT_TEAM = 43AQ936H96;
+				DEVELOPMENT_TEAM = 33YMRSYD2L;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 33YMRSYD2L;
 				EXCLUDED_SOURCE_FILE_NAMES = "Client/Nimbus/TestData/*";
 				INFOPLIST_FILE = Client/Info.plist;
@@ -20575,7 +20575,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 33YMRSYD2L;
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 33YMRSYD2L;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Shared/AppInfo.swift
+++ b/Shared/AppInfo.swift
@@ -85,6 +85,6 @@ extension AppInfo {
     
     /// Return the keychain access group.
     public static func ecosiaKeychainAccessGroupWithPrefix(_ prefix: String) -> String {
-        return "\(prefix)\(".")+\(baseBundleIdentifier)"
+        return "\(prefix).\(baseBundleIdentifier)"
     }
 }


### PR DESCRIPTION
[MOB-2775]

## Context

Some users reported passwords being broken after the upgrade (see ticket).

## Approach

After some debugging, found that the issue was while retrieving the encryption key for the secure fields (username and password) from the Keychain.

This resulted in the wrong keychain being returned as the shared instance ([this code here](https://github.com/ecosia/ios-browser/blob/3ccf192e60739c43b03103b32d8ce2c782ce1026/Shared/Extensions/KeychainWrapperExtensions.swift#L10-L15)), the reason for it being a **wrong access group identifier**.

After that it was possible to identify that the custom `ecosiaKeychainAccessGroupWithPrefix` introduced during the upgrade had a wrong `+` sign with it, which was the main issue for the error.

## Other

After fixing the issue above, I still had problems in Debug, and noticed this was due to a missing `DEVELOPMENT_TEAM` on the required debug configuration. Took the opportunity to update all instances of that throughout configurations to the expected Ecosia GmbH team (`33YMRSYD2L`). This now matches the same we had previously on 104.

Obs.: I noticed on the new version we've added the correct `DEVELOPMENT_TEAM` to the Config files, but for some reason **this was not working**, so I had to update on the project file.

## Caveat

Any passwords created after the upgrade will continue in a broken state as the app was not pointing to the correct keychain and we should instruct users to delete them. Even so, old passwords will work again with this fix 🎉 

Will make sure to inform user support accordingly.


### Checklist

- [x] I performed some relevant testing on a real device and/or simulator

[MOB-2775]: https://ecosia.atlassian.net/browse/MOB-2775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ