### PR TITLE
[MOB-2898] Set startAtHomeSetting as disabled by default

### DIFF
--- a/Client/Frontend/Browser/StartAtHomeHelper.swift
+++ b/Client/Frontend/Browser/StartAtHomeHelper.swift
@@ -32,10 +32,16 @@ class StartAtHomeHelper: FeatureFlaggable {
 
     var startAtHomeSetting: StartAtHomeSetting {
         get {
+            /* Ecosia: Set to disabled
             if let prefs = prefs.stringForKey(PrefsKeys.UserFeatureFlagPrefs.StartAtHome) {
                 return StartAtHomeSetting(rawValue: prefs) ?? .afterFourHours
             }
             return .afterFourHours
+             */
+            if let prefs = prefs.stringForKey(PrefsKeys.UserFeatureFlagPrefs.StartAtHome) {
+                return StartAtHomeSetting(rawValue: prefs) ?? .disabled
+            }
+            return .disabled
         }
         set { prefs.setString(newValue.rawValue, forKey: PrefsKeys.UserFeatureFlagPrefs.StartAtHome) }
     }


### PR DESCRIPTION
[MOB-2898]

## Approach

Switch default homepage behaviour so that it always returns last tab.

Obs.: I kept the fetching from settings so the tests still work, but we never set them so it will always use the default value.

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I added the `// Ecosia:` helper comments where needed

[MOB-2898]: https://ecosia.atlassian.net/browse/MOB-2898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ