### PR TITLE
[MOB-2845] Fix collapsed url bar opening app on landscape

### DIFF
--- a/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -796,9 +796,7 @@ class BrowserViewController: UIViewController,
 
         // During split screen launching on iPad, this callback gets fired before viewDidLoad gets a chance to
         // set things up. Make sure to only update the toolbar state if the view is ready for it.
-        // Ecosia: Update check
-        // if isViewLoaded {
-        if isViewLoaded && UIDevice.current.userInterfaceIdiom == .pad {
+        if isViewLoaded {
             updateToolbarStateForTraitCollection(newCollection)
         }
 


### PR DESCRIPTION
[MOB-2845]

## Context

A bug was reported showing a collapsed url bar (see ticket).

## Approach

Took a while but I found out that to reproduce it reliable one needs to open the app while on landscape mode.
After that, I was able to identify the issue being that we update the toolbar visibility state only on view did load but not when the phone is rotated.

To fix it, I only had to remove a restriction added by us that only updated the toolbar state on rotation if the device was iPad. 

<details>
<summary>Video examples</summary>

### Video with Bug

https://github.com/user-attachments/assets/0cfb6d79-0a35-4df9-8f6d-f29f4c7ba5d9

### Video with fix

https://github.com/user-attachments/assets/c13485a7-53c9-425a-acb7-0f542a101515

</details>

## Other

This [restriction was introduced on this PR](https://github.com/ecosia/ios-browser/pull/712/files#diff-731e828f90bc8f282c2f87e1d178036da99525826e1f9786778edadfb984a40e) and caused other issues such as the landscape orientation not unifying url bar and toolbar if the app was opened on portrait.

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator

[MOB-2845]: https://ecosia.atlassian.net/browse/MOB-2845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ