### PR TITLE
[MOB-2815] Implement Top Site calculation fix

### DIFF
--- a/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
+++ b/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
@@ -209,13 +209,17 @@ extension TopSitesViewModel: HomepageViewModelProtocol, FeatureFlaggable {
                      size: CGSize,
                      isPortrait: Bool = UIWindow.isPortrait,
                      device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) {
+        // Ecosia: correctly assign the latest set `numberOfRows` and calculate based on all top sites
+        numberOfRows = topSitesDataAdaptor.numberOfRows
+        topSites = unfilteredTopSites
         let interface = TopSitesUIInterface(trait: traitCollection,
                                             availableWidth: size.width)
         let sectionDimension = dimensionManager.getSectionDimension(for: topSites,
                                                                     numberOfRows: numberOfRows,
                                                                     interface: interface)
         numberOfItems = sectionDimension.numberOfRows * sectionDimension.numberOfTilesPerRow
-        topSites = unfilteredTopSites
+        // Ecosia: Move topsite declaration up
+        // topSites = unfilteredTopSites
         if numberOfItems < unfilteredTopSites.count {
             let range = numberOfItems..<unfilteredTopSites.count
             topSites.removeSubrange(range)


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2815]

## Context

An issue when the HopePage didn't set the latest TopSites based on the customisation setting was found by our fellow Ecosian.

## Approach

Find root cause and fix it.

That's likely an issue in our base branch. 
Not only the calculation of the `topSite` is not done counting on the whole set of loaded `topSites`, but the `numberOfRows` is not reflecting the latest set via the appropriate UI setting.
Changing that allowed the correct UI update.

| Video |
| ------ |
|![Simulator Screen Recording - iPhone 15 - 2024-08-12 at 16 43 40](https://github.com/user-attachments/assets/20369de2-8601-4141-a5a4-005492a9c5d9)|

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I added the `// Ecosia:` helper comments where needed

[MOB-2815]: https://ecosia.atlassian.net/browse/MOB-2815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ