### PR TITLE
[MOB-3077] Add `en-AU` release notes

### DIFF
--- a/.tx/release_notes_integration_config.yml
+++ b/.tx/release_notes_integration_config.yml
@@ -7,6 +7,7 @@ settings:
     de: de-DE
     es: es-ES
     es_MX: es-MX
+    en_AU: en-AU
 
 filters:
 

--- a/fastlane/metadata/en-AU/release_notes.txt
+++ b/fastlane/metadata/en-AU/release_notes.txt
@@ -1,0 +1,1 @@
+We fixed some bugs and added some stability improvements.


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-3077]

## Context

We are adding a new language to the AppStore metadata, mainly for Marketing reasons.

## Approach

Add the `en-AU` with the appropriate mapping. 

## Other

Take the occasion to rename the `yml` file, as wronly added with the `:`.

[MOB-3077]: https://ecosia.atlassian.net/browse/MOB-3077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ