### PR TITLE
[MOB-2819] Removed 2nd tracking occurrance of onboarding page number

### DIFF
--- a/firefox-ios/Client/Ecosia/UI/Onboarding/Welcome.swift
+++ b/firefox-ios/Client/Ecosia/UI/Onboarding/Welcome.swift
@@ -62,7 +62,7 @@ final class Welcome: UIViewController {
         addMask()
         fadeIn()
         didAppear = true
-        Analytics.shared.introDisplaying(page: .start, at: 0)
+        Analytics.shared.introDisplaying(page: .start)
 
         MMP.sendEvent(.onboardingStart)
     }
@@ -283,11 +283,11 @@ final class Welcome: UIViewController {
         tour.modalTransitionStyle = .crossDissolve
         tour.modalPresentationStyle = .overCurrentContext
         present(tour, animated: true, completion: nil)
-        Analytics.shared.introClick(.next, page: .start, index: 0)
+        Analytics.shared.introClick(.next, page: .start)
     }
 
     @objc func skip() {
-        Analytics.shared.introClick(.skip, page: .start, index: 0)
+        Analytics.shared.introClick(.skip, page: .start)
         delegate?.welcomeDidFinish(self)
     }
 }

--- a/firefox-ios/Client/Ecosia/UI/Onboarding/WelcomeTour.swift
+++ b/firefox-ios/Client/Ecosia/UI/Onboarding/WelcomeTour.swift
@@ -344,11 +344,6 @@ final class WelcomeTour: UIViewController, Themeable {
         return index
     }
 
-    private var currentAnalyticsIndex: Int {
-        // Needed since the start screen is considered 0
-        return currentIndex + 1
-    }
-
     private func isFirstStep() -> Bool {
         return currentIndex == 0
     }

--- a/firefox-ios/Client/Ecosia/UI/Onboarding/WelcomeTour.swift
+++ b/firefox-ios/Client/Ecosia/UI/Onboarding/WelcomeTour.swift
@@ -269,7 +269,7 @@ final class WelcomeTour: UIViewController, Themeable {
             }
         }
 
-        Analytics.shared.introDisplaying(page: current?.analyticsValue, at: currentAnalyticsIndex)
+        Analytics.shared.introDisplaying(page: current?.analyticsValue)
         updateAccessibilityLabels(step: step)
     }
 
@@ -308,7 +308,7 @@ final class WelcomeTour: UIViewController, Themeable {
     @objc func back() {
         guard !isFirstStep() else {
             dismiss(animated: true) {
-                Analytics.shared.introDisplaying(page: .start, at: 0)
+                Analytics.shared.introDisplaying(page: .start)
             }
             return
         }
@@ -321,7 +321,7 @@ final class WelcomeTour: UIViewController, Themeable {
             complete()
             return
         }
-        Analytics.shared.introClick(.next, page: current?.analyticsValue, index: currentAnalyticsIndex)
+        Analytics.shared.introClick(.next, page: current?.analyticsValue)
         let displayingStep = currentIndex + 1
         display(step: steps[displayingStep])
         UIAccessibility.post(notification: .screenChanged, argument: titleLabel)
@@ -333,7 +333,7 @@ final class WelcomeTour: UIViewController, Themeable {
     }
 
     @objc func skip() {
-        Analytics.shared.introClick(.skip, page: current?.analyticsValue, index: currentAnalyticsIndex)
+        Analytics.shared.introClick(.skip, page: current?.analyticsValue)
         delegate?.welcomeTourDidFinish(self)
     }
 

--- a/firefox-ios/Ecosia/Analytics/Analytics.swift
+++ b/firefox-ios/Ecosia/Analytics/Analytics.swift
@@ -218,7 +218,7 @@ open class Analytics {
     }
 
     // MARK: Onboarding
-    public func introDisplaying(page: Property.OnboardingPage?, at index: Int) {
+    public func introDisplaying(page: Property.OnboardingPage?) {
         guard let page else {
             return
         }
@@ -228,7 +228,7 @@ open class Analytics {
         track(event)
     }
 
-    public func introClick(_ label: Label.Onboarding, page: Property.OnboardingPage?, index: Int) {
+    public func introClick(_ label: Label.Onboarding, page: Property.OnboardingPage?) {
         guard let page else {
             return
         }

--- a/firefox-ios/Ecosia/Analytics/Analytics.swift
+++ b/firefox-ios/Ecosia/Analytics/Analytics.swift
@@ -225,7 +225,6 @@ open class Analytics {
         let event = Structured(category: Category.intro.rawValue,
                                action: Action.display.rawValue)
             .property(page.rawValue)
-            .value(.init(integerLiteral: index))
         track(event)
     }
 
@@ -237,7 +236,6 @@ open class Analytics {
                                action: Action.click.rawValue)
             .label(label.rawValue)
             .property(page.rawValue)
-            .value(.init(integerLiteral: index))
         track(event)
     }
 

--- a/firefox-ios/EcosiaTests/Analytics/AnalyticsSpyTests.swift
+++ b/firefox-ios/EcosiaTests/Analytics/AnalyticsSpyTests.swift
@@ -66,19 +66,15 @@ final class AnalyticsSpy: Analytics {
     }
 
     var introDisplayingPageCalled: Property.OnboardingPage?
-    var introDisplayingIndexCalled: Int?
-    override func introDisplaying(page: Property.OnboardingPage?, at index: Int) {
+    override func introDisplaying(page: Property.OnboardingPage?) {
         introDisplayingPageCalled = page
-        introDisplayingIndexCalled = index
     }
 
     var introClickLabelCalled: Label.Onboarding?
     var introClickPageCalled: Property.OnboardingPage?
-    var introClickIndexCalled: Int?
-    override func introClick(_ label: Label.Onboarding, page: Property.OnboardingPage?, index: Int) {
+    override func introClick(_ label: Label.Onboarding, page: Property.OnboardingPage?) {
         introClickLabelCalled = label
         introClickPageCalled = page
-        introClickIndexCalled = index
     }
 
     var navigationActionCalled: Action?
@@ -379,7 +375,6 @@ final class AnalyticsSpyTests: XCTestCase {
         // Arrange
         let welcome = makeWelcome()
         XCTAssertNil(analyticsSpy.introDisplayingPageCalled)
-        XCTAssertNil(analyticsSpy.introDisplayingIndexCalled)
 
         // Act
         welcome.loadViewIfNeeded()
@@ -387,15 +382,12 @@ final class AnalyticsSpyTests: XCTestCase {
 
         // Assert
         XCTAssertEqual(analyticsSpy.introDisplayingPageCalled, .start, "Analytics should track intro displaying page as .start.")
-        XCTAssertEqual(analyticsSpy.introDisplayingIndexCalled, 0, "Analytics should track intro displaying index as 0.")
     }
 
     func testWelcomeGetStartedTracksIntroClickNext() {
         // Arrange
         let welcome = makeWelcome()
         XCTAssertNil(analyticsSpy.introClickLabelCalled)
-        XCTAssertNil(analyticsSpy.introClickPageCalled)
-        XCTAssertNil(analyticsSpy.introClickIndexCalled)
 
         // Act
         welcome.getStarted()
@@ -403,7 +395,6 @@ final class AnalyticsSpyTests: XCTestCase {
         // Assert
         XCTAssertEqual(analyticsSpy.introClickLabelCalled, .next, "Analytics should track intro click label as .next.")
         XCTAssertEqual(analyticsSpy.introClickPageCalled, .start, "Analytics should track intro click page as .start.")
-        XCTAssertEqual(analyticsSpy.introClickIndexCalled, 0, "Analytics should track intro click index as 0.")
     }
 
     func testWelcomeSkipTracksIntroClickSkip() {
@@ -411,7 +402,6 @@ final class AnalyticsSpyTests: XCTestCase {
         let welcome = makeWelcome()
         XCTAssertNil(analyticsSpy.introClickLabelCalled)
         XCTAssertNil(analyticsSpy.introClickPageCalled)
-        XCTAssertNil(analyticsSpy.introClickIndexCalled)
 
         // Act
         welcome.skip()
@@ -419,7 +409,6 @@ final class AnalyticsSpyTests: XCTestCase {
         // Assert
         XCTAssertEqual(analyticsSpy.introClickLabelCalled, .skip, "Analytics should track intro click label as .skip.")
         XCTAssertEqual(analyticsSpy.introClickPageCalled, .start, "Analytics should track intro click page as .start.")
-        XCTAssertEqual(analyticsSpy.introClickIndexCalled, 0, "Analytics should track intro click index as 0.")
     }
 
     // MARK: - Onboarding / Welcome Tour Tests
@@ -428,7 +417,6 @@ final class AnalyticsSpyTests: XCTestCase {
         // Arrange
         let welcomeTour = makeWelcomeTour()
         XCTAssertNil(analyticsSpy.introDisplayingPageCalled)
-        XCTAssertNil(analyticsSpy.introDisplayingIndexCalled)
 
         // Act
         welcomeTour.loadViewIfNeeded()
@@ -436,7 +424,6 @@ final class AnalyticsSpyTests: XCTestCase {
 
         // Assert
         XCTAssertEqual(analyticsSpy.introDisplayingPageCalled, .greenSearch, "Analytics should track intro displaying page as .greenSearch.")
-        XCTAssertEqual(analyticsSpy.introDisplayingIndexCalled, 1, "Analytics should track intro displaying index as 1.")
     }
 
     func testWelcomeTourNextTracksIntroClickNext() {
@@ -444,7 +431,6 @@ final class AnalyticsSpyTests: XCTestCase {
         let welcomeTour = makeWelcomeTour()
         XCTAssertNil(analyticsSpy.introClickLabelCalled)
         XCTAssertNil(analyticsSpy.introClickPageCalled)
-        XCTAssertNil(analyticsSpy.introClickIndexCalled)
 
         // Act
         welcomeTour.loadViewIfNeeded()
@@ -454,7 +440,6 @@ final class AnalyticsSpyTests: XCTestCase {
         // Assert
         XCTAssertEqual(analyticsSpy.introClickLabelCalled, .next, "Analytics should track intro click label as .next.")
         XCTAssertEqual(analyticsSpy.introClickPageCalled, .greenSearch, "Analytics should track intro click page as .greenSearch.")
-        XCTAssertEqual(analyticsSpy.introClickIndexCalled, 1, "Analytics should track intro click index as 1.")
     }
 
     func testWelcomeTourSkipTracksIntroClickSkip() {
@@ -462,7 +447,6 @@ final class AnalyticsSpyTests: XCTestCase {
         let welcomeTour = makeWelcomeTour()
         XCTAssertNil(analyticsSpy.introClickLabelCalled)
         XCTAssertNil(analyticsSpy.introClickPageCalled)
-        XCTAssertNil(analyticsSpy.introClickIndexCalled)
 
         // Act
         welcomeTour.loadViewIfNeeded()
@@ -472,7 +456,6 @@ final class AnalyticsSpyTests: XCTestCase {
         // Assert
         XCTAssertEqual(analyticsSpy.introClickLabelCalled, .skip, "Analytics should track intro click label as .skip.")
         XCTAssertEqual(analyticsSpy.introClickPageCalled, .greenSearch, "Analytics should track intro click page as .greenSearch.")
-        XCTAssertEqual(analyticsSpy.introClickIndexCalled, 1, "Analytics should track intro click index as 1.")
     }
 
     func testWelcomeTourTracksAnalyticsForAllPages() {
@@ -490,7 +473,6 @@ final class AnalyticsSpyTests: XCTestCase {
         for (index, page) in pages.enumerated() {
             // Reset analyticsSpy properties
             analyticsSpy.introDisplayingPageCalled = nil
-            analyticsSpy.introDisplayingIndexCalled = nil
 
             if index < pages.count - 1 {
                 // Act
@@ -499,13 +481,11 @@ final class AnalyticsSpyTests: XCTestCase {
                 // Assert
                 XCTAssertEqual(analyticsSpy.introClickLabelCalled, .next, "Analytics should track intro click label as .next.")
                 XCTAssertEqual(analyticsSpy.introClickPageCalled, page, "Analytics should track intro click page as \(page).")
-                XCTAssertEqual(analyticsSpy.introClickIndexCalled, index + 1, "Analytics should track intro click index as \(index + 1).")
             }
 
             // Reset analyticsSpy properties
             analyticsSpy.introClickLabelCalled = nil
             analyticsSpy.introClickPageCalled = nil
-            analyticsSpy.introClickIndexCalled = nil
         }
     }
 

--- a/firefox-ios/EcosiaTests/Analytics/AnalyticsSpyTests.swift
+++ b/firefox-ios/EcosiaTests/Analytics/AnalyticsSpyTests.swift
@@ -388,6 +388,7 @@ final class AnalyticsSpyTests: XCTestCase {
         // Arrange
         let welcome = makeWelcome()
         XCTAssertNil(analyticsSpy.introClickLabelCalled)
+        XCTAssertNil(analyticsSpy.introClickPageCalled)
 
         // Act
         welcome.getStarted()


### PR DESCRIPTION
https://ecosia.atlassian.net/browse/MOB-2819

My cat kinda deleted the PR Preset, but basically I removed two lines of code which seem to track the property in question.

I also ran tests and they actually failed in (and only in) `AnalyticsSpyTest.swift` but this seems to be already the case on the base banch. But before I mess something up, can you maybe look into that as well? Just to be safe :)