### PR TITLE
[MOB-3416] Include new DownloadHelper from latest Firefox

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -686,11 +686,10 @@ extension BrowserViewController: WKNavigationDelegate {
         }
 
         // Check if this response should be downloaded.
-        if let downloadHelper = DownloadHelper(request: request,
-                                               response: response,
-                                               cookieStore: cookieStore,
-                                               canShowInWebView: canShowInWebView,
-                                               forceDownload: forceDownload) {
+        if let downloadHelper = DownloadHelper(request: request, response: response, cookieStore: cookieStore),
+            downloadHelper.shouldDownloadFile(canShowInWebView: canShowInWebView,
+                                              forceDownload: forceDownload,
+                                              isForMainFrame: navigationResponse.isForMainFrame) {
             // Clear the pending download web view so that subsequent navigations from the same
             // web view don't invoke another download.
             pendingDownloadWebView = nil

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DownloadHelperTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DownloadHelperTests.swift
@@ -11,136 +11,96 @@ class DownloadHelperTests: XCTestCase {
     func test_init_whenMIMETypeIsNil_initializeCorrectly() {
         let response = anyResponse(mimeType: nil)
 
-        var subject = DownloadHelper(
-            request: anyRequest(),
-            response: response,
-            cookieStore: cookieStore(),
-            canShowInWebView: true,
-            forceDownload: false
-        )
-        XCTAssertNotNil(subject)
-
-        subject = DownloadHelper(
-            request: anyRequest(),
-            response: response,
-            cookieStore: cookieStore(),
-            canShowInWebView: false,
-            forceDownload: true
-        )
-        XCTAssertNotNil(subject)
-
-        subject = DownloadHelper(
-            request: anyRequest(),
-            response: response,
-            cookieStore: cookieStore(),
-            canShowInWebView: false,
-            forceDownload: false
-        )
-        XCTAssertNotNil(subject)
-
-        subject = DownloadHelper(
-            request: anyRequest(),
-            response: response,
-            cookieStore: cookieStore(),
-            canShowInWebView: true,
-            forceDownload: true
-        )
+        let subject = createSubject(request: anyRequest(),
+                                    response: response,
+                                    cookieStore: cookieStore())
         XCTAssertNotNil(subject)
     }
 
-    func test_init_whenMIMETypeIsNotOctetStream_initializeCorrectly() {
-        for mimeType in allMIMETypes() {
-            if mimeType == MIMEType.OctetStream { continue }
+    func test_shouldDownloadFile_whenMIMETypeOctetStream_isTrue() {
+        let mimeType = MIMEType.OctetStream
 
-            let response = anyResponse(mimeType: mimeType)
+        let response = anyResponse(mimeType: mimeType)
+        let subject = createSubject(request: anyRequest(),
+                                    response: response,
+                                    cookieStore: cookieStore())
+        let shouldDownload = subject?.shouldDownloadFile(canShowInWebView: true,
+                                                         forceDownload: false,
+                                                         isForMainFrame: false)
+        XCTAssertTrue(shouldDownload ?? false)
+    }
 
-            var subject = DownloadHelper(
-                request: anyRequest(),
-                response: response,
-                cookieStore: cookieStore(),
-                canShowInWebView: true,
-                forceDownload: false
-            )
-            XCTAssertNil(subject)
+    func test_shouldDownloadFile_whenMIMETypeIsNotOctetStream_isFalse() {
+        let mimeType = MIMEType.GIF
 
-            subject = DownloadHelper(
-                request: anyRequest(),
-                response: response,
-                cookieStore: cookieStore(),
-                canShowInWebView: false,
-                forceDownload: true
-            )
-            XCTAssertNotNil(subject)
-
-            subject = DownloadHelper(
-                request: anyRequest(),
-                response: response,
-                cookieStore: cookieStore(),
-                canShowInWebView: false,
-                forceDownload: false
-            )
-            XCTAssertNotNil(subject)
-
-            subject = DownloadHelper(
-                request: anyRequest(),
-                response: response,
-                cookieStore: cookieStore(),
-                canShowInWebView: true,
-                forceDownload: true
-            )
-            XCTAssertNotNil(subject)
+        let response = anyResponse(mimeType: mimeType)
+        if let subject = createSubject(request: anyRequest(),
+                                       response: response,
+                                       cookieStore: cookieStore()) {
+            let shouldDownload = subject.shouldDownloadFile(canShowInWebView: true,
+                                                            forceDownload: false,
+                                                            isForMainFrame: false)
+            XCTAssertFalse(shouldDownload)
         }
     }
 
-    func test_init_whenMIMETypeIsOctetStream_initializeCorrectly() {
-        let response = anyResponse(mimeType: MIMEType.OctetStream)
+    func test_shouldDownloadFile_whenCanShowInWebview_isFalse() {
+        let response = anyResponse(mimeType: MIMEType.GIF)
 
-        var subject = DownloadHelper(
-            request: anyRequest(),
-            response: response,
-            cookieStore: cookieStore(),
-            canShowInWebView: true,
-            forceDownload: false
-        )
-        XCTAssertNotNil(subject)
+        if let subject = createSubject(request: anyRequest(),
+                                       response: response,
+                                       cookieStore: cookieStore()) {
+            let shouldDownload = subject.shouldDownloadFile(canShowInWebView: true,
+                                                            forceDownload: false,
+                                                            isForMainFrame: false)
+            XCTAssertFalse(shouldDownload)
+        }
+    }
 
-        subject = DownloadHelper(
-            request: anyRequest(),
-            response: response,
-            cookieStore: cookieStore(),
-            canShowInWebView: false,
-            forceDownload: true
-        )
-        XCTAssertNotNil(subject)
+    func test_shouldDownloadFile_whenCanNotShowInWebview_isTrue() {
+        let response = anyResponse(mimeType: MIMEType.GIF)
 
-        subject = DownloadHelper(
-            request: anyRequest(),
-            response: response,
-            cookieStore: cookieStore(),
-            canShowInWebView: true,
-            forceDownload: true
-        )
-        XCTAssertNotNil(subject)
+        if let subject = createSubject(request: anyRequest(),
+                                       response: response,
+                                       cookieStore: cookieStore()) {
+            let shouldDownload = subject.shouldDownloadFile(canShowInWebView: false,
+                                                            forceDownload: false,
+                                                            isForMainFrame: false)
+            XCTAssertTrue(shouldDownload)
+        }
+    }
 
-        subject = DownloadHelper(
-            request: anyRequest(),
-            response: response,
-            cookieStore: cookieStore(),
-            canShowInWebView: false,
-            forceDownload: false
-        )
-        XCTAssertNotNil(subject)
+    func test_shouldDownloadFile_whenNotForceDownload_isFalse() {
+        let response = anyResponse(mimeType: MIMEType.GIF)
+
+        if let subject = createSubject(request: anyRequest(),
+                                       response: response,
+                                       cookieStore: cookieStore()) {
+            let shouldDownload = subject.shouldDownloadFile(canShowInWebView: true,
+                                                            forceDownload: false,
+                                                            isForMainFrame: false)
+            XCTAssertFalse(shouldDownload)
+        }
+    }
+
+    func test_shouldDownloadFile_whenForceDownload_isTrue() {
+        let response = anyResponse(mimeType: MIMEType.GIF)
+
+        if let subject = createSubject(request: anyRequest(),
+                                       response: response,
+                                       cookieStore: cookieStore()) {
+            let shouldDownload = subject.shouldDownloadFile(canShowInWebView: false,
+                                                            forceDownload: true,
+                                                            isForMainFrame: false)
+            XCTAssertTrue(shouldDownload)
+        }
     }
 
     func test_downloadViewModel_whenRequestURLIsWrong_deliversEmptyResult() {
         let request = anyRequest(urlString: "wrong-url.com")
-        let subject = DownloadHelper(
-            request: request,
-            response: anyResponse(mimeType: nil),
-            cookieStore: cookieStore(),
-            canShowInWebView: true,
-            forceDownload: false
-        )
+        let subject = createSubject(request: request,
+                                    response: anyResponse(mimeType: nil),
+                                    cookieStore: cookieStore())
 
         let downloadViewModel = subject?.downloadViewModel(windowUUID: .XCTestDefaultUUID, okAction: { _ in })
 
@@ -149,13 +109,9 @@ class DownloadHelperTests: XCTestCase {
 
     func test_downloadViewModel_deliversCorrectTitle() {
         let response = anyResponse(urlString: "http://some-domain.com/some-image.jpg")
-        let subject = DownloadHelper(
-            request: anyRequest(),
-            response: response,
-            cookieStore: cookieStore(),
-            canShowInWebView: true,
-            forceDownload: false
-        )
+        let subject = createSubject(request: anyRequest(),
+                                    response: response,
+                                    cookieStore: cookieStore())
 
         let downloadViewModel = subject?.downloadViewModel(windowUUID: .XCTestDefaultUUID, okAction: { _ in })
 
@@ -163,13 +119,9 @@ class DownloadHelperTests: XCTestCase {
     }
 
     func test_downloadViewModel_deliversCorrectCancelButtonTitle() {
-        let subject = DownloadHelper(
-            request: anyRequest(),
-            response: anyResponse(mimeType: nil),
-            cookieStore: cookieStore(),
-            canShowInWebView: true,
-            forceDownload: false
-        )
+        let subject = createSubject(request: anyRequest(),
+                                    response: anyResponse(mimeType: nil),
+                                    cookieStore: cookieStore())
 
         let downloadViewModel = subject?.downloadViewModel(windowUUID: .XCTestDefaultUUID, okAction: { _ in })
 
@@ -177,6 +129,14 @@ class DownloadHelperTests: XCTestCase {
     }
 
     // MARK: - Helpers
+
+    private func createSubject(request: URLRequest,
+                               response: URLResponse,
+                               cookieStore: WKHTTPCookieStore) -> DownloadHelper? {
+        return DownloadHelper(request: request,
+                              response: response,
+                              cookieStore: cookieStore)
+    }
 
     private func anyRequest(urlString: String = "http://any-url.com") -> URLRequest {
         return URLRequest(url: URL(string: urlString)!, cachePolicy: anyCachePolicy(), timeoutInterval: 60.0)
@@ -206,23 +166,5 @@ class DownloadHelperTests: XCTestCase {
 
     private func anyCachePolicy() -> URLRequest.CachePolicy {
         return .useProtocolCachePolicy
-    }
-
-    private func allMIMETypes() -> [String] {
-        return [MIMEType.Bitmap,
-                MIMEType.CSS,
-                MIMEType.GIF,
-                MIMEType.JavaScript,
-                MIMEType.JPEG,
-                MIMEType.HTML,
-                MIMEType.OctetStream,
-                MIMEType.Passbook,
-                MIMEType.PDF,
-                MIMEType.PlainText,
-                MIMEType.PNG,
-                MIMEType.WebP,
-                MIMEType.Calendar,
-                MIMEType.USDZ,
-                MIMEType.Reality]
     }
 }


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-3416]

## Context

Certain download attempts are not working on certain websites.

## Approach

Identify the root cause via 👇 :
- Compare with the old (before the upgrade) version
- Acknowledge differences
- Compared with Firefox Vanilla (v133) and acknowledged the same issue
- Compared with the latest Firefox and acknowledged the issue **not appearing**
- Debugging various websites and the way they serve the PDF download (or other files in general). Via `blob`, via https with mime-type `application/PDF` etc...
- Understand the changes between vanilla v133 and the current Firefox.
   - There is an ongoing "pdf refactor" see for instance [this computed property](https://github.com/mozilla-mobile/firefox-ios/blob/4e3086b5715e4ca085ed7bf44d7758061ef989c0/firefox-ios/Client/TabManagement/Tab.swift#L430)
   - Realise that this refactor is touching multiple places in the app
   - Acknowledged that, specifically, the PDF Refactor is not linked to the inability to download them
   -  Getting back to debugging
 - Found out via debugging the two (`main` Firefox) and our codebase, the differences in the redirect and conditional logic, and realised that for our specific issue, the solution was to apply the latest, reviewed DownloadHelper (and adapt it to our codebase), which takes into account the `application/PDF` mime-type as downloadable candidate. 

## Other

[Video](https://ecosia.atlassian.net/browse/MOB-3416?focusedCommentId=104364) with fix.

Reviewed tests as well.
As it's Firefox code, I decided not to apply any comments, even though the current file split is different in the current Firefox (`MIMEType` struct as its own file), but the whole file's layout is different (DownloadHelper has its own folder). 

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I wrote Unit Tests that confirm the expected behaviour
- [x] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)

[MOB-3416]: https://ecosia.atlassian.net/browse/MOB-3416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ