### PR TITLE
[MOB-2759] Add onboarding card NTP source language strings

### DIFF
--- a/Client/Ecosia/L10N/String.swift
+++ b/Client/Ecosia/L10N/String.swift
@@ -242,7 +242,11 @@ extension String {
         case apnConsentCTAAllowButtonTitle = "Allow push notifications"
         case apnConsentSkipButtonTitle = "Not now"
         case apnConsentLastReminderSkipButtonTitle = "No thanks"
-        case climateImpactCTAExperimentText1 = "See where our money goes"
-        case climateImpactCTAExperimentText2 = "Check out our monthly updates"
+        case onboardingCardNTPExperimentTitle1 = "Let’s get acquainted"
+        case onboardingCardNTPExperimentDescription1 = "Learn more about Ecosia and our climate action by taking our welcome tour."
+        case onboardingCardNTPExperimentButtonText1 = "Check it out"
+        case onboardingCardNTPExperimentTitle2 = "Wondering how it all works?"
+        case onboardingCardNTPExperimentDescription2 = "Take our welcome tour to learn more about how we contribute to climate action."
+        case onboardingCardNTPExperimentButtonText2 = "Learn more about Ecosia"
     }
 }

--- a/Client/Ecosia/L10N/en.lproj/Ecosia.strings
+++ b/Client/Ecosia/L10N/en.lproj/Ecosia.strings
@@ -68,8 +68,12 @@
 "Show on homepage" = "Show on homepage";
 "Top Sites" = "Top Sites";
 "Quick Search" = "Quick Search";
-"See where our money goes" = "See where our money goes";
-"Check out our monthly updates" = "Check out our monthly updates";
+"Let’s get acquainted" = "Let’s get acquainted";
+"Learn more about Ecosia and our climate action by taking our welcome tour." = "Learn more about Ecosia and our climate action by taking our welcome tour.";
+"Check it out" = "Check it out";
+"Wondering how it all works?" = "Wondering how it all works?";
+"Take our welcome tour to learn more about how we contribute to climate action." = "Take our welcome tour to learn more about how we contribute to climate action.";
+"Learn more about Ecosia" = "Learn more about Ecosia";
 
 // Impact
 "A friend accepted your invitation and each of you will help plant 1 tree!" = "A friend has accepted your invite! You have each helped plant 1 extra tree.";


### PR DESCRIPTION
[MOB-2759](https://ecosia.atlassian.net/browse/MOB-2759)

Adding strings in preparation for the task so they already get translated. This is only source language since others are handled by Transifex integration.

## Other

Noticed a couple strings missing from a previous clean-up (https://github.com/ecosia/ios-browser/pull/768) and already removed them.

[MOB-2759]: https://ecosia.atlassian.net/browse/MOB-2759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ