### PR TITLE
[MOB-2846] Apple Navigation appearance same as Widgets settting

### DIFF
--- a/Client/Frontend/Settings/SettingsNavigationController.swift
+++ b/Client/Frontend/Settings/SettingsNavigationController.swift
@@ -46,6 +46,7 @@ class ThemedNavigationController: DismissableNavigationViewController, Themeable
         let standardAppearance = UINavigationBarAppearance()
         standardAppearance.configureWithDefaultBackground()
         standardAppearance.backgroundColor = theme.colors.layer1
+        // Ecosia: Define `largeTitleTextAttributes` as done for ThemedDefaultNavigationController utilized in Widgets
         standardAppearance.largeTitleTextAttributes = [.foregroundColor: theme.colors.textPrimary]
         standardAppearance.titleTextAttributes = [.foregroundColor: theme.colors.textPrimary]
 

--- a/Client/Frontend/Settings/SettingsNavigationController.swift
+++ b/Client/Frontend/Settings/SettingsNavigationController.swift
@@ -46,6 +46,7 @@ class ThemedNavigationController: DismissableNavigationViewController, Themeable
         let standardAppearance = UINavigationBarAppearance()
         standardAppearance.configureWithDefaultBackground()
         standardAppearance.backgroundColor = theme.colors.layer1
+        standardAppearance.largeTitleTextAttributes = [.foregroundColor: theme.colors.textPrimary]
         standardAppearance.titleTextAttributes = [.foregroundColor: theme.colors.textPrimary]
 
         // Ecosia: Update navigationBar properties


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2846]

## Context

As noticed by one of our fellow Ecosians, when switching the theme with the settings page opened, the Settings title doesn’t behave correctly.

## Approach

Investigated and found out that for the `ThemeDefaultNavigationController` (why having `ThemedNavigationController` and this 🤷‍♂️ ) the `largeTitleTextAttributes` are defined and override the NavigationController's navigation bar appearance.
A recorded simulator with the issue fixed is provided as part of a Jira comment on the ticket.

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I added the `// Ecosia:` helper comments where needed


[MOB-2846]: https://ecosia.atlassian.net/browse/MOB-2846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ