### PR TITLE
[MOB-3010] Add Onboarding Remove experiment

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -21438,7 +21438,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ecosia/ios-core.git";
 			requirement = {
-				branch = "dc-mob-3010-onboarding-card-ntp-experiment-remove";
+				branch = main;
 				kind = branch;
 			};
 		};

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -384,6 +384,7 @@
 		2CE294492B7CDD78006C22B2 /* Core in Frameworks */ = {isa = PBXBuildFile; productRef = 2CE294482B7CDD78006C22B2 /* Core */; };
 		2CE2E24D2B9B1FCB00973C16 /* Core in Frameworks */ = {isa = PBXBuildFile; productRef = 2CE2E24C2B9B1FCB00973C16 /* Core */; };
 		2CF4DA632BB31970001C340A /* Core in Frameworks */ = {isa = PBXBuildFile; productRef = 2CF4DA622BB31970001C340A /* Core */; };
+		2CFE600C2CD3AAB6001F35D2 /* OnboardingRemoveExperiment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CFE600B2CD3AAB6001F35D2 /* OnboardingRemoveExperiment.swift */; };
 		2F13E79B1AC0C02700D75081 /* StringExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F13E79A1AC0C02700D75081 /* StringExtensionsTests.swift */; };
 		2F44FA1B1A9D426A00FD20CC /* TestHashExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F44FA1A1A9D426A00FD20CC /* TestHashExtensions.swift */; };
 		2F44FB2C1A9D5D8500FD20CC /* Library.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F84B22261A09127C00AAB793 /* Library.xcassets */; };
@@ -2563,6 +2564,7 @@
 		2CF21D0820A4A163000D08B7 /* PocketTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PocketTests.swift; sourceTree = "<group>"; };
 		2CF449A41E7BFE2C00FD7595 /* NavigationTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavigationTest.swift; sourceTree = "<group>"; };
 		2CF9D9A920067FA10083DF2A /* BrowsingPDFTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowsingPDFTests.swift; sourceTree = "<group>"; };
+		2CFE600B2CD3AAB6001F35D2 /* OnboardingRemoveExperiment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingRemoveExperiment.swift; sourceTree = "<group>"; };
 		2D434B33B5B653C6602FB516 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		2D4D4136886E42550B1AD716 /* uz */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uz; path = uz.lproj/Localizable.strings; sourceTree = "<group>"; };
 		2D5D468686FEA0B04D7F04CE /* az */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = az; path = az.lproj/Search.strings; sourceTree = "<group>"; };
@@ -8677,6 +8679,7 @@
 				2C6188F82B7A8A22006B70D7 /* BrazeIntegrationExperiment.swift */,
 				2C6B5B402CAAF3AA00F15323 /* SeedCounterNTPExperiment.swift */,
 				1285E2B62CC68BF00053506B /* APNConsentOnLaunchExperiment.swift */,
+				2CFE600B2CD3AAB6001F35D2 /* OnboardingRemoveExperiment.swift */,
 			);
 			path = Unleash;
 			sourceTree = "<group>";
@@ -13581,6 +13584,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2CFE600C2CD3AAB6001F35D2 /* OnboardingRemoveExperiment.swift in Sources */,
 				45D5EDD2292D89A200311934 /* PinnedSite.swift in Sources */,
 				8A4AC0EC28C929D700439F83 /* URLSessionProtocol.swift in Sources */,
 				C2A72A672A76938C002ACCE2 /* DownloadsCoordinator.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -21438,7 +21438,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ecosia/ios-core.git";
 			requirement = {
-				branch = main;
+				branch = "dc-mob-3010-onboarding-card-ntp-experiment-remove";
 				kind = branch;
 			};
 		};

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
-        "branch" : "dc-mob-3010-onboarding-card-ntp-experiment-remove",
-        "revision" : "0c61e03d5a6b543bbf3e28319d0e8b776f3a6771"
+        "branch" : "main",
+        "revision" : "2a957f6fd4fd4a322ec64c05d770d22ea749689a"
       }
     },
     {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "2106a8ccb6b2acb100d4021df0032479c0fbda2d"
+        "branch" : "dc-mob-3010-onboarding-card-ntp-experiment-remove",
+        "revision" : "0c61e03d5a6b543bbf3e28319d0e8b776f3a6771"
       }
     },
     {

--- a/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -279,7 +279,9 @@ class BrowserCoordinator: BaseCoordinator,
         browserViewController.presentIntroViewController()
     }
     
-    private func showIntroOnboarding() {
+    // Ecosia: Add `forceSkipExperiment` - used for `OnboardingRemoveExperiment`
+    // private func showIntroOnboarding() {
+    private func showIntroOnboarding(skipExperiment: Bool = false) {
         let introManager = IntroScreenManager(prefs: profile.prefs)
         let launchType = LaunchType.intro(manager: introManager)
         startLaunch(with: launchType)

--- a/Client/Coordinators/Launch/LaunchCoordinator.swift
+++ b/Client/Coordinators/Launch/LaunchCoordinator.swift
@@ -29,8 +29,27 @@ class LaunchCoordinator: BaseCoordinator,
     func start(with launchType: LaunchType) {
         let isFullScreen = launchType.isFullScreenAvailable(isIphone: isIphone)
         switch launchType {
-         case .intro(let manager):
-            presentIntroOnboarding(with: manager, isFullScreen: isFullScreen)
+            /* Ecosia: Change to support `OnboardingRemoveExperiment` conditions
+             case .intro(let manager):
+             presentIntroOnboarding(with: manager, isFullScreen: isFullScreen)
+             */
+        case .intro(let manager, let checkExperiment):
+            guard checkExperiment else {
+                presentIntroOnboarding(with: manager, isFullScreen: isFullScreen)
+                return
+            }
+            // TODO: Refactor `FeatureManagement.fetchConfiguration()` pre-condition - maybe a notification from FeatureManagement?
+            Task {
+                await FeatureManagement.fetchConfiguration()
+                DispatchQueue.main.async { [weak self] in
+                    guard let self = self else { return }
+                    guard !OnboardingRemoveExperiment.shouldRemoveOnboarding else {
+                        self.parentCoordinator?.didFinishLaunch(from: self)
+                        return
+                    }
+                    self.presentIntroOnboarding(with: manager, isFullScreen: isFullScreen)
+                }
+            }
         case .update(let viewModel):
             presentUpdateOnboarding(with: viewModel, isFullScreen: isFullScreen)
         case .defaultBrowser:

--- a/Client/Coordinators/Launch/LaunchType.swift
+++ b/Client/Coordinators/Launch/LaunchType.swift
@@ -11,8 +11,9 @@ enum LaunchCoordinatorType {
 }
 
 enum LaunchType {
+    // Ecosia: Add `checkExperiment` - used for `OnboardingRemoveExperiment`
     /// Showing the intro onboarding
-    case intro(manager: IntroScreenManager)
+    case intro(manager: IntroScreenManager, checkExperiment: Bool = true)
 
     /// Show the update onboarding
     case update(viewModel: UpdateViewModel)

--- a/Client/Ecosia/Analytics/Analytics.swift
+++ b/Client/Ecosia/Analytics/Analytics.swift
@@ -270,7 +270,8 @@ extension Analytics {
     private func appendTestContextIfNeeded(_ action: Analytics.Action.Activity, _ event: Structured) {
         switch action {
         case .resume, .launch:
-            addABTestContexts(to: event, toggles: [.brazeIntegration])
+            // Add `onboardingRemove` - used for `OnboardingRemoveExperiment` AB Test
+            addABTestContexts(to: event, toggles: [.brazeIntegration, .onboardingRemove])
             addCookieConsentContext(to: event)
         }
     }

--- a/Client/Ecosia/Experiments/Unleash/OnboardingRemoveExperiment.swift
+++ b/Client/Ecosia/Experiments/Unleash/OnboardingRemoveExperiment.swift
@@ -1,0 +1,28 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Core
+
+struct OnboardingRemoveExperiment {
+    
+    private init() {}
+    
+    private enum Variant: String {
+        case control
+        case test
+    }
+    
+    private static var variant: Variant {
+        Variant(rawValue: Unleash.getVariant(.onboardingRemove).name) ?? .control
+    }
+    
+    private static var isEnabled: Bool {
+        Unleash.isEnabled(.onboardingRemove)
+    }
+    
+    static var shouldRemoveOnboarding: Bool {
+        isEnabled && variant != .control
+    }
+}

--- a/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
+++ b/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
@@ -151,7 +151,8 @@ extension AppSettingsTableViewController {
             FasterInactiveTabs(settings: self, settingsDelegate: self),
             UnleashBrazeIntegrationSetting(settings: self),
             UnleashAPNConsentOnLaunchSetting(settings: self),
-            UnleashSeedCounterNTPSetting(settings: self)
+            UnleashSeedCounterNTPSetting(settings: self),
+            UnleashOnboardingRemoveSetting(settings: self)
         ]
         
         if SeedCounterNTPExperiment.isEnabled {

--- a/Client/Ecosia/Settings/EcosiaDebugSettings.swift
+++ b/Client/Ecosia/Settings/EcosiaDebugSettings.swift
@@ -233,3 +233,12 @@ final class AnalyticsIdentifierSetting: HiddenSetting {
     }
 }
 
+final class UnleashOnboardingRemoveSetting: UnleashVariantResetSetting {
+    override var titleName: String? {
+        "Onboarding Remove Experiment"
+    }
+
+    override var variant: Unleash.Variant? {
+        Unleash.getVariant(.onboardingRemove)
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Launch/LaunchCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/Launch/LaunchCoordinatorTests.swift
@@ -40,7 +40,8 @@ final class LaunchCoordinatorTests: XCTestCase {
     func testStart_introNotIphone_present() throws {
         let introScreenManager = IntroScreenManager(prefs: profile.prefs)
         let subject = createSubject(isIphone: false)
-        subject.start(with: .intro(manager: introScreenManager))
+        // Ecosia: Add `checkExperiment` - used for `OnboardingRemoveExperiment`
+        subject.start(with: .intro(manager: introScreenManager, checkExperiment: false))
         XCTAssertEqual(mockRouter.presentCalled, 1)
         XCTAssertEqual(mockRouter.setRootViewControllerCalled, 0)
         let presentedViewController = try XCTUnwrap(mockRouter.presentedViewController)
@@ -52,7 +53,8 @@ final class LaunchCoordinatorTests: XCTestCase {
     func testStart_introIsIphone_setRootView() throws {
         let introScreenManager = IntroScreenManager(prefs: profile.prefs)
         let subject = createSubject(isIphone: true)
-        subject.start(with: .intro(manager: introScreenManager))
+        // Ecosia: Add `checkExperiment` - used for `OnboardingRemoveExperiment`
+        subject.start(with: .intro(manager: introScreenManager, checkExperiment: false))
         XCTAssertEqual(mockRouter.presentCalled, 1)
         XCTAssertEqual(mockRouter.setRootViewControllerCalled, 0)
         let pushedVC = try XCTUnwrap(mockRouter.presentedViewController)


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-3010]

## Context

After testing the onboarding card NTP, we got a significant uplift in W1 retention as well as a close to significant D1 retention uplift.
We want to test the onboarding removal in isolation.

## Approach

- Following the path of the onboarding card changes (https://github.com/ecosia/ios-browser/pull/778), we modify the codebase to remove the onboarding for certain users.
- Include Analytics ABTest context

## Other

## Before merging

Once this https://github.com/ecosia/ios-core/pull/168 is merged, update this PR and revert to main.

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I modified Unit Tests that confirm the expected behavior
- [x] I added the `// Ecosia:` helper comments where needed
- [x] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)

[MOB-3010]: https://ecosia.atlassian.net/browse/MOB-3010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ