### PR TITLE
[MOB-2759] Implement `screenWasShown()` from protocol and overridden for the Onboarding card

### DIFF
--- a/Client/Ecosia/UI/NTP/NudgeCards/NTPConfigurableNudgeCardCellViewModel.swift
+++ b/Client/Ecosia/UI/NTP/NudgeCards/NTPConfigurableNudgeCardCellViewModel.swift
@@ -88,6 +88,10 @@ class NTPConfigurableNudgeCardCellViewModel: HomepageViewModelProtocol {
     var isEnabled: Bool {
         fatalError("Needs to be implemented")
     }
+    
+    func screenWasShown() {
+        fatalError("Needs to be implemented. Implement empty if not needed")
+    }
 }
 
 extension NTPConfigurableNudgeCardCellViewModel: HomepageSectionHandler {

--- a/Client/Ecosia/UI/NTP/NudgeCards/OnboardingCard/NTPOnboardingCardViewModel.swift
+++ b/Client/Ecosia/UI/NTP/NudgeCards/OnboardingCard/NTPOnboardingCardViewModel.swift
@@ -9,4 +9,8 @@ final class NTPOnboardingCardViewModel: NTPConfigurableNudgeCardCellViewModel {
     override var isEnabled: Bool {
         OnboardingCardNTPExperiment.shouldShowCard
     }
+    
+    override func screenWasShown() {
+        OnboardingCardNTPExperiment.trackExperimentImpression()
+    }
 }


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2759]

## Context

As part of the bigger refactor to make the Card view configurable, the specific analytics behaviour after showing the card was missed.

## Approach

Re-implementing it from the configurable component and overridden for the Onboarding Card specific scenario.

## Other

For the sake of pushing the experiment thru, I'm adding both iOS and Android Ecosian to review the tiny PR. 

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)

[MOB-2759]: https://ecosia.atlassian.net/browse/MOB-2759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ