### PR TITLE
[MOB-2758] Add source translations for climate impact CTA experiment

### DIFF
--- a/Client/Ecosia/L10N/String.swift
+++ b/Client/Ecosia/L10N/String.swift
@@ -242,5 +242,7 @@ extension String {
         case apnConsentCTAAllowButtonTitle = "Allow push notifications"
         case apnConsentSkipButtonTitle = "Not now"
         case apnConsentLastReminderSkipButtonTitle = "No thanks"
+        case climateImpactCTAExperimentText1 = "See where our money goes"
+        case climateImpactCTAExperimentText2 = "Check out our monthly updates"
     }
 }

--- a/Client/Ecosia/L10N/en.lproj/Ecosia.strings
+++ b/Client/Ecosia/L10N/en.lproj/Ecosia.strings
@@ -68,6 +68,8 @@
 "Show on homepage" = "Show on homepage";
 "Top Sites" = "Top Sites";
 "Quick Search" = "Quick Search";
+"See where our money goes" = "See where our money goes";
+"Check out our monthly updates" = "Check out our monthly updates";
 
 // Impact
 "A friend accepted your invitation and each of you will help plant 1 tree!" = "A friend has accepted your invite! You have each helped plant 1 extra tree.";


### PR DESCRIPTION
[MOB-2758]

In preparation for https://github.com/ecosia/ios-browser/pull/749, adding necessary English translations as source language.

This will trigger Transifex's integration to get the texts on other languages.

[MOB-2758]: https://ecosia.atlassian.net/browse/MOB-2758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ