### PR TITLE
[MOB-2877] Update `actionButton` in `NTPImpactRowView`

### DIFF
--- a/BrowserKit/Sources/ComponentLibrary/Buttons/ResizableButton.swift
+++ b/BrowserKit/Sources/ComponentLibrary/Buttons/ResizableButton.swift
@@ -40,8 +40,13 @@ open class ResizableButton: UIButton {
         }
 
         let size = title.sizeThatFits(CGSize(width: availableWidth, height: .greatestFiniteMagnitude))
+        /* Ecosia: Update Size calculation
         return CGSize(width: size.width + widthContentInset,
                       height: size.height + heightContentInset)
+         */
+        let boundingBox = title.text?.boundingRect(with: size, options: .usesLineFragmentOrigin, context: nil) ?? .zero
+        return CGSize(width: boundingBox.width + widthContentInset,
+                      height: boundingBox.height + heightContentInset)
     }
 
     override public func layoutSubviews() {

--- a/Client/Ecosia/UI/NTP/Impact/NTPImpactRowView.swift
+++ b/Client/Ecosia/UI/NTP/Impact/NTPImpactRowView.swift
@@ -6,7 +6,12 @@ import Foundation
 import Common
 import ComponentLibrary
 
+/// A view representing an individual impact row, used in the New Tab Page to display environmental impact information.
 final class NTPImpactRowView: UIView, Themeable {
+
+    // MARK: - UX Constants
+
+    /// Contains constants used for layout and sizing within the `NTPImpactRowView`.
     struct UX {
         static let cornerRadius: CGFloat = 10
         static let horizontalSpacing: CGFloat = 8
@@ -18,25 +23,42 @@ final class NTPImpactRowView: UIView, Themeable {
         static let progressLineWidth: CGFloat = 2
     }
     
+    // MARK: - UI Elements
+
+    /// Stack view to arrange title and subtitle labels vertically.
+    private let titleAndSubtitleContainerView = UIStackView()
+    
+    /// Main horizontal stack view that arranges the image, title, subtitle, and action button.
+    private let mainContainerView = UIStackView()
+
+    /// A container view for the image.
     private lazy var imageContainer: UIView = {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
+    
+    /// The image view representing the icon in the row.
     private lazy var imageView: UIImageView = {
         let image = UIImageView()
         image.translatesAutoresizingMaskIntoConstraints = false
         image.contentMode = .scaleAspectFit
         return image
     }()
+    
+    /// A view displaying the total progress as part of the impact.
     private lazy var totalProgressView: ProgressView = {
         ProgressView(size: .init(width: UX.progressWidth, height: UX.progressHeight),
                      lineWidth: UX.progressLineWidth)
     }()
+    
+    /// A view displaying the current progress as part of the impact.
     private lazy var currentProgressView: ProgressView = {
         ProgressView(size: .init(width: UX.progressWidth, height: UX.progressHeight),
                      lineWidth: UX.progressLineWidth)
     }()
+    
+    /// A label for displaying the title of the row.
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
         label.font = .preferredFont(forTextStyle: .title2).bold()
@@ -44,6 +66,8 @@ final class NTPImpactRowView: UIView, Themeable {
         label.adjustsFontForContentSizeCategory = true
         return label
     }()
+    
+    /// A label for displaying the subtitle of the row.
     private lazy var subtitleLabel: UILabel = {
         let label = UILabel()
         label.font = .preferredFont(forTextStyle: .footnote)
@@ -51,25 +75,35 @@ final class NTPImpactRowView: UIView, Themeable {
         label.adjustsFontForContentSizeCategory = true
         return label
     }()
+    
+    /// A resizable button for performing actions related to the row.
     private lazy var actionButton: ResizableButton = {
         let button = ResizableButton()
         button.translatesAutoresizingMaskIntoConstraints = false
         button.titleLabel?.font = .preferredFont(forTextStyle: .callout)
         button.titleLabel?.textAlignment = .right
         button.contentHorizontalAlignment = .right
+        button.contentVerticalAlignment = .center
         button.buttonEdgeSpacing = 0
         button.setContentCompressionResistancePriority(.required, for: .horizontal)
         button.addTarget(self, action: #selector(buttonAction), for: .touchUpInside)
         button.clipsToBounds = true
         return button
     }()
+    
+    /// A divider view separating rows visually.
     private lazy var dividerView: UIView = {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
     
+    // MARK: - Properties
+
+    /// Delegate for handling user interactions with the row.
     weak var delegate: NTPImpactCellDelegate?
+    
+    /// The information to display in this row, including title, subtitle, and button information.
     var info: ClimateImpactInfo {
         didSet {
             imageView.image = info.image
@@ -80,6 +114,8 @@ final class NTPImpactRowView: UIView, Themeable {
             actionButton.setTitle(info.buttonTitle, for: .normal)
         }
     }
+    
+    /// The current position of this row in the overall list (used for layout adjustments like masking).
     var position: (row: Int, totalCount: Int) = (0, 0) {
         didSet {
             let (row, count) = position
@@ -87,70 +123,90 @@ final class NTPImpactRowView: UIView, Themeable {
             setMaskedCornersUsingPosition(row: row, totalCount: count)
         }
     }
+    
+    /// Whether to forcefully hide the action button in this row.
     var forceHideActionButton: Bool = false {
         didSet {
             actionButton.isHidden = forceHideActionButton
         }
     }
+    
+    /// Optional background color for the row.
     var customBackgroundColor: UIColor? = nil
     
     // MARK: - Themeable Properties
-    
+
     var themeManager: ThemeManager { AppContainer.shared.resolve() }
     var themeObserver: NSObjectProtocol?
     var notificationCenter: NotificationProtocol = NotificationCenter.default
 
-    // MARK: - Init
-    
+    // MARK: - Initialization
+
+    /// Initializes a new `NTPImpactRowView` with the provided `ClimateImpactInfo`.
+    ///
+    /// - Parameter info: The `ClimateImpactInfo` object containing the data to display in the row.
     init(info: ClimateImpactInfo) {
         self.info = info
         super.init(frame: .zero)
         defer {
-            // Needed to force info setup after init
+            // Ensure info setup is completed after initialization
             self.info = info
         }
-        
+        setupView()
+        setupConstraints()
+        applyTheme()
+    }
+    
+    /// Not supported, as `NTPImpactRowView` requires `ClimateImpactInfo` during initialization.
+    required init?(coder: NSCoder) { nil }
+    
+    // MARK: - Setup Methods
+
+    /// Configures and adds subviews to the view.
+    private func setupView() {
         translatesAutoresizingMaskIntoConstraints = false
         layer.cornerRadius = UX.cornerRadius
         
-        let hStack = UIStackView()
-        hStack.translatesAutoresizingMaskIntoConstraints = false
-        hStack.axis = .horizontal
-        hStack.alignment = .center
-        hStack.spacing = UX.horizontalSpacing
-        hStack.addArrangedSubview(imageContainer)
+        mainContainerView.translatesAutoresizingMaskIntoConstraints = false
+        mainContainerView.axis = .horizontal
+        mainContainerView.alignment = .center
+        mainContainerView.spacing = UX.horizontalSpacing
+        mainContainerView.addArrangedSubview(imageContainer)
         imageContainer.addSubview(imageView)
-        addSubview(hStack)
+        addSubview(mainContainerView)
         addSubview(dividerView)
         
-        let vStack = UIStackView()
-        vStack.translatesAutoresizingMaskIntoConstraints = false
-        vStack.axis = .vertical
-        vStack.alignment = .leading
-        vStack.addArrangedSubview(titleLabel)
-        vStack.addArrangedSubview(subtitleLabel)
-        vStack.isAccessibilityElement = true
-        vStack.shouldGroupAccessibilityChildren = true
-        vStack.accessibilityLabel = info.accessibilityLabel
-        vStack.accessibilityIdentifier = info.accessibilityIdentifier
+        titleAndSubtitleContainerView.translatesAutoresizingMaskIntoConstraints = false
+        titleAndSubtitleContainerView.axis = .vertical
+        titleAndSubtitleContainerView.alignment = .leading
+        titleAndSubtitleContainerView.addArrangedSubview(titleLabel)
+        titleAndSubtitleContainerView.addArrangedSubview(subtitleLabel)
+        titleAndSubtitleContainerView.isAccessibilityElement = true
+        titleAndSubtitleContainerView.shouldGroupAccessibilityChildren = true
+        titleAndSubtitleContainerView.accessibilityLabel = info.accessibilityLabel
+        titleAndSubtitleContainerView.accessibilityIdentifier = info.accessibilityIdentifier
         
-        hStack.addArrangedSubview(vStack)
-        hStack.addArrangedSubview(actionButton)
-        
+        mainContainerView.addArrangedSubview(titleAndSubtitleContainerView)
+        mainContainerView.addArrangedSubview(actionButton)
+    }
+    
+    /// Sets up the layout constraints for the view's subviews.
+    private func setupConstraints() {
+                
         NSLayoutConstraint.activate([
-            hStack.topAnchor.constraint(equalTo: topAnchor, constant: UX.padding),
-            hStack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: UX.padding),
-            hStack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -UX.padding),
-            hStack.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -UX.padding),
-            actionButton.widthAnchor.constraint(equalTo: hStack.widthAnchor, multiplier: 1/3),
+            mainContainerView.topAnchor.constraint(equalTo: topAnchor, constant: UX.padding),
+            mainContainerView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: UX.padding),
+            mainContainerView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -UX.padding),
+            mainContainerView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -UX.padding),
             dividerView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: UX.padding),
             dividerView.trailingAnchor.constraint(equalTo: trailingAnchor),
             dividerView.bottomAnchor.constraint(equalTo: bottomAnchor),
             dividerView.heightAnchor.constraint(equalToConstant: 1),
             imageContainer.heightAnchor.constraint(equalToConstant: UX.imageHeight),
             imageContainer.widthAnchor.constraint(equalTo: imageContainer.heightAnchor),
-            actionButton.topAnchor.constraint(lessThanOrEqualTo: imageContainer.topAnchor),
-            actionButton.bottomAnchor.constraint(lessThanOrEqualTo: imageContainer.bottomAnchor)
+            actionButton.topAnchor.constraint(equalTo: titleAndSubtitleContainerView.topAnchor),
+            actionButton.bottomAnchor.constraint(equalTo: titleAndSubtitleContainerView.bottomAnchor),
+            actionButton.widthAnchor.constraint(equalTo: mainContainerView.widthAnchor, multiplier: 1/3)
         ])
         
         NSLayoutConstraint.activate([
@@ -158,23 +214,10 @@ final class NTPImpactRowView: UIView, Themeable {
             imageView.leadingAnchor.constraint(equalTo: imageContainer.leadingAnchor),
             imageView.trailingAnchor.constraint(equalTo: imageContainer.trailingAnchor),
             imageView.bottomAnchor.constraint(equalTo: imageContainer.bottomAnchor),
-        ])
-        
-        applyTheme()
+        ])                
     }
     
-    required init?(coder: NSCoder) { nil }
-    
-    func applyTheme() {
-        backgroundColor = customBackgroundColor ?? .legacyTheme.ecosia.secondaryBackground
-        titleLabel.textColor = .legacyTheme.ecosia.primaryText
-        subtitleLabel.textColor = .legacyTheme.ecosia.secondaryText
-        actionButton.setTitleColor(.legacyTheme.ecosia.primaryButton, for: .normal)
-        dividerView.backgroundColor = .legacyTheme.ecosia.border
-        totalProgressView.color = .legacyTheme.ecosia.ntpBackground
-        currentProgressView.color = .legacyTheme.ecosia.treeCounterProgressCurrent
-    }
-    
+    /// Configures and sets up the progress indicators for the impact row.
     private func setupProgressIndicator() {
         imageContainer.addSubview(totalProgressView)
         imageContainer.addSubview(currentProgressView)
@@ -191,6 +234,22 @@ final class NTPImpactRowView: UIView, Themeable {
         ])
     }
     
+    // MARK: - Themeable
+    
+    /// Applies the current theme to the view, updating colors and styles as needed.
+    func applyTheme() {
+        backgroundColor = customBackgroundColor ?? .legacyTheme.ecosia.secondaryBackground
+        titleLabel.textColor = .legacyTheme.ecosia.primaryText
+        subtitleLabel.textColor = .legacyTheme.ecosia.secondaryText
+        actionButton.setTitleColor(.legacyTheme.ecosia.primaryButton, for: .normal)
+        dividerView.backgroundColor = .legacyTheme.ecosia.border
+        totalProgressView.color = .legacyTheme.ecosia.ntpBackground
+        currentProgressView.color = .legacyTheme.ecosia.treeCounterProgressCurrent
+    }
+    
+    // MARK: - Actions
+    
+    /// Handles the action button tap event, notifying the delegate.
     @objc private func buttonAction() {
         delegate?.impactCellButtonClickedWithInfo(info)
     }


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2877]

## Context

We found out that the action button for the impact rows gets cropped whenever an accessibility font increases.

## Approach

- Review thoroughly and tried different approaches to fix it.
- Found out eventually that a small change to the `ResizableButton` will eventually update the height correctly whenever the button doesn't have the correct frame to calculate the height against
- Had a tour of the app and found no regression given the new approach 

(Video with proof in the ticket comment)

## Other

- Reviewed the `NTPImpactRowView` adding comments and extracted some code from the `init(:)` into different functions.

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I added the `// Ecosia:` helper comments where needed

[MOB-2877]: https://ecosia.atlassian.net/browse/MOB-2877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ