### PR TITLE
[MOB-3162] Add analytics tracking for private data clearance

### DIFF
--- a/Client/Ecosia/Analytics/Analytics.Values.swift
+++ b/Client/Ecosia/Analytics/Analytics.Values.swift
@@ -27,6 +27,7 @@ extension Analytics {
     enum Label: String {
         case
         analytics,
+        clear,
         market,
         toolbar
 
@@ -247,5 +248,12 @@ extension Analytics {
             mostVisited = "most_visited",
             pinned
         }
+        
+        enum SettingsPrivateDataSection: String {
+            case
+            websites = "websites_data",
+            main = "all_private_data"
+        }
+
     }
 }

--- a/Client/Ecosia/Analytics/Analytics.Values.swift
+++ b/Client/Ecosia/Analytics/Analytics.Values.swift
@@ -248,12 +248,11 @@ extension Analytics {
             mostVisited = "most_visited",
             pinned
         }
-        
+
         enum SettingsPrivateDataSection: String {
             case
             websites = "websites_data",
             main = "all_private_data"
         }
-
     }
 }

--- a/Client/Ecosia/Analytics/Analytics.swift
+++ b/Client/Ecosia/Analytics/Analytics.swift
@@ -274,6 +274,13 @@ open class Analytics {
             .label(Label.analytics.rawValue)
             .property(enabled ? Property.enable.rawValue : Property.disable.rawValue))
     }
+
+    func clearsDataFromSection(_ section: Analytics.Property.SettingsPrivateDataSection) {
+        track(Structured(category: Category.settings.rawValue,
+                         action: Action.click.rawValue)
+            .label(Analytics.Label.clear.rawValue)
+            .property(section.rawValue))
+    }
 }
 
 extension Analytics {

--- a/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
+++ b/Client/Frontend/Settings/ClearPrivateDataTableViewController.swift
@@ -147,6 +147,8 @@ class ClearPrivateDataTableViewController: ThemedTableViewController {
             let view = WebsiteDataManagementViewController()
             navigationController?.pushViewController(view, animated: true)
         } else if indexPath.section == sectionButton {
+            // Ecosia: Track "Clear Private Data" button click
+            Analytics.shared.clearsDataFromSection(.main)
             let alert: UIAlertController
             if self.toggles[historyClearableIndex] && profile.hasAccount() {
                 alert = clearSyncedHistoryAlert(okayCallback: clearPrivateData)

--- a/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewController.swift
+++ b/Client/Frontend/Settings/WebsiteDataManagement/WebsiteDataManagementViewController.swift
@@ -200,6 +200,8 @@ class WebsiteDataManagementViewController: UIViewController, UITableViewDataSour
             showMoreButtonEnabled = false
             tableView.reloadData()
         case .clearButton:
+            // Ecosia: Track "Clear Private Data" button click
+            Analytics.shared.clearsDataFromSection(.websites)
             let generator = UIImpactFeedbackGenerator(style: .heavy)
             generator.impactOccurred()
             let alert = viewModel.createAlertToRemove()

--- a/EcosiaTests/Analytics/AnalyticsSpyTests.swift
+++ b/EcosiaTests/Analytics/AnalyticsSpyTests.swift
@@ -122,6 +122,11 @@ final class AnalyticsSpy: Analytics {
         ntpTopSitePropertyCalled = property
         ntpTopSitePositionCalled = position
     }
+
+    var clearAllPrivateDataSectionCalled: Property.SettingsPrivateDataSection?
+    override func clearsDataFromSection(_ section: Analytics.Property.SettingsPrivateDataSection) {
+        clearAllPrivateDataSectionCalled = section
+    }
 }
 
 // MARK: - AnalyticsSpyTests
@@ -831,6 +836,32 @@ final class AnalyticsSpyTests: XCTestCase {
         if let userContext = userContext {
             XCTAssertEqual(userContext.data["push_notification_state"] as? String, "disabled")
         }
+    }
+
+    // MARK: Analytics Private Data clearance
+
+    func testClearPrivateDataTracksEvent() {
+        // Arrange
+        let vc = ClearPrivateDataTableViewController(profile: profileMock, tabManager: tabManagerMock)
+        vc.loadViewIfNeeded()
+
+        // Act
+        vc.tableView(vc.tableView, didSelectRowAt: IndexPath(row: 0, section: 2))
+
+        // Assert
+        XCTAssertEqual(analyticsSpy.clearAllPrivateDataSectionCalled, .main, "Analytics should track clearAllPrivateDataSectionCalled as .main because we are simulating the click on Clear Private Data")
+    }
+
+    func testClearWebsitesDataTracksEvent() {
+        // Arrange
+        let vc = WebsiteDataManagementViewController()
+        vc.loadViewIfNeeded()
+
+        // Act
+        vc.tableView(vc.tableView, didSelectRowAt: IndexPath(row: 0, section: 2))
+
+        // Assert
+        XCTAssertEqual(analyticsSpy.clearAllPrivateDataSectionCalled, .websites, "Analytics should track clearAllPrivateDataSectionCalled as .websites because we are simulating the click on Clear Websiste Data")
     }
 }
 


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-3162]

## Context

To quantify how many active cookie deleters we have
We want to send a structured event when the user "clears private data" or "clears all websites data".

## Approach

Add Analytics to the buttons.

## Other

I discussed with the product whether to track the alert buttons clicked upon tapping either the websites' or all private data's button. There is no need 👍 

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I wrote Unit Tests that confirm the expected behaviour
- [x] I added the `// Ecosia:` helper comments where needed
- [x] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)

[MOB-3162]: https://ecosia.atlassian.net/browse/MOB-3162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ