### PR TITLE
Update release notes to default message in all languages

### DIFF
--- a/fastlane/metadata/de-DE/release_notes.txt
+++ b/fastlane/metadata/de-DE/release_notes.txt
@@ -1,1 +1,1 @@
-Wir haben die Probleme mit dem Passwort-Manager gelöst und ein paar Fehler behoben.
+Wir haben einige Bugs behoben und die Stabilität verbessert.

--- a/fastlane/metadata/en-US/release_notes.txt
+++ b/fastlane/metadata/en-US/release_notes.txt
@@ -1,1 +1,1 @@
-We've resolved the issues with the password manager and fixed a few bugs
+We fixed some bugs and added some stability improvements.

--- a/fastlane/metadata/es-ES/release_notes.txt
+++ b/fastlane/metadata/es-ES/release_notes.txt
@@ -1,1 +1,1 @@
-Hemos resuelto los problemas con el administrador de contraseñas y corregido algunos errores.
+Arreglamos algunos bugs y añadimos algunas mejoras de estabilidad.

--- a/fastlane/metadata/fr-FR/release_notes.txt
+++ b/fastlane/metadata/fr-FR/release_notes.txt
@@ -1,1 +1,1 @@
-Nous avons résolu les problèmes avec le gestionnaire de mots de passe et corrigé quelques bugs.
+Nous avons résolu quelques problèmes et ajouté des améliorations en termes de stabilité.

--- a/fastlane/metadata/it/release_notes.txt
+++ b/fastlane/metadata/it/release_notes.txt
@@ -1,1 +1,1 @@
-Abbiamo risolto i problemi con il gestore delle password e corretto alcuni bug.
+Abbiamo risolto alcuni bug e aggiunto alcuni miglioramenti della stabilità.

--- a/fastlane/metadata/nl-NL/release_notes.txt
+++ b/fastlane/metadata/nl-NL/release_notes.txt
@@ -1,1 +1,1 @@
-We hebben de problemen met de wachtwoordmanager opgelost en een paar bugs verholpen.
+We hebben een aantal bugs verholpen en een aantal stabiliteitsverbeteringen doorgevoerd.


### PR DESCRIPTION
Falling back to the default messaging, took it out from [this commit the english](https://github.com/ecosia/ios-browser/commit/ea0f0d064dbf8271c3841844c15706b4a562baad) and [this PR the other languages](https://github.com/ecosia/ios-browser/pull/729/files).