### PR TITLE
Enable AI inline code suggestions

### DIFF
--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -25,5 +25,6 @@ jobs:
           github_action_config.auto_describe: "false" 
           github_action_config.auto_improve: "true" 
           github_action_config.enable_output: "false"
-          PR_REVIEWER.INLINE_CODE_COMMENTS: "true" 
-          PR_REVIEWER.ENABLE_REVIEW_LABELS_EFFORT: "false" 
+          pr_reviewer.inline_code_comments: "true" 
+          pr_reviewer.num_code_suggestions: 5
+          pr_reviewer.enable_review_labels_effort: "false" 


### PR DESCRIPTION
From qodo (codium) docs it says for `inline_code_comments`

> If set to true, the tool will publish the code suggestions as comments on the code diff. Default is false. Note that you need to set num_code_suggestions>0 to get code suggestions

This PR sets `num_code_suggestions` to 5 to enable `inline_code_comments`