### PR TITLE
[MOB-3077] Remove redundant release notes folder

### DIFF
--- a/fastlane/metadata/en_AU/release_notes.txt
+++ b/fastlane/metadata/en_AU/release_notes.txt
@@ -1,1 +1,0 @@
-We fixed some bugs and added some stability improvements.


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-3077]

## Context

As a result of the work done here https://github.com/ecosia/ios-browser/pull/821 and a subsequent release, our CI triggered the Release Update.
The Release Notes workflow got into [an error](https://github.com/ecosia/ios-browser/actions/runs/12159996749/job/33911313714).

## Approach

I realized there was a folder wrongly named `en_AU`. I'm removing that to leave only the one added as part of https://github.com/ecosia/ios-browser/pull/821.

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing running the Release Updates flow from a local machine 

[MOB-3077]: https://ecosia.atlassian.net/browse/MOB-3077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ