### PR TITLE
[MOB-3208] Bring back custom Ecosia menu icon

### DIFF
--- a/BrowserKit/Sources/Common/Constants/StandardImageIdentifiers.swift
+++ b/BrowserKit/Sources/Common/Constants/StandardImageIdentifiers.swift
@@ -39,7 +39,10 @@ public struct StandardImageIdentifiers {
     public struct Large {
         public static let addToHomescreen = "addToHomescreenLarge"
         public static let appendUpLeft = "appendUpLeftLarge"
+        /* Ecosia: Update Menu icon
         public static let appMenu = "appMenuLarge"
+         */
+        public static let appMenu = "nav-menu"
         public static let arrowClockwise = "arrowClockwiseLarge"
         public static let avatarCircle = "avatarCircleLarge"
         public static let back = "backLarge"


### PR DESCRIPTION
[MOB-3208]

## Approach

Check that the image is still there and replace it on the correct `StandardImageIdentifiers` item.

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I added the `// Ecosia:` helper comments where needed

[MOB-3208]: https://ecosia.atlassian.net/browse/MOB-3208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ