### PR TITLE
[MOB-2875] Seed Counter Debug Settings

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -380,6 +380,7 @@
 		2CCBB5232CAE9826006E2E10 /* ArcProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CCBB5222CAE9826006E2E10 /* ArcProgressView.swift */; };
 		2CCBB5252CAEA9DF006E2E10 /* SeedProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CCBB5242CAEA9DF006E2E10 /* SeedProgressView.swift */; };
 		2CCBB5272CAEAD53006E2E10 /* SeedCounterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CCBB5262CAEAD53006E2E10 /* SeedCounterView.swift */; };
+		2CCBB5372CAF0E8C006E2E10 /* SeedCounterHiddenSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CCBB5362CAF0E8C006E2E10 /* SeedCounterHiddenSettings.swift */; };
 		2CCBB5352CAF06DE006E2E10 /* SeedProgressManagerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CCBB5342CAF06DE006E2E10 /* SeedProgressManagerProtocol.swift */; };
 		2CCFB3D72C0FBEE800BEDCA0 /* TabToolbarHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D815A3A724A53F3200AAB221 /* TabToolbarHelperTests.swift */; };
 		2CD48B7F2C7F7E4100A70908 /* EcosiaOverlayModeManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD48B7E2C7F7E4100A70908 /* EcosiaOverlayModeManagerTests.swift */; };
@@ -2551,6 +2552,7 @@
 		2CCBB5222CAE9826006E2E10 /* ArcProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArcProgressView.swift; sourceTree = "<group>"; };
 		2CCBB5242CAEA9DF006E2E10 /* SeedProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeedProgressView.swift; sourceTree = "<group>"; };
 		2CCBB5262CAEAD53006E2E10 /* SeedCounterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeedCounterView.swift; sourceTree = "<group>"; };
+		2CCBB5362CAF0E8C006E2E10 /* SeedCounterHiddenSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeedCounterHiddenSettings.swift; sourceTree = "<group>"; };
 		2CCBB5342CAF06DE006E2E10 /* SeedProgressManagerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeedProgressManagerProtocol.swift; sourceTree = "<group>"; };
 		2CCF17522105E4FD00705AE5 /* DisplaySettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplaySettingsTests.swift; sourceTree = "<group>"; };
 		2CCFB3D42C0F1EA500BEDCA0 /* LoadingScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoadingScreen.swift; sourceTree = "<group>"; };
@@ -8872,6 +8874,7 @@
 				2CCBB5222CAE9826006E2E10 /* ArcProgressView.swift */,
 				2CCBB5242CAEA9DF006E2E10 /* SeedProgressView.swift */,
 				2CCBB5262CAEAD53006E2E10 /* SeedCounterView.swift */,
+				2CCBB5362CAF0E8C006E2E10 /* SeedCounterHiddenSettings.swift */,
 				2C5A5E682CB53E05005BFE8B /* SeedProgressManager */,
 				2C5A5E642CB53DB7005BFE8B /* SeedLevelConfig.swift */,
 			);
@@ -13630,6 +13633,7 @@
 				8ADAE4262A33A13B007BF926 /* OpenSupportPageSetting.swift in Sources */,
 				8A590C6128C123100032F1AA /* OpenPassBookHelper.swift in Sources */,
 				EBB895332193FFF400EB91A0 /* ContentBlockerSettingViewController.swift in Sources */,
+				2CCBB5372CAF0E8C006E2E10 /* SeedCounterHiddenSettings.swift in Sources */,
 				8A5D1CB42A30D7D9005AD35C /* NoImageModeSetting.swift in Sources */,
 				8A3EF8152A2FD08800796E3A /* OpenFiftyTabsDebugOption.swift in Sources */,
 				D38F02D11C05127100175932 /* Authenticator.swift in Sources */,

--- a/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
+++ b/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
@@ -156,9 +156,12 @@ extension AppSettingsTableViewController {
         }
         
         if SeedCounterNTPExperiment.isEnabled {
-            hiddenDebugSettings.append(AddOneSeedSetting(settings: self))
-            hiddenDebugSettings.append(AddFiveSeedsSetting(settings: self))
-            hiddenDebugSettings.append(ResetSeedCounterSetting(settings: self))
+            hiddenDebugSettings.append(AddOneSeedSetting(settings: self,
+                                                         progressManagerType: UserDefaultsSeedProgressManager.self))
+            hiddenDebugSettings.append(AddFiveSeedsSetting(settings: self,
+                                                           progressManagerType: UserDefaultsSeedProgressManager.self))
+            hiddenDebugSettings.append(ResetSeedCounterSetting(settings: self,
+                                                               progressManagerType: UserDefaultsSeedProgressManager.self))
         }
         
         return SettingSection(title: NSAttributedString(string: "Debug"), children: hiddenDebugSettings)

--- a/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
+++ b/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
@@ -135,7 +135,7 @@ extension AppSettingsTableViewController {
     
     private func getEcosiaDebugSupportSection() -> SettingSection {
         
-        let hiddenDebugSettings = [
+        var hiddenDebugSettings = [
             ExportBrowserDataSetting(settings: self),
             ForceCrashSetting(settings: self),
             PushBackInstallation(settings: self),
@@ -149,8 +149,17 @@ extension AppSettingsTableViewController {
             ResetSearchCount(settings: self),
             EngagementServiceIdentifierSetting(settings: self),
             FasterInactiveTabs(settings: self, settingsDelegate: self),
-            UnleashOnboardingCardNTPSetting(settings: self),
         ]
+        
+        if OnboardingCardNTPExperiment.isEnabled {
+            hiddenDebugSettings.append(UnleashOnboardingCardNTPSetting(settings: self))
+        }
+        
+        if SeedCounterNTPExperiment.isEnabled {
+            hiddenDebugSettings.append(AddOneSeedSetting(settings: self))
+            hiddenDebugSettings.append(AddFiveSeedsSetting(settings: self))
+            hiddenDebugSettings.append(ResetSeedCounterSetting(settings: self))
+        }
         
         return SettingSection(title: NSAttributedString(string: "Debug"), children: hiddenDebugSettings)
     }

--- a/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
+++ b/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
@@ -149,11 +149,9 @@ extension AppSettingsTableViewController {
             ResetSearchCount(settings: self),
             EngagementServiceIdentifierSetting(settings: self),
             FasterInactiveTabs(settings: self, settingsDelegate: self),
+            UnleashOnboardingCardNTPSetting(settings: self),
+            UnleashSeedCounterNTPSetting(settings: self)
         ]
-        
-        if OnboardingCardNTPExperiment.isEnabled {
-            hiddenDebugSettings.append(UnleashOnboardingCardNTPSetting(settings: self))
-        }
         
         if SeedCounterNTPExperiment.isEnabled {
             hiddenDebugSettings.append(AddOneSeedSetting(settings: self,

--- a/Client/Ecosia/UI/NTP/ClimateImpactCounter/SeedCounterHiddenSettings.swift
+++ b/Client/Ecosia/UI/NTP/ClimateImpactCounter/SeedCounterHiddenSettings.swift
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
-import Foundation
+import Core
 
 final class AddOneSeedSetting: HiddenSetting {
     
@@ -116,5 +116,16 @@ final class ResetSeedCounterSetting: HiddenSetting {
         // Reset the seed counter using the static method of the passed progressManager type
         progressManagerType.resetCounter()
         settings.tableView.reloadData()
+    }
+}
+
+final class UnleashSeedCounterNTPSetting: UnleashVariantResetSetting {
+    // MARK: - Title
+    override var titleName: String? {
+        "Seed Counter NTP"
+    }
+    
+    override var variant: Unleash.Variant? {
+        Unleash.getVariant(.seedCounterNTP)
     }
 }

--- a/Client/Ecosia/UI/NTP/ClimateImpactCounter/SeedCounterHiddenSettings.swift
+++ b/Client/Ecosia/UI/NTP/ClimateImpactCounter/SeedCounterHiddenSettings.swift
@@ -6,6 +6,18 @@ import Foundation
 import Foundation
 
 final class AddOneSeedSetting: HiddenSetting {
+    
+    // This property holds a reference to the type conforming to SeedProgressManagerProtocol
+    private let progressManagerType: SeedProgressManagerProtocol.Type
+
+    // MARK: - Init
+    init(settings: SettingsTableViewController, 
+         progressManagerType: SeedProgressManagerProtocol.Type) {
+        self.progressManagerType = progressManagerType
+        super.init(settings: settings)
+    }
+
+    // MARK: - Title
     override var title: NSAttributedString? {
         return NSAttributedString(
             string: "Debug: Add One Seed",
@@ -13,52 +25,96 @@ final class AddOneSeedSetting: HiddenSetting {
         )
     }
 
+    // MARK: - Status
     override var status: NSAttributedString? {
-        let seedsCollected = SeedProgressManager.loadSeedsCollected()
-        let level = SeedProgressManager.loadLevel()
+        let seedsCollected = progressManagerType.loadTotalSeedsCollected()
+        let level = progressManagerType.loadCurrentLevel()
         return NSAttributedString(
             string: "Seeds: \(seedsCollected) | Level: \(level)",
             attributes: [NSAttributedString.Key.foregroundColor: UIColor.legacyTheme.tableView.rowText]
         )
     }
 
+    // MARK: - Action
     override func onClick(_ navigationController: UINavigationController?) {
-        // Add 1 seed to the counter
-        SeedProgressManager.addSeeds(1)
+        // Add 1 seed to the counter using the static method of the passed progressManager type
+        progressManagerType.addSeeds(1)
         settings.tableView.reloadData()
     }
 }
 
 final class AddFiveSeedsSetting: HiddenSetting {
+    
+    // This property holds a reference to the type conforming to SeedProgressManagerProtocol
+    private let progressManagerType: SeedProgressManagerProtocol.Type
+
+    // MARK: - Init
+    init(settings: SettingsTableViewController,
+         progressManagerType: SeedProgressManagerProtocol.Type) {
+        self.progressManagerType = progressManagerType
+        super.init(settings: settings)
+    }
+
+    // MARK: - Title
     override var title: NSAttributedString? {
-        return NSAttributedString(string: "Debug: Add Five Seeds", attributes: [NSAttributedString.Key.foregroundColor: UIColor.legacyTheme.tableView.rowText])
+        return NSAttributedString(
+            string: "Debug: Add Five Seeds",
+            attributes: [NSAttributedString.Key.foregroundColor: UIColor.legacyTheme.tableView.rowText]
+        )
     }
 
+    // MARK: - Status
     override var status: NSAttributedString? {
-        let seedsCollected = SeedProgressManager.loadSeedsCollected()
-        let level = SeedProgressManager.loadLevel()
-        return NSAttributedString(string: "Seeds: \(seedsCollected) | Level: \(level)", attributes: [NSAttributedString.Key.foregroundColor: UIColor.legacyTheme.tableView.rowText])
+        let seedsCollected = progressManagerType.loadTotalSeedsCollected()
+        let level = progressManagerType.loadCurrentLevel()
+        return NSAttributedString(
+            string: "Seeds: \(seedsCollected) | Level: \(level)",
+            attributes: [NSAttributedString.Key.foregroundColor: UIColor.legacyTheme.tableView.rowText]
+        )
     }
 
+    // MARK: - Action
     override func onClick(_ navigationController: UINavigationController?) {
-        SeedProgressManager.addSeeds(5)
+        // Add 5 seeds to the counter using the static method of the passed progressManager type
+        progressManagerType.addSeeds(5)
         settings.tableView.reloadData()
     }
 }
 
 final class ResetSeedCounterSetting: HiddenSetting {
+    
+    // This property holds a reference to the type conforming to SeedProgressManagerProtocol
+    private let progressManagerType: SeedProgressManagerProtocol.Type
+
+    // MARK: - Init
+    init(settings: SettingsTableViewController,
+         progressManagerType: SeedProgressManagerProtocol.Type) {
+        self.progressManagerType = progressManagerType
+        super.init(settings: settings)
+    }
+
+    // MARK: - Title
     override var title: NSAttributedString? {
-        return NSAttributedString(string: "Debug: Reset Seed Counter", attributes: [NSAttributedString.Key.foregroundColor: UIColor.legacyTheme.tableView.rowText])
+        return NSAttributedString(
+            string: "Debug: Reset Seed Counter",
+            attributes: [NSAttributedString.Key.foregroundColor: UIColor.legacyTheme.tableView.rowText]
+        )
     }
 
+    // MARK: - Status
     override var status: NSAttributedString? {
-        let seedsCollected = SeedProgressManager.loadSeedsCollected()
-        let level = SeedProgressManager.loadLevel()
-        return NSAttributedString(string: "Seeds: \(seedsCollected) | Level: \(level)", attributes: [NSAttributedString.Key.foregroundColor: UIColor.legacyTheme.tableView.rowText])
+        let seedsCollected = progressManagerType.loadTotalSeedsCollected()
+        let level = progressManagerType.loadCurrentLevel()
+        return NSAttributedString(
+            string: "Seeds: \(seedsCollected) | Level: \(level)",
+            attributes: [NSAttributedString.Key.foregroundColor: UIColor.legacyTheme.tableView.rowText]
+        )
     }
 
+    // MARK: - Action
     override func onClick(_ navigationController: UINavigationController?) {
-        SeedProgressManager.resetCounter()
+        // Reset the seed counter using the static method of the passed progressManager type
+        progressManagerType.resetCounter()
         settings.tableView.reloadData()
     }
 }

--- a/Client/Ecosia/UI/NTP/ClimateImpactCounter/SeedCounterHiddenSettings.swift
+++ b/Client/Ecosia/UI/NTP/ClimateImpactCounter/SeedCounterHiddenSettings.swift
@@ -38,7 +38,7 @@ final class AddOneSeedSetting: HiddenSetting {
     // MARK: - Action
     override func onClick(_ navigationController: UINavigationController?) {
         // Add 1 seed to the counter using the static method of the passed progressManager type
-        progressManagerType.addSeeds(1)
+        progressManagerType.addSeeds(1, relativeToDate: progressManagerType.loadLastAppOpenDate())
         settings.tableView.reloadData()
     }
 }
@@ -76,7 +76,7 @@ final class AddFiveSeedsSetting: HiddenSetting {
     // MARK: - Action
     override func onClick(_ navigationController: UINavigationController?) {
         // Add 5 seeds to the counter using the static method of the passed progressManager type
-        progressManagerType.addSeeds(5)
+        progressManagerType.addSeeds(5, relativeToDate: progressManagerType.loadLastAppOpenDate())
         settings.tableView.reloadData()
     }
 }

--- a/Client/Ecosia/UI/NTP/ClimateImpactCounter/SeedCounterHiddenSettings.swift
+++ b/Client/Ecosia/UI/NTP/ClimateImpactCounter/SeedCounterHiddenSettings.swift
@@ -5,7 +5,7 @@
 import Foundation
 import Foundation
 
-final class AddOneSeed: HiddenSetting {
+final class AddOneSeedSetting: HiddenSetting {
     override var title: NSAttributedString? {
         return NSAttributedString(
             string: "Debug: Add One Seed",
@@ -29,7 +29,7 @@ final class AddOneSeed: HiddenSetting {
     }
 }
 
-final class AddFiveSeeds: HiddenSetting {
+final class AddFiveSeedsSetting: HiddenSetting {
     override var title: NSAttributedString? {
         return NSAttributedString(string: "Debug: Add Five Seeds", attributes: [NSAttributedString.Key.foregroundColor: UIColor.legacyTheme.tableView.rowText])
     }
@@ -46,7 +46,7 @@ final class AddFiveSeeds: HiddenSetting {
     }
 }
 
-final class ResetSeedCounter: HiddenSetting {
+final class ResetSeedCounterSetting: HiddenSetting {
     override var title: NSAttributedString? {
         return NSAttributedString(string: "Debug: Reset Seed Counter", attributes: [NSAttributedString.Key.foregroundColor: UIColor.legacyTheme.tableView.rowText])
     }

--- a/Client/Ecosia/UI/NTP/ClimateImpactCounter/SeedCounterHiddenSettings.swift
+++ b/Client/Ecosia/UI/NTP/ClimateImpactCounter/SeedCounterHiddenSettings.swift
@@ -1,0 +1,64 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Foundation
+
+final class AddOneSeed: HiddenSetting {
+    override var title: NSAttributedString? {
+        return NSAttributedString(
+            string: "Debug: Add One Seed",
+            attributes: [NSAttributedString.Key.foregroundColor: UIColor.legacyTheme.tableView.rowText]
+        )
+    }
+
+    override var status: NSAttributedString? {
+        let seedsCollected = SeedProgressManager.loadSeedsCollected()
+        let level = SeedProgressManager.loadLevel()
+        return NSAttributedString(
+            string: "Seeds: \(seedsCollected) | Level: \(level)",
+            attributes: [NSAttributedString.Key.foregroundColor: UIColor.legacyTheme.tableView.rowText]
+        )
+    }
+
+    override func onClick(_ navigationController: UINavigationController?) {
+        // Add 1 seed to the counter
+        SeedProgressManager.addSeeds(1)
+        settings.tableView.reloadData()
+    }
+}
+
+final class AddFiveSeeds: HiddenSetting {
+    override var title: NSAttributedString? {
+        return NSAttributedString(string: "Debug: Add Five Seeds", attributes: [NSAttributedString.Key.foregroundColor: UIColor.legacyTheme.tableView.rowText])
+    }
+
+    override var status: NSAttributedString? {
+        let seedsCollected = SeedProgressManager.loadSeedsCollected()
+        let level = SeedProgressManager.loadLevel()
+        return NSAttributedString(string: "Seeds: \(seedsCollected) | Level: \(level)", attributes: [NSAttributedString.Key.foregroundColor: UIColor.legacyTheme.tableView.rowText])
+    }
+
+    override func onClick(_ navigationController: UINavigationController?) {
+        SeedProgressManager.addSeeds(5)
+        settings.tableView.reloadData()
+    }
+}
+
+final class ResetSeedCounter: HiddenSetting {
+    override var title: NSAttributedString? {
+        return NSAttributedString(string: "Debug: Reset Seed Counter", attributes: [NSAttributedString.Key.foregroundColor: UIColor.legacyTheme.tableView.rowText])
+    }
+
+    override var status: NSAttributedString? {
+        let seedsCollected = SeedProgressManager.loadSeedsCollected()
+        let level = SeedProgressManager.loadLevel()
+        return NSAttributedString(string: "Seeds: \(seedsCollected) | Level: \(level)", attributes: [NSAttributedString.Key.foregroundColor: UIColor.legacyTheme.tableView.rowText])
+    }
+
+    override func onClick(_ navigationController: UINavigationController?) {
+        SeedProgressManager.resetCounter()
+        settings.tableView.reloadData()
+    }
+}


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2875]

## Context

In light of the Seed Counter feature, we would like to improve our testing experience by adding some debug settings.

## Approach

- Add debug settings to:
  - add 1 seed
  - add 5 seeds
  - reset the seed counter and level back to the original state

## Other

Took the occasion to review the settings for the Onboarding Card to be added regardless of the experiment enabled.

## Before merging

Marking this as `Draft` as will function purely as a PR Train 🚂 to better review it in advance. Will remove the `Draft` and update the `base` branch as soon as this one https://github.com/ecosia/ios-browser/pull/786 will be merged in `main` 

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator

[MOB-2875]: https://ecosia.atlassian.net/browse/MOB-2875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ