### PR TITLE
[MOB-2749] Update SPM to squeeze in the Unleash improvement

### DIFF
--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -69,7 +69,7 @@
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
         "branch" : "main",
-        "revision" : "9448d059627ecd447ef3f58ede00d385c6232119"
+        "revision" : "50868f486260f5ba2c44e8fffdb9de130ad103d4"
       }
     },
     {


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2749]

## Context

We found multiple crashes possibly due to different threads trying to access and return the Unleash initialisation model.

## Approach

Update SPM to link to the latest Unleash implementation.

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator

[MOB-2749]: https://ecosia.atlassian.net/browse/MOB-2749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ