### PR TITLE
[MOB-3209] Update tiles colors and shadows

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabCell.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabCell.swift
@@ -331,26 +331,22 @@ extension TabCell {
         let activeBGColor = isPrivate ?
             theme.colors.ecosia.tabSelectedPrivateBackground :
             theme.colors.ecosia.buttonBackgroundPrimary
-        headerView.backgroundColor = isSelectedTab ? activeBGColor : theme.colors.ecosia.ntpCellBackground
 
-        titleText.textColor = isSelectedTab ? theme.colors.ecosia.textInversePrimary : theme.colors.ecosia.textPrimary
-        favicon.tintColor = isSelectedTab ? theme.colors.ecosia.textInversePrimary : theme.colors.ecosia.textPrimary
-        closeButton.tintColor = isSelectedTab ? theme.colors.ecosia.textInversePrimary : theme.colors.ecosia.textPrimary
+        titleText.textColor = theme.colors.ecosia.textPrimary
+        favicon.tintColor = theme.colors.ecosia.textPrimary
+        closeButton.tintColor = theme.colors.ecosia.textPrimary
 
-        let borderWidth: CGFloat = 3
+        layer.shadowOffset = .zero
 
         if isSelectedTab {
             // This creates a border around a tabcell. Using the shadow craetes a border _outside_ of the tab frame.
             layer.masksToBounds = false
             layer.shadowOpacity = 1
             layer.shadowRadius = 0 // A 0 radius creates a solid border instead of a gradient blur
-            // create a frame that is "BorderWidth" size bigger than the cell
-            layer.shadowOffset = CGSize(width: -borderWidth, height: -borderWidth)
             layer.shadowColor = activeBGColor.cgColor
         } else if theme.type == .dark {
             layer.masksToBounds = true
             layer.shadowOpacity = 0
-            layer.shadowOffset = .zero
         } else {
             layer.masksToBounds = false
             layer.shadowOffset = .init(width: 0, height: 1)


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-3209]

## Context

In the upgraded version we see that in the tab list, the currently selected tab
- has uneven borders 
- has a dark green colored header 

## Approach

- assess current upgrade status vs production
- acknowledge the new views' layout structure
- realize FF made it simpler to deal with our outer border
- simplify current Ecosia theming
- assess results

## Other

Video with fix proof can be found as part of [this ticket's comment](https://ecosia.atlassian.net/browse/MOB-3209?focusedCommentId=100822)

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I added the `// Ecosia:` helper comments where needed
- [x] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)

[MOB-3209]: https://ecosia.atlassian.net/browse/MOB-3209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ