### PR TITLE
[MOB-3051] Improvement on Analytics + Schema version

### DIFF
--- a/Client/Ecosia/Analytics/Analytics.swift
+++ b/Client/Ecosia/Analytics/Analytics.swift
@@ -10,7 +10,7 @@ open class Analytics {
     static let installSchema = "iglu:org.ecosia/ios_install_event/jsonschema/1-0-0"
     private static let abTestSchema = "iglu:org.ecosia/abtest_context/jsonschema/1-0-1"
     private static let consentSchema = "iglu:org.ecosia/eccc_context/jsonschema/1-0-2"
-    static let userSchema = "iglu:org.ecosia/app_user_state_context/jsonschema/1-0-3"
+    static let userSchema = "iglu:org.ecosia/app_user_state_context/jsonschema/1-0-0"
     private static let abTestRoot = "ab_tests"
     private static let namespace = "ios_sp"
 

--- a/Client/Frontend/Home/HomepageViewController.swift
+++ b/Client/Frontend/Home/HomepageViewController.swift
@@ -887,8 +887,10 @@ extension HomepageViewController: Notifiable {
 
             // Ecosia: Seed Counter Experiment
             case SeedCounterNTPExperiment.progressManagerType.levelUpNotification:
+                guard SeedCounterNTPExperiment.isEnabled else { return }
                 SeedCounterNTPExperiment.trackSeedLevellingUp()
             case UIApplication.didBecomeActiveNotification:
+                guard SeedCounterNTPExperiment.isEnabled else { return }
                 SeedCounterNTPExperiment.trackSeedCollectionIfNewDayAppOpening()
                 SeedCounterNTPExperiment.progressManagerType.collectDailySeed()
             default: break


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-3051]

## Context

Throughout the testing of MOB-3051, I realized there were a couple of unintended events being sent.
This PR prevents them from being sent.
On top of that, it also aligns the JSON schema version number for the newly added context. 

## Approach

- Add a check for the Seed Counter experiment enabled before sending those events
- Review the JSON Schema of the newly added context, starting from first revision `1-0-0`

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-3051]: https://ecosia.atlassian.net/browse/MOB-3051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ