### PR TITLE
[MOB-3160] Hide launch screen experiment

### DIFF
--- a/firefox-ios/Client/Coordinators/LaunchView/LaunchScreenViewController.swift
+++ b/firefox-ios/Client/Coordinators/LaunchView/LaunchScreenViewController.swift
@@ -17,8 +17,11 @@ class LaunchScreenViewController: UIViewController, LaunchFinishedLoadingDelegat
     private let nimbusSplashScreenFeatureLayer = NimbusSplashScreenFeatureLayer()
 
     private var shouldTriggerSplashScreenExperiment: Bool {
+        /* Ecosia: Hide experiment
         return featureFlags.isFeatureEnabled(.splashScreen, checking: .buildOnly)
         && !viewModel.getSplashScreenExperimentHasShown()
+         */
+        return false
     }
 
     init(windowUUID: WindowUUID,


### PR DESCRIPTION
[MOB-3160]

## Context

Firefox logo loading was shown - see ticket.

## Approach

Noticed this is related to an added experiment, so turned it off.

_Not sure whether we have a pattern to turn off feature flags in a more general way, but could no find anything._

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I added the `// Ecosia:` helper comments where needed

[MOB-3160]: https://ecosia.atlassian.net/browse/MOB-3160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ