### PR TITLE
[MOB-2758] Fix button layout issue on FinancialReportsCTAView

### DIFF
--- a/Client/Ecosia/UI/NTP/Impact/FinancialReportsCTAView.swift
+++ b/Client/Ecosia/UI/NTP/Impact/FinancialReportsCTAView.swift
@@ -20,6 +20,7 @@ final class FinancialReportsCTAView: UIView, Themeable {
         button.buttonEdgeSpacing = 0
         button.addTarget(self, action: #selector(buttonAction), for: .touchUpInside)
         button.clipsToBounds = true
+        button.setTitleColor(.legacyTheme.ecosia.primaryButton, for: .normal)
         return button
     }()
     

--- a/Client/Ecosia/UI/NTP/Impact/NTPImpactCell.swift
+++ b/Client/Ecosia/UI/NTP/Impact/NTPImpactCell.swift
@@ -96,6 +96,7 @@ final class NTPImpactCell: UICollectionViewCell, Themeable, ReusableCell {
         guard ClimateImpactCTAExperiment.isEnabled else { return }
         row.updateLayoutForCTA()
         containerStack.addArrangedSubview(financialReportCTAView)
+        financialReportCTAView.layoutSubviews() // Needed since it's here that the intended size is known
         ClimateImpactCTAExperiment.trackExperimentImpression()
     }
     


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2758]

## Context

A layouting bug was reported on [this comment](https://ecosia.atlassian.net/browse/MOB-2758?focusedCommentId=93924).

## Approach

Figured out this is due to the button having the wrong frame when initialising. It was hard to reproduce because other sections (like news) trigger refresh of the table after it initialised and therefore fix the issue. **Hiding other section made the issue easily reproducible.**

In the end, forcing re-layout when the view was already added to the stack (and therefore can calculate it's intrinsic size correctly) fixed the issue.

## Other

Not sure why color was also affected, but setting it when initialising the button fixes that 🤷 

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator

[MOB-2758]: https://ecosia.atlassian.net/browse/MOB-2758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ