### PR TITLE
[MOB-3166] Tabs migration cleanup

### DIFF
--- a/firefox-ios/Client/TabManagement/Legacy/LegacySavedTab.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacySavedTab.swift
@@ -5,9 +5,6 @@
 import Foundation
 import Shared
 
-// TODO Ecosia Upgrade: Do we still want the logic to restore tabs? [MOB-3166]
-// https://github.com/ecosia/ios-browser/commit/5e5ab45a1c9c61eb3c863c269292c787c6bfee7e
-
 class LegacySavedTab: Codable {
     var isSelected: Bool
     var title: String?

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabDataRetriever.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabDataRetriever.swift
@@ -15,8 +15,6 @@ struct LegacyTabDataRetrieverImplementation: LegacyTabDataRetriever {
 
     init(fileManager: LegacyTabFileManager = FileManager.default) {
         self.fileManager = fileManager
-        // Ecosia: Tabs architecture implementation from ~v112 to ~116
-        self.tabsStateArchivePath = deprecatedTabsStateArchivePath()
     }
 
     func getTabData() -> Data? {
@@ -26,16 +24,3 @@ struct LegacyTabDataRetrieverImplementation: LegacyTabDataRetriever {
         return try? Data(contentsOf: tabStateArchivePath)
     }
 }
-
-// Ecosia: Tabs architecture implementation from ~v112 to ~116
-// This is temprorary in order to fix a migration error, can be removed after our Ecosia 10.0.0 has been well adopted
-
-extension LegacyTabDataRetrieverImplementation {
-
-    private func deprecatedTabsStateArchivePath() -> URL? {
-        guard let path = fileManager.tabPath else { return nil }
-        return URL(fileURLWithPath: path).appendingPathComponent("tabsState.archive")
-    }
-}
-
-// Ecosia: End Tabs architecture implementation from ~v112 to ~116

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabGroupData.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabGroupData.swift
@@ -17,10 +17,7 @@ enum LegacyTabGroupTimerState: String, Codable {
     case none
 }
 
-// Ecosia: Tabs architecture implementation from ~v112 to ~116
-// class LegacyTabGroupData: Codable {
-class LegacyTabGroupData: NSObject, Codable, NSCoding {
-
+class LegacyTabGroupData: Codable {
     var tabAssociatedSearchTerm: String = ""
     var tabAssociatedSearchUrl: String = ""
     var tabAssociatedNextUrl: String = ""
@@ -41,9 +38,7 @@ class LegacyTabGroupData: NSObject, Codable, NSCoding {
         case tabHistoryCurrentState
     }
 
-    // Ecosia: Tabs architecture implementation from ~v112 to ~116
-    // convenience init() {
-    override convenience init() {
+    convenience init() {
         self.init(searchTerm: "",
                   searchUrl: "",
                   nextReferralUrl: "",
@@ -55,31 +50,5 @@ class LegacyTabGroupData: NSObject, Codable, NSCoding {
         self.tabAssociatedSearchUrl = searchUrl
         self.tabAssociatedNextUrl = nextReferralUrl
         self.tabHistoryCurrentState = tabHistoryCurrentState
-    }
-
-    // Ecosia: Tabs architecture implementation from ~v112 to ~116
-    // This is temprorary in order to fix a migration error, can be removed after our Ecosia 10.0.0 has been well adopted
-
-    var jsonDictionary: [String: Any] {
-        return [
-            CodingKeys.tabAssociatedSearchTerm.rawValue: String(self.tabAssociatedSearchTerm),
-            CodingKeys.tabAssociatedSearchUrl.rawValue: String(self.tabAssociatedSearchUrl),
-            CodingKeys.tabAssociatedNextUrl.rawValue: String(self.tabAssociatedNextUrl),
-            CodingKeys.tabHistoryCurrentState.rawValue: String(self.tabHistoryCurrentState),
-        ]
-    }
-
-    public required init?(coder: NSCoder) {
-        self.tabAssociatedSearchTerm = coder.decodeObject(forKey: CodingKeys.tabAssociatedSearchTerm.rawValue) as? String ?? ""
-        self.tabAssociatedSearchUrl = coder.decodeObject(forKey: CodingKeys.tabAssociatedSearchUrl.rawValue) as? String ?? ""
-        self.tabAssociatedNextUrl = coder.decodeObject(forKey: CodingKeys.tabAssociatedNextUrl.rawValue) as? String ?? ""
-        self.tabHistoryCurrentState = coder.decodeObject(forKey: CodingKeys.tabHistoryCurrentState.rawValue) as? String ?? ""
-    }
-
-    public func encode(with coder: NSCoder) {
-        coder.encode(tabAssociatedSearchTerm, forKey: CodingKeys.tabAssociatedSearchTerm.rawValue)
-        coder.encode(tabAssociatedSearchUrl, forKey: CodingKeys.tabAssociatedSearchUrl.rawValue)
-        coder.encode(tabAssociatedNextUrl, forKey: CodingKeys.tabAssociatedNextUrl.rawValue)
-        coder.encode(tabHistoryCurrentState, forKey: CodingKeys.tabHistoryCurrentState.rawValue)
     }
 }

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -8,10 +8,6 @@ import Storage
 import Common
 import Shared
 import WebKit
-import Ecosia
-
-// Ecosia: Used to get last visited sites
-import struct MozillaAppServices.VisitTransitionSet
 
 // This class subclasses the legacy tab manager temporarily so we can
 // gradually migrate to the new system
@@ -113,8 +109,7 @@ class TabManagerImplementation: LegacyTabManager, Notifiable, WindowSimpleTabsPr
         tabs = [Tab]()
         Task {
             // Only attempt a tab data store fetch if we know we should have tabs on disk (ignore new windows)
-            var windowData: WindowData? = windowIsNew ? nil : await self.tabDataStore.fetchWindowData(uuid: windowUUID)
-
+            let windowData: WindowData? = windowIsNew ? nil : await self.tabDataStore.fetchWindowData(uuid: windowUUID)
             await buildTabRestore(window: windowData)
             logger.log("Tabs restore ended after fetching window data", level: .debug, category: .tabs)
             logger.log("Normal tabs count; \(normalTabs.count), Inactive tabs count; \(inactiveTabs.count), Private tabs count; \(privateTabs.count)", level: .debug, category: .tabs)

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -115,14 +115,6 @@ class TabManagerImplementation: LegacyTabManager, Notifiable, WindowSimpleTabsPr
             // Only attempt a tab data store fetch if we know we should have tabs on disk (ignore new windows)
             var windowData: WindowData? = windowIsNew ? nil : await self.tabDataStore.fetchWindowData(uuid: windowUUID)
 
-            // TODO Ecosia Upgrade: Do we want to keep this? [MOB-3166]
-            /* Ecosia: Upgrading from v9.x to v10.0.0 caused an issue where migrated URLs were blank.
-            await buildTabRestore(window: await self.tabDataStore.fetchWindowData())
-             */
-            if shouldRestoreMigratedv10TabsMissingUrl {
-                windowData = await restoreMigratedv10TabsMissingUrlIfNeeded(window: windowData)
-            }
-
             await buildTabRestore(window: windowData)
             logger.log("Tabs restore ended after fetching window data", level: .debug, category: .tabs)
             logger.log("Normal tabs count; \(normalTabs.count), Inactive tabs count; \(inactiveTabs.count), Private tabs count; \(privateTabs.count)", level: .debug, category: .tabs)
@@ -583,80 +575,5 @@ class TabManagerImplementation: LegacyTabManager, Notifiable, WindowSimpleTabsPr
                                     activeTabId: self.selectedTabUUID ?? UUID(),
                                     tabData: self.generateTabDataForSaving())
         return SimpleTab.convertToSimpleTabs(windowData.tabData)
-    }
-}
-
-extension TabManagerImplementation {
-    /// Ecosia: Get last visited sites from Places DB.
-    /// - Parameter count: How many sites should be fetched.
-    /// - Returns: Array of fetched sites.
-    private func fetchLastVisitedSitesFromDB(count: Int) async -> [Site] {
-        do {
-            let sites = try await withCheckedThrowingContinuation { continuation in
-                profile.places.getSitesWithBound(
-                    limit: count,
-                    offset: 0,
-                    excludedTypes: VisitTransitionSet(0)
-                ).upon { result in
-                    if let successValue = result.successValue {
-                        continuation.resume(returning: successValue.asArray())
-                    } else {
-                        continuation.resume(returning: [])
-                    }
-                }
-            }
-            return sites
-        } catch {
-            return []
-        }
-    }
-
-    private static let restoreMigratedv10TabsMissingUrlKey = "restoreMigratedv10TabsMissingUrl"
-    private var shouldRestoreMigratedv10TabsMissingUrl: Bool {
-        !UserDefaults.standard.bool(forKey: Self.restoreMigratedv10TabsMissingUrlKey)
-    }
-    /// Fix tabs that where migrated from v9.x to v10.0.0 by fetching from last visited sites instead.
-    /// This should be removed after there are no significant number of users on v10.0.0.
-    /// - Parameter window: Window to be updated.
-    /// - Returns: Updated window.
-    private func restoreMigratedv10TabsMissingUrlIfNeeded(window: WindowData?) async -> WindowData? {
-        defer {
-            UserDefaults.standard.setValue(true, forKey: Self.restoreMigratedv10TabsMissingUrlKey)
-        }
-        // We only want to run it if the user just upgraded to the version containing this restoration code.
-        // Otherwise it means the user is a fresh install and we just mark it as restoration done.
-        guard EcosiaInstallType.get() == .upgrade else {
-            return window
-        }
-        // We only restore if there are actually any tabs with empty url.
-        guard let window = window,
-              window.tabData.contains(where: { $0.siteUrl.isEmpty }) else {
-            return window
-        }
-        let sites = await fetchLastVisitedSitesFromDB(count: 1000)
-        var restoredTabs = [TabData]()
-        window.tabData.forEach { tab in
-            var restoredUrl = tab.siteUrl
-            if restoredUrl.isEmpty {
-                restoredUrl = sites.first(where: { $0.title == tab.title })?.url ?? ""
-                // If we don't have a URL and the tab has no title, it means it should be the homepage (or at least that's better than blank)
-                if restoredUrl.isEmpty && (tab.title ?? "").isEmpty {
-                    restoredUrl = URL.homepageUrlString
-                }
-            }
-            restoredTabs.append(
-                .init(id: tab.id,
-                      title: tab.title,
-                      siteUrl: restoredUrl,
-                      faviconURL: tab.faviconURL,
-                      isPrivate: tab.isPrivate,
-                      lastUsedTime: tab.lastUsedTime,
-                      createdAtTime: tab.createdAtTime,
-                      tabGroupData: tab.tabGroupData)
-            )
-        }
-        return WindowData(id: window.id,
-                          activeTabId: window.activeTabId,
-                          tabData: restoredTabs)
     }
 }


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-3166]

## Context

We ran an investigation regarding the tabs migration between version upgrades.
If all good, then the next steps would require a migration cleanup.

## Approach

- Cleanup the respective code, especially counting on this commit https://github.com/ecosia/ios-browser/commit/5e5ab45a1c9c61eb3c863c269292c787c6bfee7e 
- Restore the codebase as referenced in our [Firefox Vanilla version](https://github.com/mozilla-mobile/firefox-ios/tree/release/v133)
- Execute smoke tests
- Execute Unit Tests

## Other

Refer to [this jira comment](https://ecosia.atlassian.net/browse/MOB-3166?focusedCommentId=101632) for more info on the tests performed and the overall versions installed against current users. 

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I checked Unit Tests that confirm the expected behaviour
- [x] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)

[MOB-3166]: https://ecosia.atlassian.net/browse/MOB-3166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ