### PR TITLE
[MOB-2862] No URLBar overlay on new tabs showing the New Tab Page

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -370,6 +370,7 @@
 		2CABD7282C12EF1E00A0750F /* PrivateModeButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CABD7272C12EF1E00A0750F /* PrivateModeButtonTests.swift */; };
 		2CC8AC342C4F887D000A669A /* MockAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC8AC332C4F887D000A669A /* MockAnalytics.swift */; };
 		2CCFB3D72C0FBEE800BEDCA0 /* TabToolbarHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D815A3A724A53F3200AAB221 /* TabToolbarHelperTests.swift */; };
+		2CD48B7F2C7F7E4100A70908 /* EcosiaOverlayModeManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD48B7E2C7F7E4100A70908 /* EcosiaOverlayModeManagerTests.swift */; };
 		2CE294472B7CDD56006C22B2 /* Core in Frameworks */ = {isa = PBXBuildFile; productRef = 2CE294462B7CDD56006C22B2 /* Core */; };
 		2CE294492B7CDD78006C22B2 /* Core in Frameworks */ = {isa = PBXBuildFile; productRef = 2CE294482B7CDD78006C22B2 /* Core */; };
 		2CE2E24D2B9B1FCB00973C16 /* Core in Frameworks */ = {isa = PBXBuildFile; productRef = 2CE2E24C2B9B1FCB00973C16 /* Core */; };
@@ -2532,6 +2533,7 @@
 		2CCF17522105E4FD00705AE5 /* DisplaySettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplaySettingsTests.swift; sourceTree = "<group>"; };
 		2CCFB3D42C0F1EA500BEDCA0 /* LoadingScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoadingScreen.swift; sourceTree = "<group>"; };
 		2CD368492C5BC31700972871 /* OnboardingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingTests.swift; sourceTree = "<group>"; };
+		2CD48B7E2C7F7E4100A70908 /* EcosiaOverlayModeManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EcosiaOverlayModeManagerTests.swift; sourceTree = "<group>"; };
 		2CE294442B7CDD05006C22B2 /* CoreAudioTypes.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudioTypes.framework; path = System/Library/Frameworks/CoreAudioTypes.framework; sourceTree = SDKROOT; };
 		2CE294672B7FC5A4006C22B2 /* EcosiaInstallTypeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EcosiaInstallTypeTests.swift; sourceTree = "<group>"; };
 		2CE294692B7FC5A5006C22B2 /* AnalyticsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnalyticsTests.swift; sourceTree = "<group>"; };
@@ -8910,6 +8912,7 @@
 				2C26EA132C04CAD100795552 /* EcosiaTopSitesHelperTests.swift */,
 				2CABD7272C12EF1E00A0750F /* PrivateModeButtonTests.swift */,
 				2C2349A22C57E5BC007A5894 /* EcosiaPerformanceTestHistory.swift */,
+				2CD48B7E2C7F7E4100A70908 /* EcosiaOverlayModeManagerTests.swift */,
 			);
 			path = EcosiaTests;
 			sourceTree = "<group>";
@@ -14629,6 +14632,7 @@
 				D82ED2641FEB3C420059570B /* DefaultSearchPrefsTests.swift in Sources */,
 				1D74FF502B2797EA00FF01D0 /* WindowManagerTests.swift in Sources */,
 				CA24B53B24ABFE5D0093848C /* PasswordManagerDataSourceHelperTests.swift in Sources */,
+				2CD48B7F2C7F7E4100A70908 /* EcosiaOverlayModeManagerTests.swift in Sources */,
 				E1390FB828B42EF200C9EF3E /* WallpaperManagerMock.swift in Sources */,
 				ABB507CF2A136FB2009CAA67 /* UserConversionMetricsTests.swift in Sources */,
 				21FA8FB22AE856EB0013B815 /* MockTabTrayCoordinatorDelegate.swift in Sources */,

--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -122,11 +122,7 @@ class BrowserCoordinator: BaseCoordinator,
         // -> delay of 0.5s to wait for animations and dismissals to finish
         if inline, !User.shared.firstTime {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
-                if self?.browserViewController.presentInsightfulSheetsIfNeeded() == true {
-                    (overlayManager as? DefaultOverlayModeManager)?.overrideShouldEnterOverlayMode = false
-                } else {
-                    (overlayManager as? DefaultOverlayModeManager)?.overrideShouldEnterOverlayMode = nil
-                }
+                self?.browserViewController.presentInsightfulSheetsIfNeeded()
                 // Ecosia: at this stage, we consider it a safe place where storing the current version
                 EcosiaInstallType.evaluateCurrentEcosiaInstallType(storeUpgradeVersion: true)
             }

--- a/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2560,6 +2560,7 @@ extension BrowserViewController {
         user.referrals.pendingClaim != nil
     }
 
+    // Ecosia: Function that presents the Ecosia cards at given priority if needed
     func presentInsightfulSheetsIfNeeded() {
         guard isHomePage(),
               !showLoadingScreen(for: .shared) else { return }

--- a/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2560,9 +2560,9 @@ extension BrowserViewController {
         user.referrals.pendingClaim != nil
     }
 
-    func presentInsightfulSheetsIfNeeded() -> Bool {
+    func presentInsightfulSheetsIfNeeded() {
         guard isHomePage(),
-              !showLoadingScreen(for: .shared) else { return false }
+              !showLoadingScreen(for: .shared) else { return }
         
         // TODO: To review this logic as part of the upgrade
         /*
@@ -2579,7 +2579,7 @@ extension BrowserViewController {
             presentAPNConsentIfNeeded
         ]
 
-        return (presentationFunctions.first(where: { $0() }) != nil)
+        _ = presentationFunctions.first(where: { $0() })
     }
 
     private func isHomePage() -> Bool {

--- a/Client/Frontend/Toolbar+URLBar/OverlayModeManager.swift
+++ b/Client/Frontend/Toolbar+URLBar/OverlayModeManager.swift
@@ -76,7 +76,13 @@ class DefaultOverlayModeManager: OverlayModeManager {
         // The NewTabPage cases are weird topSites = homepage
         // and homepage = customURL
         switch newTabSettings {
-        case .topSites: return url?.isFxHomeUrl ?? true
+        /*
+         Ecosia: Given the upper comment, we'll return `false` for `topSites`
+         so that it won't go in overlay mode as soon as we open a new tab
+         and present the New Tab Page.
+         */
+        // case .topSites: return url?.isFxHomeUrl ?? true
+        case .topSites: return false
         case .blankPage: return true
         case .homePage: return false
         }

--- a/EcosiaTests/EcosiaOverlayModeManagerTests.swift
+++ b/EcosiaTests/EcosiaOverlayModeManagerTests.swift
@@ -1,0 +1,47 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+
+@testable import Client
+
+final class EcosiaOverlayModeManagerTests: XCTestCase {
+    
+    private var urlBar: MockURLBarView!
+    private var subject: MockOverlayModeManager!
+
+    override func setUp() {
+        super.setUp()
+        urlBar = MockURLBarView()
+        subject = MockOverlayModeManager()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        urlBar = nil
+        subject = nil
+    }
+
+    // MARK: - Test URLBarView Overlay override nil
+    func testOverridesToEnterOverlayMode_EntersOverlayMode_ForNewTabHome_WithNilURL() {
+        subject.setURLBar(urlBarView: urlBar)
+        subject.openNewTab(url: nil, newTabSettings: .topSites)
+        XCTAssertFalse(subject.inOverlayMode)
+        subject.overrideShouldEnterOverlayMode = true
+        subject.openNewTab(url: nil, newTabSettings: .topSites)
+        XCTAssertTrue(subject.inOverlayMode)
+        XCTAssertEqual(subject.enterOverlayModeCallCount, 2)
+    }
+
+    func testOverridesToEnterOverlayMode_EntersOverlayMode_ForNewTabHome_WithHomeURL() {
+        subject.setURLBar(urlBarView: urlBar)
+        subject.openNewTab(url: URL(string: "internal://local/about/home"),
+                           newTabSettings: .topSites)
+        XCTAssertFalse(subject.inOverlayMode)
+        subject.overrideShouldEnterOverlayMode = true
+        subject.openNewTab(url: nil, newTabSettings: .topSites)
+        XCTAssertTrue(subject.inOverlayMode)
+        XCTAssertEqual(subject.enterOverlayModeCallCount, 2)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/ContextualHints/ContextualHintEligibilityUtilityTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/ContextualHints/ContextualHintEligibilityUtilityTests.swift
@@ -165,6 +165,11 @@ class ContextualHintEligibilityUtilityTests: XCTestCase {
         XCTAssertFalse(result)
     }
 
+    /*
+     Ecosia: Remove faulty `JumpBackIn` tests
+     depending on the overlay state as for new tabs
+     the overlay state is false by default
+     
     func test_shouldNotPresentJumpBackHint_WithOverlayMode() {
         subject = ContextualHintEligibilityUtility(with: profile,
                                                    overlayState: overlayState,
@@ -173,6 +178,7 @@ class ContextualHintEligibilityUtilityTests: XCTestCase {
         let result = subject.canPresent(.jumpBackIn)
         XCTAssertFalse(result)
     }
+     */
 
     func test_shouldNotPresentJumpBackInWhenSyncedTabConfigured() {
         profile.prefs.setBool(true, forKey: CFRPrefsKeys.jumpBackInSyncedTabConfiguredKey.rawValue)
@@ -188,6 +194,11 @@ class ContextualHintEligibilityUtilityTests: XCTestCase {
         XCTAssertFalse(result)
     }
 
+    /*
+     Ecosia: Remove faulty `JumpBackIn` tests
+     depending on the overlay state as for new tabs
+     the overlay state is false by default
+     
     func test_shouldNotPresentSyncedHint_WithOverlayMode() {
         subject = ContextualHintEligibilityUtility(with: profile,
                                                    overlayState: overlayState,
@@ -196,6 +207,7 @@ class ContextualHintEligibilityUtilityTests: XCTestCase {
         let result = subject.canPresent(.jumpBackInSyncedTab)
         XCTAssertFalse(result)
     }
+     */
 
     // Test Shopping CFRs
     func test_canPresentShoppingCFR_FirstDisplay_UserHasNotOptedIn() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OverlayModeManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OverlayModeManagerTests.swift
@@ -32,8 +32,9 @@ class OverlayModeManagerTests: XCTestCase {
     func testEnterOverlayMode_ForNewTabHome_WithNilURL() {
         subject.setURLBar(urlBarView: urlBar)
         subject.openNewTab(url: nil, newTabSettings: .topSites)
-
-        XCTAssertTrue(subject.inOverlayMode)
+        // Ecosia: Update with the new Ecosia's behaviour where overlay mode is OFF for New Tab
+        // XCTAssertTrue(subject.inOverlayMode)
+        XCTAssertFalse(subject.inOverlayMode)
         XCTAssertEqual(subject.enterOverlayModeCallCount, 1)
     }
 
@@ -42,7 +43,9 @@ class OverlayModeManagerTests: XCTestCase {
         subject.openNewTab(url: URL(string: "internal://local/about/home"),
                            newTabSettings: .topSites)
 
-        XCTAssertTrue(subject.inOverlayMode)
+        // Ecosia: Update with the new Ecosia's behaviour where overlay mode is OFF for New Tab
+        // XCTAssertTrue(subject.inOverlayMode)
+        XCTAssertFalse(subject.inOverlayMode)
         XCTAssertEqual(subject.enterOverlayModeCallCount, 1)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/OverlayModeManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/OverlayModeManagerTests.swift
@@ -29,7 +29,9 @@ class OverlayModeManagerTests: XCTestCase {
     }
 
     // MARK: - Test EnterOverlay for New tab
-    func testEnterOverlayMode_ForNewTabHome_WithNilURL() {
+    // Ecosia: Update test name according to the expected behaviour
+    // func testEnterOverlayMode_ForNewTabHome_WithNilURL() {
+    func testDoesNotEnterOverlayMode_ForNewTabHome_WithNilURL() {
         subject.setURLBar(urlBarView: urlBar)
         subject.openNewTab(url: nil, newTabSettings: .topSites)
         // Ecosia: Update with the new Ecosia's behaviour where overlay mode is OFF for New Tab
@@ -38,7 +40,9 @@ class OverlayModeManagerTests: XCTestCase {
         XCTAssertEqual(subject.enterOverlayModeCallCount, 1)
     }
 
-    func testEnterOverlayMode_ForNewTabHome_WithHomeURL() {
+    // Ecosia: Update test name according to the expected behaviour
+    // func testEnterOverlayMode_ForNewTabHome_WithHomeURL() {
+    func testDoesNotEnterOverlayMode_ForNewTabHome_WithHomeURL() {
         subject.setURLBar(urlBarView: urlBar)
         subject.openNewTab(url: URL(string: "internal://local/about/home"),
                            newTabSettings: .topSites)


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2862]

## Context

One of the features we got from Firefox was the Auto-focus of the URL Bar upon opening an NTP.
While this is handy for a product whose main purpose is browsing, we want to turn it off to favor the discovery of the NTP itself.

## Approach

To keep the feature and mix it with our custom UX when showing cards, we implemented an overridden mechanism for the `DefaultOverlayModeManager` only. While we'll keep it for further convenience, we'll remove it for this UX specifically, as well as forcing the URLBar not to enter overlay mode whenever a New Tab Page is presented.

## Other

- Enriched Unit Tests for the overridden state and modified the current ones for the overlay behaviour.

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I wrote Unit Tests that confirm the expected behaviour
- [x] I added the `// Ecosia:` helper comments where needed

[MOB-2862]: https://ecosia.atlassian.net/browse/MOB-2862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ