### PR TITLE
[MOB-2896] Enable already normalized hosts to be pinned

### DIFF
--- a/BrowserKit/Sources/Common/Extensions/URLExtension.swift
+++ b/BrowserKit/Sources/Common/Extensions/URLExtension.swift
@@ -71,7 +71,9 @@ extension URL {
         if let range = host.range(of: "^(www|mobile|m)\\.", options: .regularExpression) {
             host.replaceSubrange(range, with: "")
         }
-        guard host != publicSuffix else { return nil }
+        // If the host equals the public suffix, it means that the host is already normalized.
+        // Therefore, we return the original host without any modifications.
+        guard host != publicSuffix else { return components.host }
 
         return host
     }

--- a/BrowserKit/Tests/CommonTests/Extensions/URLExtensionTests.swift
+++ b/BrowserKit/Tests/CommonTests/Extensions/URLExtensionTests.swift
@@ -104,6 +104,12 @@ final class URLExtensionTests: XCTestCase {
         XCTAssertEqual(host!, "bugzilla.mozilla.org")
         XCTAssertEqual(url!.fragment!, "h=dupes%7CData%20%26%20BI%20Services%20Team%7C")
     }
+    
+    func testNormalizedHostReturnsOriginalHost() {
+        let url = URL(string: "https://mobile.co.uk")!
+        let host = url.normalizedHost
+        XCTAssertEqual(host, "mobile.co.uk")
+    }
 
     func testIPv6Domain() {
         let url = URL(string: "http://[::1]/foo/bar")!


### PR DESCRIPTION
[MOB-2896]

## Context

An user reached out with a problem of not being able to unpin a website.

## Approach

After some investigation, found out that this could be related to an error [when the host is resolved](https://github.com/ecosia/ios-browser/blob/3e9f3aa57a6e1b34381082d8063053b7951d354f/Storage/SQL/SQLitePinnedSites.swift#L43-L45). 

Trying out exactly the url reported by the user (gov.uk) showed that we have an issue on the `normalizedHost` property for hosts that are already normalized (aka when they 100% match a top level domain from [our supported list](https://github.com/ecosia/ios-browser/blob/main/BrowserKit/Sources/Common/Constants/EffectiveTLDNames.swift)) where this would return `nil`.

To fix that I looked how it was on the latest Firefox and noticed this was already fixed there by [this PR change](https://github.com/mozilla-mobile/firefox-ios/pull/19733/files#diff-8e531330b32bc0064301e0740a902fcfd7b0c9069e3f737fee94dd936417e28f), so I just applied the relevant change in our code. Also took the opportunity to add the same unit test for that case implemented on Firefox. Since this is already Firefox code, not adding any Ecosia comment as well.

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I wrote Unit Tests that confirm the expected behaviour
- [x] I added the `// Ecosia:` helper comments where needed

[MOB-2896]: https://ecosia.atlassian.net/browse/MOB-2896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ