### PR TITLE
[MOB-3199] Change request: tapping on the card does not dismiss it

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -498,7 +498,6 @@ class AppSettingsTableViewController: SettingsTableViewController,
                 self?.hideDefaultBrowserNudgeCardInSection(section)
             }
             header.onTap = { [weak self] in
-                User.shared.hideDefaultBrowserSettingNudgeCard()
                 self?.showDefaultBrowserDetailView()
             }
             header.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-3199]

## Context

Product and Design caught up once they were able to test the app phisically on device.
They ackowledged after some tests performed via fellow Ecosian that the card being dismissed when moving on the detail screen is not ideal and confuses people (kinda agree).

## Approach

Tapping on the card to show its detail does not dismiss the card. 

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)

[MOB-3199]: https://ecosia.atlassian.net/browse/MOB-3199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ