### PR TITLE
Update source release notes for 10.0.5

### DIFF
--- a/fastlane/metadata/en-US/release_notes.txt
+++ b/fastlane/metadata/en-US/release_notes.txt
@@ -1,1 +1,1 @@
-We fixed some bugs and added some stability improvements.
+We've resolved the issues with the password manager and fixed a few bugs


### PR DESCRIPTION
Updating release notes in preparation for https://github.com/ecosia/ios-browser/pull/739.
