### PR TITLE
[MOB-2960] Integrate Jira notify + Pre-commit hook

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
           name: Upload to Browserstack
           command: bundle exec fastlane upload_to_browserstack
       - jira/notify:
-          issue_regexp: (?i)([A-Z]+[-_]\d+)
+          issue_regexp: "([A-Za-z]{2,30}-[0-9]+)"
           pipeline_id: << pipeline.id >>
           pipeline_number: << pipeline.number >>
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,10 +76,17 @@ jobs:
       - run:
           name: Upload to Browserstack
           command: bundle exec fastlane upload_to_browserstack
+      - jira/notify:
+          issue_regexp: (?i)([A-Z]+[-_]\d+)
+          pipeline_id: << pipeline.id >>
+          pipeline_number: << pipeline.number >>
+
+
 
 orbs:
   path-filtering: circleci/path-filtering@0.1.1
   macos: circleci/macos@2
+  jira: circleci/jira@2.0
 
 workflows:
   build-and-upload-to-delivery-platforms:
@@ -106,3 +113,4 @@ workflows:
             branches:
               only: 
                 - /^.*main.*/
+          context: napps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,9 +80,6 @@ jobs:
           issue_regexp: "([A-Za-z]{2,30}-[0-9]+)"
           pipeline_id: << pipeline.id >>
           pipeline_number: << pipeline.number >>
-
-
-
 orbs:
   path-filtering: circleci/path-filtering@0.1.1
   macos: circleci/macos@2

--- a/README.md
+++ b/README.md
@@ -26,7 +26,18 @@ If more information is required or you have any questions then we suggest reachi
 - Chat on Element channel [#fx-ios](https://chat.mozilla.org/#/room/#fx-ios:mozilla.org) for general discussion, or write DMs to specific teammates for questions.
 - Open a [Github discussion](https://github.com/mozilla-mobile/firefox-ios/discussions) which can be used for general questions.
 
-Want to contribute on the codebase but don't know where to start? Here is a list of [issues that are contributor friendly](https://github.com/mozilla-mobile/firefox-ios/labels/Contributor%20OK), but make sure to read the [Contributing guidelines](https://github.com/mozilla-mobile/firefox-ios/blob/main/CONTRIBUTING.md) first. 
+Want to contribute on the codebase but don't know where to start? Here is a list of [issues that are contributor friendly](https://github.com/mozilla-mobile/firefox-ios/labels/Contributor%20OK), but make sure to read the [Contributing guidelines](https://github.com/mozilla-mobile/firefox-ios/blob/main/CONTRIBUTING.md) first.
+
+After cloning (for Ecosians)
+-----------
+
+This project uses custom Git hooks to enforce commit message formatting and other automated tasks. 
+To ensure that these hooks are installed correctly in your local `.git/hooks` directory, you need to run the provided setup script after cloning the repository.
+
+- Navigate into the project directory
+- Run the setup script to install the Git hooks: `./setup-hooks.sh`
+
+This script will copy all the necessary hooks (such as `prepare-commit-msg`) to your local `.git/hooks` directory, ensuring they are executable.
 
 Building the code
 -----------------

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Directory containing your custom hooks
+HOOKS_DIR="hooks"
+
+# Check if hooks have already been installed in the .git/hooks directory
+# We check for one example hook to verify, you can change this to your preference
+if [ ! -f ".git/hooks/prepare-commit-msg" ]; then
+  echo "Git hooks not found in .git/hooks. Running setup-hooks.sh to install them."
+  
+  # Run the setup script to copy the hooks
+  ./setup-hooks.sh
+else
+  echo "Git hooks are already installed."
+fi

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -5,11 +5,19 @@ HOOKS_DIR="hooks"
 
 # Check if hooks have already been installed in the .git/hooks directory
 # We check for one example hook to verify, you can change this to your preference
-if [ ! -f ".git/hooks/prepare-commit-msg" ]; then
-  echo "Git hooks not found in .git/hooks. Running setup-hooks.sh to install them."
-  
+required_hooks=("prepare-commit-msg" "post-checkout")
+missing_hooks=()
+
+for hook in "${required_hooks[@]}"; do
+  if [ ! -f ".git/hooks/$hook" ]; then
+    missing_hooks+=("$hook")
+  fi
+done
+
+if [ ${#missing_hooks[@]} -ne 0 ]; then
+  echo "Missing hooks: ${missing_hooks[*]}. Running setup_hooks.sh to install them."
   # Run the setup script to copy the hooks
-  ./setup-hooks.sh
+  ./setup_hooks.sh
 else
   echo "Git hooks are already installed."
 fi

--- a/hooks/prepare-commit-msg
+++ b/hooks/prepare-commit-msg
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+import sys
+import re
+from subprocess import check_output
+
+commit_msg_filepath = sys.argv[1]
+
+# Get the current branch name
+branch = check_output(
+    ["git", "symbolic-ref", "--short", "HEAD"]
+).strip().decode()
+
+# Define the regex to match the JIRA ticket in the branch name
+regex = r"(?i)([A-Z]+[-_]\d+)"
+match = re.search(regex, branch)
+
+if match:
+    # Extract the JIRA ticket from the branch name and format it correctly
+    jira_ticket = match.group(0).upper().replace('_', '-')  # Ensure ticket uses hyphen
+    with open(commit_msg_filepath, "r+") as fh:
+        commit_msg = fh.read().strip()
+
+        # Prefix the commit message with the JIRA ticket
+        updated_commit_msg = f"[{jira_ticket}] {commit_msg}"
+
+        # Write the updated commit message back to the file
+        fh.seek(0, 0)
+        fh.write(updated_commit_msg)
+        fh.truncate()

--- a/setup_hooks.sh
+++ b/setup_hooks.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
 
-# Copy all hooks from the hooks directory to .git/hooks
+# Check if the .git/hooks directory exists
+if [ ! -d ".git/hooks" ]; then
+  echo ".git/hooks directory does not exist. Creating it now."
+  mkdir -p .git/hooks
+fi
+
+# Copy all custom hooks from hooks/ to .git/hooks/
 cp hooks/* .git/hooks/
 
-# Make sure all hooks are executable
+# Ensure the hooks are executable
 chmod +x .git/hooks/*
+
+echo "Git hooks have been installed successfully."

--- a/setup_hooks.sh
+++ b/setup_hooks.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Copy all hooks from the hooks directory to .git/hooks
+cp hooks/* .git/hooks/
+
+# Make sure all hooks are executable
+chmod +x .git/hooks/*


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2960]

## Context

To let QA successfully test the ticket we worked on, we append the build number available via AppCenter to each ticket as soon as it’s available.

Sometimes, when the ticket bounce back due to something needing a change, a new build needs to be pushed.

This process is manual and can be automated.

## Approach

This pull request introduces two key improvements to our project:

#### Automated Git Hooks Setup:
  - Added a `setup_hooks.sh` script to automate the installation of Git hooks for consistent commit message formatting (e.g., adding JIRA ticket numbers to commits (e.g. `[MOB-2960] Integrate JIRA Notify Orb`).
  - Included a post-checkout hook to automatically check and install hooks on branch changes, reducing the need for manual setup.

#### JIRA Notify Orb Integration:
  - Integrated the CircleCI JIRA Notify orb to automatically notify JIRA when builds complete. This allows us fulfilling what's stated in the context part.
  - Configured the `issue_regexp` parameter to correctly capture JIRA issue keys from branch names using the pattern: `[A-Za-z]+[-_][0-9]+`.

[MOB-2960]: https://ecosia.atlassian.net/browse/MOB-2960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MOB-2960]: https://ecosia.atlassian.net/browse/MOB-2960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ