### PR TITLE
[MOB-2912] Install event check for upgrading users

### DIFF
--- a/Client/Ecosia/Analytics/Analytics+Configuration.swift
+++ b/Client/Ecosia/Analytics/Analytics+Configuration.swift
@@ -57,7 +57,7 @@ extension Analytics {
         return plugin.filter(schemas: [
             Self.installSchema
         ]) { _ in
-            return Self.isFirstInstall(for: identifier) && EcosiaInstallType.get() != .upgrade
+            return Self.isFirstInstall(for: identifier)
         }
     }
 }
@@ -73,7 +73,7 @@ extension Analytics {
             defaults.set(false, forKey: identifier)
             return true
         }()
-        return isFirstTime
+        return isFirstTime && EcosiaInstallType.get() != .upgrade
     }
 }
 

--- a/Client/Ecosia/Analytics/Analytics+Configuration.swift
+++ b/Client/Ecosia/Analytics/Analytics+Configuration.swift
@@ -57,7 +57,7 @@ extension Analytics {
         return plugin.filter(schemas: [
             Self.installSchema
         ]) { _ in
-            return Self.isFirstInstall(for: identifier)
+            return Self.isFirstInstall(for: identifier) && EcosiaInstallType.get() != .upgrade
         }
     }
 }

--- a/EcosiaTests/AnalyticsTests.swift
+++ b/EcosiaTests/AnalyticsTests.swift
@@ -77,36 +77,72 @@ final class AnalyticsTests: XCTestCase {
 
     func testIsFirstInstall_FirstCall_ReturnsTrue() {
         // Given: No previous installation flag exists in UserDefaults for the identifier
-        // (Handled by setUpWithError)
+        // Also, EcosiaInstallType is not set to .upgrade
+        let defaults = UserDefaults.standard
+        defaults.removeObject(forKey: "installCheckIdentifier")
+        defaults.removeObject(forKey: EcosiaInstallType.installTypeKey)
+        
+        // Set EcosiaInstallType to .fresh to simulate a fresh install
+        EcosiaInstallType.set(type: .fresh)
         
         // When: The method is called for the first time
         let result = Analytics.isFirstInstall(for: "installCheckIdentifier")
         
         // Then: The result should be true indicating the first install
-        XCTAssertTrue(result, "The first install should return true")
+        XCTAssertTrue(result, "The first install should return TRUE when not an upgrade")
     }
-    
+
     func testIsFirstInstall_SecondCall_ReturnsFalse() {
         // Given: The method has already been called once
+        let defaults = UserDefaults.standard
+        defaults.removeObject(forKey: "installCheckIdentifier")
+        defaults.removeObject(forKey: EcosiaInstallType.installTypeKey)
+        
+        // Set EcosiaInstallType to .fresh to simulate a fresh install
+        EcosiaInstallType.set(type: .fresh)
+        
+        // First call to set the flag
         _ = Analytics.isFirstInstall(for: "installCheckIdentifier")
         
         // When: The method is called again
         let result = Analytics.isFirstInstall(for: "installCheckIdentifier")
         
         // Then: The result should be false indicating it is no longer the first install
-        XCTAssertFalse(result, "The second call should return false as the app is no longer on its first install")
+        XCTAssertFalse(result, "The second call should return FALSE as the app is no longer on its first install")
     }
-    
+
     func testIsFirstInstall_StoresValueInUserDefaults() {
         // Given: The method is called for the first time
+        let defaults = UserDefaults.standard
+        defaults.removeObject(forKey: "installCheckIdentifier")
+        defaults.removeObject(forKey: EcosiaInstallType.installTypeKey)
+        
+        // Set EcosiaInstallType to .fresh to simulate a fresh install
+        EcosiaInstallType.set(type: .fresh)
+        
         _ = Analytics.isFirstInstall(for: "installCheckIdentifier")
         
         // When: The value is retrieved from UserDefaults
-        let defaults = UserDefaults.standard
         let storedValue = defaults.object(forKey: "installCheckIdentifier") as? Bool
         
         // Then: The stored value should be false indicating the first install has been recorded
         XCTAssertNotNil(storedValue, "The value should be stored in UserDefaults")
-        XCTAssertEqual(storedValue, false, "The stored value in UserDefaults should be false after the first call")
+        XCTAssertEqual(storedValue, false, "The stored value in UserDefaults should be FALSE after the first call")
     }
-}
+
+    func testIsFirstInstall_FirstCallOnUpgrade_ReturnsFalse() {
+        // Given: No previous installation flag exists in UserDefaults for the identifier
+        // Also, EcosiaInstallType is set to .upgrade
+        let defaults = UserDefaults.standard
+        defaults.removeObject(forKey: "installCheckIdentifier")
+        defaults.removeObject(forKey: EcosiaInstallType.installTypeKey)
+        
+        // Set EcosiaInstallType to .upgrade to simulate an upgrade scenario
+        EcosiaInstallType.set(type: .upgrade)
+        
+        // When: The method is called for the first time
+        let result = Analytics.isFirstInstall(for: "installCheckIdentifier")
+        
+        // Then: The result should be false because it's an upgrade
+        XCTAssertFalse(result, "The first install should return FALSE when it's an upgrade")
+    }}

--- a/PULL_REQUEST_TEMPLATE
+++ b/PULL_REQUEST_TEMPLATE
@@ -19,4 +19,5 @@ Don't forget to add a prefix to the pr title in this format
 - [ ] I wrote Unit Tests that confirm the expected behaviour
 - [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
 - [ ] I added the `// Ecosia:` helper comments where needed
+- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
 - [ ] I included documentation updates to the coding standards or Confluence doc, when needed


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2912]

## Context

Due to an issue found after releasing the latest version of the app where the install event fired for upgrading apps, we also want to make the condition more robust, checking for those performing the upgrade.

## Approach

- Update the Snowplow plugin configuration `appInstallTrackingPluginConfiguration` , adding the “install type” check.
- Update tests to accommodate this behavior so to prevent this from happening in the future

## Other

- To further improve and prevent events like these from happening in the future, I'm proposing to add another item in our Checklist

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I wrote Unit Tests that confirm the expected behaviour

[MOB-2912]: https://ecosia.atlassian.net/browse/MOB-2912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ