### PR TITLE
[MOB-3050] Implement APN Consent Feature, under its temporary flag.

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -21497,7 +21497,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ecosia/ios-core.git";
 			requirement = {
-				branch = main;
+				branch = "dc-mob-3050-display-push-consent-experiment";
 				kind = branch;
 			};
 		};

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		126509872CD925B40011BA36 /* BrazeUI in Frameworks */ = {isa = PBXBuildFile; productRef = 126509862CD925B40011BA36 /* BrazeUI */; };
 		1265098A2CDA32790011BA36 /* BrazeServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 126509882CDA31890011BA36 /* BrazeServiceTests.swift */; };
 		1285E2B52CC293CA0053506B /* AnalyticsSpyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1285E2B42CC293CA0053506B /* AnalyticsSpyTests.swift */; };
+		1285E2B72CC68BF00053506B /* APNConsent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1285E2B62CC68BF00053506B /* APNConsent.swift */; };
 		158241282820698B00956B39 /* RustRemoteTabsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 158241272820698B00956B39 /* RustRemoteTabsTests.swift */; };
 		15DE98FD27FCED4F00F1ECDB /* RustRemoteTabs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15DE98FC27FCED4F00F1ECDB /* RustRemoteTabs.swift */; };
 		1B3D99F1270E89D0006E1264 /* Telemetry in Frameworks */ = {isa = PBXBuildFile; productRef = 1B3D99F0270E89D0006E1264 /* Telemetry */; };
@@ -2029,6 +2030,7 @@
 		126A40A4A5AFDFD655B0FDF4 /* ca */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ca; path = ca.lproj/ClearHistoryConfirm.strings; sourceTree = "<group>"; };
 		126F44CCB14373DC7813DE1F /* hr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hr; path = hr.lproj/ClearPrivateDataConfirm.strings; sourceTree = "<group>"; };
 		1285E2B42CC293CA0053506B /* AnalyticsSpyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsSpyTests.swift; sourceTree = "<group>"; };
+		1285E2B62CC68BF00053506B /* APNConsent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APNConsent.swift; sourceTree = "<group>"; };
 		12EA4881BFBE296298150D4A /* bn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bn; path = bn.lproj/LoginManager.strings; sourceTree = "<group>"; };
 		12F949169C30744CCC749588 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/HistoryPanel.strings; sourceTree = "<group>"; };
 		1323403C8071FC19BB79C191 /* su */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = su; path = su.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -7974,6 +7976,7 @@
 		126509802CD9249C0011BA36 /* Braze */ = {
 			isa = PBXGroup;
 			children = (
+				1285E2B62CC68BF00053506B /* APNConsent.swift */,
 				126509812CD924C00011BA36 /* BrazeService.swift */,
 			);
 			path = Braze;
@@ -13901,6 +13904,7 @@
 				8A2783F1275FFDC50080D29D /* KeyboardPressesHandler.swift in Sources */,
 				E650755C1E37F747006961AC /* Swizzling.m in Sources */,
 				74821FC51DB56A2500EEEA72 /* OpenWithSettingsViewController.swift in Sources */,
+				1285E2B72CC68BF00053506B /* APNConsent.swift in Sources */,
 				C84656012887A0F700861B4A /* WallpaperMetadataUtility.swift in Sources */,
 				E1B04A9D28E20A8300670E54 /* InstructionsView.swift in Sources */,
 				D3B6923D1B9F9444004B87A4 /* FindInPageBar.swift in Sources */,

--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -21497,7 +21497,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ecosia/ios-core.git";
 			requirement = {
-				branch = "dc-mob-3050-display-push-consent-experiment";
+				branch = main;
 				kind = branch;
 			};
 		};

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
-        "branch" : "dc-mob-3050-display-push-consent-experiment",
-        "revision" : "009e184b4ea98704a70cba69554c364a7a496ae9"
+        "branch" : "main",
+        "revision" : "def9d182ab7c7fd65b092ab5d8044811ac1a3826"
       }
     },
     {

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ecosia/ios-core.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "d7dc6360e05f7da8ba5c703a68ef9e9c33381624"
+        "branch" : "dc-mob-3050-display-push-consent-experiment",
+        "revision" : "009e184b4ea98704a70cba69554c364a7a496ae9"
       }
     },
     {

--- a/Client/Application/AppDelegate.swift
+++ b/Client/Application/AppDelegate.swift
@@ -191,6 +191,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             await FeatureManagement.fetchConfiguration()
             // Ecosia: Braze Service Initialization helper
             await BrazeService.shared.initialize()
+            // Ecosia: Directly ask for consent
+            await APNConsent.requestIfNeeded()
             // Ecosia: Lifecycle tracking. Needs to happen after Unleash start so that the flags are correctly added to the analytics context.
             Analytics.shared.activity(.launch)
         }

--- a/Client/Ecosia/Analytics/Analytics.Values.swift
+++ b/Client/Ecosia/Analytics/Analytics.Values.swift
@@ -217,7 +217,7 @@ extension Analytics {
         enum APNConsent: String {
             case
             home,
-            onLaunchRollout = "on_launch_rollout"
+            onLaunchPrompt = "on_launch_prompt"
         }
 
         enum Bookmarks: String {

--- a/Client/Ecosia/Analytics/Analytics.Values.swift
+++ b/Client/Ecosia/Analytics/Analytics.Values.swift
@@ -217,7 +217,7 @@ extension Analytics {
         enum APNConsent: String {
             case
             home,
-            onLaunchExperiment = "on_launch_experiment"
+            onLaunchRollout = "on_launch_rollout"
         }
 
         enum Bookmarks: String {

--- a/Client/Ecosia/Analytics/Analytics.swift
+++ b/Client/Ecosia/Analytics/Analytics.swift
@@ -254,7 +254,7 @@ open class Analytics {
     func apnConsent(_ action: Action.APNConsent) {
         let event = Structured(category: Category.pushNotificationConsent.rawValue,
                                action: action.rawValue)
-            .property(Property.APNConsent.onLaunchRollout.rawValue)
+            .property(Property.APNConsent.onLaunchPrompt.rawValue)
         track(event)
     }
 

--- a/Client/Ecosia/Analytics/Analytics.swift
+++ b/Client/Ecosia/Analytics/Analytics.swift
@@ -250,6 +250,14 @@ open class Analytics {
         track(event)
     }
 
+    // MARK: Push Notifications Consent
+    func apnConsent(_ action: Action.APNConsent) {
+        let event = Structured(category: Category.pushNotificationConsent.rawValue,
+                               action: action.rawValue)
+            .property(Property.APNConsent.onLaunchRollout.rawValue)
+        track(event)
+    }
+
     // MARK: Referrals
     func referral(action: Action.Referral, label: Label.Referral? = nil) {
         track(Structured(category: Category.invitations.rawValue,

--- a/Client/Ecosia/Braze/APNConsent.swift
+++ b/Client/Ecosia/Braze/APNConsent.swift
@@ -9,7 +9,7 @@ struct APNConsent {
     private init() {}
 
     private static var toggleName: Unleash.Toggle.Name {
-        .apnConsentOnLaunch
+        .apnConsent
     }
 
     private static var isEnabled: Bool {

--- a/Client/Ecosia/Braze/APNConsent.swift
+++ b/Client/Ecosia/Braze/APNConsent.swift
@@ -1,0 +1,32 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Core
+
+struct APNConsent {
+    private init() {}
+
+    private static var toggleName: Unleash.Toggle.Name {
+        .apnConsentOnLaunch
+    }
+
+    private static var isEnabled: Bool {
+        // Depends on Braze Integration being enabled - we should make sure targets on Unleash match
+        Unleash.isEnabled(toggleName) && BrazeIntegrationExperiment.isEnabled
+    }
+
+    static func requestIfNeeded() async {
+        guard isEnabled, BrazeService.shared.notificationAuthorizationStatus == .notDetermined else {
+            return
+        }
+        Analytics.shared.apnConsent(.view)
+        do {
+            let granted = try await BrazeService.shared.requestAPNConsent()
+            Analytics.shared.apnConsent(granted ? .allow : .deny)
+        } catch {
+            Analytics.shared.apnConsent(.error)
+        }
+    }
+}

--- a/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
+++ b/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
@@ -150,6 +150,7 @@ extension AppSettingsTableViewController {
             AnalyticsIdentifierSetting(settings: self),
             FasterInactiveTabs(settings: self, settingsDelegate: self),
             UnleashBrazeIntegrationSetting(settings: self),
+            UnleashAPNConsentOnLaunchSetting(settings: self),
             UnleashSeedCounterNTPSetting(settings: self),
             UnleashNewsletterCardSetting(settings: self)
         ]

--- a/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
+++ b/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
@@ -150,7 +150,7 @@ extension AppSettingsTableViewController {
             AnalyticsIdentifierSetting(settings: self),
             FasterInactiveTabs(settings: self, settingsDelegate: self),
             UnleashBrazeIntegrationSetting(settings: self),
-            UnleashAPNConsentOnLaunchSetting(settings: self),
+            UnleashAPNConsent(settings: self),
             UnleashSeedCounterNTPSetting(settings: self),
             UnleashNewsletterCardSetting(settings: self)
         ]

--- a/Client/Ecosia/Settings/EcosiaDebugSettings.swift
+++ b/Client/Ecosia/Settings/EcosiaDebugSettings.swift
@@ -208,6 +208,16 @@ final class UnleashBrazeIntegrationSetting: UnleashVariantResetSetting {
     }
 }
 
+final class UnleashAPNConsentOnLaunchSetting: UnleashVariantResetSetting {
+    override var titleName: String? {
+        "APN Consent On Launch"
+    }
+
+    override var variant: Unleash.Variant? {
+        Unleash.getVariant(.apnConsentOnLaunch)
+    }
+}
+
 final class AnalyticsIdentifierSetting: HiddenSetting {
     override var title: NSAttributedString? {
         return NSAttributedString(string: "Debug: Analytics Identifier", attributes: [NSAttributedString.Key.foregroundColor: UIColor.legacyTheme.tableView.rowText])

--- a/Client/Ecosia/Settings/EcosiaDebugSettings.swift
+++ b/Client/Ecosia/Settings/EcosiaDebugSettings.swift
@@ -208,13 +208,13 @@ final class UnleashBrazeIntegrationSetting: UnleashVariantResetSetting {
     }
 }
 
-final class UnleashAPNConsentOnLaunchSetting: UnleashVariantResetSetting {
+final class UnleashAPNConsent: UnleashVariantResetSetting {
     override var titleName: String? {
-        "APN Consent On Launch"
+        "APN Consent Feature Rollout"
     }
 
     override var variant: Unleash.Variant? {
-        Unleash.getVariant(.apnConsentOnLaunch)
+        Unleash.getVariant(.apnConsent)
     }
 }
 


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-3050]

## Context

Given the success of the "push notification consent on launch" A/B Test, we want to make it a proper feature.

## Approach

This PR revisits the implementation of the previous `APNConsentOnLaunchExperiment` and turns it into a proper feature. It will still be under a flag.
A `"Release"` flag. 
The Release flag on Unleash is similar to an `"Experiment"` one, but its inner purpose is different.
> A Release flag, Manages the deployment of new or incomplete features. 

Ultimate goal of this feature is to remove the flag after reaching 💯 of our userbase.

## Other

I wanted to keep the Analytics to track the allow/deny button so I reviewed its inner properties. 
If 👍 , then I will update the Analytics file with the new ones.

🚧 
Will update SPM back to main once the https://github.com/ecosia/ios-core/pull/175 is merged.
🚧 

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I added the `// Ecosia:` helper comments where needed
- [x] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)

[MOB-3050]: https://ecosia.atlassian.net/browse/MOB-3050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ