### PR TITLE
[MOB-3314] Fix settings clipboard status text

### DIFF
--- a/firefox-ios/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
@@ -82,7 +82,7 @@ extension AppSettingsTableViewController {
                 prefKey: "showClipboardBar",
                 defaultValue: false,
                 titleText: .SettingsOfferClipboardBarTitle,
-                statusText: .SettingsOfferClipboardBarStatus
+                statusText: String(format: .SettingsOfferClipboardBarStatus, AppName.shortName.rawValue)
             ),
             BoolSetting(
                 prefs: profile.prefs,

--- a/firefox-ios/Client/Frontend/Strings.swift
+++ b/firefox-ios/Client/Frontend/Strings.swift
@@ -3434,7 +3434,7 @@ extension String {
     public static let SettingsOfferClipboardBarStatus = MZLocalizedString(
         key: "Settings.OfferClipboardBar.Status.v128",
         tableName: nil,
-        value: "When Opening Ecosia",
+        value: "When opening %@",
         comment: "Description displayed under the ”Offer to Open Copied Link” option. See https://bug1223660.bmoattachments.org/attachment.cgi?id=8898349")
 }
 


### PR DESCRIPTION
[MOB-3314]

## Context

We found a `%@` appearing on a settings item.

## Approach

Compare to current Firefox and noticed it was caused to the introduction of the AppName on the string, which was not reflected on our custom Ecosia settings controller.

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator

[MOB-3314]: https://ecosia.atlassian.net/browse/MOB-3314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ