### PR TITLE
[MOB-3211] Bring back custom NetError as a different asset file

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -74,6 +74,8 @@
 		121416782D6373BA0097788B /* AddressFormManager.js in Resources */ = {isa = PBXBuildFile; fileRef = 121416712D6373BA0097788B /* AddressFormManager.js */; };
 		1214167B2D6375960097788B /* MainFrameAtDocumentStart.js in Resources */ = {isa = PBXBuildFile; fileRef = 1214167A2D6375960097788B /* MainFrameAtDocumentStart.js */; };
 		1214167C2D6375960097788B /* MainFrameAtDocumentEnd.js in Resources */ = {isa = PBXBuildFile; fileRef = 121416792D6375960097788B /* MainFrameAtDocumentEnd.js */; };
+		12141E6C2D6877EB0097788B /* EcosiaNetError.html in Resources */ = {isa = PBXBuildFile; fileRef = 12141E682D686C030097788B /* EcosiaNetError.html */; };
+		12141E6D2D6877F00097788B /* EcosiaNetError.css in Resources */ = {isa = PBXBuildFile; fileRef = 12141E6A2D686C1C0097788B /* EcosiaNetError.css */; };
 		124DAE822D350EFD0050104C /* String+Punycode.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6B2AC11D41F02D00429414 /* String+Punycode.swift */; };
 		124DAE8A2D3512FA0050104C /* DispatchQueueHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83821FF1FC7961D00303C12 /* DispatchQueueHelper.swift */; };
 		1251623C2D59FB30005CB958 /* Ecosia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2CFE99662D45329200B25CE0 /* Ecosia.framework */; };
@@ -2369,6 +2371,8 @@
 		121416742D6373BA0097788B /* AutofillAllFramesAtDocumentStart.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = AutofillAllFramesAtDocumentStart.js; sourceTree = "<group>"; };
 		121416792D6375960097788B /* MainFrameAtDocumentEnd.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = MainFrameAtDocumentEnd.js; sourceTree = "<group>"; };
 		1214167A2D6375960097788B /* MainFrameAtDocumentStart.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = MainFrameAtDocumentStart.js; sourceTree = "<group>"; };
+		12141E682D686C030097788B /* EcosiaNetError.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = EcosiaNetError.html; sourceTree = "<group>"; };
+		12141E6A2D686C1C0097788B /* EcosiaNetError.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = EcosiaNetError.css; sourceTree = "<group>"; };
 		123045959E0F295753B4B4DB /* lo */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lo; path = lo.lproj/Today.strings; sourceTree = "<group>"; };
 		124DAE792D2FD1330050104C /* LegacyDarkTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyDarkTheme.swift; sourceTree = "<group>"; };
 		124DAE7A2D2FD1330050104C /* RecoveredLegacyTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoveredLegacyTheme.swift; sourceTree = "<group>"; };
@@ -14601,6 +14605,8 @@
 				43879AFB287BDFB100B15D10 /* CC_Script */,
 				D308EE551CBF0BF5006843F2 /* CertError.css */,
 				D38A1EDF1CB458EC0080C842 /* CertError.html */,
+				12141E6A2D686C1C0097788B /* EcosiaNetError.css */,
+				12141E682D686C030097788B /* EcosiaNetError.html */,
 				F84B22391A0914A300AAB793 /* Fonts */,
 				D0E17FA7201F847600F1FCB5 /* FxASignIn.js */,
 				F84B21EF1A0910F600AAB793 /* Images.xcassets */,
@@ -15649,6 +15655,7 @@
 				2C4BFFCA2D470E4100707D2F /* disconnect-block-cookies-analytics.json in Resources */,
 				2C4BFFCB2D470E4100707D2F /* disconnect-block-cookies-advertising.json in Resources */,
 				2C4BFFCC2D470E4100707D2F /* disconnect-block-cookies-social.json in Resources */,
+				12141E6C2D6877EB0097788B /* EcosiaNetError.html in Resources */,
 				2C4BFFCD2D470E4100707D2F /* disconnect-block-social.json in Resources */,
 				2C4BFFCE2D470E4100707D2F /* disconnect-block-advertising.json in Resources */,
 				2C4BFFCF2D470E4100707D2F /* disconnect-block-cookies-content.json in Resources */,
@@ -15666,6 +15673,7 @@
 				E1AF3567286DE5F800960045 /* PerformanceTestPlan.xctestplan in Resources */,
 				8A1A935A2B757C7C0069C190 /* portrait.json in Resources */,
 				23BEA76A251A99ED00A014BF /* NewYorkMedium-RegularItalic.otf in Resources */,
+				12141E6D2D6877F00097788B /* EcosiaNetError.css in Resources */,
 				1214167B2D6375960097788B /* MainFrameAtDocumentStart.js in Resources */,
 				1214167C2D6375960097788B /* MainFrameAtDocumentEnd.js in Resources */,
 				7B2142FE1E5E055000CDD3FC /* InfoPlist.strings in Resources */,

--- a/firefox-ios/Client/Assets/EcosiaNetError.css
+++ b/firefox-ios/Client/Assets/EcosiaNetError.css
@@ -1,0 +1,93 @@
+/* 
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0
+*/
+
+/* Light mode */
+@media (prefers-color-scheme: light) {
+:root {
+    --body-bg: #F0F0EB;
+    --body-color: #333333;
+    --error-title-text-color: #333333;
+    --error-short-desc-color: #6C6C6C;
+    --refresh-button-color: #008009;
+}
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+:root {
+    --body-bg: #1A1A1A;
+    --body-color: #FFFFFF;
+    --error-title-text-color: #FFFFFF;
+    --error-short-desc-color: #DEDED9;
+    --refresh-button-color: #5DD25E;
+}
+}
+
+html,
+body {
+    margin: 0;
+    padding: 0;
+    height: 100%;
+}
+
+body {
+    background-color: var(--body-bg);
+    padding: 0 65px;
+    -webkit-text-size-adjust: none;
+    font-size: 17px;
+    font: -apple-system-body;
+    text-align: center;
+}
+
+.error-title {
+    color: var(--error-title-text-color);
+    font-weight: 600;
+}
+
+.error-description {
+    color: var(--error-short-desc-color);
+    font-weight: 400;
+}
+
+img {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+    width: 50%;
+}
+
+button {
+    /* Force buttons to display: block here to try and enforce collapsing margins */
+    display: block;
+    width: 100%;
+    border: none;
+    padding: 1rem;
+    font: -apple-system-body;
+    background-color: transparent;
+    font-weight: 300;
+    border-radius: 5px;
+    background-image: none;
+    margin: 10px 0 0;
+    position: -webkit-sticky;
+    bottom: 5px;
+    font-weight: 400;
+    font-size: 17px;
+    color: var(--refresh-button-color);
+}
+
+.error-container {
+    -webkit-transform: translateY(127px);
+    padding-bottom: 10px;
+    min-height: calc(100% - 127px - 10px);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.error-description-container {
+    /* Margins between the li and buttons below it won't be collapsed. Remove the bottom margin here. */
+    margin: 20px 0 0;
+}

--- a/firefox-ios/Client/Assets/EcosiaNetError.html
+++ b/firefox-ios/Client/Assets/EcosiaNetError.html
@@ -1,0 +1,43 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+  <title>%error_title%</title>
+  <meta name="viewport" content="initial-scale=1, maximum-scale=1">
+  <link rel="stylesheet" href="internal://local/errorpage-resource/EcosiaNetError.css" type="text/css" media="all" />
+  <script type="application/javascript">
+    // If the user swipes back and forth to this tab, we want to make sure we make an attempt to reload the original page.
+    var fresh = true;
+    window.addEventListener('popstate', function () {
+      if (fresh)
+        fresh = false;
+      else
+        webkit.messageHandlers.localRequestHelper.postMessage({ appIdToken: APP_ID_TOKEN, type: "reload" });
+    });
+  </script>
+</head>
+
+<body dir="&locale.dir;">
+  <div class="error-container">
+    <div>
+      <!-- Placeholder image is replaced inside `InternalSchemeHandler` -->
+      <img src="internal://local/errorpage-resource/EcosiaErrorPlaceholderPath.png" />
+    </div>
+    <div>
+      <p class="error-title">%error_title%</p>
+    </div>
+    <div>
+      <div class="error-description-container">
+        <p class="error-description">%short_description%</p>
+      </div>
+      <!-- Actions are replaced inside `ErrorPageHandler` -->
+      <div id="actions">%actions%</div>
+    </div>
+  </div>
+</div>
+</body>
+
+</html>

--- a/firefox-ios/Client/Frontend/InternalSchemeHandler/ErrorPageHelper.swift
+++ b/firefox-ios/Client/Frontend/InternalSchemeHandler/ErrorPageHelper.swift
@@ -199,13 +199,24 @@ class ErrorPageHandler: InternalSchemeResponse, FeatureFlaggable {
             "short_description": errDomain,
             ]
 
+        /* Ecosia: Update button text
         let tryAgain: String = .ErrorPageTryAgain
+         */
+        let tryAgain: String = noConnectionErrorButtonTitle
+
         // swiftlint:disable line_length
         var actions = "<script>function reloader() { location.replace((new URL(location.href)).searchParams.get(\"url\")); }" +
                     "</script><button onclick='reloader()'>\(tryAgain)</button>"
         // swiftlint:enable line_length
 
+        /* Ecosia: Add custom no internet screen
         if errDomain == kCFErrorDomainCFNetwork as String {
+         */
+        if errDomain == NSURLErrorDomain {
+            asset = Bundle.main.path(forResource: "EcosiaNetError", ofType: "html")
+            variables["error_title"] = noConnectionErrorTitle
+            variables["short_description"] = noConnectionErrorMessage
+        } else if errDomain == kCFErrorDomainCFNetwork as String {
             if let code = CFNetworkErrors(rawValue: Int32(errCode)) {
                 errDomain = cfErrorToName(code)
             }

--- a/firefox-ios/Client/Frontend/InternalSchemeHandler/InternalSchemeHandler.swift
+++ b/firefox-ios/Client/Frontend/InternalSchemeHandler/InternalSchemeHandler.swift
@@ -57,6 +57,7 @@ class InternalSchemeHandler: NSObject, WKURLSchemeHandler {
                 urlSchemeTask.didReceive(data)
                 urlSchemeTask.didFinish()
                 return true
+            // Ecosia: Replace placeholder error image
             } else if path.hasSuffix("EcosiaErrorPlaceholderPath.png"),
                       let data = UIImage(named: "noInternet")?.pngData() {
                 urlSchemeTask.didReceive(URLResponse(url: url, mimeType: nil, expectedContentLength: -1, textEncodingName: nil))

--- a/firefox-ios/Client/Frontend/InternalSchemeHandler/InternalSchemeHandler.swift
+++ b/firefox-ios/Client/Frontend/InternalSchemeHandler/InternalSchemeHandler.swift
@@ -33,6 +33,9 @@ class InternalSchemeHandler: NSObject, WKURLSchemeHandler {
         let allowedInternalResources = [
             "/errorpage-resource/NetError.css",
             "/errorpage-resource/CertError.css",
+            // Ecosia: Allow EcosiaNetError resources
+            "/errorpage-resource/EcosiaNetError.css",
+            "/errorpage-resource/EcosiaErrorPlaceholderPath.png",
            // "/reader-mode/..."
         ]
 
@@ -51,6 +54,12 @@ class InternalSchemeHandler: NSObject, WKURLSchemeHandler {
                         textEncodingName: nil
                     )
                 )
+                urlSchemeTask.didReceive(data)
+                urlSchemeTask.didFinish()
+                return true
+            } else if path.hasSuffix("EcosiaErrorPlaceholderPath.png"),
+                      let data = UIImage(named: "noInternet")?.pngData() {
+                urlSchemeTask.didReceive(URLResponse(url: url, mimeType: nil, expectedContentLength: -1, textEncodingName: nil))
                 urlSchemeTask.didReceive(data)
                 urlSchemeTask.didFinish()
                 return true


### PR DESCRIPTION
[MOB-3211]

## Context

Ever since the previous upgrade (aka already on production), we've lost our custom Ecosia no internet page.

## Approach

After understanding how Firefox handles error pages as static htmls and comparing the current version with an old one to pinpoint key differences, I was able to apply changes from https://github.com/ecosia/ios-browser/pull/424 to bring our custom page back again.

Even so, this proved how prone to errors it is to re-use the generic html form Firefox, so I moved our custom page to a separate file `EcosiaNetError` so we avoid other conflicts in the future. Also took the opportunity to refactor a bit the html and css following some Web best practices.

Here's the re-introduced error page:

![IMG_0655](https://github.com/user-attachments/assets/f252f16e-1066-41a8-b96b-75dcaf924a67)


## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I added the `// Ecosia:` helper comments where needed

[MOB-3211]: https://ecosia.atlassian.net/browse/MOB-3211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ