### PR TITLE
[MOB-2773] Set version on install when fresh install type

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -21358,7 +21358,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ecosia/ios-core.git";
 			requirement = {
-				branch = "ls-mob-2773-send-version-on-install-to-unleash";
+				branch = main;
 				kind = branch;
 			};
 		};

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -21358,7 +21358,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ecosia/ios-core.git";
 			requirement = {
-				branch = main;
+				branch = "ls-mob-2773-send-version-on-install-to-unleash";
 				kind = branch;
 			};
 		};

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "66ec7f099ec1e31841468c6636474919fe9a4bf8"
+        "branch" : "ls-mob-2773-send-version-on-install-to-unleash",
+        "revision" : "31a28d0279f2619c33da5e53bb18bc9174feb6c4"
       }
     },
     {
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SDWebImage/SDWebImage.git",
       "state" : {
-        "revision" : "be0bcd7823ce56629948491f2eaeaa19979514f7",
-        "version" : "5.19.4"
+        "revision" : "5191b801aca999b704eb93f118f91468b4570571",
+        "version" : "5.19.6"
       }
     },
     {
@@ -147,7 +147,7 @@
     {
       "identity" : "snowplow-ios-tracker",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/snowplow/snowplow-ios-tracker",
+      "location" : "https://github.com/snowplow/snowplow-ios-tracker.git",
       "state" : {
         "revision" : "1e16a929cef8e944bd41dc36a1d2779e06bd0a3c",
         "version" : "5.2.0"

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
-        "branch" : "ls-mob-2773-send-version-on-install-to-unleash",
-        "revision" : "31a28d0279f2619c33da5e53bb18bc9174feb6c4"
+        "branch" : "main",
+        "revision" : "9448d059627ecd447ef3f58ede00d385c6232119"
       }
     },
     {

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -174,7 +174,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             ))
         }
          */
-        // Ecosia: Update EcosiaInstallType if needed
+        // Ecosia: Update EcosiaInstallType if needed. This should always happen before `FeatureManagement`.
         EcosiaInstallType.evaluateCurrentEcosiaInstallType()
         // Ecosia: Disable BG sync //backgroundSyncUtil = BackgroundSyncUtil(profile: profile, application: application)
         

--- a/Client/Ecosia/Helpers/EcosiaInstallType/EcosiaInstallType+Extensions.swift
+++ b/Client/Ecosia/Helpers/EcosiaInstallType/EcosiaInstallType+Extensions.swift
@@ -23,6 +23,7 @@ extension EcosiaInstallType {
             EcosiaInstallType.get() == .unknown {
             EcosiaInstallType.set(type: .fresh)
             EcosiaInstallType.updateCurrentVersion(version: versionProvider.version)
+            User.shared.versionOnInstall = versionProvider.version
         }
         
         if EcosiaInstallType.persistedCurrentVersion() != versionProvider.version {

--- a/EcosiaTests/EcosiaInstallTypeTests.swift
+++ b/EcosiaTests/EcosiaInstallTypeTests.swift
@@ -97,6 +97,26 @@ extension EcosiaInstallTypeTests {
         XCTAssertEqual(EcosiaInstallType.get(), .upgrade)
         XCTAssertEqual(EcosiaInstallType.persistedCurrentVersion(), "1.0.0")
     }
+    
+    func testEvaluateUpgradeInstallType_UpdatesVersionOnInstall_WhenFirstTime() {
+        User.shared.firstTime = true
+        User.shared.versionOnInstall = "0.0.1"
+        
+        let versionProvider = MockAppVersionInfoProvider(mockedAppVersion: "1.0.0")
+        EcosiaInstallType.evaluateCurrentEcosiaInstallType(withVersionProvider: versionProvider)
+        
+        XCTAssertEqual(User.shared.versionOnInstall, "1.0.0")
+    }
+    
+    func testEvaluateUpgradeInstallType_DoesNotUpdatesVersionOnInstall_WhenNotFirstTime() {
+        User.shared.firstTime = false
+        User.shared.versionOnInstall = "0.0.1"
+        
+        let versionProvider = MockAppVersionInfoProvider(mockedAppVersion: "1.0.0")
+        EcosiaInstallType.evaluateCurrentEcosiaInstallType(withVersionProvider: versionProvider)
+        
+        XCTAssertEqual(User.shared.versionOnInstall, "0.0.1")
+    }
 }
 
 extension EcosiaInstallTypeTests {


### PR DESCRIPTION
[MOB-2773]

## Context
We want to store version on install so this can be sent to Unleash.

## Approach
Using the existing `EcosiaInstallType` to know exactly when it is a fresh install and should be stored.

## Before merging

- [x] Merge https://github.com/ecosia/ios-core/pull/155

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I wrote Unit Tests that confirm the expected behaviour

[MOB-2773]: https://ecosia.atlassian.net/browse/MOB-2773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ