### PR TITLE
Specify Linux platform in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -227,6 +227,7 @@ PLATFORMS
   arm64-darwin-22
   universal-darwin-23
   x86_64-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   base64


### PR DESCRIPTION
## Context

The new Gemfile requires the platforms to be explicitly specified.
For the Release Notes Update we use a linux platform (faster image) to install the Bundles and let the process work.  

## Approach

Add the linux platform.