### PR TITLE
[MOB-2820] Make sure the install event is sent only once

### DIFF
--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -211,6 +211,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         widgetManager = TopSitesWidgetManager(topSitesProvider: topSitesProvider)
 
         addObservers()
+        
+        // Ecosia: Send the install event. It happens only once per App install.
+        Analytics.shared.install()
 
         logger.log("didFinishLaunchingWithOptions end",
                    level: .info,

--- a/Client/Coordinators/Launch/LaunchCoordinator.swift
+++ b/Client/Coordinators/Launch/LaunchCoordinator.swift
@@ -60,7 +60,6 @@ class LaunchCoordinator: BaseCoordinator,
         let introViewController = WelcomeNavigation(rootViewController: Welcome(delegate: self))
         introViewController.isNavigationBarHidden = true
         introViewController.edgesForExtendedLayout = UIRectEdge(rawValue: 0)
-        Analytics.shared.install()
         if isFullScreen {
             introViewController.modalPresentationStyle = .fullScreen
             router.present(introViewController, animated: false)

--- a/Client/Ecosia/Analytics/Analytics+Configuration.swift
+++ b/Client/Ecosia/Analytics/Analytics+Configuration.swift
@@ -67,7 +67,7 @@ extension Analytics {
     /// Checks if the current installation is the first time the app has been installed.
     /// - Parameter identifier: A unique identifier used to store and retrieve the first install check status from `UserDefaults`.
     /// - Returns: A Boolean value indicating whether the app is being installed for the first time.
-    private static func isFirstInstall(for identifier: String) -> Bool {
+    static func isFirstInstall(for identifier: String) -> Bool {
         let defaults = UserDefaults.standard
         let isFirstTime = defaults.object(forKey: identifier) as? Bool ?? {
             defaults.set(false, forKey: identifier)
@@ -82,7 +82,7 @@ extension Analytics {
     /// Checks if a day has passed since the last check for a specific event.
     /// - Parameter identifier: A unique identifier used to store and retrieve the last check date from `UserDefaults`.
     /// - Returns: A Boolean value indicating whether a day has passed since the last check. If no previous check exists, returns `true` and records the current date.
-    private static func hasDayPassedSinceLastCheck(for identifier: String) -> Bool {
+    static func hasDayPassedSinceLastCheck(for identifier: String) -> Bool {
         let now = Date()
         let defaults = UserDefaults.standard
         

--- a/Client/Ecosia/Analytics/Analytics+Configuration.swift
+++ b/Client/Ecosia/Analytics/Analytics+Configuration.swift
@@ -92,18 +92,22 @@ extension Analytics {
             let calendar = Calendar.current
             let components = calendar.dateComponents([.day], from: lastCheck, to: now)
             
-            if let day = components.day, day >= 1 {
-                // If a day or more has passed, update the last check date and return true
+            if let day = components.day {
+                // if a day or more has passed
+                if day >= 1 {
+                    defaults.set(now, forKey: identifier) // update the last check date
+                    return true
+                } else {
+                    // less than a day has passed
+                    return false
+                }
+            } else {
+                // If no last check date exists, set the current date and return true
                 defaults.set(now, forKey: identifier)
                 return true
-            } else {
-                // If less than a day has passed, return false
-                return false
             }
-        } else {
-            // If no last check date exists, set the current date and return true
-            defaults.set(now, forKey: identifier)
-            return true
         }
+        
+        return false
     }
 }

--- a/Client/Ecosia/Analytics/Analytics+Configuration.swift
+++ b/Client/Ecosia/Analytics/Analytics+Configuration.swift
@@ -8,6 +8,9 @@ import Core
 
 extension Analytics {
     
+    /// Configuration for the Snowplow tracker.
+    /// - Includes settings such as application ID, session context, application context, platform context, and geolocation context.
+    /// - This configuration also enables tracking of minimal device properties like Apple ID for vendors (IDFV).
     static let trackerConfiguration = TrackerConfiguration()
         .appId(Bundle.version)
         .sessionContext(true)
@@ -18,9 +21,15 @@ extension Analytics {
         .deepLinkContext(false)
         .screenContext(false)
     
+    /// Configuration for the Snowplow subject.
+    /// - Sets the user ID using the unique analytics ID associated with the user.
     static let subjectConfiguration = SubjectConfiguration()
         .userId(User.shared.analyticsId.uuidString)
 
+    /// Configuration for the daily tracking plugin.
+    /// - This plugin filters events based on whether a day has passed since the last check for a specific identifier.
+    /// - It specifically filters structured events related to in-app navigation and resume actions.
+    /// - Returns: A configured `PluginConfiguration` that determines whether the event should be tracked.
     static var appResumeDailyTrackingPluginConfiguration: PluginConfiguration {
         let identifier = "appResumeDailyTrackingPluginConfiguration"
         let plugin = PluginConfiguration(identifier: identifier)
@@ -38,40 +47,63 @@ extension Analytics {
             return Self.hasDayPassedSinceLastCheck(for: identifier)
         }
     }
+    
+    /// Configuration for the install tracking plugin.
+    /// - This plugin filters install events, allowing them to be tracked only if it's the first installation.
+    /// - Returns: A configured `PluginConfiguration` that determines whether the event should be tracked.
+    static var appInstallTrackingPluginConfiguration: PluginConfiguration {
+        let identifier = "appInstallTrackingPluginConfiguration"
+        let plugin = PluginConfiguration(identifier: identifier)
+        return plugin.filter(schemas: [
+            Self.installSchema
+        ]) { _ in
+            return Self.isFirstInstall(for: identifier)
+        }
+    }
 }
 
 extension Analytics {
     
-    /// Function to check if a day has passed since the last check for a specific identifier.
-    /// - Parameter identifier: The unique identifier used to save the last check date in UserDefaults.
-    /// - Returns: Boolean. True if a day or more has passed since the last check OR in case of first time checking, False otherwise.
+    /// Checks if the current installation is the first time the app has been installed.
+    /// - Parameter identifier: A unique identifier used to store and retrieve the first install check status from `UserDefaults`.
+    /// - Returns: A Boolean value indicating whether the app is being installed for the first time.
+    static func isFirstInstall(for identifier: String) -> Bool {
+        let defaults = UserDefaults.standard
+        let isFirstTime = defaults.object(forKey: identifier) as? Bool ?? {
+            defaults.set(false, forKey: identifier)
+            return true
+        }()
+        return isFirstTime
+    }
+}
+
+extension Analytics {
+    
+    /// Checks if a day has passed since the last check for a specific event.
+    /// - Parameter identifier: A unique identifier used to store and retrieve the last check date from `UserDefaults`.
+    /// - Returns: A Boolean value indicating whether a day has passed since the last check. If no previous check exists, returns `true` and records the current date.
     static func hasDayPassedSinceLastCheck(for identifier: String) -> Bool {
         let now = Date()
         let defaults = UserDefaults.standard
         
-        // get the date of the last check from UserDefaults
+        // Retrieve the last check date from UserDefaults
         if let lastCheck = defaults.object(forKey: identifier) as? Date {
-            // calculate the difference in days between now and the last check
+            // Calculate the number of days between the last check and now
             let calendar = Calendar.current
             let components = calendar.dateComponents([.day], from: lastCheck, to: now)
             
-            if let day = components.day {
-                // if a day or more has passed
-                if day >= 1 {
-                    defaults.set(now, forKey: identifier) // update the last check date
-                    return true
-                } else {
-                    // less than a day has passed
-                    return false
-                }
+            if let day = components.day, day >= 1 {
+                // If a day or more has passed, update the last check date and return true
+                defaults.set(now, forKey: identifier)
+                return true
+            } else {
+                // If less than a day has passed, return false
+                return false
             }
         } else {
-            // if the last check date does not exist in UserDefaults, set it to now
-            // We return `true` in this special scenario to mark the fact that there was no last check
+            // If no last check date exists, set the current date and return true
             defaults.set(now, forKey: identifier)
             return true
         }
-        
-        return false
     }
 }

--- a/Client/Ecosia/Analytics/Analytics+Configuration.swift
+++ b/Client/Ecosia/Analytics/Analytics+Configuration.swift
@@ -101,13 +101,13 @@ extension Analytics {
                     // less than a day has passed
                     return false
                 }
-            } else {
-                // If no last check date exists, set the current date and return true
-                defaults.set(now, forKey: identifier)
-                return true
             }
+        } else {
+            // If no last check date exists, set the current date and return true
+            defaults.set(now, forKey: identifier)
+            return true
         }
-        
+
         return false
     }
 }

--- a/Client/Ecosia/Analytics/Analytics+Configuration.swift
+++ b/Client/Ecosia/Analytics/Analytics+Configuration.swift
@@ -107,7 +107,7 @@ extension Analytics {
             defaults.set(now, forKey: identifier)
             return true
         }
-
+        
         return false
     }
 }

--- a/Client/Ecosia/Analytics/Analytics+Configuration.swift
+++ b/Client/Ecosia/Analytics/Analytics+Configuration.swift
@@ -67,7 +67,7 @@ extension Analytics {
     /// Checks if the current installation is the first time the app has been installed.
     /// - Parameter identifier: A unique identifier used to store and retrieve the first install check status from `UserDefaults`.
     /// - Returns: A Boolean value indicating whether the app is being installed for the first time.
-    static func isFirstInstall(for identifier: String) -> Bool {
+    private static func isFirstInstall(for identifier: String) -> Bool {
         let defaults = UserDefaults.standard
         let isFirstTime = defaults.object(forKey: identifier) as? Bool ?? {
             defaults.set(false, forKey: identifier)
@@ -82,7 +82,7 @@ extension Analytics {
     /// Checks if a day has passed since the last check for a specific event.
     /// - Parameter identifier: A unique identifier used to store and retrieve the last check date from `UserDefaults`.
     /// - Returns: A Boolean value indicating whether a day has passed since the last check. If no previous check exists, returns `true` and records the current date.
-    static func hasDayPassedSinceLastCheck(for identifier: String) -> Bool {
+    private static func hasDayPassedSinceLastCheck(for identifier: String) -> Bool {
         let now = Date()
         let defaults = UserDefaults.standard
         

--- a/Client/Ecosia/Analytics/Analytics.swift
+++ b/Client/Ecosia/Analytics/Analytics.swift
@@ -7,7 +7,7 @@ protocol AnalyticsProtocol {
 }
 
 final class Analytics: AnalyticsProtocol {
-    private static let installSchema = "iglu:org.ecosia/ios_install_event/jsonschema/1-0-0"
+    static let installSchema = "iglu:org.ecosia/ios_install_event/jsonschema/1-0-0"
     private static let abTestSchema = "iglu:org.ecosia/abtest_context/jsonschema/1-0-1"
     private static let consentSchema = "iglu:org.ecosia/eccc_context/jsonschema/1-0-2"
     private static let abTestRoot = "ab_tests"
@@ -19,6 +19,7 @@ final class Analytics: AnalyticsProtocol {
                                       network: .init(endpoint: Environment.current.urlProvider.snowplow),
                                       configurations: [Self.trackerConfiguration,
                                                        Self.subjectConfiguration,
+                                                       Self.appInstallTrackingPluginConfiguration,
                                                        Self.appResumeDailyTrackingPluginConfiguration])!
     }
     

--- a/EcosiaTests/AnalyticsTests.swift
+++ b/EcosiaTests/AnalyticsTests.swift
@@ -8,14 +8,6 @@ import XCTest
 @testable import Client
 
 final class AnalyticsTests: XCTestCase {
-    
-    // Setup method that runs before each test
-    override func setUpWithError() throws {
-        let defaults = UserDefaults.standard
-        // Remove any saved dates or flags from UserDefaults before each test to ensure a clean slate
-        defaults.removeObject(forKey: "dayPassedCheckIdentifier")
-        defaults.removeObject(forKey: "installCheckIdentifier")
-    }
 
     // Cleanup method that runs after each test
     override func tearDownWithError() throws {
@@ -48,19 +40,6 @@ final class AnalyticsTests: XCTestCase {
         
         // Then: The result should be false since less than a day has passed
         XCTAssertFalse(result, "The check should return false if it's been less than a day since the last check.")
-    }
-
-    func testCheckAfterADayReturnsTrue() throws {
-        // Given: A date more than a day ago is saved as the last check date
-        let defaults = UserDefaults.standard
-        let moreThanADayAgo = Calendar.current.date(byAdding: .day, value: -2, to: Date())!
-        defaults.set(moreThanADayAgo, forKey: "dayPassedCheckIdentifier")
-        
-        // When: The method is called after more than a day has passed
-        let result = Analytics.hasDayPassedSinceLastCheck(for: "dayPassedCheckIdentifier")
-        
-        // Then: The result should be true since more than a day has passed
-        XCTAssertTrue(result, "The check should return true if more than a day has passed since the last check.")
     }
 
     func testDateUpdateAfterADayPasses() throws {

--- a/EcosiaTests/AnalyticsTests.swift
+++ b/EcosiaTests/AnalyticsTests.swift
@@ -9,37 +9,125 @@ import XCTest
 
 final class AnalyticsTests: XCTestCase {
     
+    // Setup method that runs before each test
     override func setUpWithError() throws {
         let defaults = UserDefaults.standard
-        // Remove any saved dates from UserDefaults before each test
-        defaults.removeObject(forKey: "testIdentifier")
+        // Remove any saved dates or flags from UserDefaults before each test to ensure a clean slate
+        defaults.removeObject(forKey: "dayPassedCheckIdentifier")
+        defaults.removeObject(forKey: "installCheckIdentifier")
     }
 
-    func testFirstCheck() throws {
-        // The first check should always return true since it sets the date for the first time
-        XCTAssertTrue(Analytics.hasDayPassedSinceLastCheck(for: "testIdentifier"))
-    }
-
-    func testCheckWithinADay() throws {        
-        //Given
+    // Cleanup method that runs after each test
+    override func tearDownWithError() throws {
         let defaults = UserDefaults.standard
+        // Remove any saved dates or flags after each test to avoid side effects between tests
+        defaults.removeObject(forKey: "dayPassedCheckIdentifier")
+        defaults.removeObject(forKey: "installCheckIdentifier")
+    }
+    
+    // MARK: - hasDayPassedSinceLastCheck Tests
+    
+    func testFirstCheckAlwaysReturnsTrue() throws {
+        // Given: No previous date exists in UserDefaults for the identifier
+        // (Handled by setUpWithError)
         
-        //When
-        defaults.set(Date(), forKey: "testIdentifier")
+        // When: The method is called for the first time
+        let result = Analytics.hasDayPassedSinceLastCheck(for: "dayPassedCheckIdentifier")
         
-        //Then
-        XCTAssertFalse(Analytics.hasDayPassedSinceLastCheck(for: "testIdentifier"))
+        // Then: The result should be true because no previous date exists
+        XCTAssertTrue(result, "The first check should return true because no previous date exists.")
     }
 
-    func testCheckAfterADay() throws {
-        //Given
+    func testCheckWithinADayReturnsFalse() throws {
+        // Given: The current date is saved as the last check date
+        let defaults = UserDefaults.standard
+        defaults.set(Date(), forKey: "dayPassedCheckIdentifier")
+        
+        // When: The method is called within the same day
+        let result = Analytics.hasDayPassedSinceLastCheck(for: "dayPassedCheckIdentifier")
+        
+        // Then: The result should be false since less than a day has passed
+        XCTAssertFalse(result, "The check should return false if it's been less than a day since the last check.")
+    }
+
+    func testCheckAfterADayReturnsTrue() throws {
+        // Given: A date more than a day ago is saved as the last check date
         let defaults = UserDefaults.standard
         let moreThanADayAgo = Calendar.current.date(byAdding: .day, value: -2, to: Date())!
+        defaults.set(moreThanADayAgo, forKey: "dayPassedCheckIdentifier")
         
-        //When
-        defaults.set(moreThanADayAgo, forKey: "testIdentifier")
+        // When: The method is called after more than a day has passed
+        let result = Analytics.hasDayPassedSinceLastCheck(for: "dayPassedCheckIdentifier")
         
-        //Then
-        XCTAssertTrue(Analytics.hasDayPassedSinceLastCheck(for: "testIdentifier"))
+        // Then: The result should be true since more than a day has passed
+        XCTAssertTrue(result, "The check should return true if more than a day has passed since the last check.")
+    }
+
+    func testDateUpdateAfterADayPasses() throws {
+        // Given: A date more than a day ago is saved as the last check date
+        let defaults = UserDefaults.standard
+        let moreThanADayAgo = Calendar.current.date(byAdding: .day, value: -2, to: Date())!
+        defaults.set(moreThanADayAgo, forKey: "dayPassedCheckIdentifier")
+        
+        // When: The method is called after more than a day has passed
+        let result = Analytics.hasDayPassedSinceLastCheck(for: "dayPassedCheckIdentifier")
+        
+        // Then: The method should return true and update the last check date to today
+        XCTAssertTrue(result, "The check should return true since more than a day has passed.")
+        let updatedDate = defaults.object(forKey: "dayPassedCheckIdentifier") as? Date
+        XCTAssertNotNil(updatedDate, "The date should be updated in UserDefaults.")
+        XCTAssertTrue(Calendar.current.isDateInToday(updatedDate!), "The last check date should be updated to today's date.")
+    }
+
+    func testHandleCorruptedOrMissingData() throws {
+        // Given: Corrupted data (e.g., a string instead of a Date) is saved in UserDefaults
+        let defaults = UserDefaults.standard
+        defaults.set("corruptedData", forKey: "dayPassedCheckIdentifier")
+        
+        // When: The method is called
+        let result = Analytics.hasDayPassedSinceLastCheck(for: "dayPassedCheckIdentifier")
+        
+        // Then: The method should return true, treat it as the first check, and reset the last check date to today
+        XCTAssertTrue(result, "The method should handle corrupted data gracefully and treat it as the first check.")
+        let updatedDate = defaults.object(forKey: "dayPassedCheckIdentifier") as? Date
+        XCTAssertNotNil(updatedDate, "The date should be reset in UserDefaults after detecting corrupted data.")
+        XCTAssertTrue(Calendar.current.isDateInToday(updatedDate!), "The last check date should be updated to today's date after handling corrupted data.")
+    }
+    
+    // MARK: - isFirstInstall Tests
+
+    func testIsFirstInstall_FirstCall_ReturnsTrue() {
+        // Given: No previous installation flag exists in UserDefaults for the identifier
+        // (Handled by setUpWithError)
+        
+        // When: The method is called for the first time
+        let result = Analytics.isFirstInstall(for: "installCheckIdentifier")
+        
+        // Then: The result should be true indicating the first install
+        XCTAssertTrue(result, "The first install should return true")
+    }
+    
+    func testIsFirstInstall_SecondCall_ReturnsFalse() {
+        // Given: The method has already been called once
+        _ = Analytics.isFirstInstall(for: "installCheckIdentifier")
+        
+        // When: The method is called again
+        let result = Analytics.isFirstInstall(for: "installCheckIdentifier")
+        
+        // Then: The result should be false indicating it is no longer the first install
+        XCTAssertFalse(result, "The second call should return false as the app is no longer on its first install")
+    }
+    
+    func testIsFirstInstall_StoresValueInUserDefaults() {
+        // Given: The method is called for the first time
+        _ = Analytics.isFirstInstall(for: "installCheckIdentifier")
+        
+        // When: The value is retrieved from UserDefaults
+        let defaults = UserDefaults.standard
+        let storedValue = defaults.object(forKey: "installCheckIdentifier") as? Bool
+        
+        // Then: The stored value should be false indicating the first install has been recorded
+        XCTAssertNotNil(storedValue, "The value should be stored in UserDefaults")
+        XCTAssertEqual(storedValue, false, "The stored value in UserDefaults should be false after the first call")
     }
 }


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2820]

## Context

At the moment we fire the install event on iOS just before presenting the onboarding.
We would like to decouple the install event from a UX entry point as well as make sure it is triggered only once.

## Approach

Make use of Snowplow's plugin configuration and inject a dedicated configuration that tells Snowplow to send the install event only once per app install.

## Other

- Improved comments for other Snowplow's functions.

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I added the `// Ecosia:` helper comments where needed

[MOB-2820]: https://ecosia.atlassian.net/browse/MOB-2820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ