### PR TITLE
[MOB-3221] Native SRPV Analytics

### DIFF
--- a/firefox-ios/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
@@ -152,6 +152,7 @@ extension AppSettingsTableViewController {
             FasterInactiveTabs(settings: self, settingsDelegate: self),
             UnleashBrazeIntegrationSetting(settings: self),
             UnleashAPNConsent(settings: self),
+            UnleashNativeSRPVAnalyticsSetting(settings: self),
             UnleashSeedCounterNTPSetting(settings: self),
         ]
 

--- a/firefox-ios/Client/Ecosia/Settings/EcosiaDebugSettings.swift
+++ b/firefox-ios/Client/Ecosia/Settings/EcosiaDebugSettings.swift
@@ -224,6 +224,16 @@ final class UnleashAPNConsent: UnleashVariantResetSetting {
     }
 }
 
+final class UnleashNativeSRPVAnalyticsSetting: UnleashVariantResetSetting {
+    override var titleName: String? {
+        "Native SRPV Analytics"
+    }
+
+    override var unleashEnabled: Bool? {
+        Unleash.isEnabled(.nativeSRPVAnalytics)
+    }
+}
+
 final class AnalyticsIdentifierSetting: HiddenSetting {
     override var title: NSAttributedString? {
         return NSAttributedString(string: "Debug: Analytics Identifier", attributes: [NSAttributedString.Key.foregroundColor: theme.colors.ecosia.tableViewRowText])

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -576,10 +576,6 @@ extension BrowserViewController: WKNavigationDelegate {
                     return
                 }
             }
-//            if url.isEcosiaSearchVertical() {
-//                // TODO: Fix double event on start
-//                Analytics.shared.inappSearch(url: url)
-//            }
 
             decisionHandler(.allow)
             return

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -8,6 +8,7 @@ import Common
 import Shared
 import UIKit
 import Photos
+import Ecosia
 
 // MARK: - WKUIDelegate
 extension BrowserViewController: WKUIDelegate {
@@ -575,6 +576,11 @@ extension BrowserViewController: WKNavigationDelegate {
                     webView.load(navigationAction.request)
                     return
                 }
+            }
+
+            if url.isEcosiaSearchVertical() {
+                // TODO: Fix double event on start
+                Analytics.shared.inappSearch(url: url)
             }
 
             decisionHandler(.allow)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -8,7 +8,6 @@ import Common
 import Shared
 import UIKit
 import Photos
-import Ecosia
 
 // MARK: - WKUIDelegate
 extension BrowserViewController: WKUIDelegate {
@@ -577,11 +576,10 @@ extension BrowserViewController: WKNavigationDelegate {
                     return
                 }
             }
-
-            if url.isEcosiaSearchVertical() {
-                // TODO: Fix double event on start
-                Analytics.shared.inappSearch(url: url)
-            }
+//            if url.isEcosiaSearchVertical() {
+//                // TODO: Fix double event on start
+//                Analytics.shared.inappSearch(url: url)
+//            }
 
             decisionHandler(.allow)
             return

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -6,6 +6,7 @@ import Common
 import Shared
 import SnapKit
 import UIKit
+import Ecosia
 
 private struct URLBarViewUX {
     static let LocationLeftPadding: CGFloat = 8
@@ -248,15 +249,22 @@ class URLBarView: UIView,
         }
 
         set(newURL) {
-            // Ecosia: Update URL accordingly
-            // locationView.url = newURL
+            /* Ecosia: Change setter to update URL accordingly and track search event when needed
+            locationView.url = newURL
+             */
+            let oldURL = currentURL
             var updatedUrl = newURL
+            // Ecosify if needed
             if updatedUrl?.shouldEcosify() ?? false {
                 updatedUrl = newURL?.ecosified(isIncognitoEnabled: isPrivate)
             }
             locationView.url = updatedUrl
-
-            // Ecosia: update visibility of reload/multi-state button
+            // Track search if url changed and is Ecosia's vertical
+            // (this has to be done after ecosifying so we properly track only if changed)
+            if let updatedUrl = updatedUrl, oldURL != updatedUrl, updatedUrl.isEcosiaSearchVertical() {
+                Analytics.shared.inappSearch(url: updatedUrl)
+            }
+            // Update constraints if needed
             if !inOverlayMode {
                 setNeedsUpdateConstraints()
             }

--- a/firefox-ios/Ecosia/Analytics/Analytics.swift
+++ b/firefox-ios/Ecosia/Analytics/Analytics.swift
@@ -257,7 +257,8 @@ open class Analytics {
 
     // MARK: In-App Search
     public func inappSearch(url: URL) {
-        guard let query = url.getEcosiaSearchQuery() else {
+        guard NativeSRPVAnalyticsExperiment.isEnabled,
+              let query = url.getEcosiaSearchQuery() else {
             return
         }
         let payload: [String: Any?] = [

--- a/firefox-ios/Ecosia/Analytics/Analytics.swift
+++ b/firefox-ios/Ecosia/Analytics/Analytics.swift
@@ -267,9 +267,8 @@ open class Analytics {
             "plt_v": Bundle.version as NSObject,
             "search_type": url.getEcosiaSearchVerticalPath()
         ]
-        // TODO: Uncomment when schema is created
-//        track(SelfDescribing(schema: Self.inappSearchSchema,
-//                             payload: payload.compactMapValues({ $0 })))
+        track(SelfDescribing(schema: Self.inappSearchSchema,
+                             payload: payload.compactMapValues({ $0 })))
     }
 
     // MARK: Settings

--- a/firefox-ios/Ecosia/Analytics/Analytics.swift
+++ b/firefox-ios/Ecosia/Analytics/Analytics.swift
@@ -10,6 +10,7 @@ open class Analytics {
     private static let abTestSchema = "iglu:org.ecosia/abtest_context/jsonschema/1-0-1"
     private static let consentSchema = "iglu:org.ecosia/eccc_context/jsonschema/1-0-2"
     static let userSchema = "iglu:org.ecosia/app_user_state_context/jsonschema/1-0-0"
+    static let inappSearchSchema = "iglu:org.ecosia/inapp_search_event/jsonschema/1-0-0"
     private static let abTestRoot = "ab_tests"
     private static let namespace = "ios_sp"
 
@@ -252,6 +253,23 @@ open class Analytics {
         track(Structured(category: Category.invitations.rawValue,
                          action: action.rawValue)
             .label(label?.rawValue))
+    }
+
+    // MARK: In-App Search
+    public func inappSearch(url: URL) {
+        guard let query = url.getEcosiaSearchQuery() else {
+            return
+        }
+        let payload: [String: Any?] = [
+            "query": query,
+            "page_num": url.getEcosiaSearchPage(),
+            "plt_name": "ios",
+            "plt_v": Bundle.version as NSObject,
+            "search_type": url.getEcosiaSearchVerticalPath()
+        ]
+        // TODO: Uncomment when schema is created
+//        track(SelfDescribing(schema: Self.inappSearchSchema,
+//                             payload: payload.compactMapValues({ $0 })))
     }
 
     // MARK: Settings

--- a/firefox-ios/Ecosia/Core/FeatureManagement/Unleash/Unleash.Model.swift
+++ b/firefox-ios/Ecosia/Core/FeatureManagement/Unleash/Unleash.Model.swift
@@ -24,6 +24,7 @@ extension Unleash {
             case brazeIntegration = "mob_ios_braze_integration"
             case configTest = "mob_ios_staging_config"
             case seedCounterNTP = "mob_ios_seed_counter_ntp"
+            case nativeSRPVAnalytics = "mob_ios_native_srpv_analytics"
             case newsletterCard = "mob_ios_newsletter_card"
         }
 

--- a/firefox-ios/Ecosia/Experiments/Unleash/NativeSRPVAnalyticsExperiment.swift
+++ b/firefox-ios/Ecosia/Experiments/Unleash/NativeSRPVAnalyticsExperiment.swift
@@ -1,0 +1,14 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+struct NativeSRPVAnalyticsExperiment {
+
+    private init() {}
+
+    static var isEnabled: Bool {
+        Unleash.isEnabled(.nativeSRPVAnalytics)
+    }
+}


### PR DESCRIPTION
[MOB-3221]

## Context

We want to have Native SRPV we can use to base retention metrics of.

## Approach

* Investigate what's the best place to track any web navigation (i.e. change in url) - **see section below** 
* Create Analytics unstructured event and extract info from url using utils methods
* Put event behind a feature flag so we can control who receives it

### Finding where to track

Finding out exactly where in code is the best place to track this url can was trickier than expected, as the tab flow is quite complex and changes might happens on multiple places. Here are some attempts worth documenting:
1.  The first attempt was using [webView(_:decidePolicyFor:decisionHandler:)](https://developer.apple.com/documentation/webkit/wknavigationdelegate/webview(_:decidepolicyfor:decisionhandler:)-2ni62) as that is the closest we have from a direct webview delegate method. This did in fact trigger whenever we wanted, but also triggered extra times like with different web redirects or, more problematically, multiple times at once like on launch.
2. Once `1` did not fit, a number of other candidates where attempted like for example using the [observed URL value change](https://github.com/ecosia/ios-browser/blob/91e1c7ff8049fa655bd8e01f3a4877a249590ae2/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift#L1380-L1398) which in turn triggered the [tab event handler](https://github.com/ecosia/ios-browser/blob/91e1c7ff8049fa655bd8e01f3a4877a249590ae2/Client/TabManagement/TabEventHandler.swift#L109-L110). They seem great but in the end have the same core issue of being triggered multiple times from different places.
3. To solve the multiple triggers, I resorted to the main place where I could guarantee no events would be double fired: the [url bar view setter](https://github.com/ecosia/ios-browser/blob/91e1c7ff8049fa655bd8e01f3a4877a249590ae2/Client/Frontend/Toolbar%2BURLBar/URLBarView.swift#L238). There I can actually compare the new and old values and guarantee that the event is only tracked once (even if this is also triggered multiple time). This is also where we currently ecosify our urls, so we can combo both changes together.

Some things that still trigger the event (if the url matches) but there's not much way around without over-complicating:
* Back button
* Forward button
* Refresh
* Launching the app (resume doesn't trigger though)
* Switching tabs

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [x] I added the `// Ecosia:` helper comments where needed
- [x] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)

[MOB-3221]: https://ecosia.atlassian.net/browse/MOB-3221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ