### PR TITLE
[MOB-3251] Re-enable button on exiting Add Bookmark details

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LegacyBookmarksPanel.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/Legacy/LegacyBookmarksPanel.swift
@@ -62,6 +62,8 @@ class LegacyBookmarksPanel: SiteTableViewController,
             return [flexibleSpace, bottomRightButton]
         case .bookmarks(state: .inFolderEditMode):
             bottomRightButton.title = String.AppSettingsDone
+            // Ecosia: Enable the Done button after closing the panel details
+            bottomRightButton.isEnabled = true
             return [bottomLeftButton, flexibleSpace, bottomRightButton]
         case .bookmarks(state: .itemEditMode):
             bottomRightButton.title = String.AppSettingsDone


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-3251]

## Context

The `Done` button results greyed out upon exiting a "New Bookmark" page.

## Approach

- Performed an early investigation
- Checked whether Ecosia's changes either in the current version or the production ones could have altered the behaviour
- Found out it's something flagged on Firefox as well https://github.com/mozilla-mobile/firefox-ios/pull/23345/files
- Acknowledged the required change
- Realised it's not _cherry-pickable_ 🍒 so decided to only Apply the change
- Marked the fix as "Ecosia's" to get it spotted in the next upgrade and acknowledge the root cause

Proof in the JIRA comment

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I added the `// Ecosia:` helper comments where needed

[MOB-3251]: https://ecosia.atlassian.net/browse/MOB-3251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ