### PR TITLE
[MOB-2960] Pre-commit hooks fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This project uses custom Git hooks to enforce commit message formatting and othe
 To ensure that these hooks are installed correctly in your local `.git/hooks` directory, you need to run the provided setup script after cloning the repository.
 
 - Navigate into the project directory
-- Run the setup script to install the Git hooks: `./setup-hooks.sh`
+- Run the setup script to install the Git hooks: `./setup_hooks.sh`
 
 This script will copy all the necessary hooks (such as `prepare-commit-msg`) to your local `.git/hooks` directory, ensuring they are executable.
 

--- a/hooks/prepare-commit-msg
+++ b/hooks/prepare-commit-msg
@@ -2,29 +2,34 @@
 
 import sys
 import re
-from subprocess import check_output
+from subprocess import check_output, CalledProcessError
 
 commit_msg_filepath = sys.argv[1]
 
-# Get the current branch name
-branch = check_output(
-    ["git", "symbolic-ref", "--short", "HEAD"]
-).strip().decode()
+try:
+    # Try to get the current branch name
+    branch = check_output(
+        ["git", "symbolic-ref", "--short", "HEAD"]
+    ).strip().decode()
 
-# Define the regex to match the JIRA ticket in the branch name
-regex = r"(?i)([A-Z]+[-_]\d+)"
-match = re.search(regex, branch)
+    # Define the regex to match the JIRA ticket in the branch name
+    regex = r"(?i)([A-Za-z]+[-_]\d+)"
+    match = re.search(regex, branch)
 
-if match:
-    # Extract the JIRA ticket from the branch name and format it correctly
-    jira_ticket = match.group(0).upper().replace('_', '-')  # Ensure ticket uses hyphen
-    with open(commit_msg_filepath, "r+") as fh:
-        commit_msg = fh.read().strip()
+    if match:
+        # Extract the JIRA ticket from the branch name and format it correctly
+        jira_ticket = match.group(0).upper().replace('_', '-')  # Ensure ticket uses hyphen
+        with open(commit_msg_filepath, "r+") as fh:
+            commit_msg = fh.read().strip()
 
-        # Prefix the commit message with the JIRA ticket
-        updated_commit_msg = f"[{jira_ticket}] {commit_msg}"
+            # Prefix the commit message with the JIRA ticket
+            updated_commit_msg = f"[{jira_ticket}] {commit_msg}"
 
-        # Write the updated commit message back to the file
-        fh.seek(0, 0)
-        fh.write(updated_commit_msg)
-        fh.truncate()
+            # Write the updated commit message back to the file
+            fh.seek(0, 0)
+            fh.write(updated_commit_msg)
+            fh.truncate()
+
+except CalledProcessError:
+    # If we're in a detached HEAD state (such as during rebase), skip the branch name lookup
+    print("Detached HEAD state detected. Skipping branch name extraction.")


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2960]

## Context

When rebasing on the latest `main` after merging https://github.com/ecosia/ios-browser/pull/793 I realized that the pre-commit script prevented a smooth rebase.

## Approach

- Apply the rebase condition
- Small script layout improvements 

## Other

Found a small typo in the README's script section. Fixing that too.

[MOB-2960]: https://ecosia.atlassian.net/browse/MOB-2960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ