### PR TITLE
[MOB-2894] Top sites analytics

### DIFF
--- a/Client/Ecosia/Analytics/Analytics.Values.swift
+++ b/Client/Ecosia/Analytics/Analytics.Values.swift
@@ -41,12 +41,13 @@ extension Analytics {
         
         enum NTP: String {
             case
-            customize,
-            topSites = "top_sites",
-            impact,
-            news,
             about,
-            onboardingCard = "onboarding_card"
+            customize,
+            impact,
+            library,
+            news,
+            onboardingCard = "onboarding_card",
+            topSites = "top_sites"
         }
         
         enum Browser: String {
@@ -123,6 +124,16 @@ extension Analytics {
             case
             `import`
         }
+        
+        enum TopSite: String {
+            case
+            click,
+            openNewTab = "open_new_tab",
+            openPrivateTab = "open_private_tab",
+            pin,
+            remove,
+            unpin
+        }
     }
     
     enum Property {
@@ -142,12 +153,19 @@ extension Analytics {
             }
         }
         
+        enum Library: String {
+            case
+            bookmarks,
+            downloads,
+            history,
+            readingList = "reading_list"
+        }
+        
         enum TopSite: String {
             case
-            blog,
-            privacy,
-            financialReports = "financial_reports",
-            howEcosiaWorks = "how_ecosia_works"
+            `default`,
+            mostVisited,
+            pinned
         }
         
         enum Bookmarks: String {

--- a/Client/Ecosia/Analytics/Analytics.Values.swift
+++ b/Client/Ecosia/Analytics/Analytics.Values.swift
@@ -44,7 +44,7 @@ extension Analytics {
             about,
             customize,
             impact,
-            library,
+            quickActions = "quick_actions",
             news,
             onboardingCard = "onboarding_card",
             topSites = "top_sites"

--- a/Client/Ecosia/Analytics/Analytics.Values.swift
+++ b/Client/Ecosia/Analytics/Analytics.Values.swift
@@ -164,7 +164,7 @@ extension Analytics {
         enum TopSite: String {
             case
             `default`,
-            mostVisited,
+            mostVisited = "most_visited",
             pinned
         }
         

--- a/Client/Ecosia/Analytics/Analytics.swift
+++ b/Client/Ecosia/Analytics/Analytics.swift
@@ -82,6 +82,21 @@ final class Analytics: AnalyticsProtocol {
             .label(label.rawValue))
     }
     
+    func ntpTopSite(_ action: Action.TopSite, property: Property.TopSite, position: NSNumber) {
+        track(Structured(category: Category.ntp.rawValue,
+                         action: action.rawValue)
+            .label(Label.NTP.topSites.rawValue)
+            .property(property.rawValue)
+            .value(position))
+    }
+    
+    func ntpLibraryItem(_ action: Action, property: Property.Library) {
+        track(Structured(category: Category.ntp.rawValue,
+                         action: action.rawValue)
+            .label(Label.NTP.library.rawValue)
+            .property(property.rawValue))
+    }
+    
     func ntpOnboardingCardExperiment(_ action: Action) {
         track(Structured(category: Category.ntp.rawValue,
                          action: action.rawValue)

--- a/Client/Ecosia/Analytics/Analytics.swift
+++ b/Client/Ecosia/Analytics/Analytics.swift
@@ -82,7 +82,7 @@ final class Analytics: AnalyticsProtocol {
             .label(label.rawValue))
     }
     
-    func ntpTopSite(_ action: Action.TopSite, property: Property.TopSite, position: NSNumber) {
+    func ntpTopSite(_ action: Action.TopSite, property: Property.TopSite, position: NSNumber? = nil) {
         track(Structured(category: Category.ntp.rawValue,
                          action: action.rawValue)
             .label(Label.NTP.topSites.rawValue)

--- a/Client/Ecosia/Analytics/Analytics.swift
+++ b/Client/Ecosia/Analytics/Analytics.swift
@@ -93,7 +93,7 @@ final class Analytics: AnalyticsProtocol {
     func ntpLibraryItem(_ action: Action, property: Property.Library) {
         track(Structured(category: Category.ntp.rawValue,
                          action: action.rawValue)
-            .label(Label.NTP.library.rawValue)
+            .label(Label.NTP.quickActions.rawValue)
             .property(property.rawValue))
     }
     

--- a/Client/Ecosia/UI/NTP/Library/NTPLibraryCell.swift
+++ b/Client/Ecosia/UI/NTP/Library/NTPLibraryCell.swift
@@ -27,12 +27,22 @@ class NTPLibraryCell: UICollectionViewCell, Themeable, ReusableCell {
             case .downloads: return .AppMenu.AppMenuDownloadsTitleString
             }
         }
+        
         var image: UIImage? {
             switch self {
             case .bookmarks: return .init(named: "libraryFavorites")
             case .history: return .init(named: "libraryHistory")
             case .readingList: return .init(named: "libraryReading")
             case .downloads: return .init(named: "libraryDownloads")
+            }
+        }
+        
+        var analyticsProperty: Analytics.Property.Library {
+            switch self {
+            case .bookmarks: return .bookmarks
+            case .history: return .history
+            case .readingList: return .readingList
+            case .downloads: return .downloads
             }
         }
     }
@@ -107,7 +117,9 @@ class NTPLibraryCell: UICollectionViewCell, Themeable, ReusableCell {
     }
 
     @objc func tapped(_ sender: UIButton) {
-        switch Item(rawValue: sender.tag) {
+        guard let item = Item(rawValue: sender.tag) else { return }
+        Analytics.shared.ntpLibraryItem(.click, property: item.analyticsProperty)
+        switch item {
         case .bookmarks:
             delegate?.libraryCellOpenBookmarks()
         case .history:
@@ -116,8 +128,6 @@ class NTPLibraryCell: UICollectionViewCell, Themeable, ReusableCell {
             delegate?.libraryCellOpenReadlist()
         case .downloads:
             delegate?.libraryCellOpenDownloads()
-        default:
-            break
         }
     }
 }

--- a/Client/Frontend/Home/HomepageContextMenuHelper.swift
+++ b/Client/Frontend/Home/HomepageContextMenuHelper.swift
@@ -89,9 +89,14 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
     }
 
     // MARK: - Default actions
-    func getOpenInNewPrivateTabAction(siteURL: URL, sectionType: HomepageSectionType) -> PhotonRowActions {
+    /* Ecosia: Receive `Site` in addition to `URL`. Required for tracking.
+     func getOpenInNewPrivateTabAction(siteURL: URL, sectionType: HomepageSectionType) -> PhotonRowActions {
+     */
+    func getOpenInNewPrivateTabAction(site: Site, siteURL: URL, sectionType: HomepageSectionType) -> PhotonRowActions {
         return SingleActionViewModel(title: .OpenInNewPrivateTabContextMenuTitle, iconString: ImageIdentifiers.newPrivateTab) { _ in
             self.delegate?.homePanelDidRequestToOpenInNewTab(siteURL, isPrivate: true)
+            // Ecosia: Track open in new tab top site action
+            self.viewModel.topSiteViewModel.trackTopSiteMenuAction(site: site, action: .openPrivateTab)
             // Ecosia: Remove Telemetry section type helper
             // sectionType.newPrivateTabActionTelemetry()
         }.items
@@ -150,9 +155,15 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
         return [openInNewTabAction, openInNewPrivateTabAction, bookmarkAction, shareAction]
     }
      */
-    private func getOpenInNewTabAction(siteURL: URL, sectionType: HomepageSectionType) -> PhotonRowActions {
+    
+    /* Ecosia: Receive `Site` in addition to `URL`. Required for tracking.
+     private func getOpenInNewTabAction(siteURL: URL, sectionType: HomepageSectionType) -> PhotonRowActions {
+     */
+    private func getOpenInNewTabAction(site: Site, siteURL: URL, sectionType: HomepageSectionType) -> PhotonRowActions {
         return SingleActionViewModel(title: .OpenInNewTabContextMenuTitle, iconString: StandardImageIdentifiers.Large.plus) { _ in
             self.delegate?.homePanelDidRequestToOpenInNewTab(siteURL, isPrivate: false)
+            // Ecosia: Track open in new tab top site action
+            self.viewModel.topSiteViewModel.trackTopSiteMenuAction(site: site, action: .openNewTab)
             /* Ecosia: Remove History Highlights and Pocket
             if sectionType == .pocket {
                 let originExtras = TelemetryWrapper.getOriginExtras(isZeroSearch: self.viewModel.isZeroSearch)
@@ -235,20 +246,38 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
         guard let siteURL = site.url.asURL else { return nil }
 
         let topSiteActions: [PhotonRowActions]
+        /* Ecosia: Include `site: Site` wherever required by tracking
+         if let site = site as? PinnedSite {
+             topSiteActions = [getRemovePinTopSiteAction(site: site),
+                               getOpenInNewTabAction(siteURL: siteURL, sectionType: .topSites),
+                               getOpenInNewPrivateTabAction(siteURL: siteURL, sectionType: .topSites),
+                               getRemoveTopSiteAction(site: site)]
+         } else if site as? SponsoredTile != nil {
+             topSiteActions = [getOpenInNewTabAction(siteURL: siteURL, sectionType: .topSites),
+                               getOpenInNewPrivateTabAction(siteURL: siteURL, sectionType: .topSites),
+                               getSettingsAction(),
+                               getSponsoredContentAction()]
+         } else {
+             topSiteActions = [getPinTopSiteAction(site: site),
+                               getOpenInNewTabAction(siteURL: siteURL, sectionType: .topSites),
+                               getOpenInNewPrivateTabAction(siteURL: siteURL, sectionType: .topSites),
+                               getRemoveTopSiteAction(site: site)]
+         }
+         */
         if let site = site as? PinnedSite {
             topSiteActions = [getRemovePinTopSiteAction(site: site),
-                              getOpenInNewTabAction(siteURL: siteURL, sectionType: .topSites),
-                              getOpenInNewPrivateTabAction(siteURL: siteURL, sectionType: .topSites),
+                              getOpenInNewTabAction(site: site, siteURL: siteURL, sectionType: .topSites),
+                              getOpenInNewPrivateTabAction(site: site, siteURL: siteURL, sectionType: .topSites),
                               getRemoveTopSiteAction(site: site)]
         } else if site as? SponsoredTile != nil {
-            topSiteActions = [getOpenInNewTabAction(siteURL: siteURL, sectionType: .topSites),
-                              getOpenInNewPrivateTabAction(siteURL: siteURL, sectionType: .topSites),
+            topSiteActions = [getOpenInNewTabAction(site: site, siteURL: siteURL, sectionType: .topSites),
+                              getOpenInNewPrivateTabAction(site: site, siteURL: siteURL, sectionType: .topSites),
                               getSettingsAction(),
                               getSponsoredContentAction()]
         } else {
             topSiteActions = [getPinTopSiteAction(site: site),
-                              getOpenInNewTabAction(siteURL: siteURL, sectionType: .topSites),
-                              getOpenInNewPrivateTabAction(siteURL: siteURL, sectionType: .topSites),
+                              getOpenInNewTabAction(site: site, siteURL: siteURL, sectionType: .topSites),
+                              getOpenInNewPrivateTabAction(site: site, siteURL: siteURL, sectionType: .topSites),
                               getRemoveTopSiteAction(site: site)]
         }
         return topSiteActions
@@ -265,6 +294,8 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
             }
 
             self.sendTopSiteContextualTelemetry(type: .remove)
+            // Ecosia: Track remove top site action
+            self.viewModel.topSiteViewModel.trackTopSiteMenuAction(site: site, action: .remove)
         }).items
     }
 
@@ -274,6 +305,8 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
                                      tapHandler: { _ in
             self.viewModel.topSiteViewModel.pinTopSite(site)
             self.sendTopSiteContextualTelemetry(type: .pin)
+            // Ecosia: Track pin top site action
+            self.viewModel.topSiteViewModel.trackTopSiteMenuAction(site: site, action: .pin)
         }).items
     }
 
@@ -284,6 +317,8 @@ class HomepageContextMenuHelper: HomepageContextMenuProtocol {
                                      tapHandler: { _ in
             self.viewModel.topSiteViewModel.removePinTopSite(site)
             self.sendTopSiteContextualTelemetry(type: .unpin)
+            // Ecosia: Track unpin top site action
+            self.viewModel.topSiteViewModel.trackTopSiteMenuAction(site: site, action: .unpin)
         }).items
     }
 

--- a/Client/Frontend/Home/TopSites/DataManagement/TopSiteHistoryManager.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/TopSiteHistoryManager.swift
@@ -35,6 +35,12 @@ class TopSiteHistoryManager: DataObserver {
         _ = profile.pinnedSites.removeFromPinnedTopSites(site)
     }
 
+    // Ecosia: New method to check if default top site
+    func isDefaultTopSite(site: Site) -> Bool {
+        let url = site.tileURL.absoluteString
+        return topSitesProvider.defaultTopSites(profile.prefs).contains(where: { $0.url == url })
+    }
+    
     /// If the default top sites contains the siteurl. also wipe it from default suggested sites.
     func removeDefaultTopSitesTile(site: Site) {
         let url = site.tileURL.absoluteString

--- a/Client/Frontend/Home/TopSites/DataManagement/TopSiteHistoryManager.swift
+++ b/Client/Frontend/Home/TopSites/DataManagement/TopSiteHistoryManager.swift
@@ -37,8 +37,7 @@ class TopSiteHistoryManager: DataObserver {
 
     // Ecosia: New method to check if default top site
     func isDefaultTopSite(site: Site) -> Bool {
-        let url = site.tileURL.absoluteString
-        return topSitesProvider.defaultTopSites(profile.prefs).contains(where: { $0.url == url })
+        return topSitesProvider.defaultTopSites(profile.prefs).contains(where: { $0.url == site.url })
     }
     
     /// If the default top sites contains the siteurl. also wipe it from default suggested sites.

--- a/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
+++ b/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
@@ -60,7 +60,20 @@ class TopSitesViewModel {
 
     func tilePressed(site: TopSite, position: Int) {
         topSitePressTracking(homeTopSite: site, position: position)
+        // Ecosia: Track Top Site click
+        trackTopSitePressed(topSite: site, position: position)
         tilePressedHandler?(site.site, site.isGoogleURL)
+    }
+    
+    // Ecosia: Track Top Site click
+    func trackTopSitePressed(topSite: TopSite, position: Int) {
+        var property: Analytics.Property.TopSite = .mostVisited
+        if topSite.isPinned {
+            property = .pinned
+        } else if topSiteHistoryManager.isDefaultTopSite(site: topSite.site) {
+            property = .default
+        }
+        Analytics.shared.ntpTopSite(.click, property: property, position: position as NSNumber)
     }
 
     // MARK: - Telemetry

--- a/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
+++ b/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
@@ -65,15 +65,26 @@ class TopSitesViewModel {
         tilePressedHandler?(site.site, site.isGoogleURL)
     }
     
-    // Ecosia: Track Top Site click
-    func trackTopSitePressed(topSite: TopSite, position: Int) {
-        var property: Analytics.Property.TopSite = .mostVisited
-        if topSite.isPinned {
-            property = .pinned
-        } else if topSiteHistoryManager.isDefaultTopSite(site: topSite.site) {
-            property = .default
+    // MARK: - Ecosia Top Sites Analytics
+    
+    private func ecosiaAnalyticsProperty(forSite site: Site) -> Analytics.Property.TopSite {
+        if (site as? PinnedSite) != nil {
+            return .pinned
+        } else if topSiteHistoryManager.isDefaultTopSite(site: site) {
+            return .default
+        } else {
+            return .mostVisited
         }
+    }
+    
+    func trackTopSitePressed(topSite: TopSite, position: Int) {
+        let property = ecosiaAnalyticsProperty(forSite: topSite.site)
         Analytics.shared.ntpTopSite(.click, property: property, position: position as NSNumber)
+    }
+    
+    func trackTopSiteMenuAction(site: Site, action: Analytics.Action.TopSite) {
+        let property = ecosiaAnalyticsProperty(forSite: site)
+        Analytics.shared.ntpTopSite(action, property: property)
     }
 
     // MARK: - Telemetry

--- a/EcosiaTests/EcosiaTopSitesHelperTests.swift
+++ b/EcosiaTests/EcosiaTopSitesHelperTests.swift
@@ -20,7 +20,7 @@ extension TopSitesHelperTests {
             
             XCTAssertTrue((sites.first(where: { $0.url.asURL?.absoluteString == "https://blog.ecosia.org/ecosia-financial-reports-tree-planting-receipts/" }) != nil))
             XCTAssertTrue((sites.first(where: { $0.url.asURL?.absoluteString == "https://www.ecosia.org/privacy" }) != nil))
-            XCTAssertTrue((sites.first(where: { $0.url.asURL?.absoluteString == "https://blog.ecosia.org/" }) != nil))
+            XCTAssertTrue((sites.first(where: { $0.url.asURL?.absoluteString == "https://blog.ecosia.org/tag/where-does-ecosia-plant-trees/" }) != nil))
 
             expectation.fulfill()
         }

--- a/Storage/DefaultSuggestedSites.swift
+++ b/Storage/DefaultSuggestedSites.swift
@@ -155,7 +155,7 @@ open class DefaultSuggestedSites {
                 title: NSLocalizedString("Privacy", tableName: "Ecosia", comment: "")
             ),
             SuggestedSiteData(
-                url: Environment.current.urlProvider.blog.absoluteString,
+                url: Environment.current.urlProvider.trees.absoluteString,
                 bgColor: "0x000000",
                 imageUrl: "asset://suggestedsites_ecosia-org",
                 faviconUrl: "asset://defaultFavicon",


### PR DESCRIPTION
[MOB-2894]

## Context

We want to track user interaction with the top sites to see how often it's used.

## Approach

Created the Analytics values and functions and triggered them close to Firefox's telemetry. Made sure to add Ecosia comments everywhere I had to update existing classes.

## Other

Took the opportunity to update the url used by our "Our trees" default top site as [aligned with the team](https://ecosia-team.slack.com/archives/C07CWQ35E7P/p1728372133732369).

## Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] ~~I wrote Unit Tests that confirm the expected behaviour~~ Did not find a simple way to do it and thought it wasn't worth more effort, up for suggestions 💡 
- [x] I added the `// Ecosia:` helper comments where needed
- [x] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)

[MOB-2894]: https://ecosia.atlassian.net/browse/MOB-2894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ