### PR TITLE
[MOB-2979] Analytics integration tests continuation

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -370,6 +370,7 @@
 		2C872A632B8CD7E000B318A0 /* WhatsNewLocalDataProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE2946B2B7FC5A5006C22B2 /* WhatsNewLocalDataProviderTests.swift */; };
 		2C872A642B8CD7E000B318A0 /* EcosiaHomeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C872A562B8CD65100B318A0 /* EcosiaHomeViewModelTests.swift */; };
 		2C9A62C02CDE1F7600CDA7D1 /* MockWelcomeDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9A62BF2CDE1F7600CDA7D1 /* MockWelcomeDelegate.swift */; };
+		2C9A62C22CDE4A3B00CDA7D1 /* MockNewsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9A62C12CDE4A3B00CDA7D1 /* MockNewsModel.swift */; };
 		2CA995282CA2C06A001064CC /* NTPConfigurableNudgeCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA995272CA2C06A001064CC /* NTPConfigurableNudgeCardCell.swift */; };
 		2CA9952A2CA2C0BB001064CC /* NTPConfigurableNudgeCardCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA995292CA2C0BB001064CC /* NTPConfigurableNudgeCardCellViewModel.swift */; };
 		2CABD7162C11C9CC00A0750F /* MozillaAppServices in Frameworks */ = {isa = PBXBuildFile; productRef = 2CABD7152C11C9CC00A0750F /* MozillaAppServices */; };
@@ -2514,6 +2515,7 @@
 		2C9144B0B15218D8A0FCD538 /* es-AR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-AR"; path = "es-AR.lproj/ClearPrivateData.strings"; sourceTree = "<group>"; };
 		2C97EC701E72C80E0092EC18 /* TopTabsTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopTabsTest.swift; sourceTree = "<group>"; };
 		2C9A62BF2CDE1F7600CDA7D1 /* MockWelcomeDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWelcomeDelegate.swift; sourceTree = "<group>"; };
+		2C9A62C12CDE4A3B00CDA7D1 /* MockNewsModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNewsModel.swift; sourceTree = "<group>"; };
 		2CA16FDD1E5F089100332277 /* SearchTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchTest.swift; sourceTree = "<group>"; };
 		2CA995272CA2C06A001064CC /* NTPConfigurableNudgeCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NTPConfigurableNudgeCardCell.swift; sourceTree = "<group>"; };
 		2CA995292CA2C0BB001064CC /* NTPConfigurableNudgeCardCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NTPConfigurableNudgeCardCellViewModel.swift; sourceTree = "<group>"; };
@@ -8881,6 +8883,7 @@
 			children = (
 				2C872A532B8CD47600B318A0 /* MockAppVersionInfoProvider.swift */,
 				2C9A62BF2CDE1F7600CDA7D1 /* MockWelcomeDelegate.swift */,
+				2C9A62C12CDE4A3B00CDA7D1 /* MockNewsModel.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -14486,6 +14489,7 @@
 				C29B64872AD69D0200F3244B /* QRCodeCoordinatorTests.swift in Sources */,
 				0BA8964B1A250E6500C1010C /* ProfileTest.swift in Sources */,
 				8AE80BAF2891960300BC12EA /* MockTraitCollection.swift in Sources */,
+				2C9A62C22CDE4A3B00CDA7D1 /* MockNewsModel.swift in Sources */,
 				E19443F82AF953B000964EA5 /* MockSidebarEnabledView.swift in Sources */,
 				8A832A9729DCBD3C0025D5DD /* LaunchTypeTests.swift in Sources */,
 				8A28C628291028870078A81A /* CanRemoveQuickActionBookmarkTests.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -369,6 +369,7 @@
 		2C872A622B8CD7E000B318A0 /* VersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE294702B7FC5A6006C22B2 /* VersionTests.swift */; };
 		2C872A632B8CD7E000B318A0 /* WhatsNewLocalDataProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE2946B2B7FC5A5006C22B2 /* WhatsNewLocalDataProviderTests.swift */; };
 		2C872A642B8CD7E000B318A0 /* EcosiaHomeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C872A562B8CD65100B318A0 /* EcosiaHomeViewModelTests.swift */; };
+		2C9A62C02CDE1F7600CDA7D1 /* MockWelcomeDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9A62BF2CDE1F7600CDA7D1 /* MockWelcomeDelegate.swift */; };
 		2CA995282CA2C06A001064CC /* NTPConfigurableNudgeCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA995272CA2C06A001064CC /* NTPConfigurableNudgeCardCell.swift */; };
 		2CA9952A2CA2C0BB001064CC /* NTPConfigurableNudgeCardCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA995292CA2C0BB001064CC /* NTPConfigurableNudgeCardCellViewModel.swift */; };
 		2CABD7162C11C9CC00A0750F /* MozillaAppServices in Frameworks */ = {isa = PBXBuildFile; productRef = 2CABD7152C11C9CC00A0750F /* MozillaAppServices */; };
@@ -2512,6 +2513,7 @@
 		2C8C07761E7800EA00DC1237 /* FindInPageTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FindInPageTests.swift; sourceTree = "<group>"; };
 		2C9144B0B15218D8A0FCD538 /* es-AR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-AR"; path = "es-AR.lproj/ClearPrivateData.strings"; sourceTree = "<group>"; };
 		2C97EC701E72C80E0092EC18 /* TopTabsTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopTabsTest.swift; sourceTree = "<group>"; };
+		2C9A62BF2CDE1F7600CDA7D1 /* MockWelcomeDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWelcomeDelegate.swift; sourceTree = "<group>"; };
 		2CA16FDD1E5F089100332277 /* SearchTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchTest.swift; sourceTree = "<group>"; };
 		2CA995272CA2C06A001064CC /* NTPConfigurableNudgeCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NTPConfigurableNudgeCardCell.swift; sourceTree = "<group>"; };
 		2CA995292CA2C0BB001064CC /* NTPConfigurableNudgeCardCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NTPConfigurableNudgeCardCellViewModel.swift; sourceTree = "<group>"; };
@@ -8878,6 +8880,7 @@
 			isa = PBXGroup;
 			children = (
 				2C872A532B8CD47600B318A0 /* MockAppVersionInfoProvider.swift */,
+				2C9A62BF2CDE1F7600CDA7D1 /* MockWelcomeDelegate.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -14566,6 +14569,7 @@
 				C2B808B12A77FA3F00A65487 /* DownloadsCoordinatorTests.swift in Sources */,
 				5A475E9129DB8AA7009C13FD /* MockDiskImageStore.swift in Sources */,
 				DFA51484276103A000266AA0 /* HistoryHighlightsManagerTests.swift in Sources */,
+				2C9A62C02CDE1F7600CDA7D1 /* MockWelcomeDelegate.swift in Sources */,
 				C2506C952A6A8D2600F2B76E /* HistoryCoordinatorTests.swift in Sources */,
 				8ADAFAC628AEBF6300FFEBE3 /* HomeLogoHeaderViewModelTests.swift in Sources */,
 				E14BF33E2950B1230039758D /* MailProvidersTests.swift in Sources */,

--- a/Client/Ecosia/UI/MultiplyImpact/MultiplyImpact.swift
+++ b/Client/Ecosia/UI/MultiplyImpact/MultiplyImpact.swift
@@ -10,7 +10,7 @@ import LinkPresentation
 import Common
 
 class MultiplyImpact: UIViewController, Themeable {
-    
+
     // MARK: - UX
 
     private struct UX {
@@ -86,9 +86,9 @@ class MultiplyImpact: UIViewController, Themeable {
     private weak var copyDividerRight: UIView?
     private weak var moreSharingMethods: UILabel?
     private(set) weak var inviteButton: EcosiaPrimaryButton!
-    
+
     private(set) weak var learnMoreButton: UIButton?
-    
+
     private weak var flowTitle: UILabel?
     private weak var flowBackground: UIView?
     private weak var flowStack: UIStackView?

--- a/Client/Ecosia/UI/MultiplyImpact/MultiplyImpact.swift
+++ b/Client/Ecosia/UI/MultiplyImpact/MultiplyImpact.swift
@@ -9,8 +9,8 @@ import MobileCoreServices
 import LinkPresentation
 import Common
 
-final class MultiplyImpact: UIViewController, Themeable {
-
+class MultiplyImpact: UIViewController, Themeable {
+    
     // MARK: - UX
 
     private struct UX {
@@ -79,16 +79,16 @@ final class MultiplyImpact: UIViewController, Themeable {
 
     private weak var sharingYourLink: UILabel?
     private weak var sharing: UIView?
-    private weak var copyControl: UIControl?
+    private(set) weak var copyControl: UIControl?
     private weak var copyLink: UILabel?
     private weak var copyText: UILabel?
     private weak var copyDividerLeft: UIView?
     private weak var copyDividerRight: UIView?
     private weak var moreSharingMethods: UILabel?
-    private weak var inviteButton: EcosiaPrimaryButton!
-
-    private weak var learnMoreButton: UIButton?
-
+    private(set) weak var inviteButton: EcosiaPrimaryButton!
+    
+    private(set) weak var learnMoreButton: UIButton?
+    
     private weak var flowTitle: UILabel?
     private weak var flowBackground: UIView?
     private weak var flowStack: UIStackView?

--- a/Client/Ecosia/UI/NTP/AboutEcosia/NTPAboutEcosiaCell.swift
+++ b/Client/Ecosia/UI/NTP/AboutEcosia/NTPAboutEcosiaCell.swift
@@ -61,7 +61,7 @@ final class NTPAboutEcosiaCell: UICollectionViewCell, ReusableCell {
         label.setContentCompressionResistancePriority(.init(rawValue: 0), for: .horizontal)
         return label
     }()
-    private lazy var learnMoreButton: UIButton = {
+    private(set) lazy var learnMoreButton: UIButton = {
         let button = UIButton()
         button.translatesAutoresizingMaskIntoConstraints = false
         button.layer.borderWidth = 1

--- a/Client/Ecosia/UI/NTP/News/NewsController.swift
+++ b/Client/Ecosia/UI/NTP/News/NewsController.swift
@@ -8,7 +8,7 @@ import Common
 
 final class NewsController: UIViewController, UICollectionViewDelegate, UICollectionViewDataSource,
     UICollectionViewDelegateFlowLayout, Themeable {
-    private weak var collection: UICollectionView!
+    private(set) weak var collection: UICollectionView!
     private var items = [NewsModel]()
     private let images = Images(.init(configuration: .ephemeral))
     private let news = News()

--- a/EcosiaTests/Analytics/AnalyticsSpyTests.swift
+++ b/EcosiaTests/Analytics/AnalyticsSpyTests.swift
@@ -590,7 +590,7 @@ final class AnalyticsSpyTests: XCTestCase {
         analyticsSpy.referralExpectation = expectation
 
         // Act
-        multiplyImpact.learnMoreButton.sendActions(for: .primaryActionTriggered)
+        multiplyImpact.learnMoreButton?.sendActions(for: .primaryActionTriggered)
 
         // Wait for the expectation
         waitForExpectations(timeout: 1)
@@ -612,7 +612,7 @@ final class AnalyticsSpyTests: XCTestCase {
         analyticsSpy.referralExpectation = expectation
 
         // Act
-        multiplyImpact.copyControl!.sendActions(for: .touchUpInside)
+        multiplyImpact.copyControl?.sendActions(for: .touchUpInside)
 
         // Wait for the expectation
         waitForExpectations(timeout: 1)

--- a/EcosiaTests/Analytics/AnalyticsSpyTests.swift
+++ b/EcosiaTests/Analytics/AnalyticsSpyTests.swift
@@ -106,11 +106,9 @@ final class AnalyticsSpy: Analytics {
         DispatchQueue.main.async {
             switch action {
             case .click:
-                print("Referral action called: .click, label: \(String(describing: label))")
                 self.referralClickExpectation?.fulfill()
                 self.referralClickExpectation = nil // Prevent multiple fulfillments
             case .send:
-                print("Referral action called: .send, label: \(String(describing: label))")
                 self.referralSendExpectation?.fulfill()
                 self.referralSendExpectation = nil // Prevent multiple fulfillments
             default:

--- a/EcosiaTests/Analytics/AnalyticsSpyTests.swift
+++ b/EcosiaTests/Analytics/AnalyticsSpyTests.swift
@@ -66,6 +66,20 @@ final class AnalyticsSpy: Analytics {
         introClickPageCalled = page
         introClickIndexCalled = index
     }
+    
+    var navigationActionCalled: Action?
+    var navigationLabelCalled: Label.Navigation?
+    
+    override func navigation(_ action: Action, label: Label.Navigation) {
+        navigationActionCalled = action
+        navigationLabelCalled = label
+    }
+
+    var navigationOpenNewsIdCalled: String?
+    
+    override func navigationOpenNews(_ id: String) {
+        navigationOpenNewsIdCalled = id
+    }
 }
 
 final class AnalyticsSpyTests: XCTestCase {
@@ -432,5 +446,47 @@ final class AnalyticsSpyTests: XCTestCase {
             analyticsSpy.introClickPageCalled = nil
             analyticsSpy.introClickIndexCalled = nil
         }
+    }
+    
+    // MARK: News Detail
+    
+    func testNewsControllerViewDidAppearTracksNavigationViewNews() {
+        // Create sample NewsModel
+        let item = try! createMockNewsModel()!
+        let items = [item]
+        let newsController = NewsController(items: items)
+        
+        // Ensure analytics methods have not been called yet
+        XCTAssertNil(analyticsSpy.navigationActionCalled)
+        XCTAssertNil(analyticsSpy.navigationLabelCalled)
+        
+        // Simulate view lifecycle
+        newsController.loadViewIfNeeded()
+        newsController.viewDidAppear(false)
+        
+        // Verify that navigation(.view, label: .news) was called
+        XCTAssertEqual(analyticsSpy.navigationActionCalled, .view)
+        XCTAssertEqual(analyticsSpy.navigationLabelCalled, .news)
+    }
+    
+    func testNewsControllerDidSelectItemTracksNavigationOpenNews() {
+        // Create sample NewsModel
+        let item = try! createMockNewsModel()!
+        let items = [item]
+        let newsController = NewsController(items: items)
+        
+        // Ensure analytics methods have not been called yet
+        XCTAssertNil(analyticsSpy.navigationOpenNewsIdCalled)
+        
+        // Simulate view loading
+        newsController.loadView()
+        newsController.collection.reloadData()
+        
+        // Simulate item selection
+        let indexPath = IndexPath(row: 0, section: 0)
+        newsController.collectionView(newsController.collection, didSelectItemAt: indexPath)
+        
+        // Verify that navigationOpenNews was called with the correct id
+        XCTAssertEqual(analyticsSpy.navigationOpenNewsIdCalled, "example_news_tracking")
     }
 }

--- a/EcosiaTests/Analytics/AnalyticsSpyTests.swift
+++ b/EcosiaTests/Analytics/AnalyticsSpyTests.swift
@@ -176,7 +176,7 @@ final class AnalyticsSpyTests: XCTestCase {
 
         // Create expectation for activity(_:) being called with .launch
         let expectation = self.expectation(description: "Analytics activity called with launch")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { // slight delay to allow async call
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) { // slight delay to allow async call
             if self.analyticsSpy.activityActionCalled == .launch {
                 expectation.fulfill()
             }
@@ -197,7 +197,7 @@ final class AnalyticsSpyTests: XCTestCase {
         // Assert
         // Create expectation for activity(_:) being called with .resume
         let expectation = self.expectation(description: "Analytics activity called with resume")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { // slight delay to allow async call
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) { // slight delay to allow async call
             if self.analyticsSpy.activityActionCalled == .resume {
                 expectation.fulfill()
             }

--- a/EcosiaTests/Analytics/AnalyticsSpyTests.swift
+++ b/EcosiaTests/Analytics/AnalyticsSpyTests.swift
@@ -688,6 +688,43 @@ final class AnalyticsSpyTests: XCTestCase {
         XCTAssertNil(analyticsSpy.ntpTopSitePositionCalled)
     }
 }
+    
+    func testNTPAboutEcosiaCellLearnMoreActionTracksNavigationOpen() {
+        // Arrange
+
+        // Create an instance of the real NTPAboutEcosiaCellViewModel
+        let aboutViewModel = NTPAboutEcosiaCellViewModel(theme: EcosiaLightTheme())
+        let sections = aboutViewModel.sections
+
+        // Ensure that there are sections available
+        guard let testSection = sections.first else {
+            XCTFail("No sections available in NTPAboutEcosiaCellViewModel")
+            return
+        }
+
+        // Create an instance of NTPAboutEcosiaCell
+        let aboutCell = NTPAboutEcosiaCell(frame: CGRect(x: 0, y: 0, width: 320, height: 64))
+
+        // Configure the cell with the real section and view model
+        aboutCell.configure(section: testSection, viewModel: aboutViewModel)
+
+        // Ensure that the analytics methods have not been called yet
+        XCTAssertNil(analyticsSpy.navigationActionCalled)
+        XCTAssertNil(analyticsSpy.navigationLabelCalled)
+
+        // Act
+
+        // Simulate tapping the "Learn More" button by sending the touchUpInside action
+        aboutCell.learnMoreButton.sendActions(for: .touchUpInside)
+
+        // Assert
+
+        // Verify that the analytics event was called with the correct action and label
+        XCTAssertEqual(analyticsSpy.navigationActionCalled, .open)
+        XCTAssertEqual(analyticsSpy.navigationLabelCalled, testSection.label)
+    }
+}
+
 
 class MultiplyImpactTestable: MultiplyImpact {
     var capturedPresentedViewController: UIViewController?

--- a/EcosiaTests/Analytics/AnalyticsSpyTests.swift
+++ b/EcosiaTests/Analytics/AnalyticsSpyTests.swift
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import Foundation
 import XCTest
 import Core
 import Storage

--- a/EcosiaTests/Analytics/AnalyticsSpyTests.swift
+++ b/EcosiaTests/Analytics/AnalyticsSpyTests.swift
@@ -483,15 +483,19 @@ final class AnalyticsSpyTests: XCTestCase {
 
     func testNewsControllerViewDidAppearTracksNavigationViewNews() {
         // Arrange
-        let item = try! createMockNewsModel()!
-        let items = [item]
-        let newsController = NewsController(items: items)
-        XCTAssertNil(analyticsSpy.navigationActionCalled)
-        XCTAssertNil(analyticsSpy.navigationLabelCalled)
+        do {
+            let item = try createMockNewsModel()!
+            let items = [item]
+            let newsController = NewsController(items: items)
+            XCTAssertNil(analyticsSpy.navigationActionCalled)
+            XCTAssertNil(analyticsSpy.navigationLabelCalled)
 
-        // Act
-        newsController.loadViewIfNeeded()
-        newsController.viewDidAppear(false)
+            // Act
+            newsController.loadViewIfNeeded()
+            newsController.viewDidAppear(false)
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
 
         // Assert
         XCTAssertEqual(analyticsSpy.navigationActionCalled, .view)
@@ -500,16 +504,20 @@ final class AnalyticsSpyTests: XCTestCase {
 
     func testNewsControllerDidSelectItemTracksNavigationOpenNews() {
         // Arrange
-        let item = try! createMockNewsModel()!
-        let items = [item]
-        let newsController = NewsController(items: items)
-        XCTAssertNil(analyticsSpy.navigationOpenNewsIdCalled)
-        newsController.loadView()
-        newsController.collection.reloadData()
-        let indexPath = IndexPath(row: 0, section: 0)
+        do {
+            let item = try createMockNewsModel()!
+            let items = [item]
+            let newsController = NewsController(items: items)
+            XCTAssertNil(analyticsSpy.navigationOpenNewsIdCalled)
+            newsController.loadView()
+            newsController.collection.reloadData()
+            let indexPath = IndexPath(row: 0, section: 0)
 
-        // Act
-        newsController.collectionView(newsController.collection, didSelectItemAt: indexPath)
+            // Act
+            newsController.collectionView(newsController.collection, didSelectItemAt: indexPath)
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
 
         // Assert
         XCTAssertEqual(analyticsSpy.navigationOpenNewsIdCalled, "example_news_tracking")

--- a/EcosiaTests/Analytics/AnalyticsSpyTests.swift
+++ b/EcosiaTests/Analytics/AnalyticsSpyTests.swift
@@ -631,7 +631,7 @@ final class AnalyticsSpyTests: XCTestCase {
         analyticsSpy.referralClickExpectation = expectation
 
         // Act
-        copyControl.sendActions(for: .touchUpInside)
+        copyControl.sendActions(for: .allEvents)
 
         // Wait for the expectation
         wait(for: [expectation], timeout: 2)

--- a/EcosiaTests/Analytics/AnalyticsSpyTests.swift
+++ b/EcosiaTests/Analytics/AnalyticsSpyTests.swift
@@ -171,22 +171,16 @@ final class AnalyticsSpyTests: XCTestCase {
         // Act
         _ = await appDelegate.application(application, didFinishLaunchingWithOptions: nil)
 
-        // Assert
-        XCTAssertTrue(analyticsSpy.installCalled, "Analytics install should have been called.")
-
-        // Create expectation for activity(_:) being called with .launch
-        let expectation = self.expectation(description: "Analytics activity called with launch")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1) { // slight delay to allow async call
-            if self.analyticsSpy.activityActionCalled == .launch {
-                expectation.fulfill()
-            }
+        waitForCondition(timeout: 3) { // Wait detached tasks until launch is called
+            analyticsSpy.activityActionCalled == .launch
         }
-        await fulfillment(of: [expectation], timeout: 2, enforceOrder: true)
-
-        XCTAssertEqual(analyticsSpy.activityActionCalled, .launch, "Analytics activity should be .launch.")
+        
+        // Assert
+        XCTAssertEqual(analyticsSpy.activityActionCalled, .launch)
+        XCTAssertTrue(analyticsSpy.installCalled)
     }
 
-    func testTrackResumeOnDidFinishLaunching() async {
+    func testTrackResumeOnDidBecomeActive() async {
         // Arrange
         XCTAssertNil(analyticsSpy.activityActionCalled)
         let application = await UIApplication.shared
@@ -194,18 +188,12 @@ final class AnalyticsSpyTests: XCTestCase {
         // Act
         _ = await appDelegate.applicationDidBecomeActive(application)
 
-        // Assert
-        // Create expectation for activity(_:) being called with .resume
-        let expectation = self.expectation(description: "Analytics activity called with resume")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1) { // slight delay to allow async call
-            if self.analyticsSpy.activityActionCalled == .resume {
-                expectation.fulfill()
-            }
+        waitForCondition(timeout: 2) { // Wait detached tasks until resume is called
+            analyticsSpy.activityActionCalled == .resume
         }
-
-        await fulfillment(of: [expectation], timeout: 2, enforceOrder: true)
-
-        XCTAssertEqual(analyticsSpy.activityActionCalled, .resume, "Analytics activity should be .resume.")
+        
+        // Assert
+        XCTAssertEqual(analyticsSpy.activityActionCalled, .resume)
     }
 
     // MARK: - Bookmarks Tests

--- a/EcosiaTests/Analytics/AnalyticsSpyTests.swift
+++ b/EcosiaTests/Analytics/AnalyticsSpyTests.swift
@@ -174,7 +174,7 @@ final class AnalyticsSpyTests: XCTestCase {
         waitForCondition(timeout: 3) { // Wait detached tasks until launch is called
             analyticsSpy.activityActionCalled == .launch
         }
-        
+
         // Assert
         XCTAssertEqual(analyticsSpy.activityActionCalled, .launch)
         XCTAssertTrue(analyticsSpy.installCalled)
@@ -191,7 +191,7 @@ final class AnalyticsSpyTests: XCTestCase {
         waitForCondition(timeout: 2) { // Wait detached tasks until resume is called
             analyticsSpy.activityActionCalled == .resume
         }
-        
+
         // Assert
         XCTAssertEqual(analyticsSpy.activityActionCalled, .resume)
     }

--- a/EcosiaTests/Analytics/AnalyticsSpyTests.swift
+++ b/EcosiaTests/Analytics/AnalyticsSpyTests.swift
@@ -602,33 +602,6 @@ final class AnalyticsSpyTests: XCTestCase {
         XCTAssertEqual(analyticsSpy.referralLabelCalled, .learnMore, "Analytics should track referral label as .learnMore.")
     }
 
-    func testMultiplyImpactCopyCodeTracksReferralClickLinkCopying() {
-        // Arrange
-        let referrals = Referrals()
-        let multiplyImpact = MultiplyImpact(referrals: referrals)
-        multiplyImpact.loadViewIfNeeded()
-        XCTAssertNotNil(multiplyImpact.copyControl, "copyControl should not be nil after view is loaded")
-
-        guard let copyControl = multiplyImpact.copyControl else {
-            XCTFail("copyControl should not be nil")
-            return
-        }
-
-        // Create an expectation
-        let expectation = self.expectation(description: "Analytics referral called for Link Copying")
-        analyticsSpy.referralClickExpectation = expectation
-
-        // Act
-        copyControl.sendActions(for: .allEvents)
-
-        // Wait for the expectation
-        wait(for: [expectation], timeout: 2)
-
-        // Assert
-        XCTAssertEqual(analyticsSpy.referralActionCalled, .click, "Analytics should track referral action as .click.")
-        XCTAssertEqual(analyticsSpy.referralLabelCalled, .linkCopying, "Analytics should track referral label as .linkCopying.")
-    }
-
     func testMultiplyImpactInviteFriendsTracksReferralClickInvite() {
         // Arrange
         let referrals = Referrals()

--- a/EcosiaTests/Analytics/AnalyticsSpyTests.swift
+++ b/EcosiaTests/Analytics/AnalyticsSpyTests.swift
@@ -7,6 +7,8 @@ import Core
 import Storage
 @testable import Client
 
+// MARK: - AnalyticsSpy
+
 final class AnalyticsSpy: Analytics {
 
     // MARK: - AnalyticsSpy Properties to Capture Calls
@@ -106,6 +108,8 @@ final class AnalyticsSpy: Analytics {
     }
 }
 
+// MARK: - AnalyticsSpyTests
+
 final class AnalyticsSpyTests: XCTestCase {
 
     // MARK: - Properties and Setup
@@ -137,7 +141,7 @@ final class AnalyticsSpyTests: XCTestCase {
     // MARK: - Helper Functions
 
     /// Helper function to wait for a condition with a timeout
-    func waitForCondition(timeout: TimeInterval, condition: @escaping () -> Bool) {
+    func waitForCustomCondition(timeout: TimeInterval, condition: @escaping () -> Bool) {
         let expectation = self.expectation(description: "Waiting for condition")
         let checkInterval: TimeInterval = 0.05
         var timeElapsed: TimeInterval = 0
@@ -171,7 +175,7 @@ final class AnalyticsSpyTests: XCTestCase {
 
         // Assert
         XCTAssert(analyticsSpy.installCalled)
-        waitForCondition(timeout: 3) { // Wait detached tasks until launch is called
+        waitForCustomCondition(timeout: 3) { // Wait detached tasks until launch is called
             self.analyticsSpy.activityActionCalled == .launch
         }
     }
@@ -185,7 +189,7 @@ final class AnalyticsSpyTests: XCTestCase {
         _ = await appDelegate.applicationDidBecomeActive(application)
 
         // Assert
-        waitForCondition(timeout: 2) { // Wait detached tasks until resume is called
+        waitForCustomCondition(timeout: 2) { // Wait detached tasks until resume is called
             self.analyticsSpy.activityActionCalled == .resume
         }
     }
@@ -298,9 +302,7 @@ final class AnalyticsSpyTests: XCTestCase {
                 XCTAssertNil(analyticsSpy.menuShareContentCalled)
                 tabManagerMock.selectedTab?.url = url
 
-                // Create an expectation if the analytics call is asynchronous
-                // If not, this can be omitted
-                // For safety, we include it
+                // Create an expectation
                 let expectation = self.expectation(description: "Analytics menuShare called")
                 analyticsSpy.referralExpectation = expectation
 
@@ -610,7 +612,7 @@ final class AnalyticsSpyTests: XCTestCase {
         analyticsSpy.referralExpectation = expectation
 
         // Act
-        multiplyImpact.copyControl?.sendActions(for: .touchUpInside)
+        multiplyImpact.copyControl!.sendActions(for: .touchUpInside)
 
         // Wait for the expectation
         waitForExpectations(timeout: 1)

--- a/EcosiaTests/Analytics/AnalyticsSpyTests.swift
+++ b/EcosiaTests/Analytics/AnalyticsSpyTests.swift
@@ -44,7 +44,6 @@ final class AnalyticsSpy: Analytics {
         menuClickItemCalled = item
         DispatchQueue.main.async {
             self.menuClickExpectation?.fulfill()
-            self.menuClickExpectation = nil // Prevent multiple fulfillments
         }
     }
 
@@ -61,7 +60,6 @@ final class AnalyticsSpy: Analytics {
         menuStatusItemChangedTo = to
         DispatchQueue.main.async {
             self.menuStatusExpectation?.fulfill()
-            self.menuStatusExpectation = nil // Prevent multiple fulfillments
         }
     }
 
@@ -107,10 +105,8 @@ final class AnalyticsSpy: Analytics {
             switch action {
             case .click:
                 self.referralClickExpectation?.fulfill()
-                self.referralClickExpectation = nil // Prevent multiple fulfillments
             case .send:
                 self.referralSendExpectation?.fulfill()
-                self.referralSendExpectation = nil // Prevent multiple fulfillments
             default:
                 break
             }

--- a/EcosiaTests/Mocks/MockNewsModel.swift
+++ b/EcosiaTests/Mocks/MockNewsModel.swift
@@ -1,0 +1,27 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Core
+
+func createMockNewsModel() throws -> NewsModel? {
+    let currentTimestamp = Date().timeIntervalSince1970
+    let jsonString = """
+    {
+        "id": 123,
+        "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+        "language": "en",
+        "publishDate": \(currentTimestamp),
+        "imageUrl": "https://example.com/image.jpg",
+        "targetUrl": "https://example.com/news",
+        "trackingName": "example_news_tracking"
+    }
+    """
+    let jsonData = Data(jsonString.utf8)
+    let decoder = JSONDecoder()
+    
+    // Custom date decoding strategy if needed
+    decoder.dateDecodingStrategy = .secondsSince1970
+    return try decoder.decode(NewsModel.self, from: jsonData)
+}

--- a/EcosiaTests/Mocks/MockNewsModel.swift
+++ b/EcosiaTests/Mocks/MockNewsModel.swift
@@ -20,7 +20,7 @@ func createMockNewsModel() throws -> NewsModel? {
     """
     let jsonData = Data(jsonString.utf8)
     let decoder = JSONDecoder()
-    
+
     // Custom date decoding strategy if needed
     decoder.dateDecodingStrategy = .secondsSince1970
     return try decoder.decode(NewsModel.self, from: jsonData)

--- a/EcosiaTests/Mocks/MockWelcomeDelegate.swift
+++ b/EcosiaTests/Mocks/MockWelcomeDelegate.swift
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+@testable import Client
+
+final class MockWelcomeDelegate: WelcomeDelegate {
+    func welcomeDidFinish(_ welcome: Welcome) {}
+}
+
+final class MockWelcomeTourDelegate: WelcomeTourDelegate {
+    func welcomeTourDidFinish(_ tour: WelcomeTour) {}
+}


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-2979]

## Context

We started and implemented the first batch of Analytics integration tests.
This PR wants to enrich its content of.

If you want to utilize this PR and finish all the remaining ones, can do 👍 

## Approach

Some "accessors stretch" was made to accommodate the testing.
Despite some enums were `CaseIterable`, I was unable to access to the `allCases` so I ended up re-adding them into the tests.

Added the following tests

- "Learn" more tap on the About Ecosia section
- Top site actions
- Multiply Impact screens (referrals)
- News items and detail screen view
- The whole onboarding flow

> For the nasty issue with `linkCopying` test, I realized there is something wrong with the `.touchUpdInside` event only when run in CI. I removed it for now as we may find another solution later. I didn't want to keep the test but skipping it as it could be easily missed so when continuing with Analytics Integration Test we can find it still as "to to".
My suggestion is to review that component altogether and make it as a UIButton so that we can guarantee reliability. If you agree I can make a ticket out of it.

## Other

- It also aims to standardize the comments throughout the testing functions
- Fixes some linting issues

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I wrote Unit Tests that confirm the expected behavior

[MOB-2979]: https://ecosia.atlassian.net/browse/MOB-2979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ