### PR TITLE
[MOB-3352] Align prefs key for Private Tabs settings

### DIFF
--- a/firefox-ios/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
@@ -114,7 +114,7 @@ extension AppSettingsTableViewController {
             EcosiaSendAnonymousUsageDataSetting(prefs: profile.prefs, theme: themeManager.getCurrentTheme(for: windowUUID)),
             BoolSetting(prefs: profile.prefs,
                         theme: themeManager.getCurrentTheme(for: windowUUID),
-                        prefKey: "settings.closePrivateTabs",
+                        prefKey: PrefsKeys.Settings.closePrivateTabs,
                         defaultValue: false,
                         titleText: .AppSettingsClosePrivateTabsTitle,
                         statusText: .AppSettingsClosePrivateTabsDescription),


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-3352]

## Context

There is a rising set of feedback from end users about the tabs section autoclosing not reflecting their settings.

## Approach

Find the root cause and fix it.
Aligned with standard Firefox.

### Explanation
We inherited this behaviour from our old codebase, where the key was hardcoded.
However, the check performed upon CRUD requests against the `UserDefault` was referring to another key, causing the mismatch.
As we do not rely on any feature flag manager or any other OTA settings update, it's worth aligning with the Firefox's default pref key, to avoid issues in the coming upgrades as well.

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator

[MOB-3352]: https://ecosia.atlassian.net/browse/MOB-3352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ