### PR TITLE
[MOB-2872] Seed Counter Animations

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -211,7 +211,7 @@
 		2C49854E206173C800893DAE /* photon-colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C49854D206173C800893DAE /* photon-colors.swift */; };
 		2C4ABD492CB58E4F00FF86F9 /* Sparkle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4ABD482CB58E4F00FF86F9 /* Sparkle.swift */; };
 		2C4D16602C76360800E89C95 /* environment.json in Resources */ = {isa = PBXBuildFile; fileRef = 2C4D165F2C76360800E89C95 /* environment.json */; };
-		2C5A5E652CB53DB7005BFE8B /* SeedLevelConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C5A5E642CB53DB7005BFE8B /* SeedLevelConfig.swift */; };
+		2C5A5E652CB53DB7005BFE8B /* SeedCounterConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C5A5E642CB53DB7005BFE8B /* SeedCounterConfig.swift */; };
 		2C5A5E672CB53DF9005BFE8B /* UserDefaultsSeedProgressManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C5A5E662CB53DF9005BFE8B /* UserDefaultsSeedProgressManager.swift */; };
 		2C5B81C82C75388300B81D95 /* LocaleRetriever.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C5B81C72C75388300B81D95 /* LocaleRetriever.swift */; };
 		2C6189312B7A8A22006B70D7 /* EcosiaLaunchScreenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C6188802B7A8A21006B70D7 /* EcosiaLaunchScreenView.swift */; };
@@ -2370,7 +2370,7 @@
 		2C4ABD482CB58E4F00FF86F9 /* Sparkle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Sparkle.swift; sourceTree = "<group>"; };
 		2C4B6BF220349EB800A009C2 /* OnboardingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingTests.swift; sourceTree = "<group>"; };
 		2C4D165F2C76360800E89C95 /* environment.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = environment.json; sourceTree = "<group>"; };
-		2C5A5E642CB53DB7005BFE8B /* SeedLevelConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeedLevelConfig.swift; sourceTree = "<group>"; };
+		2C5A5E642CB53DB7005BFE8B /* SeedCounterConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeedCounterConfig.swift; sourceTree = "<group>"; };
 		2C5A5E662CB53DF9005BFE8B /* UserDefaultsSeedProgressManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsSeedProgressManager.swift; sourceTree = "<group>"; };
 		2C5B81C72C75388300B81D95 /* LocaleRetriever.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocaleRetriever.swift; sourceTree = "<group>"; };
 		2C6045859589979C43AF09E0 /* jv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = jv; path = jv.lproj/ClearPrivateDataConfirm.strings; sourceTree = "<group>"; };
@@ -8879,7 +8879,7 @@
 				2CCBB5262CAEAD53006E2E10 /* SeedCounterView.swift */,
 				2CCBB5362CAF0E8C006E2E10 /* SeedCounterHiddenSettings.swift */,
 				2C5A5E682CB53E05005BFE8B /* SeedProgressManager */,
-				2C5A5E642CB53DB7005BFE8B /* SeedLevelConfig.swift */,
+				2C5A5E642CB53DB7005BFE8B /* SeedCounterConfig.swift */,
 			);
 			path = ClimateImpactCounter;
 			sourceTree = "<group>";
@@ -13928,7 +13928,7 @@
 				AB52ED3B2A0E8873001067F5 /* UserConversionMetrics.swift in Sources */,
 				219935EC2B07110900E5966F /* TabTrayModel.swift in Sources */,
 				8A3EF7F72A2FCF6D00796E3A /* ExportLogDataSetting.swift in Sources */,
-				2C5A5E652CB53DB7005BFE8B /* SeedLevelConfig.swift in Sources */,
+				2C5A5E652CB53DB7005BFE8B /* SeedCounterConfig.swift in Sources */,
 				43E69EC3254D081D00B591C2 /* SimpleTab.swift in Sources */,
 				8ADAE4202A33A0FD007BF926 /* SendFeedbackSetting.swift in Sources */,
 				C29B64812AD6959E00F3244B /* QRCodeCoordinator.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -194,6 +194,7 @@
 		28E91E751B443AD5009DF274 /* SyncConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28E91E741B443AD5009DF274 /* SyncConstants.swift */; };
 		28ECD9BF1BA1F19900D829DA /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = E6231C001B90A44F005ABB0D /* libz.tbd */; };
 		2C0360DA2C1747E6006706F2 /* FxNimbus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C0360D92C1747E6006706F2 /* FxNimbus.swift */; };
+		2C03A4152CB7C7CC00AB228B /* DispatchQueueHelper+BuildChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C03A4142CB7C7CC00AB228B /* DispatchQueueHelper+BuildChannel.swift */; };
 		2C1298A52BF5EB16005AE4E4 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 2C1298A42BF5EB16005AE4E4 /* PrivacyInfo.xcprivacy */; };
 		2C1298A62BF5EB1E005AE4E4 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 2C1298A42BF5EB16005AE4E4 /* PrivacyInfo.xcprivacy */; };
 		2C1298A72BF5EB1F005AE4E4 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 2C1298A42BF5EB16005AE4E4 /* PrivacyInfo.xcprivacy */; };
@@ -2350,6 +2351,7 @@
 		2BAA411FAF1D49B9990A7720 /* sat-Olck */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "sat-Olck"; path = "sat-Olck.lproj/Shared.strings"; sourceTree = "<group>"; };
 		2BAB4A40A318F5A577488909 /* mr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = mr; path = mr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		2C0360D92C1747E6006706F2 /* FxNimbus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FxNimbus.swift; sourceTree = "<group>"; };
+		2C03A4142CB7C7CC00AB228B /* DispatchQueueHelper+BuildChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DispatchQueueHelper+BuildChannel.swift"; sourceTree = "<group>"; };
 		2C08319B2B89127200BD7134 /* Ecosia.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Ecosia.entitlements; sourceTree = "<group>"; };
 		2C08319C2B89127200BD7134 /* EcosiaBeta.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = EcosiaBeta.entitlements; sourceTree = "<group>"; };
 		2C1298A42BF5EB16005AE4E4 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
@@ -8754,6 +8756,7 @@
 				2C61890D2B7A8A22006B70D7 /* AppSettingsTableViewController+Ecosia.swift */,
 				2C61890E2B7A8A22006B70D7 /* DeviceInfo+Ecosia.swift */,
 				2C61890F2B7A8A22006B70D7 /* Toolbar+URLBar */,
+				2C03A4142CB7C7CC00AB228B /* DispatchQueueHelper+BuildChannel.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -14278,6 +14281,7 @@
 				1D2F68AD2ACB266300524B92 /* RemoteTabsPanelState.swift in Sources */,
 				4347B398298D6D7B0045F677 /* CreditCardTableViewModel.swift in Sources */,
 				1DFE57FD27BADD7D0025DE58 /* HomepageViewModel.swift in Sources */,
+				2C03A4152CB7C7CC00AB228B /* DispatchQueueHelper+BuildChannel.swift in Sources */,
 				D3A9949D1A3686BD008AD1AC /* Tab.swift in Sources */,
 				8AD40FD127BADCBA00672675 /* ToolbarButton.swift in Sources */,
 				A93067E81D0FE18E00C49C6E /* NightModeHelper.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -209,6 +209,7 @@
 		2C26FAAA2C8752D20055760A /* LegacyThemeManager+Ecosia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C6189012B7A8A22006B70D7 /* LegacyThemeManager+Ecosia.swift */; };
 		2C3BD5EB2BF6193B00E25B0D /* EcosiaThemeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C6188C32B7A8A22006B70D7 /* EcosiaThemeManager.swift */; };
 		2C49854E206173C800893DAE /* photon-colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C49854D206173C800893DAE /* photon-colors.swift */; };
+		2C4ABD492CB58E4F00FF86F9 /* Sparkle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C4ABD482CB58E4F00FF86F9 /* Sparkle.swift */; };
 		2C4D16602C76360800E89C95 /* environment.json in Resources */ = {isa = PBXBuildFile; fileRef = 2C4D165F2C76360800E89C95 /* environment.json */; };
 		2C5A5E652CB53DB7005BFE8B /* SeedLevelConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C5A5E642CB53DB7005BFE8B /* SeedLevelConfig.swift */; };
 		2C5A5E672CB53DF9005BFE8B /* UserDefaultsSeedProgressManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C5A5E662CB53DF9005BFE8B /* UserDefaultsSeedProgressManager.swift */; };
@@ -380,8 +381,8 @@
 		2CCBB5232CAE9826006E2E10 /* ArcProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CCBB5222CAE9826006E2E10 /* ArcProgressView.swift */; };
 		2CCBB5252CAEA9DF006E2E10 /* SeedProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CCBB5242CAEA9DF006E2E10 /* SeedProgressView.swift */; };
 		2CCBB5272CAEAD53006E2E10 /* SeedCounterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CCBB5262CAEAD53006E2E10 /* SeedCounterView.swift */; };
-		2CCBB5372CAF0E8C006E2E10 /* SeedCounterHiddenSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CCBB5362CAF0E8C006E2E10 /* SeedCounterHiddenSettings.swift */; };
 		2CCBB5352CAF06DE006E2E10 /* SeedProgressManagerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CCBB5342CAF06DE006E2E10 /* SeedProgressManagerProtocol.swift */; };
+		2CCBB5372CAF0E8C006E2E10 /* SeedCounterHiddenSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CCBB5362CAF0E8C006E2E10 /* SeedCounterHiddenSettings.swift */; };
 		2CCFB3D72C0FBEE800BEDCA0 /* TabToolbarHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D815A3A724A53F3200AAB221 /* TabToolbarHelperTests.swift */; };
 		2CD48B7F2C7F7E4100A70908 /* EcosiaOverlayModeManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD48B7E2C7F7E4100A70908 /* EcosiaOverlayModeManagerTests.swift */; };
 		2CE294472B7CDD56006C22B2 /* Core in Frameworks */ = {isa = PBXBuildFile; productRef = 2CE294462B7CDD56006C22B2 /* Core */; };
@@ -2366,6 +2367,7 @@
 		2C473BCF209778900008C853 /* DownloadsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadsTests.swift; sourceTree = "<group>"; };
 		2C49854D206173C800893DAE /* photon-colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "photon-colors.swift"; sourceTree = "<group>"; };
 		2C4A07DB20246EAD0083E320 /* DragAndDropTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragAndDropTests.swift; sourceTree = "<group>"; };
+		2C4ABD482CB58E4F00FF86F9 /* Sparkle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Sparkle.swift; sourceTree = "<group>"; };
 		2C4B6BF220349EB800A009C2 /* OnboardingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingTests.swift; sourceTree = "<group>"; };
 		2C4D165F2C76360800E89C95 /* environment.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = environment.json; sourceTree = "<group>"; };
 		2C5A5E642CB53DB7005BFE8B /* SeedLevelConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeedLevelConfig.swift; sourceTree = "<group>"; };
@@ -2552,8 +2554,8 @@
 		2CCBB5222CAE9826006E2E10 /* ArcProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArcProgressView.swift; sourceTree = "<group>"; };
 		2CCBB5242CAEA9DF006E2E10 /* SeedProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeedProgressView.swift; sourceTree = "<group>"; };
 		2CCBB5262CAEAD53006E2E10 /* SeedCounterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeedCounterView.swift; sourceTree = "<group>"; };
-		2CCBB5362CAF0E8C006E2E10 /* SeedCounterHiddenSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeedCounterHiddenSettings.swift; sourceTree = "<group>"; };
 		2CCBB5342CAF06DE006E2E10 /* SeedProgressManagerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeedProgressManagerProtocol.swift; sourceTree = "<group>"; };
+		2CCBB5362CAF0E8C006E2E10 /* SeedCounterHiddenSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeedCounterHiddenSettings.swift; sourceTree = "<group>"; };
 		2CCF17522105E4FD00705AE5 /* DisplaySettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplaySettingsTests.swift; sourceTree = "<group>"; };
 		2CCFB3D42C0F1EA500BEDCA0 /* LoadingScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoadingScreen.swift; sourceTree = "<group>"; };
 		2CD368492C5BC31700972871 /* OnboardingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingTests.swift; sourceTree = "<group>"; };
@@ -8869,6 +8871,7 @@
 		2C6B5B3C2CAAF27F00F15323 /* ClimateImpactCounter */ = {
 			isa = PBXGroup;
 			children = (
+				2C4ABD482CB58E4F00FF86F9 /* Sparkle.swift */,
 				2C6B5B3A2CAAF27F00F15323 /* NTPSeedCounterCell.swift */,
 				2C6B5B3B2CAAF27F00F15323 /* NTPSeedCounterViewModel.swift */,
 				2CCBB5222CAE9826006E2E10 /* ArcProgressView.swift */,
@@ -13853,6 +13856,7 @@
 				21E77E4E2AA8BA5200FABA10 /* TabTrayViewController.swift in Sources */,
 				43BDBBFE2752FA8600254DE4 /* LegacyTabCell.swift in Sources */,
 				E60D03181D511398002FE3F6 /* SyncDisplayState.swift in Sources */,
+				2C4ABD492CB58E4F00FF86F9 /* Sparkle.swift in Sources */,
 				C4E3983D1D21F1E7004E89BA /* TopTabCell.swift in Sources */,
 				2C61898C2B7A8A22006B70D7 /* HomepageViewController+Ecosia.swift in Sources */,
 				210E0EBA298D9D6400BB4F33 /* OpenSearchEngine.swift in Sources */,

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -69,7 +69,7 @@
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
         "branch" : "main",
-        "revision" : "84f2aa7e8f5941e13a1545c9df5a772c411f6ae5"
+        "revision" : "0112c7295cda3b2d62a9365ea7aae05164108d53"
       }
     },
     {
@@ -167,8 +167,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "cb53fa1bd3219b0b23ded7dfdd3b2baff266fd25",
-        "version" : "600.0.0"
+        "revision" : "0687f71944021d616d34d922343dcef086855920",
+        "version" : "600.0.1"
       }
     },
     {

--- a/Client/Ecosia/Experiments/Unleash/SeedCounterNTPExperiment.swift
+++ b/Client/Ecosia/Experiments/Unleash/SeedCounterNTPExperiment.swift
@@ -50,11 +50,11 @@ struct SeedCounterNTPExperiment {
     static var seedCounterConfig: SeedCounterConfig? {
         guard let payloadString = Unleash.getVariant(.seedCounterNTP).payload?.value,
               let payloadData = payloadString.data(using: .utf8),
-              let seedLevelConfig = try? JSONDecoder().decode(SeedCounterConfig.self, from: payloadData)
+              let seedCounterConfig = try? JSONDecoder().decode(SeedCounterConfig.self, from: payloadData)
         else {
             return nil
         }
-        return seedLevelConfig
+        return seedCounterConfig
     }
     
     static var sparklesAnimationDuration: Double {

--- a/Client/Ecosia/Experiments/Unleash/SeedCounterNTPExperiment.swift
+++ b/Client/Ecosia/Experiments/Unleash/SeedCounterNTPExperiment.swift
@@ -18,7 +18,7 @@ struct SeedCounterNTPExperiment {
     static var isEnabled: Bool {
         Unleash.isEnabled(.seedCounterNTP) &&
         variant != .control &&
-        SeedCounterNTPExperiment.seedLevelConfig != nil
+        SeedCounterNTPExperiment.seedCounterConfig != nil
     }
     
     static private var variant: Variant {
@@ -47,13 +47,17 @@ struct SeedCounterNTPExperiment {
                                                   value: NSNumber(integerLiteral: progressManagerType.loadCurrentLevel()))
     }
     
-    static var seedLevelConfig: SeedLevelConfig? {
+    static var seedCounterConfig: SeedCounterConfig? {
         guard let payloadString = Unleash.getVariant(.seedCounterNTP).payload?.value,
               let payloadData = payloadString.data(using: .utf8),
-              let seedLevelConfig = try? JSONDecoder().decode(SeedLevelConfig.self, from: payloadData)
+              let seedLevelConfig = try? JSONDecoder().decode(SeedCounterConfig.self, from: payloadData)
         else {
             return nil
         }
         return seedLevelConfig
+    }
+    
+    static var sparklesAnimationDuration: Double {
+        seedCounterConfig?.sparklesAnimationDuration ?? 0.0
     }
 }

--- a/Client/Ecosia/Extensions/DispatchQueueHelper+BuildChannel.swift
+++ b/Client/Ecosia/Extensions/DispatchQueueHelper+BuildChannel.swift
@@ -1,0 +1,24 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+
+/// Executes a block of code on the main thread.
+///
+/// - If the build channel is `.release`, the block is executed immediately.
+/// - Otherwise, it is executed after a specified delay. This might be useful for QA testing.
+///
+/// - Parameters:
+///   - work: A closure to be executed on the main thread.
+///   - delay: The time interval (in seconds) to delay the execution if the build channel is not `.release`. The default value is 5.0 seconds.
+public func executeOnMainThreadWithDelayForNonReleaseBuild(execute work: @escaping @convention(block) () -> Swift.Void,
+                                                           delayedBy delay: TimeInterval = 5.0) {
+    if BrowserKitInformation.shared.buildChannel == .release {
+        work()
+    } else {
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+            work()
+        }
+    }
+}

--- a/Client/Ecosia/UI/NTP/ClimateImpactCounter/NTPSeedCounterCell.swift
+++ b/Client/Ecosia/UI/NTP/ClimateImpactCounter/NTPSeedCounterCell.swift
@@ -60,8 +60,8 @@ final class NTPSeedCounterCell: UICollectionViewCell, Themeable, ReusableCell {
         contentView.addSubview(containerStackView)
         setupContainerStackView()
         setupSeedCounterViewHostingController()
-        setupTransparentButton()
         setupTwinkleViewHostingController()
+        setupTransparentButton()
         applyTheme()
         listenForThemeChange(contentView)
     }

--- a/Client/Ecosia/UI/NTP/ClimateImpactCounter/NTPSeedCounterCell.swift
+++ b/Client/Ecosia/UI/NTP/ClimateImpactCounter/NTPSeedCounterCell.swift
@@ -130,6 +130,11 @@ final class NTPSeedCounterCell: UICollectionViewCell, Themeable, ReusableCell {
     
     // Trigger the twinkle animation on level-up
     func triggerTwinkleEffect() {
+        
+        if UIAccessibility.isReduceMotionEnabled {
+            return  // Skip the animation if Reduce Motion is enabled
+        }
+
         isTwinkleActive = true
         updateTwinkleView()
 

--- a/Client/Ecosia/UI/NTP/ClimateImpactCounter/NTPSeedCounterCell.swift
+++ b/Client/Ecosia/UI/NTP/ClimateImpactCounter/NTPSeedCounterCell.swift
@@ -18,14 +18,20 @@ final class NTPSeedCounterCell: UICollectionViewCell, Themeable, ReusableCell {
         static let cornerRadius: CGFloat = 24
         static let containerWidthHeight: CGFloat = 48
         static let insetMargin: CGFloat = 16
+        static let twinkleSizeOffset: CGFloat = 16
     }
     
     // MARK: - Properties
     private var hostingController: UIHostingController<SeedCounterView>?
     private var containerStackView = UIStackView()
-    private var transparentOverlayButton: UIButton = UIButton(type: .custom)
-    
     weak var delegate: NTPSeedCounterDelegate?
+    private var sparklesAnimationDuration: Double {
+        SeedCounterNTPExperiment.sparklesAnimationDuration
+    }
+    // Transparent button and TwinkleView
+    private var button: UIButton = UIButton()
+    private var twinkleHostingController: UIHostingController<TwinkleView>?
+    private var isTwinkleActive: Bool = false
     
     // MARK: - Themeable Properties
     var themeManager: ThemeManager { AppContainer.shared.resolve() }
@@ -37,11 +43,15 @@ final class NTPSeedCounterCell: UICollectionViewCell, Themeable, ReusableCell {
     override init(frame: CGRect) {
         super.init(frame: frame)
         setup()
+        listenForLevelUpNotification()
     }
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
-        setup()
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self, name: UserDefaultsSeedProgressManager.levelUpNotification, object: nil)
     }
     
     // MARK: - Setup
@@ -51,27 +61,49 @@ final class NTPSeedCounterCell: UICollectionViewCell, Themeable, ReusableCell {
         setupContainerStackView()
         setupSeedCounterViewHostingController()
         setupTransparentButton()
+        setupTwinkleViewHostingController()
         applyTheme()
         listenForThemeChange(contentView)
     }
     
-    // MARK: - Action
-    
-    @objc private func seedCounterTapped() {
-        delegate?.didTapSeedCounter()
+    private func setupTransparentButton() {
+        // Transparent button to make the entire stack view tappable
+        button.backgroundColor = .clear
+        button.addTarget(self, action: #selector(openClimateImpactCounter), for: .touchUpInside)
+        
+        button.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(button)
+
+        NSLayoutConstraint.activate([
+            button.leadingAnchor.constraint(equalTo: containerStackView.leadingAnchor),
+            button.trailingAnchor.constraint(equalTo: containerStackView.trailingAnchor),
+            button.topAnchor.constraint(equalTo: containerStackView.topAnchor),
+            button.bottomAnchor.constraint(equalTo: containerStackView.bottomAnchor)
+        ])
     }
-    
-    // MARK: - Theming
-    @objc func applyTheme() {
-        containerStackView.backgroundColor = .legacyTheme.ecosia.secondaryBackground
+
+    private func setupTwinkleViewHostingController() {
+        let twinkleView = TwinkleView(active: isTwinkleActive)
+        twinkleHostingController = UIHostingController(rootView: twinkleView)
+        
+        guard let twinkleHostingController else { return }
+        
+        // Setup TwinkleView hosting
+        twinkleHostingController.view.backgroundColor = .clear
+        twinkleHostingController.view.translatesAutoresizingMaskIntoConstraints = false
+        twinkleHostingController.view.isUserInteractionEnabled = false
+        twinkleHostingController.view.clipsToBounds = true
+        contentView.addSubview(twinkleHostingController.view)
+        
+        // Add a 16-point offset around the TwinkleView
+        NSLayoutConstraint.activate([
+            twinkleHostingController.view.leadingAnchor.constraint(equalTo: containerStackView.leadingAnchor, constant: -UX.twinkleSizeOffset),
+            twinkleHostingController.view.trailingAnchor.constraint(equalTo: containerStackView.trailingAnchor, constant: UX.twinkleSizeOffset),
+            twinkleHostingController.view.topAnchor.constraint(equalTo: containerStackView.topAnchor, constant: -UX.twinkleSizeOffset),
+            twinkleHostingController.view.bottomAnchor.constraint(equalTo: containerStackView.bottomAnchor, constant: UX.twinkleSizeOffset)
+        ])
     }
-}
 
-// MARK: - Helpers
-
-extension NTPSeedCounterCell {
-
-    // Setup the SwiftUI SeedCounterView in a hosting controller
     private func setupSeedCounterViewHostingController() {
         let swiftUIView = SeedCounterView(progressManagerType: SeedCounterNTPExperiment.progressManagerType.self)
         hostingController = UIHostingController(rootView: swiftUIView)
@@ -82,36 +114,54 @@ extension NTPSeedCounterCell {
         hostingController.view.backgroundColor = .clear
         containerStackView.addArrangedSubview(hostingController.view)
     }
-
-    // Setup the containerStackView and add constraints
+    
     private func setupContainerStackView() {
         containerStackView.translatesAutoresizingMaskIntoConstraints = false
         containerStackView.layer.masksToBounds = true
         containerStackView.layer.cornerRadius = UX.cornerRadius
-        
-        contentView.addSubview(containerStackView)
-
         NSLayoutConstraint.activate([
             containerStackView.heightAnchor.constraint(equalToConstant: UX.containerWidthHeight),
             containerStackView.widthAnchor.constraint(equalToConstant: UX.containerWidthHeight),
             containerStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -UX.insetMargin)
         ])
     }
+    
+    // MARK: - Twinkle helpers
+    
+    // Trigger the twinkle animation on level-up
+    func triggerTwinkleEffect() {
+        isTwinkleActive = true
+        updateTwinkleView()
 
-    // Setup the transparent button to make the container tappable
-    private func setupTransparentButton() {
-        transparentOverlayButton.translatesAutoresizingMaskIntoConstraints = false
-        transparentOverlayButton.backgroundColor = .clear
-        transparentOverlayButton.addTarget(self, action: #selector(seedCounterTapped), for: .touchUpInside)
-        
-        contentView.addSubview(transparentOverlayButton)  // Add button over contentView
-        
-        // Button should overlay the containerStackView
-        NSLayoutConstraint.activate([
-            transparentOverlayButton.topAnchor.constraint(equalTo: containerStackView.topAnchor),
-            transparentOverlayButton.leadingAnchor.constraint(equalTo: containerStackView.leadingAnchor),
-            transparentOverlayButton.trailingAnchor.constraint(equalTo: containerStackView.trailingAnchor),
-            transparentOverlayButton.bottomAnchor.constraint(equalTo: containerStackView.bottomAnchor)
-        ])
+        // Automatically stop showing twinkle after a delay
+        DispatchQueue.main.asyncAfter(deadline: .now() + sparklesAnimationDuration) {
+            self.isTwinkleActive = false
+            self.updateTwinkleView()
+        }
+    }
+
+    // Update the TwinkleView based on `isTwinkleActive`
+    private func updateTwinkleView() {
+        twinkleHostingController?.rootView = TwinkleView(active: isTwinkleActive)
+    }
+    
+    // MARK: - Observer
+    
+    private func listenForLevelUpNotification() {
+        // Listen for the level-up notification
+        NotificationCenter.default.addObserver(forName: UserDefaultsSeedProgressManager.levelUpNotification, object: nil, queue: .main) { [weak self] _ in
+            self?.triggerTwinkleEffect()
+        }
+    }
+
+    // MARK: - Action
+    
+    @objc private func openClimateImpactCounter() {
+        delegate?.didTapSeedCounter()
+    }
+    
+    // MARK: - Theming
+    @objc func applyTheme() {
+        containerStackView.backgroundColor = .legacyTheme.ecosia.secondaryBackground
     }
 }

--- a/Client/Ecosia/UI/NTP/ClimateImpactCounter/SeedCounterConfig.swift
+++ b/Client/Ecosia/UI/NTP/ClimateImpactCounter/SeedCounterConfig.swift
@@ -4,7 +4,8 @@
 
 import Foundation
 
-struct SeedLevelConfig {
+struct SeedCounterConfig {
+    let sparklesAnimationDuration: Double
     let levels: [SeedLevel]
 
     struct SeedLevel: Codable {
@@ -13,4 +14,4 @@ struct SeedLevelConfig {
     }
 }
 
-extension SeedLevelConfig: Decodable {}
+extension SeedCounterConfig: Decodable {}

--- a/Client/Ecosia/UI/NTP/ClimateImpactCounter/SeedCounterView.swift
+++ b/Client/Ecosia/UI/NTP/ClimateImpactCounter/SeedCounterView.swift
@@ -13,11 +13,11 @@ struct SeedCounterView: View {
     @State private var seedsCollected: Int = 0
     @State private var level: Int = 1
     @State private var progressValue: CGFloat = 0.0
-    @State private var showZoomCircle = false
+    @State private var showNumberOfSeedsCollectedCircleView = false
     @StateObject var theme = ArcTheme()
     @Environment(\.themeType) var themeVal
     @Environment(\.accessibilityReduceMotion) var reduceMotion
-
+    
     // MARK: - Init
     
     init(progressManagerType: SeedProgressManagerProtocol.Type) {
@@ -41,14 +41,22 @@ struct SeedCounterView: View {
                     .lineLimit(1)
                     .minimumScaleFactor(0.5)
                     .scaledToFill()
-                    .modifier(TextAnimationModifier(seedsCollected: seedsCollected))
+                    .modifier(TextAnimationModifier(seedsCollected: seedsCollected,
+                                                    reduceMotionEnabled: reduceMotion))
             }
-            if showZoomCircle {
-                NewSeedCollectedCircleView(seedsCollected: seedsCollected)
-                    .offset(x: 20, y: -20)
+            if showNumberOfSeedsCollectedCircleView {
+                NewSeedCollectedCircleView(seedsCollected: 1)
+                    .frame(width: 20, height: 20)
                     .transition(.scale(scale: 0.1, anchor: .center))
-                    .scaleEffect(showZoomCircle ? 1.0 : 0.1)
-                    .animation(reduceMotion ? .none : .linear(duration: 10), value: showZoomCircle)
+                    .scaleEffect(showNumberOfSeedsCollectedCircleView ? 1.0 : 0.1)
+                    .modifier(ZoomEffectModifier(active: showNumberOfSeedsCollectedCircleView, reduceMotionEnabled: reduceMotion, duration: 0.4))
+                    .onAppear {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                            withAnimation(.linear(duration: 0.4)) {
+                                self.showNumberOfSeedsCollectedCircleView = false
+                            }
+                        }
+                    }
             }
         }
         .onAppear {
@@ -56,7 +64,6 @@ struct SeedCounterView: View {
             NotificationCenter.default.addObserver(forName: progressManagerType.progressUpdatedNotification, object: nil, queue: .main) { _ in
                 // Update the state when progress changes
                 self.triggerUpdateValues()
-                self.showZoomEffect()
             }
             applyTheme(theme: themeVal.theme)
         }
@@ -75,26 +82,6 @@ struct SeedCounterView: View {
         self.theme.progressColor = Color(.legacyTheme.ecosia.primaryButtonActive)
     }
     
-    private func showZoomEffect() {
-        if reduceMotion {
-            // No animation, just appear and disappear
-            showZoomCircle = true
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-                self.showZoomCircle = false
-            }
-        } else {
-            // Animate the zoom effect
-            withAnimation(.linear(duration: 0.5)) {
-                showZoomCircle = true
-            }
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                withAnimation(.linear(duration: 0.5)) {
-                    self.showZoomCircle = false
-                }
-            }
-        }
-    }
-    
     private func triggerUpdateValues() {
         if BrowserKitInformation.shared.buildChannel == .release {
             updateValues()
@@ -111,6 +98,7 @@ struct SeedCounterView: View {
         self.seedsCollected = progressManagerType.loadTotalSeedsCollected()
         self.level = progressManagerType.loadCurrentLevel()
         self.progressValue = progressManagerType.calculateInnerProgress()
+        self.showNumberOfSeedsCollectedCircleView = true
     }
 }
 
@@ -118,23 +106,38 @@ struct NewSeedCollectedCircleView: View {
     var seedsCollected: Int
     
     var body: some View {
-        Circle()
-            .fill(Color(.legacyTheme.ecosia.peach))
-            .frame(width: 20, height: 20)
-            .overlay(
-                Text("\(seedsCollected)")
-                    .font(.caption)
-                    .foregroundColor(.white)
-            )
+        ZStack {
+            Circle()
+                .fill(Color(.legacyTheme.ecosia.peach))
+            Text("+\(seedsCollected)")
+                .font(.caption)
+        }
+    }
+}
+
+struct ZoomEffectModifier: ViewModifier {
+    var active: Bool
+    var reduceMotionEnabled: Bool
+    var duration: Double
+    
+    func body(content: Content) -> some View {
+        if reduceMotionEnabled {
+            content
+        } else {
+            content
+                .scaleEffect(active ? 1.0 : 0.1)
+                .animation(.linear(duration: duration), value: active)
+        }
     }
 }
 
 struct TextAnimationModifier: ViewModifier {
     var seedsCollected: Int
-
+    var reduceMotionEnabled: Bool
+    
     func body(content: Content) -> some View {
         if #available(iOS 17.0, *) {
-            if UIAccessibility.isReduceMotionEnabled {
+            if reduceMotionEnabled {
                 content
             } else {
                 content
@@ -143,7 +146,7 @@ struct TextAnimationModifier: ViewModifier {
             }
         } else {
             content
-                .animation(!UIAccessibility.isReduceMotionEnabled ? .easeInOut(duration: 0.5) : .none, value: seedsCollected)
+                .animation(!UIAccessibility.isReduceMotionEnabled ? .easeInOut(duration: 3) : .none, value: seedsCollected)
         }
     }
 }

--- a/Client/Ecosia/UI/NTP/ClimateImpactCounter/SeedCounterView.swift
+++ b/Client/Ecosia/UI/NTP/ClimateImpactCounter/SeedCounterView.swift
@@ -33,25 +33,13 @@ struct SeedCounterView: View {
                 SeedProgressView(progressValue: progressValue,
                                  theme: theme)
                 
-                if #available(iOS 17.0, *) {
-                    if UIAccessibility.isReduceMotionEnabled {
-                        Text("\(Int(seedsCollected))")
-                            .font(.subheadline)
-                            .fontWeight(.semibold)
-                    } else {
-                        Text("\(Int(seedsCollected))")
-                            .contentTransition(.numericText(value: Double(seedsCollected)))
-                            .animation(.default, value: seedsCollected)
-                            .font(.subheadline)
-                            .fontWeight(.semibold)
-                    }
-                } else {
-                    Text("\(Int(seedsCollected))")
-                        .font(.subheadline)
-                        .fontWeight(.semibold)
-                        .animation(!UIAccessibility.isReduceMotionEnabled ? .easeInOut(duration: 0.5) : .none, value: seedsCollected)
-                }
-            }
+                Text("\(Int(seedsCollected))")
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.5)
+                    .scaledToFill()
+                    .modifier(TextAnimationModifier(seedsCollected: seedsCollected))            }
         }
         .onAppear {
             // Add observer for progress updates
@@ -92,5 +80,24 @@ struct SeedCounterView: View {
         self.seedsCollected = progressManagerType.loadTotalSeedsCollected()
         self.level = progressManagerType.loadCurrentLevel()
         self.progressValue = progressManagerType.calculateInnerProgress()
+    }
+}
+
+struct TextAnimationModifier: ViewModifier {
+    var seedsCollected: Int
+
+    func body(content: Content) -> some View {
+        if #available(iOS 17.0, *) {
+            if UIAccessibility.isReduceMotionEnabled {
+                content
+            } else {
+                content
+                    .contentTransition(.numericText(value: Double(seedsCollected)))
+                    .animation(.default, value: seedsCollected)
+            }
+        } else {
+            content
+                .animation(!UIAccessibility.isReduceMotionEnabled ? .easeInOut(duration: 0.5) : .none, value: seedsCollected)
+        }
     }
 }

--- a/Client/Ecosia/UI/NTP/ClimateImpactCounter/SeedCounterView.swift
+++ b/Client/Ecosia/UI/NTP/ClimateImpactCounter/SeedCounterView.swift
@@ -10,9 +10,11 @@ struct SeedCounterView: View {
     // MARK: - Properties
     
     private let progressManagerType: SeedProgressManagerProtocol.Type
+    private let twinkleDuration = 10.0
     @State private var seedsCollected: Int = 0
     @State private var level: Int = 1
     @State private var progressValue: CGFloat = 0.0
+    @State private var showTwinkle = false
     @StateObject var theme = ArcTheme()
     @Environment(\.themeType) var themeVal
     
@@ -28,13 +30,30 @@ struct SeedCounterView: View {
     // MARK: - View
     
     var body: some View {
-        VStack(spacing: 0) {
-            SeedProgressView(progressValue: progressValue,
-                             theme: theme)
+        ZStack {
+            VStack(spacing: 0) {
+                SeedProgressView(progressValue: progressValue,
+                                 theme: theme)
+                
+                Text("\(Int(seedsCollected))")
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+            }
+            .zIndex(0)
             
-            Text("\(Int(seedsCollected))")
-                .font(.subheadline)
-                .fontWeight(.semibold)
+            if showTwinkle {
+                TwinkleView(active: true)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .clipped(antialiased: false)
+                    .allowsHitTesting(false)
+                    .zIndex(1)
+                    .onAppear {
+                        // Automatically stop showing twinkle after a delay
+                        DispatchQueue.main.asyncAfter(deadline: .now() + twinkleDuration) {
+                            showTwinkle = false
+                        }
+                    }
+            }
         }
         .onAppear {
             // Add observer for progress updates
@@ -44,10 +63,15 @@ struct SeedCounterView: View {
                 self.level = progressManagerType.loadCurrentLevel()
                 self.progressValue = progressManagerType.calculateInnerProgress()
             }
+            NotificationCenter.default.addObserver(forName: UserDefaultsSeedProgressManager.levelUpNotification, object: nil, queue: .main) { _ in
+                // Trigger the twinkle animation when level up occurs
+                showTwinkle = true
+            }
             applyTheme(theme: themeVal.theme)
         }
         .onDisappear {
             NotificationCenter.default.removeObserver(self, name: progressManagerType.progressUpdatedNotification, object: nil)
+            NotificationCenter.default.removeObserver(self, name: UserDefaultsSeedProgressManager.levelUpNotification, object: nil)
         }
         .onChange(of: themeVal) { newThemeValue in
             applyTheme(theme: newThemeValue.theme)

--- a/Client/Ecosia/UI/NTP/ClimateImpactCounter/SeedProgressManager/SeedProgressManagerProtocol.swift
+++ b/Client/Ecosia/UI/NTP/ClimateImpactCounter/SeedProgressManager/SeedProgressManagerProtocol.swift
@@ -7,7 +7,7 @@ import Foundation
 protocol SeedProgressManagerProtocol {
     static var progressUpdatedNotification: Notification.Name { get }
     static var levelUpNotification: Notification.Name { get }
-    static var seedLevels: [SeedLevelConfig.SeedLevel] { get set }
+    static var seedLevels: [SeedCounterConfig.SeedLevel] { get set }
     
     static func loadCurrentLevel() -> Int
     static func loadTotalSeedsCollected() -> Int

--- a/Client/Ecosia/UI/NTP/ClimateImpactCounter/SeedProgressManager/UserDefaultsSeedProgressManager.swift
+++ b/Client/Ecosia/UI/NTP/ClimateImpactCounter/SeedProgressManager/UserDefaultsSeedProgressManager.swift
@@ -16,7 +16,7 @@ final class UserDefaultsSeedProgressManager: SeedProgressManagerProtocol {
     private static let currentLevelKey = "CurrentLevel"
     private static let lastAppOpenDateKey = "LastAppOpenDate"
     
-    static var seedLevels: [SeedLevelConfig.SeedLevel] = SeedCounterNTPExperiment.seedLevelConfig?.levels.compactMap { $0 } ?? []
+    static var seedLevels: [SeedCounterConfig.SeedLevel] = SeedCounterNTPExperiment.seedCounterConfig?.levels.compactMap { $0 } ?? []
     
     private init() {}
     

--- a/Client/Ecosia/UI/NTP/ClimateImpactCounter/Sparkle.swift
+++ b/Client/Ecosia/UI/NTP/ClimateImpactCounter/Sparkle.swift
@@ -1,0 +1,114 @@
+// Source: https://gist.github.com/UnderscoreDavidSmith/60ca0c6727d0c76c9b0012a27dfe1008
+// Modified to get bigger sparkles
+
+import SwiftUI
+
+struct TwinkleView: View {
+    
+    private func position(in proxy: GeometryProxy, sparkle: Sparkle) -> CGPoint {
+        let radius = min(proxy.size.width, proxy.size.height) / 2.0
+        let drawnRadius = (radius - 5) * sparkle.position.x
+        let angle = Double.pi * 2.0 * sparkle.position.y
+
+        let x = proxy.size.width * 0.5 + drawnRadius * cos(angle)
+        let y = proxy.size.height * 0.5 + drawnRadius * sin(angle)
+
+        return CGPoint(x: x, y: y)
+    }
+    
+    private func scaleFor(date: Date, sparkle: Sparkle) -> CGFloat {
+        var offset = date.timeIntervalSince(sparkle.startDate)
+        offset = max(offset, 0)
+        offset = min(offset, SparkleMagic.sparkleDuration)
+        let halfDuration = SparkleMagic.sparkleDuration * 0.5
+        let value: CGFloat
+        if offset < halfDuration {
+            value = offset / halfDuration
+        } else {
+            value = 1.0 - ((offset - halfDuration) / halfDuration)
+        }
+        return value == 0 ? 0.1 : value
+    }
+    
+    let active: Bool
+    @StateObject var magic = SparkleMagic()
+    
+    var body: some View {
+        if active {
+            GeometryReader { geo in
+                ZStack {
+                    TimelineView(.animation) { context in
+                        let _ = magic.update(date: context.date)
+                        ForEach(magic.sparkles) { sparkle in
+                            SparkleShape()
+                                .fill(Color.white)
+                                .frame(width: 20, height: 20)  // Increased size of sparkles
+                                .scaleEffect(scaleFor(date: context.date, sparkle: sparkle))
+                                .position(self.position(in: geo, sparkle: sparkle))
+                        }
+                    }
+                }
+            }
+        } else {
+            EmptyView()
+        }
+    }
+}
+
+struct SparkleShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        let radius = 1.0
+        path.move(to: CGPoint(x: rect.midX, y: rect.minY))
+        path.addLine(to: CGPoint(x: rect.midX - radius, y: rect.midY - radius))
+        path.addLine(to: CGPoint(x: rect.minX, y: rect.midY))
+        path.addLine(to: CGPoint(x: rect.midX - radius, y: rect.midY + radius))
+        path.addLine(to: CGPoint(x: rect.midX, y: rect.maxY))
+        path.addLine(to: CGPoint(x: rect.midX + radius, y: rect.midY + radius))
+        path.addLine(to: CGPoint(x: rect.maxX, y: rect.midY))
+        path.addLine(to: CGPoint(x: rect.midX + radius, y: rect.midY - radius))
+        path.addLine(to: CGPoint(x: rect.midX, y: rect.minY))
+        return path
+    }
+}
+
+class Sparkle: Identifiable {
+    let id = UUID()
+    let position: CGPoint
+    let startDate: Date
+    init(position: CGPoint, startDate: Date) {
+        self.position = position
+        self.startDate = startDate
+    }
+}
+
+class SparkleMagic: ObservableObject {
+    static let sparkleDuration: Double = 2.0
+    var sparkles: [Sparkle]
+    
+    init() {
+        let anchor = Date()
+        var result: [Sparkle] = []
+        for _ in 0..<20 {
+            result.append(Sparkle(position: CGPoint(x: CGFloat.random(in: 0...1),
+                                                    y: CGFloat.random(in: 0...1)),
+                                  startDate: anchor.addingTimeInterval(Double.random(in: 0...(SparkleMagic.sparkleDuration)))))
+        }
+        self.sparkles = result
+    }
+    
+    func update(date: Date) {
+        let anchor = Date()
+        var result: [Sparkle] = []
+        for sparkle in sparkles {
+            if anchor.timeIntervalSince(sparkle.startDate) > SparkleMagic.sparkleDuration {
+                result.append(Sparkle(position: CGPoint(x: CGFloat.random(in: 0...1),
+                                                        y: CGFloat.random(in: 0...1)),
+                                      startDate: anchor.addingTimeInterval(Double.random(in: 0...(SparkleMagic.sparkleDuration)))))
+            } else {
+                result.append(sparkle)
+            }
+        }
+        self.sparkles = result
+    }
+}

--- a/Client/Ecosia/UI/NTP/ClimateImpactCounter/Sparkle.swift
+++ b/Client/Ecosia/UI/NTP/ClimateImpactCounter/Sparkle.swift
@@ -30,7 +30,7 @@ struct TwinkleView: View {
         return value == 0 ? 0.1 : value
     }
     
-    let active: Bool
+    var active: Bool // Made active a var so it can change even from UIKit
     @StateObject var magic = SparkleMagic()
     
     var body: some View {
@@ -42,7 +42,7 @@ struct TwinkleView: View {
                         ForEach(magic.sparkles) { sparkle in
                             SparkleShape()
                                 .fill(Color.white)
-                                .frame(width: 20, height: 20)  // Increased size of sparkles
+                                .frame(width: 15, height: 15)
                                 .scaleEffect(scaleFor(date: context.date, sparkle: sparkle))
                                 .position(self.position(in: geo, sparkle: sparkle))
                         }

--- a/Client/Ecosia/UI/Theme/EcosiaTheme.swift
+++ b/Client/Ecosia/UI/Theme/EcosiaTheme.swift
@@ -90,7 +90,7 @@ class EcosiaTheme {
     var welcomeElementBackground: UIColor { .Light.Background.primary }
     
     var homePanelBackground: UIColor { return .Light.Background.tertiary }
-    var peach: UIColor { .init(red: 0.255, green: 0.230, blue: 0.191, alpha: 1) }
+    var peach: UIColor { .init(rgb: 0xFFE6BF) }
 }
 
 final class DarkEcosiaTheme: EcosiaTheme {
@@ -174,6 +174,7 @@ final class DarkEcosiaTheme: EcosiaTheme {
     override var welcomeElementBackground: UIColor { .Dark.Background.secondary }
     
     override var homePanelBackground: UIColor { return .Dark.Background.secondary }
+    override var peach: UIColor { .init(rgb: 0xCC7722) }
 }
 
 extension UIImage {

--- a/Client/Ecosia/UI/Theme/EcosiaTheme.swift
+++ b/Client/Ecosia/UI/Theme/EcosiaTheme.swift
@@ -90,6 +90,7 @@ class EcosiaTheme {
     var welcomeElementBackground: UIColor { .Light.Background.primary }
     
     var homePanelBackground: UIColor { return .Light.Background.tertiary }
+    var peach: UIColor { .init(red: 0.255, green: 0.230, blue: 0.191, alpha: 1) }
 }
 
 final class DarkEcosiaTheme: EcosiaTheme {

--- a/EcosiaTests/ClimateImpactCounter/UserDefaultsSeedProgressManagerTests.swift
+++ b/EcosiaTests/ClimateImpactCounter/UserDefaultsSeedProgressManagerTests.swift
@@ -17,8 +17,8 @@ final class UserDefaultsSeedProgressManagerTests: XCTestCase {
         
         // Set initial seed levels to use in the tests
         UserDefaultsSeedProgressManager.seedLevels = [
-            SeedLevelConfig.SeedLevel(level: 1, requiredSeeds: 5),
-            SeedLevelConfig.SeedLevel(level: 2, requiredSeeds: 10)
+            SeedCounterConfig.SeedLevel(level: 1, requiredSeeds: 5),
+            SeedCounterConfig.SeedLevel(level: 2, requiredSeeds: 10)
         ]
     }
 


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2872]

## Context

We want to add animations when reaching a new level as well as collecting a new seed.

## Approach

Following the PR 🚂 approach to minimise code changes. Base will put back to `main` once other PRs will be merged.

- Kept the SwiftUI approach
- Moved the animations to "cell's context" so the animation can go over the Seed Counter View's bounds
- Add supporting comments
- Accessibility taken into account for all animations
- Updated the `SeedCounter` config struct to accept another parameter to decide how long the sparkles animation would last for, hence the renaming into -> `SeedCounterConfig` as the previous structure was made already to accept other params than just levels. 

Animation details can be found [here](https://ecosia.atlassian.net/browse/MOB-2872?focusedCommentId=95599).

## Other

- Implemented a helper function that gives us the possibility to test out those animations at manual (even automation if counting on the delay) QA, given the hidden setting that would let us reach the next level / add new points
- Tooke the Sparkles from a public gist and mentioned the URL in the file

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I added the `// Ecosia:` helper comments where needed
- [x] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)

[MOB-2872]: https://ecosia.atlassian.net/browse/MOB-2872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ