### PR TITLE
[MOB-3051] Adds the User's State context

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -21493,7 +21493,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ecosia/ios-core.git";
 			requirement = {
-				branch = main;
+				branch = "dc-mob-3051-user-state-analytics-tracking";
 				kind = branch;
 			};
 		};

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -375,6 +375,8 @@
 		2C872A622B8CD7E000B318A0 /* VersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE294702B7FC5A6006C22B2 /* VersionTests.swift */; };
 		2C872A632B8CD7E000B318A0 /* WhatsNewLocalDataProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE2946B2B7FC5A5006C22B2 /* WhatsNewLocalDataProviderTests.swift */; };
 		2C872A642B8CD7E000B318A0 /* EcosiaHomeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C872A562B8CD65100B318A0 /* EcosiaHomeViewModelTests.swift */; };
+		2C9258D92CEF97B100C6BB8D /* MockUNNotificationSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9258D82CEF97B100C6BB8D /* MockUNNotificationSettings.swift */; };
+		2C9258DB2CEFB26500C6BB8D /* AnalyticsNotificationSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9258DA2CEFB26500C6BB8D /* AnalyticsNotificationSettings.swift */; };
 		2C9A62C02CDE1F7600CDA7D1 /* MockWelcomeDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9A62BF2CDE1F7600CDA7D1 /* MockWelcomeDelegate.swift */; };
 		2C9A62C22CDE4A3B00CDA7D1 /* MockNewsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9A62C12CDE4A3B00CDA7D1 /* MockNewsModel.swift */; };
 		2CA995282CA2C06A001064CC /* NTPConfigurableNudgeCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA995272CA2C06A001064CC /* NTPConfigurableNudgeCardCell.swift */; };
@@ -2523,6 +2525,8 @@
 		2C872A562B8CD65100B318A0 /* EcosiaHomeViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EcosiaHomeViewModelTests.swift; sourceTree = "<group>"; };
 		2C8C07761E7800EA00DC1237 /* FindInPageTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FindInPageTests.swift; sourceTree = "<group>"; };
 		2C9144B0B15218D8A0FCD538 /* es-AR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-AR"; path = "es-AR.lproj/ClearPrivateData.strings"; sourceTree = "<group>"; };
+		2C9258D82CEF97B100C6BB8D /* MockUNNotificationSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockUNNotificationSettings.swift; sourceTree = "<group>"; };
+		2C9258DA2CEFB26500C6BB8D /* AnalyticsNotificationSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsNotificationSettings.swift; sourceTree = "<group>"; };
 		2C97EC701E72C80E0092EC18 /* TopTabsTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopTabsTest.swift; sourceTree = "<group>"; };
 		2C9A62BF2CDE1F7600CDA7D1 /* MockWelcomeDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWelcomeDelegate.swift; sourceTree = "<group>"; };
 		2C9A62C12CDE4A3B00CDA7D1 /* MockNewsModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNewsModel.swift; sourceTree = "<group>"; };
@@ -8846,6 +8850,7 @@
 				2C61892E2B7A8A22006B70D7 /* Analytics.swift */,
 				2C61892F2B7A8A22006B70D7 /* Analytics+Configuration.swift */,
 				2C6189302B7A8A22006B70D7 /* Analytics.Values.swift */,
+				2C9258DA2CEFB26500C6BB8D /* AnalyticsNotificationSettings.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -8906,6 +8911,7 @@
 				2C872A532B8CD47600B318A0 /* MockAppVersionInfoProvider.swift */,
 				2C9A62BF2CDE1F7600CDA7D1 /* MockWelcomeDelegate.swift */,
 				2C9A62C12CDE4A3B00CDA7D1 /* MockNewsModel.swift */,
+				2C9258D82CEF97B100C6BB8D /* MockUNNotificationSettings.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -14103,6 +14109,7 @@
 				C81A8F2526D3ED1900EBA539 /* UIWindow+Extension.swift in Sources */,
 				EBC4869E2195F58300CDA48D /* AboutHomeHandler.swift in Sources */,
 				DDA24A431FD84D630098F159 /* DefaultSearchPrefs.swift in Sources */,
+				2C9258DB2CEFB26500C6BB8D /* AnalyticsNotificationSettings.swift in Sources */,
 				E65075611E37F77D006961AC /* MenuHelper.swift in Sources */,
 				8A7A26E529D4C0A800EA76F1 /* IntroScreenManager.swift in Sources */,
 				8AB8574827D97CD40075C173 /* HomePanelType.swift in Sources */,
@@ -14713,6 +14720,7 @@
 				A83E5B1D1C1DA8D80026D912 /* UIPasteboardExtensionsTests.swift in Sources */,
 				5AB4237C28A1947A003BC40C /* MockNotificationCenter.swift in Sources */,
 				8A37C79F28DA4BA600B1FAD4 /* ContextualHintViewProviderTests.swift in Sources */,
+				2C9258D92CEF97B100C6BB8D /* MockUNNotificationSettings.swift in Sources */,
 				5A81C5DD2A4C981A00BE88C2 /* PasswordManagerCoordinatorTests.swift in Sources */,
 				8A355E5E27D267A400B9AF34 /* RecentItemsHelperTests.swift in Sources */,
 				C8699153289177FB007ACC5C /* WallpaperDataServiceTests.swift in Sources */,

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -60,7 +60,7 @@
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
         "branch" : "dc-mob-3051-user-state-analytics-tracking",
-        "revision" : "a4016e8da1b1d4241be20319d70075b05675776e"
+        "revision" : "816b04263f8e4fdf0c305512ee2292e523b24b44"
       }
     },
     {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "55fd76f4646b925b39168a1158396f36c6fd6f6f"
+        "branch" : "dc-mob-3051-user-state-analytics-tracking",
+        "revision" : "a4016e8da1b1d4241be20319d70075b05675776e"
       }
     },
     {

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -189,12 +189,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
          */
         Task {
             await FeatureManagement.fetchConfiguration()
-            // Ecosia: Lifecycle tracking. Needs to happen after Unleash start so that the flags are correctly added to the analytics context.
-            Analytics.shared.activity(.launch)
-            // Ecosia: Engagement Service Initialization helper
+            // Ecosia: Braze Service Initialization helper
             await BrazeService.shared.initialize()
             // Ecosia: Experiment that directly asks for consent
             await APNConsentOnLaunchExperiment.requestAPNConsentIfNeeded()
+            // Ecosia: Lifecycle tracking. Needs to happen after Unleash start so that the flags are correctly added to the analytics context.
+            Analytics.shared.activity(.launch)
         }
 
         // Ecosia: fetching statistics before they are used

--- a/Client/Ecosia/Analytics/Analytics.swift
+++ b/Client/Ecosia/Analytics/Analytics.swift
@@ -10,6 +10,7 @@ open class Analytics {
     static let installSchema = "iglu:org.ecosia/ios_install_event/jsonschema/1-0-0"
     private static let abTestSchema = "iglu:org.ecosia/abtest_context/jsonschema/1-0-1"
     private static let consentSchema = "iglu:org.ecosia/eccc_context/jsonschema/1-0-2"
+    private static let userSchema = "iglu:org.ecosia/app_user_state_context/jsonschema/1-0-3"
     private static let abTestRoot = "ab_tests"
     private static let namespace = "ios_sp"
 
@@ -288,6 +289,7 @@ extension Analytics {
             // Add `onboardingRemove` - used for `OnboardingRemoveExperiment` AB Test
             addABTestContexts(to: event, toggles: [.brazeIntegration, .onboardingRemove])
             addCookieConsentContext(to: event)
+            addUserStateContext(to: event)
         }
     }
 
@@ -304,6 +306,16 @@ extension Analytics {
             let consentContext = SelfDescribingJson(schema: Self.consentSchema,
                                                     andDictionary: ["cookie_consent": consentValue])
             event.entities.append(consentContext)
+        }
+    }
+
+    private func addUserStateContext(to event: Structured) {
+        let notificationCenter = UNUserNotificationCenter.current()
+        notificationCenter.getNotificationSettings { settings in
+            User.shared.updatePushNotificationUserStateWithAnalytics(from: settings.authorizationStatus)
+            let userContext = SelfDescribingJson(schema: Self.userSchema,
+                                                 andDictionary: User.shared.analyticsUserState.dictionary)
+            event.entities.append(userContext)
         }
     }
 }

--- a/Client/Ecosia/Analytics/AnalyticsNotificationSettings.swift
+++ b/Client/Ecosia/Analytics/AnalyticsNotificationSettings.swift
@@ -1,0 +1,53 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UserNotifications
+
+/// A protocol that abstracts the `UNUserNotificationCenter` to allow for dependency injection and mocking.
+/// Utilized for integration tests. Specifically `AnalyticsSpyTests`
+///
+/// By conforming to this protocol, you can replace the notification center with a mock implementation during testing.
+protocol AnalyticsUserNotificationCenterProtocol {
+    /// Retrieves the notification settings asynchronously.
+    ///
+    /// - Parameter completionHandler: A closure that is executed with the retrieved `AnalyticsUNNotificationSettingsProtocol` object.
+    func getNotificationSettingsProtocol(completionHandler: @escaping (AnalyticsUNNotificationSettingsProtocol) -> Void)
+}
+
+/// A protocol that abstracts `UNNotificationSettings`, focusing on the authorization status.
+///
+/// This protocol allows for mocking the notification settings during testing by providing a custom implementation.
+protocol AnalyticsUNNotificationSettingsProtocol {
+    /// The authorization status that indicates whether the app is authorized to schedule or receive notifications.
+    var authorizationStatus: UNAuthorizationStatus { get }
+}
+
+/// Extends `UNNotificationSettings` to conform to `AnalyticsUNNotificationSettingsProtocol`.
+///
+/// This allows `UNNotificationSettings` instances to be used wherever `AnalyticsUNNotificationSettingsProtocol` is expected.
+extension UNNotificationSettings: AnalyticsUNNotificationSettingsProtocol {}
+
+/// A wrapper class for `UNUserNotificationCenter` that conforms to `AnalyticsUserNotificationCenterProtocol`.
+///
+/// This class provides a concrete implementation of the protocol by forwarding calls to an instance of `UNUserNotificationCenter`.
+class AnalyticsUserNotificationCenterWrapper: AnalyticsUserNotificationCenterProtocol {
+    /// The underlying `UNUserNotificationCenter` instance.
+    private let center: UNUserNotificationCenter
+
+    /// Initializes the wrapper with a specific `UNUserNotificationCenter` instance.
+    ///
+    /// - Parameter center: The `UNUserNotificationCenter` instance to wrap. Defaults to the current notification center.
+    init(center: UNUserNotificationCenter = .current()) {
+        self.center = center
+    }
+
+    /// Retrieves the notification settings asynchronously.
+    ///
+    /// - Parameter completionHandler: A closure that is executed with the retrieved `AnalyticsUNNotificationSettingsProtocol` object.
+    func getNotificationSettingsProtocol(completionHandler: @escaping (AnalyticsUNNotificationSettingsProtocol) -> Void) {
+        center.getNotificationSettings { settings in
+            completionHandler(settings)
+        }
+    }
+}

--- a/Client/Ecosia/Braze/BrazeService.swift
+++ b/Client/Ecosia/Braze/BrazeService.swift
@@ -58,13 +58,11 @@ final class BrazeService: NSObject {
     }
 
     func refreshAPNRegistrationIfNeeded() async {
-        let notificationCenter = UNUserNotificationCenter.current()
-        let currentStatus = await notificationCenter.notificationSettings().authorizationStatus
-        switch currentStatus {
+        await retrieveUserCurrentNotificationAuthStatus()
+        switch notificationAuthorizationStatus {
         case .authorized, .ephemeral, .provisional:
             _ = try? await requestAPNConsent()
         default:
-            await retrieveUserCurrentNotificationAuthStatus() // Update status if not refreshed
             break
         }
     }

--- a/EcosiaTests/Analytics/AnalyticsSpyTests.swift
+++ b/EcosiaTests/Analytics/AnalyticsSpyTests.swift
@@ -790,7 +790,7 @@ final class AnalyticsSpyTests: XCTestCase {
     }
 
     // MARK: - Analytics Context Tests
-    
+
     func testAddUserStateContextOnResumeEvent() {
         // Arrange
         let analyticsSpy = makeAnalyticsSpyContextSUT(status: .ephemeral)
@@ -811,7 +811,7 @@ final class AnalyticsSpyTests: XCTestCase {
             XCTAssertEqual(userContext.data["push_notification_state"] as? String, "enabled")
         }
     }
-    
+
     func testAddUserStateContextOnLaunchEvent() {
         // Arrange
         let analyticsSpy = makeAnalyticsSpyContextSUT(status: .denied)
@@ -836,7 +836,7 @@ final class AnalyticsSpyTests: XCTestCase {
 
 // MARK: - Helper SUTs
 extension AnalyticsSpyTests {
-    
+
     func makeAnalyticsSpyContextSUT(status: UNAuthorizationStatus = .notDetermined) -> AnalyticsSpy {
         let mockSettings = MockUNNotificationSettings(authorizationStatus: status)
         let mockNotificationCenter = MockAnalyticsUserNotificationCenter(mockSettings: mockSettings)

--- a/EcosiaTests/Mocks/MockUNNotificationSettings.swift
+++ b/EcosiaTests/Mocks/MockUNNotificationSettings.swift
@@ -1,0 +1,22 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+@testable import Client
+
+struct MockUNNotificationSettings: AnalyticsUNNotificationSettingsProtocol {
+    var authorizationStatus: UNAuthorizationStatus
+}
+
+class MockAnalyticsUserNotificationCenter: AnalyticsUserNotificationCenterProtocol {
+    private let mockSettings: AnalyticsUNNotificationSettingsProtocol
+
+    init(mockSettings: AnalyticsUNNotificationSettingsProtocol) {
+        self.mockSettings = mockSettings
+    }
+
+    func getNotificationSettingsProtocol(completionHandler: @escaping (AnalyticsUNNotificationSettingsProtocol) -> Void) {
+        completionHandler(mockSettings)
+    }
+}


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-3051]

## Context

We want to start sending "User's state" values via analytics.

## Approach

- Implement a protocol-oriented approach to mock the User Notification settings successfully
- Add the approach to our current Analytics
- Implement `addUserStateContext(:)` to work completely in isolation without having to wait for Braze to gather the user notification state
- Improves a Braze service function to work with `retrieveUserCurrentNotificationAuthStatus()` solely 
- Rearrange some Ecosia's startup functions to better match the intentions

## Other

🚧 temporarily pointing to custom Core's branch 🚧 

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I wrote Unit Tests that confirm the expected behaviour
- [x] I added the `// Ecosia:` helper comments where needed
- [x] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)

[MOB-3051]: https://ecosia.atlassian.net/browse/MOB-3051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ