### PR TITLE
[MOB-2917] APN Consent on launch Experiment

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -21482,7 +21482,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ecosia/ios-core.git";
 			requirement = {
-				branch = "ls-mob-2917-apn-consent-on-launch-experiment";
+				branch = main;
 				kind = branch;
 			};
 		};

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		0BF1B7E31AC60DEA00A7B407 /* InsetButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF1B7E21AC60DEA00A7B407 /* InsetButton.swift */; };
 		12187B502C89B43D00BA88CA /* OnboardingCardNTPExperiment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12187B4F2C89B43D00BA88CA /* OnboardingCardNTPExperiment.swift */; };
 		12187B532C89E15000BA88CA /* NTPOnboardingCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12187B522C89E15000BA88CA /* NTPOnboardingCardCell.swift */; };
+		1285E2B72CC68BF00053506B /* APNConsentOnLaunchExperiment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1285E2B62CC68BF00053506B /* APNConsentOnLaunchExperiment.swift */; };
 		158241282820698B00956B39 /* RustRemoteTabsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 158241272820698B00956B39 /* RustRemoteTabsTests.swift */; };
 		15DE98FD27FCED4F00F1ECDB /* RustRemoteTabs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15DE98FC27FCED4F00F1ECDB /* RustRemoteTabs.swift */; };
 		1B3D99F1270E89D0006E1264 /* Telemetry in Frameworks */ = {isa = PBXBuildFile; productRef = 1B3D99F0270E89D0006E1264 /* Telemetry */; };
@@ -2023,6 +2024,7 @@
 		12674A038346A46589A0AC0B /* el */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = el; path = "el.lproj/Default Browser.strings"; sourceTree = "<group>"; };
 		126A40A4A5AFDFD655B0FDF4 /* ca */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ca; path = ca.lproj/ClearHistoryConfirm.strings; sourceTree = "<group>"; };
 		126F44CCB14373DC7813DE1F /* hr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hr; path = hr.lproj/ClearPrivateDataConfirm.strings; sourceTree = "<group>"; };
+		1285E2B62CC68BF00053506B /* APNConsentOnLaunchExperiment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APNConsentOnLaunchExperiment.swift; sourceTree = "<group>"; };
 		12EA4881BFBE296298150D4A /* bn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bn; path = bn.lproj/LoginManager.strings; sourceTree = "<group>"; };
 		12F949169C30744CCC749588 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/HistoryPanel.strings; sourceTree = "<group>"; };
 		1323403C8071FC19BB79C191 /* su */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = su; path = su.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -8713,6 +8715,7 @@
 				2C6188F82B7A8A22006B70D7 /* EngagementServiceExperiment.swift */,
 				12187B4F2C89B43D00BA88CA /* OnboardingCardNTPExperiment.swift */,
 				2C6B5B402CAAF3AA00F15323 /* SeedCounterNTPExperiment.swift */,
+				1285E2B62CC68BF00053506B /* APNConsentOnLaunchExperiment.swift */,
 			);
 			path = Unleash;
 			sourceTree = "<group>";
@@ -13895,6 +13898,7 @@
 				8A2783F1275FFDC50080D29D /* KeyboardPressesHandler.swift in Sources */,
 				E650755C1E37F747006961AC /* Swizzling.m in Sources */,
 				74821FC51DB56A2500EEEA72 /* OpenWithSettingsViewController.swift in Sources */,
+				1285E2B72CC68BF00053506B /* APNConsentOnLaunchExperiment.swift in Sources */,
 				C84656012887A0F700861B4A /* WallpaperMetadataUtility.swift in Sources */,
 				E1B04A9D28E20A8300670E54 /* InstructionsView.swift in Sources */,
 				D3B6923D1B9F9444004B87A4 /* FindInPageBar.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -21482,7 +21482,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ecosia/ios-core.git";
 			requirement = {
-				branch = main;
+				branch = "ls-mob-2917-apn-consent-on-launch-experiment";
 				kind = branch;
 			};
 		};

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
-        "branch" : "ls-mob-2917-apn-consent-on-launch-experiment",
-        "revision" : "a1d7952c326c54a657b91201deb5ecb861efcbfd"
+        "branch" : "main",
+        "revision" : "b2624be79f04a6f78ffbf37100ab75a422cef0b5"
       }
     },
     {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "0112c7295cda3b2d62a9365ea7aae05164108d53"
+        "branch" : "ls-mob-2917-apn-consent-on-launch-experiment",
+        "revision" : "a1d7952c326c54a657b91201deb5ecb861efcbfd"
       }
     },
     {

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -196,7 +196,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             // Ecosia: Engagement Service Initialization helper
             ClientEngagementService.shared.initializeAndUpdateNotificationRegistrationIfNeeded(notificationCenterDelegate: self)
             // Ecosia: Experiment that directly asks for consent
-            APNConsentOnLaunchExperiment.requestAPNConsentIfNeeded(delegate: self)
+            await APNConsentOnLaunchExperiment.requestAPNConsentIfNeeded(delegate: self)
         }
         
         // Ecosia: fetching statistics before they are used

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -194,7 +194,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             // Ecosia: Lifecycle tracking. Needs to happen after Unleash start so that the flags are correctly added to the analytics context.
             analytics.activity(.launch)
             // Ecosia: Engagement Service Initialization helper
-            ClientEngagementService.shared.initializeAndUpdateNotificationRegistrationIfNeeded(notificationCenterDelegate: self)
+            await ClientEngagementService.shared.initializeAndRefreshNotificationRegistration(notificationCenterDelegate: self)
             // Ecosia: Experiment that directly asks for consent
             await APNConsentOnLaunchExperiment.requestAPNConsentIfNeeded(delegate: self)
         }

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -195,6 +195,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             analytics.activity(.launch)
             // Ecosia: Engagement Service Initialization helper
             ClientEngagementService.shared.initializeAndUpdateNotificationRegistrationIfNeeded(notificationCenterDelegate: self)
+            // Ecosia: Experiment that directly asks for consent
+            APNConsentOnLaunchExperiment.requestAPNConsentIfNeeded(delegate: self)
         }
         
         // Ecosia: fetching statistics before they are used

--- a/Client/Ecosia/Analytics/Analytics.Values.swift
+++ b/Client/Ecosia/Analytics/Analytics.Values.swift
@@ -194,6 +194,12 @@ extension Analytics {
             greenSearch = "green_search",
             transparentFinances = "transparent_finances"
         }
+        
+        enum APNConsent: String {
+            case
+            home,
+            onLaunchExperiment = "on_launch_experiment"
+        }
     }
 
     enum Migration: String {

--- a/Client/Ecosia/Analytics/Analytics.swift
+++ b/Client/Ecosia/Analytics/Analytics.swift
@@ -166,7 +166,7 @@ final class Analytics: AnalyticsProtocol {
         let event = Structured(category: Category.pushNotificationConsent.rawValue,
                                action: action.rawValue)
             .label("\(User.shared.apnConsentReminderModel.optInScreenCount)")
-            .property(Property.home.rawValue)
+            .property(Property.APNConsent.home.rawValue)
         
         // When the user sees the APNConsent
         // we add the number of search counts as value of the event
@@ -180,6 +180,14 @@ final class Analytics: AnalyticsProtocol {
             event.entities.append(context)
         }
         
+        track(event)
+    }
+    
+    func apnConsentOnLaunchExperiment(_ action: Action.APNConsent) {
+        let event = Structured(category: Category.pushNotificationConsent.rawValue,
+                               action: action.rawValue)
+            .property(Property.APNConsent.onLaunchExperiment.rawValue)
+        addABTestContexts(to: event, toggles: [APNConsentOnLaunchExperiment.toggleName])
         track(event)
     }
         

--- a/Client/Ecosia/EngagementService/EngagementService.swift
+++ b/Client/Ecosia/EngagementService/EngagementService.swift
@@ -14,13 +14,11 @@ final class ClientEngagementService {
         parameters["id"] as? String
     }
     
-    func initialize(parameters: [String: Any]) {
+    func initialize(parameters: [String: Any]) async {
         do {
             try service.initialize(parameters: parameters)
             self.parameters = parameters
-            Task {
-                await retrieveUserCurrentNotificationAuthStatus()
-            }
+            await retrieveUserCurrentNotificationAuthStatus()
         } catch {
             debugPrint(error)
         }
@@ -49,12 +47,9 @@ final class ClientEngagementService {
 
 extension ClientEngagementService {
     
-    func initializeAndUpdateNotificationRegistrationIfNeeded(notificationCenterDelegate: UNUserNotificationCenterDelegate) {
-        guard EngagementServiceExperiment.isEnabled else { return }
-        initialize(parameters: ["id": User.shared.analyticsId.uuidString])
-        Task.detached {
-            await self.refreshAPNRegistrationIfNeeded(notificationCenterDelegate: notificationCenterDelegate)
-        }
+    func initializeAndRefreshNotificationRegistration(notificationCenterDelegate: UNUserNotificationCenterDelegate) async {
+        await initialize(parameters: ["id": User.shared.analyticsId.uuidString])
+        await refreshAPNRegistrationIfNeeded(notificationCenterDelegate: notificationCenterDelegate)
     }
     
     func retrieveUserCurrentNotificationAuthStatus() async {

--- a/Client/Ecosia/Experiments/Unleash/APNConsentOnLaunchExperiment.swift
+++ b/Client/Ecosia/Experiments/Unleash/APNConsentOnLaunchExperiment.swift
@@ -13,10 +13,12 @@ struct APNConsentOnLaunchExperiment {
     }
 
     static var isEnabled: Bool {
-        Unleash.isEnabled(toggleName)
+        // Make sure that the other engagement service experiment is not enabled since they are conflicting
+        Unleash.isEnabled(toggleName) && !Unleash.isEnabled(.braze)
     }
     
-    static func requestAPNConsentIfNeeded(delegate: UNUserNotificationCenterDelegate) {
+    static func requestAPNConsentIfNeeded(delegate: UNUserNotificationCenterDelegate) async {
+        await ClientEngagementService.shared.retrieveUserCurrentNotificationAuthStatus()
         guard isEnabled, ClientEngagementService.shared.notificationAuthorizationStatus == .notDetermined else {
             return
         }

--- a/Client/Ecosia/Experiments/Unleash/APNConsentOnLaunchExperiment.swift
+++ b/Client/Ecosia/Experiments/Unleash/APNConsentOnLaunchExperiment.swift
@@ -1,0 +1,28 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Core
+
+struct APNConsentOnLaunchExperiment {
+    private init() {}
+    
+    static var toggleName: Unleash.Toggle.Name {
+        .apnConsentOnLaunch
+    }
+
+    static var isEnabled: Bool {
+        Unleash.isEnabled(toggleName)
+    }
+    
+    static func requestAPNConsentIfNeeded(delegate: UNUserNotificationCenterDelegate) {
+        guard isEnabled, ClientEngagementService.shared.notificationAuthorizationStatus == .notDetermined else {
+            return
+        }
+        Analytics.shared.apnConsentOnLaunchExperiment(.view)
+        ClientEngagementService.shared.requestAPNConsent(notificationCenterDelegate: delegate) { granted, error in
+            Analytics.shared.apnConsentOnLaunchExperiment(granted ? .allow : .deny)
+        }
+    }
+}

--- a/Client/Ecosia/Experiments/Unleash/APNConsentOnLaunchExperiment.swift
+++ b/Client/Ecosia/Experiments/Unleash/APNConsentOnLaunchExperiment.swift
@@ -12,7 +12,7 @@ struct APNConsentOnLaunchExperiment {
         .apnConsentOnLaunch
     }
 
-    static var isEnabled: Bool {
+    private static var isEnabled: Bool {
         // Make sure that the other engagement service experiment is not enabled since they are conflicting
         Unleash.isEnabled(toggleName) && !Unleash.isEnabled(.braze)
     }

--- a/Client/Ecosia/Experiments/Unleash/APNConsentOnLaunchExperiment.swift
+++ b/Client/Ecosia/Experiments/Unleash/APNConsentOnLaunchExperiment.swift
@@ -18,7 +18,6 @@ struct APNConsentOnLaunchExperiment {
     }
     
     static func requestAPNConsentIfNeeded(delegate: UNUserNotificationCenterDelegate) async {
-        await ClientEngagementService.shared.retrieveUserCurrentNotificationAuthStatus()
         guard isEnabled, ClientEngagementService.shared.notificationAuthorizationStatus == .notDetermined else {
             return
         }

--- a/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
+++ b/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
@@ -150,6 +150,7 @@ extension AppSettingsTableViewController {
             EngagementServiceIdentifierSetting(settings: self),
             FasterInactiveTabs(settings: self, settingsDelegate: self),
             UnleashOnboardingCardNTPSetting(settings: self),
+            UnleashAPNConsentOnLaunchSetting(settings: self),
             UnleashSeedCounterNTPSetting(settings: self)
         ]
         

--- a/Client/Ecosia/Settings/EcosiaDebugSettings.swift
+++ b/Client/Ecosia/Settings/EcosiaDebugSettings.swift
@@ -201,6 +201,16 @@ final class UnleashOnboardingCardNTPSetting: UnleashVariantResetSetting {
     }
 }
 
+final class UnleashAPNConsentOnLaunchSetting: UnleashVariantResetSetting {
+    override var titleName: String? {
+        "APN Consent On Launch"
+    }
+    
+    override var variant: Unleash.Variant? {
+        Unleash.getVariant(.apnConsentOnLaunch)
+    }
+}
+
 final class EngagementServiceIdentifierSetting: HiddenSetting {
     override var title: NSAttributedString? {
         return NSAttributedString(string: "Debug: Engagement Service Identifier parameter", attributes: [NSAttributedString.Key.foregroundColor: UIColor.legacyTheme.tableView.rowText])


### PR DESCRIPTION
[MOB-2917]

## Context

We're setting up another experiment to get user's notification consent, see ticket for more details.

## Approach

Creating a new experiment that uses existing EngagementService logic.

## Before merging

✅  Wait for https://github.com/ecosia/ios-browser/pull/798 as there will be a number of conflicts re analytics.

✅  Wait for https://github.com/ecosia/ios-core/pull/165 (core-sode counterpart required for this one).

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] ~~I wrote Unit Tests that confirm the expected behaviour~~ Did not find any experiment related tests that seemed relevant
- [x] I added the `// Ecosia:` helper comments where needed
- [x] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)

[MOB-2917]: https://ecosia.atlassian.net/browse/MOB-2917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ