### PR TITLE
[MOB-3315] Fix TabTray toast bottom padding

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Tabs/Views/TabTrayViewController.swift
@@ -480,8 +480,11 @@ class TabTrayViewController: UIViewController,
             let toast = SimpleToast()
             toast.showAlertWithText(toastType.title,
                                     bottomContainer: view,
+                                    /* Ecosia: Remove bottom padding
                                     theme: currentTheme(),
                                     bottomConstraintPadding: -toolbarHeight)
+                                     */
+                                    theme: currentTheme())
         }
     }
 


### PR DESCRIPTION
[MOB-3315]

## Context

See ticket.

## Approach

Debug why the issue happens, turns out that spacing is expected for Firefox style toast, but not our custom Ecosia one. 

For a quick fix now until we rework toasts, removing the padding.

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I added the `// Ecosia:` helper comments where needed

[MOB-3315]: https://ecosia.atlassian.net/browse/MOB-3315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ