### PR TITLE
[MOB-2722] Snowplow Update to 6.0.8

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -21455,7 +21455,7 @@
 			repositoryURL = "https://github.com/snowplow/snowplow-ios-tracker.git";
 			requirement = {
 				kind = exactVersion;
-				version = 5.2.0;
+				version = 6.0.8;
 			};
 		};
 		2CB172802C612D68008551E2 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */ = {

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -21454,8 +21454,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/snowplow/snowplow-ios-tracker.git";
 			requirement = {
-				kind = exactVersion;
-				version = 6.0.8;
+				kind = upToNextMinorVersion;
+				minimumVersion = 6.0.8;
 			};
 		};
 		2CB172802C612D68008551E2 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */ = {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -28,15 +28,6 @@
       }
     },
     {
-      "identity" : "fmdb",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ccgus/fmdb",
-      "state" : {
-        "revision" : "1227a3fa2b9916bfd75fe380eb45cd210e69e251",
-        "version" : "2.7.12"
-      }
-    },
-    {
       "identity" : "fuzi",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nbhasin2/Fuzi.git",

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -149,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/snowplow/snowplow-ios-tracker.git",
       "state" : {
-        "revision" : "1e16a929cef8e944bd41dc36a1d2779e06bd0a3c",
-        "version" : "5.2.0"
+        "revision" : "bf1495987d63dc3595270df1a1bb516bfef8585f",
+        "version" : "6.0.8"
       }
     },
     {

--- a/Client/Ecosia/Analytics/Analytics.swift
+++ b/Client/Ecosia/Analytics/Analytics.swift
@@ -16,7 +16,7 @@ open class Analytics {
                                       configurations: [Self.trackerConfiguration,
                                                        Self.subjectConfiguration,
                                                        Self.appInstallTrackingPluginConfiguration,
-                                                       Self.appResumeDailyTrackingPluginConfiguration])!
+                                                       Self.appResumeDailyTrackingPluginConfiguration])
     }
     
     static var shared = Analytics()
@@ -27,6 +27,7 @@ open class Analytics {
         tracker.installAutotracking = true
         tracker.screenViewAutotracking = false
         tracker.lifecycleAutotracking = false
+        tracker.screenEngagementAutotracking = false
         tracker.exceptionAutotracking = false
         tracker.diagnosticAutotracking = false
     }
@@ -275,7 +276,7 @@ extension Analytics {
     private func addABTestContexts(to event: Structured, toggles: [Unleash.Toggle.Name]) {
         toggles.forEach { toggle in
             if let context = Self.getTestContext(from: toggle) {
-                event.contexts.append(context)
+                event.entities.append(context)
             }
         }
     }
@@ -284,7 +285,7 @@ extension Analytics {
         if let consentValue = User.shared.cookieConsentValue {
             let consentContext = SelfDescribingJson(schema: Self.consentSchema,
                                                     andDictionary: ["cookie_consent": consentValue])
-            event.contexts.append(consentContext)
+            event.entities.append(consentContext)
         }
     }
 }


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2722]

## Context

Guild days tackling tech-debts.
We update Snowplow to its latest major. 

## Approach

- Update to the latest release
- Set it to the latest minor to allow patch updates
- As per the [migration link](https://docs.snowplow.io/docs/collecting-data/collecting-from-own-applications/mobile-trackers/migration-guides/migration-guide-from-version-5-x-to-6-0/#other-changes) info provided, we are now explicitly disabling the `screenEngagementAutotracking`.

## Other

- `fmdb` package not needed anymore

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator

[MOB-2722]: https://ecosia.atlassian.net/browse/MOB-2722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ