### PR TITLE
[MOB-3203] Remove NTPImpactRowView's ResizableButton edge insets

### DIFF
--- a/firefox-ios/Client/Ecosia/UI/NTP/Impact/NTPImpactRowView.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/Impact/NTPImpactRowView.swift
@@ -84,6 +84,7 @@ final class NTPImpactRowView: UIView, ThemeApplicable {
         button.titleLabel?.textAlignment = .right
         button.contentHorizontalAlignment = .right
         button.contentVerticalAlignment = .center
+        button.buttonEdgeInsets = .init(top: 0, leading: 0, bottom: 0, trailing: 0)
         button.setContentCompressionResistancePriority(.required, for: .horizontal)
         button.addTarget(self, action: #selector(buttonAction), for: .touchUpInside)
         button.clipsToBounds = true


### PR DESCRIPTION
[MOB-3203]

## Context

Climate impact cell for referrals had a broken UI (see ticket).

## Approach

Debug looking into past issues we've had with this. Also trying to find out what specifically from the upgrade would have changed this.

After some trial and error, figured out that this is related to the change Firefox did in `ResizableButton`. This new way was correctly used by us as part of [this change on an earlier PR](https://github.com/ecosia/ios-browser/pull/833/files#diff-2ab69f84e4a33ebcb1b7113c53756831dc3e2ead2f94b1a4b19e5c0bac10554f), but was [mistakenly removed by the Ecosia Framework PR](https://github.com/ecosia/ios-browser/pull/837/files#diff-2ab69f84e4a33ebcb1b7113c53756831dc3e2ead2f94b1a4b19e5c0bac10554f:~:text=firefox%2Dios/Client/Ecosia/UI/NTP/Impact/NTPImpactRowView.swift).

TLDR: We were missing correctly setting the button edge insets to 0, since `ResizableButton` now has a new way for doing it.

Here are screenshots of the fixed screen in both english and German:

![Simulator Screenshot - iPhone 16 - 2025-02-24 at 11 39 45](https://github.com/user-attachments/assets/53ba7de0-008f-469c-8532-fdf417623e76)

![Simulator Screenshot - iPhone 13 mini - 2025-02-24 at 11 52 35](https://github.com/user-attachments/assets/0e59db73-2a96-4a5c-82da-ea01b8464fde)


## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator

[MOB-3203]: https://ecosia.atlassian.net/browse/MOB-3203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ