### PR TITLE
[MOB-3352] Private tabs autoclosing follow-up

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		12141E6D2D6877F00097788B /* EcosiaNetError.css in Resources */ = {isa = PBXBuildFile; fileRef = 12141E6A2D686C1C0097788B /* EcosiaNetError.css */; };
 		123475C32DA6730A0017B0C2 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A6AB4528CA6A4C00EBEBDD /* String+Extension.swift */; };
 		123475CC2DA7D6620017B0C2 /* BeforeOrAfterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123475CB2DA7D6580017B0C2 /* BeforeOrAfterView.swift */; };
+		12348FFA2DB8D2D40017B0C2 /* PrefsKeys+Ecosia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12348FF92DB8D2CC0017B0C2 /* PrefsKeys+Ecosia.swift */; };
 		124DAE822D350EFD0050104C /* String+Punycode.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6B2AC11D41F02D00429414 /* String+Punycode.swift */; };
 		124DAE8A2D3512FA0050104C /* DispatchQueueHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83821FF1FC7961D00303C12 /* DispatchQueueHelper.swift */; };
 		1251623C2D59FB30005CB958 /* Ecosia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2CFE99662D45329200B25CE0 /* Ecosia.framework */; };
@@ -2374,6 +2375,7 @@
 		12141E6A2D686C1C0097788B /* EcosiaNetError.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = EcosiaNetError.css; sourceTree = "<group>"; };
 		123045959E0F295753B4B4DB /* lo */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = lo; path = lo.lproj/Today.strings; sourceTree = "<group>"; };
 		123475CB2DA7D6580017B0C2 /* BeforeOrAfterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeforeOrAfterView.swift; sourceTree = "<group>"; };
+		12348FF92DB8D2CC0017B0C2 /* PrefsKeys+Ecosia.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PrefsKeys+Ecosia.swift"; sourceTree = "<group>"; };
 		124DAE792D2FD1330050104C /* LegacyDarkTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyDarkTheme.swift; sourceTree = "<group>"; };
 		124DAE7A2D2FD1330050104C /* RecoveredLegacyTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecoveredLegacyTheme.swift; sourceTree = "<group>"; };
 		124DAE7B2D2FD1330050104C /* LegacyThemeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyThemeManager.swift; sourceTree = "<group>"; };
@@ -10494,6 +10496,7 @@
 				2CB2894D2B07C8F000A8FCB3 /* URL+Ecosia.swift */,
 				2CF2206E2B72B0530038157D /* AppSettingsTableViewController+Ecosia.swift */,
 				12C11EA02D2828EA00E4DDBF /* DispatchQueueHelper+BuildChannel.swift */,
+				12348FF92DB8D2CC0017B0C2 /* PrefsKeys+Ecosia.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -15959,6 +15962,7 @@
 				E65075A21E37F7AB006961AC /* HexExtensions.swift in Sources */,
 				288A2DB61AB8B38D0023ABC3 /* Result.swift in Sources */,
 				EB912B9B22722B6300DF585A /* ReadWriteLock.swift in Sources */,
+				12348FFA2DB8D2D40017B0C2 /* PrefsKeys+Ecosia.swift in Sources */,
 				E65075AD1E37F7AB006961AC /* UIColorExtensions.swift in Sources */,
 				EB912B9C22722B6800DF585A /* LockProtected.swift in Sources */,
 				E650759C1E37F7AB006961AC /* DeferredUtils.swift in Sources */,

--- a/firefox-ios/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
@@ -115,7 +115,7 @@ extension AppSettingsTableViewController {
             BoolSetting(prefs: profile.prefs,
                         theme: themeManager.getCurrentTheme(for: windowUUID),
                         prefKey: PrefsKeys.Settings.closePrivateTabs,
-                        defaultValue: false,
+                        defaultValue: false, // Ecosia: This is different from Firefox
                         titleText: .AppSettingsClosePrivateTabsTitle,
                         statusText: .AppSettingsClosePrivateTabsDescription),
             ContentBlockerSetting(settings: self, settingsDelegate: parentCoordinator),

--- a/firefox-ios/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
@@ -115,7 +115,8 @@ extension AppSettingsTableViewController {
             BoolSetting(prefs: profile.prefs,
                         theme: themeManager.getCurrentTheme(for: windowUUID),
                         prefKey: PrefsKeys.Settings.closePrivateTabs,
-                        defaultValue: false, // Ecosia: This is different from Firefox
+                        // Ecosia: Default value is different from Firefox
+                        defaultValue: PrefsKeysDefaultValues.Settings.closePrivateTabs,
                         titleText: .AppSettingsClosePrivateTabsTitle,
                         statusText: .AppSettingsClosePrivateTabsDescription),
             ContentBlockerSetting(settings: self, settingsDelegate: parentCoordinator),

--- a/firefox-ios/Client/Ecosia/Extensions/PrefsKeys+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/PrefsKeys+Ecosia.swift
@@ -1,0 +1,10 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+/// This is based on `PrefsKeys`(at `Shared/Prefs`) and meant to store Ecosia's custom default values for preference keys
+public struct PrefsKeysDefaultValues {
+    public struct Settings {
+        public static let closePrivateTabs = false
+    }
+}

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -323,7 +323,7 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
             profile.prefs.removeObjectForKey(oldKey)
         }
 
-        return currentValue ?? false
+        return currentValue ?? PrefsKeysDefaultValues.Settings.closePrivateTabs
     }
 
     func cleanupClosedTabs(_ closedTabs: [Tab], previous: Tab?, isPrivate: Bool = false) {

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -312,12 +312,15 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
         // FXIOS-9519: By default if no bool value is set we close the private tabs and mark it true
         return profile.prefs.boolForKey(PrefsKeys.Settings.closePrivateTabs) ?? true
          */
-        let currentValue = profile.prefs.boolForKey(PrefsKeys.Settings.closePrivateTabs)
+        var currentValue = profile.prefs.boolForKey(PrefsKeys.Settings.closePrivateTabs)
 
-        // Only necessary for migration to version 11.x.x - remove after enough users migrated
-        let oldClosePrivateTabsValue = profile.prefs.boolForKey("settings.closePrivateTabs")
+        // Ecosia: Only necessary for migration to version 11.x.x - remove after enough users migrated
+        let oldKey = "settings.closePrivateTabs"
+        let oldClosePrivateTabsValue = profile.prefs.boolForKey(oldKey)
         if let oldValue = oldClosePrivateTabsValue, currentValue == nil {
+            currentValue = oldValue
             profile.prefs.setBool(oldValue, forKey: PrefsKeys.Settings.closePrivateTabs)
+            profile.prefs.removeObjectForKey(oldKey)
         }
 
         return currentValue ?? false

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -308,8 +308,11 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
     func preserveTabs() { fatalError("should never be called") }
 
     func shouldClearPrivateTabs() -> Bool {
+        /* Ecosia: [MOB-3352] Change default behaviour to false
         // FXIOS-9519: By default if no bool value is set we close the private tabs and mark it true
         return profile.prefs.boolForKey(PrefsKeys.Settings.closePrivateTabs) ?? true
+         */
+        return profile.prefs.boolForKey(PrefsKeys.Settings.closePrivateTabs) ?? false
     }
 
     func cleanupClosedTabs(_ closedTabs: [Tab], previous: Tab?, isPrivate: Bool = false) {

--- a/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
+++ b/firefox-ios/Client/TabManagement/Legacy/LegacyTabManager.swift
@@ -308,11 +308,19 @@ class LegacyTabManager: NSObject, FeatureFlaggable, TabManager, TabEventHandler 
     func preserveTabs() { fatalError("should never be called") }
 
     func shouldClearPrivateTabs() -> Bool {
-        /* Ecosia: [MOB-3352] Change default behaviour to false
+        /* Ecosia: [MOB-3352] Change default behaviour to false and migrate old key value
         // FXIOS-9519: By default if no bool value is set we close the private tabs and mark it true
         return profile.prefs.boolForKey(PrefsKeys.Settings.closePrivateTabs) ?? true
          */
-        return profile.prefs.boolForKey(PrefsKeys.Settings.closePrivateTabs) ?? false
+        let currentValue = profile.prefs.boolForKey(PrefsKeys.Settings.closePrivateTabs)
+
+        // Only necessary for migration to version 11.x.x - remove after enough users migrated
+        let oldClosePrivateTabsValue = profile.prefs.boolForKey("settings.closePrivateTabs")
+        if let oldValue = oldClosePrivateTabsValue, currentValue == nil {
+            profile.prefs.setBool(oldValue, forKey: PrefsKeys.Settings.closePrivateTabs)
+        }
+
+        return currentValue ?? false
     }
 
     func cleanupClosedTabs(_ closedTabs: [Tab], previous: Tab?, isPrivate: Bool = false) {


### PR DESCRIPTION
[MOB-3352]

## Context

Follow-up to https://github.com/ecosia/ios-browser/pull/896 since QA issues were reported.

## Approach

Look into Firefox history to understand, find it is very confusing (see [this Slack message](https://ecosia-team.slack.com/archives/C07CWQ35E7P/p1745332889400529?thread_ts=1745331622.291969&cid=C07CWQ35E7P)).

Proceed with:

* Change default behaviour to match what it was before upgrade and what is defined on the setting
* Introduce migration in case users had already explicitly set the old value

## Other

* Specific mention to this sort of issues was added to the [step-by-step upgrade doc](https://ecosia.atlassian.net/wiki/spaces/MOB/pages/2519302166/Firefox+Upgrades#Step-by-step) (Step `6.d`)

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I added the `// Ecosia:` helper comments where needed

[MOB-3352]: https://ecosia.atlassian.net/browse/MOB-3352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ