### PR TITLE
[MOB-2871] Seed Counter on NTP updates

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -359,6 +359,7 @@
 		2C6B5B412CAAF3AA00F15323 /* SeedCounterNTPExperiment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C6B5B402CAAF3AA00F15323 /* SeedCounterNTPExperiment.swift */; };
 		2C6C908F2C614A6C007D9B43 /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 2C6C908E2C614A6C007D9B43 /* SnapshotTesting */; };
 		2C6C90902C614A76007D9B43 /* OnboardingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD368492C5BC31700972871 /* OnboardingTests.swift */; };
+		2C728D7E2CBBDCDC00C7684B /* UnleashUserDefaultsSeedProgressManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C728D7D2CBBDCDC00C7684B /* UnleashUserDefaultsSeedProgressManagerTests.swift */; };
 		2C78374B2C1765DF00BBFFEB /* LoadingScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CCFB3D42C0F1EA500BEDCA0 /* LoadingScreen.swift */; };
 		2C7DBABD2C4EA37200BCD03F /* AnalyticsFeatureManagementIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7DBABB2C4EA17200BCD03F /* AnalyticsFeatureManagementIntegrationTests.swift */; };
 		2C82625A2C64BB9300E2A255 /* DeviceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C8262592C64BB9300E2A255 /* DeviceType.swift */; };
@@ -2511,6 +2512,7 @@
 		2C6B5B402CAAF3AA00F15323 /* SeedCounterNTPExperiment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeedCounterNTPExperiment.swift; sourceTree = "<group>"; };
 		2C6C90822C614A16007D9B43 /* EcosiaSnapshotTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EcosiaSnapshotTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		2C6E44099EACF7BE5438CEB6 /* ca */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ca; path = ca.lproj/Today.strings; sourceTree = "<group>"; };
+		2C728D7D2CBBDCDC00C7684B /* UnleashUserDefaultsSeedProgressManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnleashUserDefaultsSeedProgressManagerTests.swift; sourceTree = "<group>"; };
 		2C7DBABB2C4EA17200BCD03F /* AnalyticsFeatureManagementIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsFeatureManagementIntegrationTests.swift; sourceTree = "<group>"; };
 		2C8262572C64424300E2A255 /* EcosiaSnapshotTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = EcosiaSnapshotTests.xctestplan; sourceTree = "<group>"; };
 		2C8262592C64BB9300E2A255 /* DeviceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceType.swift; sourceTree = "<group>"; };
@@ -8384,6 +8386,7 @@
 			isa = PBXGroup;
 			children = (
 				2C16B7652CAF2425006118F8 /* UserDefaultsSeedProgressManagerTests.swift */,
+				2C728D7D2CBBDCDC00C7684B /* UnleashUserDefaultsSeedProgressManagerTests.swift */,
 			);
 			path = ClimateImpactCounter;
 			sourceTree = "<group>";
@@ -14637,6 +14640,7 @@
 				2173326A29CCF901007F20C7 /* UIPanGestureRecognizerMock.swift in Sources */,
 				5A9A09D628B01FD500B6F51E /* MockURLBarView.swift in Sources */,
 				8A33222227DFE658008F809E /* NimbusMock.swift in Sources */,
+				2C728D7E2CBBDCDC00C7684B /* UnleashUserDefaultsSeedProgressManagerTests.swift in Sources */,
 				8A6E139E2A71C78A00A88FA8 /* GridTabViewControllerTests.swift in Sources */,
 				8A8629E72880B7330096DDB1 /* BookmarksPanelTests.swift in Sources */,
 				C8B394362A0ED55D00700E49 /* MockOnboardingCardDelegate.swift in Sources */,

--- a/Client/Ecosia/UI/NTP/ClimateImpactCounter/SeedCounterConfig.swift
+++ b/Client/Ecosia/UI/NTP/ClimateImpactCounter/SeedCounterConfig.swift
@@ -6,6 +6,8 @@ import Foundation
 
 struct SeedCounterConfig {
     let sparklesAnimationDuration: Double
+    let maxCappedLevel: Int?  // Optional field to cap the level as part of the experiment
+    let maxCappedSeeds: Int? // Optional field to cap the total seeds as part of the experiment
     let levels: [SeedLevel]
 
     struct SeedLevel: Codable {

--- a/Client/Ecosia/UI/NTP/ClimateImpactCounter/SeedProgressManager/SeedProgressManagerProtocol.swift
+++ b/Client/Ecosia/UI/NTP/ClimateImpactCounter/SeedProgressManager/SeedProgressManagerProtocol.swift
@@ -7,7 +7,7 @@ import Foundation
 protocol SeedProgressManagerProtocol {
     static var progressUpdatedNotification: Notification.Name { get }
     static var levelUpNotification: Notification.Name { get }
-    static var seedLevels: [SeedCounterConfig.SeedLevel] { get set }
+    static var seedCounterConfig: SeedCounterConfig? { get set }
     
     static func loadCurrentLevel() -> Int
     static func loadTotalSeedsCollected() -> Int

--- a/Client/Ecosia/UI/NTP/ClimateImpactCounter/SeedProgressManager/UserDefaultsSeedProgressManager.swift
+++ b/Client/Ecosia/UI/NTP/ClimateImpactCounter/SeedProgressManager/UserDefaultsSeedProgressManager.swift
@@ -77,9 +77,19 @@ final class UserDefaultsSeedProgressManager: SeedProgressManagerProtocol {
         addSeeds(count, relativeToDate: loadLastAppOpenDate())
     }
 
-    // Add seeds to the counter with a specificed date
+    // Add seeds to the counter with a specific date
     static func addSeeds(_ count: Int, relativeToDate date: Date) {
+        // Load total seeds from User Defaults
         var totalSeeds = loadTotalSeedsCollected()
+        
+        // Get the seed requirement for the last level
+        let maxRequiredSeeds = seedLevels.last?.requiredSeeds ?? 0
+
+        // Early exit if the maximum number of seeds is already collected
+        if totalSeeds >= maxRequiredSeeds {
+            return
+        }
+
         var currentLevel = loadCurrentLevel()
 
         let previousLevelTotal = currentLevel > 1 ? requiredSeedsForLevel(currentLevel - 1) : 0

--- a/Client/Ecosia/UI/NTP/ClimateImpactCounter/SeedProgressManager/UserDefaultsSeedProgressManager.swift
+++ b/Client/Ecosia/UI/NTP/ClimateImpactCounter/SeedProgressManager/UserDefaultsSeedProgressManager.swift
@@ -17,7 +17,7 @@ final class UserDefaultsSeedProgressManager: SeedProgressManagerProtocol {
     private static let lastAppOpenDateKey = "LastAppOpenDate"
     
     static var seedCounterConfig: SeedCounterConfig? = SeedCounterNTPExperiment.seedCounterConfig
-    private static var seedLevels: [SeedCounterConfig.SeedLevel] = seedCounterConfig?.levels.compactMap { $0 } ?? []
+    private static var seedLevels: [SeedCounterConfig.SeedLevel] { seedCounterConfig?.levels.compactMap { $0 } ?? [] }
     
     // Fetch max level and max seeds from remote configuration if provided
     private static let maxCappedLevel = seedCounterConfig?.maxCappedLevel

--- a/Client/Ecosia/UI/NTP/ClimateImpactCounter/SeedProgressManager/UserDefaultsSeedProgressManager.swift
+++ b/Client/Ecosia/UI/NTP/ClimateImpactCounter/SeedProgressManager/UserDefaultsSeedProgressManager.swift
@@ -16,7 +16,12 @@ final class UserDefaultsSeedProgressManager: SeedProgressManagerProtocol {
     private static let currentLevelKey = "CurrentLevel"
     private static let lastAppOpenDateKey = "LastAppOpenDate"
     
-    static var seedLevels: [SeedCounterConfig.SeedLevel] = SeedCounterNTPExperiment.seedCounterConfig?.levels.compactMap { $0 } ?? []
+    static var seedCounterConfig: SeedCounterConfig? = SeedCounterNTPExperiment.seedCounterConfig
+    private static var seedLevels: [SeedCounterConfig.SeedLevel] = seedCounterConfig?.levels.compactMap { $0 } ?? []
+    
+    // Fetch max level and max seeds from remote configuration if provided
+    private static let maxCappedLevel = seedCounterConfig?.maxCappedLevel
+    private static let maxCappedSeeds = seedCounterConfig?.maxCappedSeeds
     
     private init() {}
     
@@ -53,23 +58,28 @@ final class UserDefaultsSeedProgressManager: SeedProgressManagerProtocol {
         if let seedLevel = seedLevels.first(where: { $0.level == level }) {
             return seedLevel.requiredSeeds
         }
-        return seedLevels.last?.requiredSeeds ?? 0  // If the level exceeds defined levels, use the last one
+        return seedLevels.first?.requiredSeeds ?? 0  // If the is no level matching, use the first one
     }
 
     // Calculate the inner progress for the current level (0 to 1)
     static func calculateInnerProgress() -> CGFloat {
         let totalSeeds = loadTotalSeedsCollected()
-        let currentLevel = loadCurrentLevel()
-        
-        // Get the required seeds for the current level
-        let thresholdForCurrentLevel = requiredSeedsForLevel(currentLevel)
-        
-        // Seeds needed to reach the current level
-        let previousLevelTotal = currentLevel > 1 ? requiredSeedsForLevel(currentLevel - 1) : 0
-        
-        // Inner progress is calculated between the seeds collected in the current level
-        let seedsForCurrentLevel = totalSeeds - previousLevelTotal
-        return CGFloat(seedsForCurrentLevel) / CGFloat(thresholdForCurrentLevel)
+
+        // Find the level config where total seeds fall in the range of the current level and the next level
+        guard let currentLevelConfig = seedLevels.first(where: { level in
+            let previousLevelSeeds = level.level > 1 ? requiredSeedsForLevel(level.level - 1) : 0
+            let nextLevelSeeds = requiredSeedsForLevel(level.level)
+            return totalSeeds > previousLevelSeeds && totalSeeds <= nextLevelSeeds
+        }) else {
+            return 0.0 // Default to 0 if no valid level is found
+        }
+
+        let previousLevelSeeds = currentLevelConfig.level > 1 ? requiredSeedsForLevel(currentLevelConfig.level - 1) : 0
+        let progressInCurrentLevel = totalSeeds - previousLevelSeeds
+        let requiredSeedsForCurrentLevel = currentLevelConfig.requiredSeeds - previousLevelSeeds
+
+        // Return progress as a fraction (between 0 and 1)
+        return CGFloat(progressInCurrentLevel) / CGFloat(requiredSeedsForCurrentLevel)
     }
     
     // Add seeds to the counter and handle level progression
@@ -79,33 +89,44 @@ final class UserDefaultsSeedProgressManager: SeedProgressManagerProtocol {
 
     // Add seeds to the counter with a specific date
     static func addSeeds(_ count: Int, relativeToDate date: Date) {
-        // Load total seeds from User Defaults
+        // Load total seeds and current level from User Defaults
         var totalSeeds = loadTotalSeedsCollected()
-        
-        // Get the seed requirement for the last level
-        let maxRequiredSeeds = seedLevels.last?.requiredSeeds ?? 0
+                
+        // Fetch the maximum seeds required for the current progression context
+        let standardMaxRequiredSeeds = seedLevels.last?.requiredSeeds ?? 0
+
+        // Determine the effective max seeds and level to enforce (capped or classic)
+        let effectiveMaxLevel = maxCappedLevel ?? seedLevels.count
+        let effectiveMaxRequiredSeeds = maxCappedSeeds ?? standardMaxRequiredSeeds
 
         // Early exit if the maximum number of seeds is already collected
-        if totalSeeds >= maxRequiredSeeds {
+        if totalSeeds >= effectiveMaxRequiredSeeds {
             return
         }
 
         var currentLevel = loadCurrentLevel()
 
-        let previousLevelTotal = currentLevel > 1 ? requiredSeedsForLevel(currentLevel - 1) : 0
-        let thresholdForCurrentLevel = requiredSeedsForLevel(currentLevel)
+        let thresholdForNextLevel = requiredSeedsForLevel(currentLevel + 1)
 
         totalSeeds += count
-
-        var leveledUp = false
-        // Only level up if the total seeds EXCEED the threshold for the current level
-        if totalSeeds > previousLevelTotal + thresholdForCurrentLevel {
-            if currentLevel < seedLevels.count {
-                currentLevel += 1
-                leveledUp = true
-            }
+        
+        /* 
+         If the number of seeds being added (e.g. via "add 5 seeds" debug function) exceeds the max required seeds
+         cap the totalSeeds to the maximum required.
+         This is useful in case of a seeds multiplier when the configuration has the `maxCappedSeeds` evaluted.
+         */
+        if totalSeeds >= effectiveMaxRequiredSeeds {
+            totalSeeds = effectiveMaxRequiredSeeds
         }
 
+        var leveledUp = false
+        // Only level up if the total seeds is equal or exceed the threshold for the level we are reaching to
+        if totalSeeds >= thresholdForNextLevel && currentLevel < effectiveMaxLevel {
+                currentLevel += 1
+                leveledUp = true
+        }
+        
+        // Save progress with updated total seeds and current level
         saveProgress(totalSeeds: totalSeeds, currentLevel: currentLevel, lastAppOpenDate: date)
 
         // Notify listeners if leveled up

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -124,7 +124,8 @@ class HomepageViewController:
                                        .TabsPrivacyModeChanged,
                                        .WallpaperDidChange,
                                        // Ecosia: Seed Counter Experiment
-                                       SeedCounterNTPExperiment.progressManagerType.levelUpNotification])
+                                       SeedCounterNTPExperiment.progressManagerType.levelUpNotification,
+                                       UIApplication.didBecomeActiveNotification])
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -889,6 +890,9 @@ extension HomepageViewController: Notifiable {
             // Ecosia: Seed Counter Experiment
             case SeedCounterNTPExperiment.progressManagerType.levelUpNotification:
                 SeedCounterNTPExperiment.trackSeedLevellingUp()
+            case UIApplication.didBecomeActiveNotification:
+                SeedCounterNTPExperiment.trackSeedCollectionIfNewDayAppOpening()
+                SeedCounterNTPExperiment.progressManagerType.collectDailySeed()
             default: break
             }
         }

--- a/EcosiaTests/ClimateImpactCounter/UnleashUserDefaultsSeedProgressManagerTests.swift
+++ b/EcosiaTests/ClimateImpactCounter/UnleashUserDefaultsSeedProgressManagerTests.swift
@@ -1,0 +1,74 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import Client
+
+/// Remember that we always start from 1 seed and level 1 every time.
+final class UnleashUserDefaultsSeedProgressManagerTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        // Reset UserDefaults before each test
+        UserDefaults.standard.removeObject(forKey: "CurrentLevel")
+        UserDefaults.standard.removeObject(forKey: "TotalSeedsCollected")
+        UserDefaults.standard.removeObject(forKey: "LastAppOpenDate")
+    }
+    
+    // Test experimental cap with maxCappedLevel and maxCappedSeeds using current Unleash JSON-provided levels
+    func test_experimental_cap_respected_with_json_provided_levels() {
+        // Update the config to use experimental cap with JSON-provided levels
+        UserDefaultsSeedProgressManager.seedCounterConfig = SeedCounterConfig(
+            sparklesAnimationDuration: 10,
+            maxCappedLevel: 2,
+            maxCappedSeeds: 10,
+            levels: [
+                SeedCounterConfig.SeedLevel(level: 1, requiredSeeds: 1),
+                SeedCounterConfig.SeedLevel(level: 2, requiredSeeds: 3),
+                SeedCounterConfig.SeedLevel(level: 3, requiredSeeds: 10)
+            ]
+        )
+        
+        // Add enough seeds to reach max capped seeds (10)
+        UserDefaultsSeedProgressManager.addSeeds(9) // +9 seeds; total: 10 seeds (1 initially)
+        
+        // Ensure user is capped at 10 seeds
+        let totalSeedsCollected = UserDefaultsSeedProgressManager.loadTotalSeedsCollected()
+        let currentLevel = UserDefaultsSeedProgressManager.loadCurrentLevel()
+        
+        XCTAssertEqual(currentLevel, 2, "User should reach level 2, but not go beyond.")
+        XCTAssertEqual(totalSeedsCollected, 10, "Total seeds should be capped at 10 as per the experiment.")
+    }
+    
+    // Test with JSON-provided seed levels for regular progression
+    func test_add_seeds_with_json_provided_levels() {
+        // Update the config to use current Unleash's JSON-provided levels
+        UserDefaultsSeedProgressManager.seedCounterConfig = SeedCounterConfig(
+            sparklesAnimationDuration: 10,
+            maxCappedLevel: nil,
+            maxCappedSeeds: nil,
+            levels: [
+                SeedCounterConfig.SeedLevel(level: 1, requiredSeeds: 1),
+                SeedCounterConfig.SeedLevel(level: 2, requiredSeeds: 3),
+                SeedCounterConfig.SeedLevel(level: 3, requiredSeeds: 10)
+            ]
+        )
+        
+        // Add seeds to test progression through current Unleash's JSON-defined levels
+        UserDefaultsSeedProgressManager.addSeeds(2) // +2 seed; total: 3 seeds (1 initial + 2 added)
+        var totalSeedsCollected = UserDefaultsSeedProgressManager.loadTotalSeedsCollected()
+        var currentLevel = UserDefaultsSeedProgressManager.loadCurrentLevel()
+        
+        XCTAssertEqual(currentLevel, 2, "User should reach level 2 after collecting 3 seeds in total.")
+        XCTAssertEqual(totalSeedsCollected, 3, "Total seeds should be 3.")
+        
+        // Add more seeds to progress to level 3
+        UserDefaultsSeedProgressManager.addSeeds(7) // +7 seeds; total: 10 seeds
+        totalSeedsCollected = UserDefaultsSeedProgressManager.loadTotalSeedsCollected()
+        currentLevel = UserDefaultsSeedProgressManager.loadCurrentLevel()
+        
+        XCTAssertEqual(currentLevel, 3, "User should reach level 3 after collecting 10 seeds.")
+        XCTAssertEqual(totalSeedsCollected, 10, "Total seeds should be exactly 10.")
+    }
+}

--- a/EcosiaTests/ClimateImpactCounter/UserDefaultsSeedProgressManagerTests.swift
+++ b/EcosiaTests/ClimateImpactCounter/UserDefaultsSeedProgressManagerTests.swift
@@ -62,7 +62,6 @@ final class UserDefaultsSeedProgressManagerTests: XCTestCase {
         
         let level = UserDefaultsSeedProgressManager.loadCurrentLevel()
         let totalSeedsCollected = UserDefaultsSeedProgressManager.loadTotalSeedsCollected()
-        let innerProgress = UserDefaultsSeedProgressManager.calculateInnerProgress()
 
         XCTAssertEqual(level, 2, "User should be in level 2 after adding 2 more seed beyond the threshold")
         XCTAssertEqual(totalSeedsCollected, 7, "Total seeds should accumulate across levels (6 new added + 1 accumulated at the start")
@@ -113,27 +112,27 @@ final class UserDefaultsSeedProgressManagerTests: XCTestCase {
         XCTAssertEqual(totalSeedsCollected, 2, "User should be able to collect a seed on a new day")
     }
 
-    // Test progress calculation for level 2 and beyond
-    func test_progress_calculation_beyond_level_2() {
-        // Setup to be at level 2 with 6 new seeds collected
-        UserDefaultsSeedProgressManager.addSeeds(6)
+    // Test that adding seeds beyond the maximum level stops at the maximum seeds for the last level.
+    func test_add_seeds_beyond_maximum_level_stops_at_max_seeds_for_last_level() {
+        // Add enough seeds to reach level 2
+        UserDefaultsSeedProgressManager.addSeeds(9) // +9 seeds; total: 10 seeds (5 from level 1, 5 from level 2)
         
-        let totalSeedsCollected = UserDefaultsSeedProgressManager.loadTotalSeedsCollected()
-        XCTAssertEqual(totalSeedsCollected, 7, "Total seeds accumulated (6+1)")
+        // Ensure user is at level 2 and has 10 seeds
+        var totalSeedsCollected = UserDefaultsSeedProgressManager.loadTotalSeedsCollected()
+        var currentLevel = UserDefaultsSeedProgressManager.loadCurrentLevel()
         
-        let innerProgress = UserDefaultsSeedProgressManager.calculateInnerProgress()
-        XCTAssertEqual(innerProgress, 0.2, accuracy: 0.01, "Should have 20% progress in level 2 after collecting 2 seeds in level 2")
-    }
-    
-    // Test progress calculation for level 2 and beyond, keeping the level at the last defined, 2.
-    func test_progress_calculation_collect_seeds_beyond_level_2_stays_at_level_2() {
-        // Setup to be at level 2 with 10 new seeds collected
-        UserDefaultsSeedProgressManager.addSeeds(10)
+        XCTAssertEqual(currentLevel, 2, "User should be at level 2 after collecting 10 seeds.")
+        XCTAssertEqual(totalSeedsCollected, 10, "Total seeds should be exactly 10 after reaching level 2.")
+
+        // Now, try to add more seeds beyond the maximum allowed seeds for level 2
+        UserDefaultsSeedProgressManager.addSeeds(5) // Try adding +5 seeds
         
-        let totalSeedsCollected = UserDefaultsSeedProgressManager.loadTotalSeedsCollected()
-        XCTAssertEqual(totalSeedsCollected, 11, "Total seeds accumulated (10+1)")
+        // Reload the values after adding seeds
+        totalSeedsCollected = UserDefaultsSeedProgressManager.loadTotalSeedsCollected()
+        currentLevel = UserDefaultsSeedProgressManager.loadCurrentLevel()
         
-        let currentLevel = UserDefaultsSeedProgressManager.loadCurrentLevel()
-        XCTAssertEqual(currentLevel, 2, "Should stay at level 2 when more seeds than required to go beyond the last level (2 in this testing preconditions scenario)")
+        // Ensure user is still at level 2, and total seeds should be capped at 10
+        XCTAssertEqual(currentLevel, 2, "User should remain at level 2, as it's the last level.")
+        XCTAssertEqual(totalSeedsCollected, 10, "Total seeds should be capped at 10 (the maximum for level 2) even after adding more seeds.")
     }
 }


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2871]

## Context

These changes came after clarification with the product, strictly referring to the ACs, without referencing any other requirement (figma, doc etc...)
It also introduces few enhancements to exactly match the [Seed model](https://docs.google.com/spreadsheets/d/1HdWj7LpAy0ZdKUcOjL0LdUMk4gn_zKjU8BcyBAsVQQQ/edit?gid=0#gid=0) to facilitate 1:1 interpretation without implicit calculations.

## Approach

- Update levelling management
   - we start with level 1 as per the doc, even if level 1 means 1 seed already
   - levelling matches 1:1 what's written in the doc
- Update SeedConfig, introducing an optional capped mechanism to accommodate the experiment without having to touch the code in the future in case this experiment is invalidated.
- Update the protocol to accept the config instead of the sole seed levels.
- Updates on the progress calculation so it matches the "reaching" logic
- Updated and added tests to accommodate the current Unleash configuration 
- Implements a logic that observes when the app becomes active to accommodate the Acceptance Criterion wanting the seeds to be collected (and being visible to the end User) as soon as they open the App from background, even when the NTP is already on screen.
  - This is something that our NTP anatomy doesn't process first hand. Thus the observer.
  - The observer doesn't interfere with the Thread-safe seeds collection and Analytics tracking as both are executed on the main thread. On top, neither of them is executed at the same time.   

## Other

- Updated pre-commit hook to handle rebase successfully. 

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I wrote Unit Tests that confirm the expected behaviour
- [x] I added the `// Ecosia:` helper comments where needed
- [x] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [x] Updated the [confluence doc](https://ecosia.atlassian.net/wiki/spaces/MOB/pages/3283484676/Climate+Impact+Tracking+First+Experiment#Configuration-info) adding the configuration

[MOB-2871]: https://ecosia.atlassian.net/browse/MOB-2871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ