### PR TITLE
[MOB-3212] Bookmarks icon fixes

### DIFF
--- a/BrowserKit/Sources/Common/Constants/StandardImageIdentifiers.swift
+++ b/BrowserKit/Sources/Common/Constants/StandardImageIdentifiers.swift
@@ -46,11 +46,18 @@ public struct StandardImageIdentifiers {
         public static let arrowClockwise = "arrowClockwiseLarge"
         public static let avatarCircle = "avatarCircleLarge"
         public static let back = "backLarge"
+        /* Ecosia: Update bookmark images
         public static let bookmark = "bookmarkLarge"
         public static let bookmarkFill = "bookmarkFillLarge"
         public static let bookmarkHalf = "bookmarkHalfLarge"
         public static let bookmarkSlash = "bookmarkSlashLarge"
         public static let bookmarkTrayFill = "bookmarkTrayFillLarge"
+         */
+        public static let bookmark = "bookmarksEmpty"
+        public static let bookmarkFill = "bookmarkFill"
+        public static let bookmarkHalf = "bookmarkFill"
+        public static let bookmarkSlash = "bookmarkFill"
+        public static let bookmarkTrayFill = "bookmarksEmpty"
         public static let checkmark = "checkmarkLarge"
         public static let chevronDown = "chevronDownLarge"
         public static let chevronLeft = "chevronLeftLarge"

--- a/BrowserKit/Sources/SiteImageView/FaviconImageView.swift
+++ b/BrowserKit/Sources/SiteImageView/FaviconImageView.swift
@@ -60,9 +60,14 @@ public class FaviconImageView: UIImageView, SiteImageView {
     // MARK: - SiteImageView
 
     func setURL(_ viewModel: FaviconImageViewModel) {
+        /* Ecosia: Make sure url is set even if cell is re-used with same url (was causing MOB-3212)
+         guard let siteURLString = viewModel.siteURLString,
+               let siteURL = URL(string: siteURLString, invalidCharacters: false),
+               canMakeRequest(with: siteURLString)
+         else { return }
+         */
         guard let siteURLString = viewModel.siteURLString,
-              let siteURL = URL(string: siteURLString, invalidCharacters: false),
-              canMakeRequest(with: siteURLString)
+              let siteURL = URL(string: siteURLString, invalidCharacters: false)
         else { return }
 
         // If a new request is being made on an existing image it is likely a cell or view being reused.

--- a/BrowserKit/Sources/SiteImageView/FaviconImageView.swift
+++ b/BrowserKit/Sources/SiteImageView/FaviconImageView.swift
@@ -61,10 +61,10 @@ public class FaviconImageView: UIImageView, SiteImageView {
 
     func setURL(_ viewModel: FaviconImageViewModel) {
         /* Ecosia: Make sure url is set even if cell is re-used with same url (was causing MOB-3212)
-         guard let siteURLString = viewModel.siteURLString,
-               let siteURL = URL(string: siteURLString, invalidCharacters: false),
-               canMakeRequest(with: siteURLString)
-         else { return }
+        guard let siteURLString = viewModel.siteURLString,
+              let siteURL = URL(string: siteURLString, invalidCharacters: false),
+              canMakeRequest(with: siteURLString)
+        else { return }
          */
         guard let siteURLString = viewModel.siteURLString,
               let siteURL = URL(string: siteURLString, invalidCharacters: false)


### PR DESCRIPTION
[MOB-3212]
[MOB-3250]

## Context

After the upgrade, favicons were acting strange (see ticket).

## Approach

After some debuggind, pinpointed the issue to `canMakeRequest` returning false when the cell was re-used with the same url as before... That seemed intended as per logic but is what resulted in the issue 🤷 

Couldn't understand exactly why `canMakeRequest` was there, but since I did not see downsides to removing it, went ahead with that solution.

## Other

As a bonus, noticed the bookmark icons were wrong and updated them.

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I added the `// Ecosia:` helper comments where needed

[MOB-3212]: https://ecosia.atlassian.net/browse/MOB-3212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MOB-3250]: https://ecosia.atlassian.net/browse/MOB-3250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ