### PR TITLE
[MOB-3205] Fix localized Ecosia strings

### DIFF
--- a/firefox-ios/Ecosia/L10N/String.swift
+++ b/firefox-ios/Ecosia/L10N/String.swift
@@ -10,11 +10,11 @@ extension String {
     }
 
     public static func localized(_ string: String) -> String {
-        NSLocalizedString(string, tableName: "Ecosia", comment: "")
+        Bundle.ecosia.localizedString(forKey: string, value: "", table: "Ecosia")
     }
 
     public static func localizedPlural(_ key: Key, num: Int) -> String {
-        String(format: NSLocalizedString(key.rawValue, tableName: "Plurals", comment: ""), num)
+        String(format: Bundle.ecosia.localizedString(forKey: key.rawValue, value: "", table: "Plurals"), num)
     }
 
     public enum Key: String {

--- a/firefox-ios/EcosiaTests/Analytics/AnalyticsSpyTests.swift
+++ b/firefox-ios/EcosiaTests/Analytics/AnalyticsSpyTests.swift
@@ -848,7 +848,7 @@ final class AnalyticsSpyTests: XCTestCase {
 
     func testClearWebsitesDataTracksEvent() {
         // Arrange
-        let vc = WebsiteDataManagementViewController()
+        let vc = WebsiteDataManagementViewController(windowUUID: .XCTestDefaultUUID)
         vc.loadViewIfNeeded()
 
         // Act


### PR DESCRIPTION
[MOB-3205]

## Context

After introducing the Ecosia Framework, we moved the strings assets in there and broke localizations.

## Approach

Add Ecosia Bundle to localization methods.

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator

[MOB-3205]: https://ecosia.atlassian.net/browse/MOB-3205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ