### PR TITLE
[MOB-3261] Remove border color setup for non-active url bar

### DIFF
--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -1062,7 +1062,9 @@ extension URLBarView: ThemeApplicable {
         backgroundColor = theme.colors.ecosia.backgroundPrimary
         line.backgroundColor = theme.colors.ecosia.barSeparator
 
+        /* Ecosia: Remove color for non-active location border state
         locationBorderColor = theme.colors.borderPrimary
+         */
         /* Ecosia: Take into account overlay mode for `locationView` background
         locationView.backgroundColor = theme.colors.layer3
         locationContainer.backgroundColor = theme.colors.layer3


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-3261]

## Context

We noticed a grey border appearing when be far is set back into inactive.
We want always a no-border style.

## Approach

Remove the color assignment to the URL bar, leaving `.clear` as its default one.

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I added the `// Ecosia:` helper comments where needed

[MOB-3261]: https://ecosia.atlassian.net/browse/MOB-3261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ