### PR TITLE
[MOB-3405] In-app search event review

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -578,9 +578,10 @@ extension BrowserViewController: WKNavigationDelegate {
                 }
             }
 
-            // Ecosia: Track search if url changed and is Ecosia's vertical
+            // Ecosia: Track search if is Ecosia's vertical
             let urlChanged = url != previousUrl
-            if urlChanged && url.isEcosiaSearchVertical() {
+            let isReload = navigationAction.navigationType == .reload
+            if (urlChanged || isReload) && url.isEcosiaSearchVertical() {
                 Analytics.shared.inappSearch(url: url)
             }
             previousUrl = url

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -8,6 +8,7 @@ import Common
 import Shared
 import UIKit
 import Photos
+import Ecosia
 
 // MARK: - WKUIDelegate
 extension BrowserViewController: WKUIDelegate {
@@ -576,6 +577,13 @@ extension BrowserViewController: WKNavigationDelegate {
                     return
                 }
             }
+
+            // Ecosia: Track search if url changed and is Ecosia's vertical
+            let urlChanged = url != previousUrl
+            if urlChanged && url.isEcosiaSearchVertical() {
+                Analytics.shared.inappSearch(url: url)
+            }
+            previousUrl = url
 
             decisionHandler(.allow)
             return

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -581,7 +581,8 @@ extension BrowserViewController: WKNavigationDelegate {
             // Ecosia: Track search if is Ecosia's vertical
             let urlChanged = url != previousUrl
             let isReload = navigationAction.navigationType == .reload
-            if (urlChanged || isReload) && url.isEcosiaSearchVertical() {
+            let isBackForward = navigationAction.navigationType == .backForward
+            if !isBackForward && (urlChanged || isReload) && url.isEcosiaSearchVertical() {
                 Analytics.shared.inappSearch(url: url)
             }
             previousUrl = url

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -34,6 +34,10 @@ class BrowserViewController: UIViewController,
                              NavigationToolbarContainerDelegate,
                              AddressToolbarContainerDelegate,
                              FeatureFlaggable {
+
+    // Ecosia: Used inside webview delegate to decide if search should be tracked
+    var previousUrl: URL?
+
     private enum UX {
         static let ShowHeaderTapAreaHeight: CGFloat = 32
         static let ActionSheetTitleMaxLength = 120

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -36,6 +36,7 @@ class BrowserViewController: UIViewController,
                              FeatureFlaggable {
 
     // Ecosia: Used inside webview delegate to decide if search should be tracked
+    // (for now this is not cleared across sections or tabs, but shouldn't be an issue)
     var previousUrl: URL?
 
     private enum UX {

--- a/firefox-ios/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/firefox-ios/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -249,21 +249,15 @@ class URLBarView: UIView,
         }
 
         set(newURL) {
-            /* Ecosia: Change setter to update URL accordingly and track search event when needed
+            /* Ecosia: Change setter to update URL accordingly
             locationView.url = newURL
              */
-            let oldURL = currentURL
             var updatedUrl = newURL
             // Ecosia: Ecosify if needed
             if updatedUrl?.shouldEcosify() ?? false {
                 updatedUrl = newURL?.ecosified(isIncognitoEnabled: isPrivate)
             }
             locationView.url = updatedUrl
-            // Ecosia: Track search if url changed and is Ecosia's vertical
-            // (this has to be done after ecosifying so we properly track only if changed)
-            if let updatedUrl = updatedUrl, oldURL != updatedUrl, updatedUrl.isEcosiaSearchVertical() {
-                Analytics.shared.inappSearch(url: updatedUrl)
-            }
             // Ecosia: Update constraints if needed
             if !inOverlayMode {
                 setNeedsUpdateConstraints()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockTabManager.swift
@@ -48,8 +48,14 @@ class MockTabManager: TabManager {
         return nil
     }
 
+    /* Ecosia: Allow overriding subscript
     subscript(webView: WKWebView) -> Tab? {
         return nil
+    }
+     */
+    var subscriptedTab: Tab?
+    subscript(webView: WKWebView) -> Tab? {
+        return subscriptedTab
     }
 
     func selectTab(_ tab: Tab?, previous: Tab?) {


### PR DESCRIPTION
[MOB-3405]

## Context

We're reviewing where to add the in-app search event.

## Approach

Fallback again to the first attempt mentioned on https://github.com/ecosia/ios-browser/pull/873, but now with an additional url changed check to handle any double firing.

This is a bit less elegant than the previous since we need this separate `previousUrl` variable, but should work better now. It also doesn't properly clear the variable across sessions and tabs, but as mentioned on the comment that is on purpose not to add more complexity before we validate we want to keep this.

## Other

Also fixed a couple other minor cases with regards to reloads, and back and forward button. The latter still being a possible difference from web but now more often matching behaviour (see [this ticket comment](https://ecosia.atlassian.net/browse/MOB-3405?focusedCommentId=103918)).

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I wrote Unit Tests that confirm the expected behaviour
- [x] I added the `// Ecosia:` helper comments where needed

[MOB-3405]: https://ecosia.atlassian.net/browse/MOB-3405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ