### PR TITLE
[MOB-3188] Review Cards presentation logic

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -106,7 +106,6 @@
 		12C11EA62D28291300E4DDBF /* AppSettingsTableViewController+Ecosia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CF2206E2B72B0530038157D /* AppSettingsTableViewController+Ecosia.swift */; };
 		12C11EA72D28291300E4DDBF /* ErrorPageHandler+Ecosia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CB289462B07C8F000A8FCB3 /* ErrorPageHandler+Ecosia.swift */; };
 		12C11EA82D28291300E4DDBF /* HomepageViewController+Ecosia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CB289482B07C8F000A8FCB3 /* HomepageViewController+Ecosia.swift */; };
-		12C11EA92D28291300E4DDBF /* BrowserCoordinator+Ecosia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12C11E9F2D2828C200E4DDBF /* BrowserCoordinator+Ecosia.swift */; };
 		12C11EAA2D28291300E4DDBF /* UIView+maskedCorners.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CB2894A2B07C8F000A8FCB3 /* UIView+maskedCorners.swift */; };
 		12C11EAB2D28291300E4DDBF /* NumberFormatter+Ecosia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CB2894C2B07C8F000A8FCB3 /* NumberFormatter+Ecosia.swift */; };
 		12C11EAC2D28291300E4DDBF /* UIFont+Ecosia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CB289452B07C8F000A8FCB3 /* UIFont+Ecosia.swift */; };
@@ -2401,7 +2400,6 @@
 		12C11E962D28279C00E4DDBF /* SeedCounterNTPExperiment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeedCounterNTPExperiment.swift; sourceTree = "<group>"; };
 		12C11E9C2D28289900E4DDBF /* UIButton+Ecosia.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+Ecosia.swift"; sourceTree = "<group>"; };
 		12C11E9D2D2828AA00E4DDBF /* SimpleToast+Ecosia.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SimpleToast+Ecosia.swift"; sourceTree = "<group>"; };
-		12C11E9F2D2828C200E4DDBF /* BrowserCoordinator+Ecosia.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BrowserCoordinator+Ecosia.swift"; sourceTree = "<group>"; };
 		12C11EA02D2828EA00E4DDBF /* DispatchQueueHelper+BuildChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DispatchQueueHelper+BuildChannel.swift"; sourceTree = "<group>"; };
 		12C11F662D2C298600E4DDBF /* Ecosia.ShareTo.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Ecosia.ShareTo.xcconfig; path = Configuration/Ecosia.ShareTo.xcconfig; sourceTree = "<group>"; };
 		12C11F672D2C299D00E4DDBF /* Ecosia.WidgetKit.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Ecosia.WidgetKit.xcconfig; path = Configuration/Ecosia.WidgetKit.xcconfig; sourceTree = "<group>"; };
@@ -10492,7 +10490,6 @@
 				2CB2894A2B07C8F000A8FCB3 /* UIView+maskedCorners.swift */,
 				2CB2894C2B07C8F000A8FCB3 /* NumberFormatter+Ecosia.swift */,
 				2CB2894D2B07C8F000A8FCB3 /* URL+Ecosia.swift */,
-				12C11E9F2D2828C200E4DDBF /* BrowserCoordinator+Ecosia.swift */,
 				2CF2206E2B72B0530038157D /* AppSettingsTableViewController+Ecosia.swift */,
 				12C11EA02D2828EA00E4DDBF /* DispatchQueueHelper+BuildChannel.swift */,
 			);
@@ -16903,7 +16900,6 @@
 				12C11EA62D28291300E4DDBF /* AppSettingsTableViewController+Ecosia.swift in Sources */,
 				12C11EA72D28291300E4DDBF /* ErrorPageHandler+Ecosia.swift in Sources */,
 				12C11EA82D28291300E4DDBF /* HomepageViewController+Ecosia.swift in Sources */,
-				12C11EA92D28291300E4DDBF /* BrowserCoordinator+Ecosia.swift in Sources */,
 				12C11EAA2D28291300E4DDBF /* UIView+maskedCorners.swift in Sources */,
 				12C11EAB2D28291300E4DDBF /* NumberFormatter+Ecosia.swift in Sources */,
 				12C11EAC2D28291300E4DDBF /* UIFont+Ecosia.swift in Sources */,

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -1095,7 +1095,7 @@ extension BrowserCoordinator {
 
     @discardableResult
     private func presentDefaultBrowserPromoIfNeeded() -> Bool {
-//        guard shouldShowDefaultBrowserPromo else { return false }
+        guard shouldShowDefaultBrowserPromo else { return false }
 
         if #available(iOS 14, *) {
             let defaultPromo = DefaultBrowser(windowUUID: windowUUID, delegate: browserViewController)

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -134,17 +134,6 @@ class BrowserCoordinator: BaseCoordinator,
         legacyHomepageViewController.scrollToTop()
         // We currently don't support full page screenshot of the homepage
         screenshotService.screenshotableView = nil
-
-        // Ecosia: show any of the insighful sheets if needed
-        // Workaround for time of experiment
-        // -> delay of 0.5s to wait for animations and dismissals to finish
-        if inline, !User.shared.firstTime {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
-                self?.browserViewController.presentInsightfulSheetsIfNeeded()
-                // Ecosia: at this stage, we consider it a safe place where storing the current version
-                EcosiaInstallType.evaluateCurrentEcosiaInstallType(storeUpgradeVersion: true)
-            }
-        }
     }
 
     func showHomepage() {
@@ -1060,5 +1049,68 @@ class BrowserCoordinator: BaseCoordinator,
         if rootVC === expectedCoordinator.router.rootViewController {
             action(expectedCoordinator)
         }
+    }
+}
+
+// Ecosia: BrowserCoordinator extention that implements the overlay card logic
+extension BrowserCoordinator {
+
+    func showPendingOverlayCard(inline: Bool) {
+        if inline,
+           !User.shared.firstTime {
+            // -> delay of 0.5s to wait for animations and dismissals to finish
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+                self?.presentInsightfulSheetsIfNeeded()
+                // At this stage, we consider it a safe place where storing the current version
+                EcosiaInstallType.evaluateCurrentEcosiaInstallType(storeUpgradeVersion: true)
+            }
+        }
+    }
+
+    private func presentInsightfulSheetsIfNeeded() {
+        let shouldShowLoadingScreen = User.shared.referrals.pendingClaim != nil
+        // If not on homepage or if there's a pending referral claim, do nothing
+        guard isHomePage(), !shouldShowLoadingScreen else { return }
+        // Get first function that returns `true` for a cards needs presenting.
+        _ = presentableCards.first(where: { $0() })
+    }
+
+    private var shouldShowDefaultBrowserPromo: Bool {
+        browserViewController.profile.prefs.intForKey(PrefsKeys.IntroSeen) == nil &&
+        DefaultBrowser.minPromoSearches <= User.shared.searchCount
+    }
+
+    private var presentableCards: [() -> Bool] {
+        [
+            presentDefaultBrowserPromoIfNeeded,
+            presentWhatsNewPageIfNeeded
+        ]
+    }
+
+    private var shouldShowWhatsNewPageScreen: Bool { browserViewController.whatsNewDataProvider.shouldShowWhatsNewPage }
+
+    private func isHomePage() -> Bool {
+        browserViewController.tabManager.selectedTab?.url.flatMap { InternalURL($0)?.isAboutHomeURL } ?? false
+    }
+
+    @discardableResult
+    private func presentDefaultBrowserPromoIfNeeded() -> Bool {
+//        guard shouldShowDefaultBrowserPromo else { return false }
+
+        if #available(iOS 14, *) {
+            let defaultPromo = DefaultBrowser(windowUUID: windowUUID, delegate: browserViewController)
+            present(defaultPromo, animated: true)
+        } else {
+            profile.prefs.setInt(1, forKey: PrefsKeys.IntroSeen)
+        }
+        return true
+    }
+
+    @discardableResult
+    private func presentWhatsNewPageIfNeeded() -> Bool {
+        guard shouldShowWhatsNewPageScreen else { return false }
+        let viewModel = WhatsNewViewModel(provider: browserViewController.whatsNewDataProvider)
+        WhatsNewViewController.presentOn(browserViewController, viewModel: viewModel, windowUUID: windowUUID)
+        return true
     }
 }

--- a/firefox-ios/Client/Coordinators/Browser/BrowserDelegate.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserDelegate.swift
@@ -39,4 +39,13 @@ protocol BrowserDelegate: AnyObject {
 
     /// Show the Error page to the user
     func showNativeErrorPage(overlayManager: OverlayModeManager)
+
+    /*
+     Ecosia: Add a new behavior that allows the browser to show
+     pending overlay cards on top of the Browser View if needed.
+     E.g. Default Browser Card
+     The `inline` param keeps companibility with the legacy homepage
+     showing method
+     */
+    func showPendingOverlayCard(inline: Bool)
 }

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserCoordinator+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserCoordinator+Ecosia.swift
@@ -1,8 +1,0 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/
-
-import Foundation
-import Shared
-
-extension BrowserCoordinator { }

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
@@ -95,61 +95,6 @@ extension BrowserViewController {
     }
 }
 
-// MARK: Present insightful sheets
-extension BrowserViewController {
-    private var shouldShowDefaultBrowserPromo: Bool {
-        profile.prefs.intForKey(PrefsKeys.IntroSeen) == nil &&
-        DefaultBrowser.minPromoSearches <= User.shared.searchCount
-    }
-    private var shouldShowWhatsNewPageScreen: Bool { whatsNewDataProvider.shouldShowWhatsNewPage }
-
-    func presentInsightfulSheetsIfNeeded() {
-        guard isHomePage(),
-              !showLoadingScreen(for: .shared) else { return }
-
-        // TODO: To review this logic as part of the upgrade
-        /*
-         We are not fan of this one, but given the current approach a refactor
-         would not be suitable as part of this ticke scope.
-         As part of the upgrade and with a more structured navigation approach, we will
-         refactor it.
-         The below is a decent compromise given the complexity of the decisional execution and presentation.
-         The order of the function represents the priority.
-         */
-        let presentationFunctions: [() -> Bool] = [
-            presentDefaultBrowserPromoIfNeeded,
-            presentWhatsNewPageIfNeeded
-        ]
-
-        _ = presentationFunctions.first(where: { $0() })
-    }
-
-    private func isHomePage() -> Bool {
-        tabManager.selectedTab?.url.flatMap { InternalURL($0)?.isAboutHomeURL } ?? false
-    }
-
-    @discardableResult
-    private func presentDefaultBrowserPromoIfNeeded() -> Bool {
-        guard shouldShowDefaultBrowserPromo else { return false }
-
-        if #available(iOS 14, *) {
-            let defaultPromo = DefaultBrowser(windowUUID: windowUUID, delegate: self)
-            present(defaultPromo, animated: true)
-        } else {
-            profile.prefs.setInt(1, forKey: PrefsKeys.IntroSeen)
-        }
-        return true
-    }
-
-    @discardableResult
-    private func presentWhatsNewPageIfNeeded() -> Bool {
-        guard shouldShowWhatsNewPageScreen else { return false }
-        let viewModel = WhatsNewViewModel(provider: whatsNewDataProvider)
-        WhatsNewViewController.presentOn(self, viewModel: viewModel, windowUUID: windowUUID)
-        return true
-    }
-}
-
 // MARK: Claim Referral
 extension BrowserViewController {
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1373,6 +1373,9 @@ class BrowserViewController: UIViewController,
                 overlayManager: overlayManager
             )
         }
+
+        // Ecosia: Let showOverlayCard() execute
+        browserDelegate?.showPendingOverlayCard(inline: inline)
     }
 
     func showEmbeddedWebview() {

--- a/firefox-ios/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/TopSites/TopSitesViewModel.swift
@@ -227,9 +227,6 @@ extension TopSitesViewModel: HomepageViewModelProtocol, FeatureFlaggable {
                      size: CGSize,
                      isPortrait: Bool = UIWindow.isPortrait,
                      device: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) {
-        // Ecosia: correctly assign the latest set `numberOfRows` and calculate based on all top sites
-        numberOfRows = topSitesDataAdaptor.numberOfRows
-        topSites = unfilteredTopSites
         let interface = TopSitesUIInterface(trait: traitCollection,
                                             availableWidth: size.width)
         numberOfRows = topSitesDataAdaptor.numberOfRows
@@ -238,8 +235,7 @@ extension TopSitesViewModel: HomepageViewModelProtocol, FeatureFlaggable {
                                                                     numberOfRows: numberOfRows,
                                                                     interface: interface)
         numberOfItems = sectionDimension.numberOfRows * sectionDimension.numberOfTilesPerRow
-        // Ecosia: Move topsite declaration up
-        // topSites = unfilteredTopSites
+        topSites = unfilteredTopSites
         if numberOfItems < unfilteredTopSites.count {
             let range = numberOfItems..<unfilteredTopSites.count
             topSites.removeSubrange(range)

--- a/firefox-ios/Client/Frontend/Widgets/TabsButton.swift
+++ b/firefox-ios/Client/Frontend/Widgets/TabsButton.swift
@@ -32,6 +32,9 @@ class TabsButton: UIButton, ThemeApplicable {
     private var theme: Theme?
      */
     private var theme: Theme? {
+        guard traitCollection.userInterfaceIdiom != .pad else {
+            return nil
+        }
         let themeManager: ThemeManager = AppContainer.shared.resolve()
         return themeManager.getCurrentTheme(for: currentWindowUUID)
     }


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-3188]

## Context

As part of the upgrade, we realized a few sections are worth looking at.
The presentation sheets that per-se hijack the coordinator's pattern are part of it.

## Approach

In the end, we achieved a good compromise that leverages the coordinator pattern structure for the `BrowserViewController` and `BrowserCoordinator` (as the VC, in this case, has no context on its coordinator; it's the other way around). 

- Moved everything to the Coordinator
- Implemented a supplementary method to the `BrowserDelegate` entity
- The coordinator does have a concrete implementation
- the ViewController calls the delegate as it does already when showing the homepage

## Other

- Minor improvements
- I noticed an issue with the upgrade scenario on a previous build run.
  - Attempting to make an NTP I noticed a crash on that state
 -  I went after digging deeper and realized that a a change we needed in the `refreshData(::)`'s ViewModel function for the TopSites is not needed anymore. This was likely due to an older implementation of ours and an issue our soon-legacy Firefox vanilla had been having
- Another important scenario I ran into is the iPad one
  - To make sure some TabsButton are initialized correctly on iPhone, we added a check to ensure the `var theme: Theme?` of the `TabsButton` gets correctly initialized. While this update works on the iPhone (didn't check if still strictly needed but assuming so as tests have been mainly done on the iPhone), on the iPad the flow is a bit different.
  - We show the Onboarding on top of an already-displayed NTP so the Tabs Restoration (which evaluates the `currentWindowUUID`) follows a different flow, and the WindowUUID is found `nil` when requested from the iPad flow (as the `tabsButton`'s `Theme` instance gets requested earlier 

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I checked Unit Tests that confirm the expected behaviour
- [x] I added the `// Ecosia:` helper comments where needed
- [x] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)

[MOB-3188]: https://ecosia.atlassian.net/browse/MOB-3188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ