### PR TITLE
[MOB-3292] Add locators for search logo

### DIFF
--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -1137,9 +1137,13 @@ extension URLBarView {
                 searchIconImageView.image = .templateImageNamed(StandardImageIdentifiers.Large.privateMode)?.tinted(withColor: locationActiveBorderColor)
             } else {
                 searchIconImageView.image = .init(named: "iconLogo", in: .ecosia, with: nil)
+                // Ecosia: Add Accesibility ID
+                searchIconImageView.accessibilityIdentifier = "urlbar_logo_image"
             }
         } else {
             searchIconImageView.image = .templateImageNamed("searchUrl")
+            // Ecosia: Add Accesibility ID
+            searchIconImageView.accessibilityIdentifier = "urlbar_search_image"
         }
         searchIconImageView.isHidden = !isHome && !inOverlayMode
     }


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-3292]

## Context

There are some locators that we'd like to fix. 
The ticket specifically refers to the `-` button that triggers the Swipe that reveals the `Delete` button.

## Approach

I'm using this ticket to upgrade some accessibility identifiers instead of that one to get a simple ticket reference.
Sadly, there's no best practice to update the `accessibilityIdentifier` of that `-` button.
I've thoroughly tested different options to achieve the desired result but nothing worked.
What I noticed though, is that I always retrieved correctly the `minus.circle.fill` (regardless of the OS) as an accessibility identifier via the `Accessibility Inspector` instead of Appium's.
As eventually Appium is the tool that counts, I hope we can get a different approach for that.

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I added the `// Ecosia:` helper comments where needed

[MOB-3292]: https://ecosia.atlassian.net/browse/MOB-3292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ