### PR TITLE
[MOB-3424] PayPal opens a blank page

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -31,6 +31,8 @@ extension BrowserViewController: WKUIDelegate {
             return nil
         }
 
+        guard !isPayPalPopUp(navigationAction) else { return nil }
+
         if navigationAction.canOpenExternalApp, let url = navigationAction.request.url {
             UIApplication.shared.open(url)
             return nil
@@ -148,52 +150,86 @@ extension BrowserViewController: WKUIDelegate {
         contextMenuConfigurationForElement elementInfo: WKContextMenuElementInfo,
         completionHandler: @escaping (UIContextMenuConfiguration?) -> Void
     ) {
-        guard let url = elementInfo.linkURL else { return }
-
-        completionHandler(
-            UIContextMenuConfiguration(
-                identifier: nil,
-                previewProvider: {
-                    guard self.profile.prefs.boolForKey(PrefsKeys.ContextMenuShowLinkPreviews) ?? true else { return nil }
-
-                    let previewViewController = UIViewController()
-                    previewViewController.view.isUserInteractionEnabled = false
-                    let clonedWebView = WKWebView(frame: webView.frame, configuration: webView.configuration)
-
-                    previewViewController.view.addSubview(clonedWebView)
-                    NSLayoutConstraint.activate([
-                        clonedWebView.topAnchor.constraint(equalTo: previewViewController.view.topAnchor),
-                        clonedWebView.leadingAnchor.constraint(equalTo: previewViewController.view.leadingAnchor),
-                        clonedWebView.trailingAnchor.constraint(equalTo: previewViewController.view.trailingAnchor),
-                        clonedWebView.bottomAnchor.constraint(equalTo: previewViewController.view.bottomAnchor)
-                    ])
-                    clonedWebView.translatesAutoresizingMaskIntoConstraints = false
-
-                    clonedWebView.load(URLRequest(url: url))
-
-                    return previewViewController
-                },
-                actionProvider: { [self] (suggested) -> UIMenu? in
-                    guard let currentTab = tabManager.selectedTab,
-                          let contextHelper = currentTab.getContentScript(
-                            name: ContextMenuHelper.name()
-                          ) as? ContextMenuHelper,
-                          let elements = contextHelper.elements
-                    else { return nil }
-
-                    let isPrivate = currentTab.isPrivate
-
-                    let actions = createActions(isPrivate: isPrivate,
-                                                url: url,
-                                                addTab: self.addTab,
-                                                title: elements.title,
-                                                image: elements.image,
-                                                currentTab: currentTab,
-                                                webView: webView)
-                    return UIMenu(title: url.absoluteString, children: actions)
-                })
-        )
+        guard let url = elementInfo.linkURL,
+              let currentTab = tabManager.selectedTab,
+              let contextHelper = currentTab.getContentScript(
+                name: ContextMenuHelper.name()
+              ) as? ContextMenuHelper,
+              let elements = contextHelper.elements
+        else {
+            completionHandler(nil)
+            return
+        }
+        completionHandler(contextMenuConfiguration(for: url, webView: webView, elements: elements))
     }
+
+    func webView(_ webView: WKWebView,
+                 requestMediaCapturePermissionFor origin: WKSecurityOrigin,
+                 initiatedByFrame frame: WKFrameInfo,
+                 type: WKMediaCaptureType,
+                 decisionHandler: @escaping (WKPermissionDecision) -> Void) {
+        // If the tab isn't the selected one or we're on the homepage, do not show the media capture prompt
+        guard tabManager.selectedTab?.webView === webView, !contentContainer.hasAnyHomepage else {
+            decisionHandler(.deny)
+            return
+        }
+
+        decisionHandler(.prompt)
+    }
+
+    // MARK: - Helpers
+        private func contextMenuConfiguration(for url: URL,
+                                              webView: WKWebView,
+                                              elements: ContextMenuHelper.Elements) -> UIContextMenuConfiguration {
+            return UIContextMenuConfiguration(identifier: nil,
+                                              previewProvider: contextMenuPreviewProvider(for: url, webView: webView),
+                                              actionProvider: contextMenuActionProvider(for: url,
+                                                                                        webView: webView,
+                                                                                        elements: elements))
+        }
+
+        private func contextMenuActionProvider(for url: URL,
+                                               webView: WKWebView,
+                                               elements: ContextMenuHelper.Elements) -> UIContextMenuActionProvider {
+            return { [self] (suggested) -> UIMenu? in
+                guard let currentTab = tabManager.selectedTab else { return nil }
+
+                let isPrivate = currentTab.isPrivate
+
+                let actions = createActions(isPrivate: isPrivate,
+                                            url: url,
+                                            addTab: self.addTab,
+                                            title: elements.title,
+                                            image: elements.image,
+                                            currentTab: currentTab,
+                                            webView: webView)
+                return UIMenu(title: url.normalizedHost ?? url.absoluteString, children: actions)
+            }
+        }
+
+        private func contextMenuPreviewProvider(for url: URL, webView: WKWebView) -> UIContextMenuContentPreviewProvider? {
+            let provider: UIContextMenuContentPreviewProvider = {
+                guard self.profile.prefs.boolForKey(PrefsKeys.ContextMenuShowLinkPreviews) ?? true else { return nil }
+
+                let previewViewController = UIViewController()
+                previewViewController.view.isUserInteractionEnabled = false
+                let clonedWebView = WKWebView(frame: webView.frame, configuration: webView.configuration)
+
+                previewViewController.view.addSubview(clonedWebView)
+                NSLayoutConstraint.activate([
+                    clonedWebView.topAnchor.constraint(equalTo: previewViewController.view.topAnchor),
+                    clonedWebView.leadingAnchor.constraint(equalTo: previewViewController.view.leadingAnchor),
+                    clonedWebView.trailingAnchor.constraint(equalTo: previewViewController.view.trailingAnchor),
+                    clonedWebView.bottomAnchor.constraint(equalTo: previewViewController.view.bottomAnchor)
+                ])
+                clonedWebView.translatesAutoresizingMaskIntoConstraints = false
+
+                clonedWebView.load(URLRequest(url: url))
+
+                return previewViewController
+            }
+            return provider
+        }
 
     func addTab(rURL: URL, isPrivate: Bool, currentTab: Tab) {
         var setAddTabAdSearchParam = false
@@ -332,21 +368,6 @@ extension BrowserViewController: WKUIDelegate {
 
     func assignWebView(_ webView: WKWebView?) {
         pendingDownloadWebView = webView
-    }
-
-    @available(iOS 15, *)
-    func webView(_ webView: WKWebView,
-                 requestMediaCapturePermissionFor origin: WKSecurityOrigin,
-                 initiatedByFrame frame: WKFrameInfo,
-                 type: WKMediaCaptureType,
-                 decisionHandler: @escaping (WKPermissionDecision) -> Void) {
-        // If the tab isn't the selected one or we're on the homepage, do not show the media capture prompt
-        guard tabManager.selectedTab?.webView == webView, !contentContainer.hasLegacyHomepage else {
-            decisionHandler(.deny)
-            return
-        }
-
-        decisionHandler(.prompt)
     }
 
     func writeToPhotoAlbum(image: UIImage) {
@@ -1018,6 +1039,13 @@ private extension BrowserViewController {
         }
 
         return false
+    }
+
+    // The WKNavigationAction request for Paypal popUp is empty which causes that we open a blank page in
+    // createWebViewWith. We will show Paypal popUp in page like mobile devices using the mobile User Agent
+    // so we will block the creation of a new Webview with this check
+    func isPayPalPopUp(_ navigationAction: WKNavigationAction) -> Bool {
+        return navigationAction.sourceFrame.request.url?.baseDomain == "paypal.com"
     }
 
     func shouldDisplayJSAlertForWebView(_ webView: WKWebView) -> Bool {

--- a/firefox-ios/Client/Frontend/Components/ContentContainer.swift
+++ b/firefox-ios/Client/Frontend/Components/ContentContainer.swift
@@ -36,6 +36,11 @@ class ContentContainer: UIView {
     var hasHomepage: Bool {
         return type == .homepage
     }
+    
+    // Ecosia: add computed var due to cherry pick https://github.com/mozilla-mobile/firefox-ios/pull/24609
+    var hasAnyHomepage: Bool {
+        return hasLegacyHomepage || hasHomepage || hasPrivateHomepage
+    }
 
     var hasWebView: Bool {
         return type == .webview

--- a/firefox-ios/Client/Frontend/Components/ContentContainer.swift
+++ b/firefox-ios/Client/Frontend/Components/ContentContainer.swift
@@ -36,7 +36,7 @@ class ContentContainer: UIView {
     var hasHomepage: Bool {
         return type == .homepage
     }
-    
+
     // Ecosia: add computed var due to cherry pick https://github.com/mozilla-mobile/firefox-ios/pull/24609
     var hasAnyHomepage: Bool {
         return hasLegacyHomepage || hasHomepage || hasPrivateHomepage

--- a/firefox-ios/Shared/UserAgent.swift
+++ b/firefox-ios/Shared/UserAgent.swift
@@ -73,9 +73,7 @@ open class UserAgent {
     }
 
     public static func mobileUserAgent() -> String {
-        // Ecosia: Always returns the Ecosia's UA as default one
-        // return UserAgentBuilder.defaultMobileUserAgent().userAgent()
-        UserAgentBuilder.ecosiaMobileUserAgent().userAgent()
+         return UserAgentBuilder.defaultMobileUserAgent().userAgent()
     }
 
     public static func oppositeUserAgent(domain: String) -> String {
@@ -201,15 +199,15 @@ public struct UserAgentBuilder {
     }
 
     public static func defaultMobileUserAgent() -> UserAgentBuilder {
+        /* Ecosia: Always returns the Ecosia's UA as default one
         return UserAgentBuilder(
             product: UserAgent.product,
             systemInfo: "(\(UIDevice.current.model); CPU iPhone OS \(UIDevice.current.systemVersion.replacingOccurrences(of: ".", with: "_")) like Mac OS X)",
             platform: UserAgent.platform,
             platformDetails: UserAgent.platformDetails,
-            /* Ecosia: Update extension
             extensions: "FxiOS/\(AppInfo.appVersion)  \(UserAgent.uaBitMobile) \(UserAgent.uaBitSafari)")
-             */
-            extensions: "Ecosia/\(AppInfo.appVersion)  \(UserAgent.uaBitMobile) \(UserAgent.uaBitSafari)")
+         */
+        return UserAgentBuilder.ecosiaMobileUserAgent()
     }
 
     public static func defaultDesktopUserAgent() -> UserAgentBuilder {
@@ -225,7 +223,7 @@ public struct UserAgentBuilder {
     }
 }
 
-// Ecosia: Ecosia Mobile UA + Paypal fix
+// Ecosia: Ecosia Mobile UA
 extension UserAgentBuilder {
 
     public static func ecosiaMobileUserAgent() -> UserAgentBuilder {
@@ -234,14 +232,5 @@ extension UserAgentBuilder {
                          platform: UserAgent.platform,
                          platformDetails: UserAgent.platformDetails,
                          extensions: "\(UserAgent.uaBitVersion) \(UserAgent.uaBitMobile) \(UserAgent.uaBitSafari) \(UserAgent.uaBitEcosia)")
-    }
-
-    public static func defaultPayPalMobileUserAgent() -> UserAgentBuilder {
-        return UserAgentBuilder(
-            product: UserAgent.product,
-            systemInfo: "(\(UIDevice.current.model); CPU iPhone OS \(UIDevice.current.systemVersion.replacingOccurrences(of: ".", with: "_")) like Mac OS X)",
-            platform: UserAgent.platform,
-            platformDetails: UserAgent.platformDetails,
-            extensions: "FxiOS/\(AppInfo.appVersion)  \(UserAgent.uaBitMobile) \(UserAgent.uaBitSafari)")
     }
 }

--- a/firefox-ios/Shared/UserAgent.swift
+++ b/firefox-ios/Shared/UserAgent.swift
@@ -137,14 +137,12 @@ struct CustomUserAgentConstant {
     private static let defaultMobileUA = UserAgentBuilder.defaultMobileUserAgent().userAgent()
     private static let customDesktopUA = UserAgentBuilder.defaultDesktopUserAgent().clone(extensions: "Version/\(AppInfo.appVersion) \(UserAgent.uaBitSafari)")
 
-    public static let customMobileUAForDomain = [
-        // Ecosia: Update paypal UA
-        // "paypal.com": defaultMobileUA,
-        "paypal.com": UserAgentBuilder.defaultPayPalMobileUserAgent().userAgent(),
-        "yahoo.com": defaultMobileUA,
-        "disneyplus.com": customDesktopUA]
+    static let customMobileUAForDomain = [
+        "disneyplus.com": customDesktopUA
+    ]
 
-    public static let customDesktopUAForDomain = [
+    static let customDesktopUAForDomain = [
+        "paypal.com": defaultMobileUA,
         "firefox.com": defaultMobileUA,
         // Ecosia: Add Ecosia URLs
         Ecosia.URLProvider.production.domain: UserAgent.ecosiaDesktopUA,

--- a/firefox-ios/firefox-ios-tests/Tests/SharedTests/UserAgentBuilderTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/SharedTests/UserAgentBuilderTests.swift
@@ -45,7 +45,7 @@ final class UserAgentBuilderTests: XCTestCase {
         /* Ecosia: Update extensions
         let extensions = "FxiOS/\(AppInfo.appVersion)  \(UserAgent.uaBitMobile) \(UserAgent.uaBitSafari)"
          */
-        let extensions = "Ecosia/\(AppInfo.appVersion)  \(UserAgent.uaBitMobile) \(UserAgent.uaBitSafari)"
+        let extensions = "\(UserAgent.uaBitVersion) \(UserAgent.uaBitMobile) \(UserAgent.uaBitSafari) \(UserAgent.uaBitEcosia)"
         let testAgent = "\(UserAgent.product) \(systemInfo) \(UserAgent.platform) \(UserAgent.platformDetails) \(extensions)"
         XCTAssertEqual(builder.userAgent(), testAgent)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/SharedTests/UserAgentTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/SharedTests/UserAgentTests.swift
@@ -22,4 +22,16 @@ final class UserAgentTests: XCTestCase {
             XCTAssertEqual(agent, UserAgent.getUserAgent(domain: domain, platform: .Mobile))
         }
     }
+
+    func testGetUserAgentDesktop_withPaypalDomain_returnMobileUserAgent() {
+        let paypalDomain = "paypal.com"
+        XCTAssertEqual(UserAgent.mobileUserAgent(),
+                       UserAgent.getUserAgent(domain: paypalDomain, platform: .Desktop))
+    }
+
+    func testGetUserAgentMobile_withPaypalDomain_returnProperUserAgent() {
+        let paypalDomain = "paypal.com"
+        XCTAssertEqual(UserAgent.mobileUserAgent(),
+                       UserAgent.getUserAgent(domain: paypalDomain, platform: .Mobile))
+    }
 }


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-3424]

## Context

After the investigation performed as part of our PayPal/Banks spike resulted [in this doc](https://ecosia.atlassian.net/wiki/spaces/MOB/pages/3864592396/PayPal+Banks+Investigation), we realised that PayPal behaves differently on some websites.

This PR serves as a follow-up fix.

## Approach

- Found one of the websites having the issue
- Checked against both vanilla + current Firefox
- Debugged the flow
- Double-checked on Firefox's pull requests
- Implemented relevant fixes via cherry-picks and adapted to the current Ecosia's codebase.

More info:

PayPal behaves differently, considering the source spinning up the PayPal web content.
As stated in the Jira tickets we worked on and confirmed by the [Firefox community](https://github.com/mozilla-mobile/firefox-ios/pulls?q=paypal), PayPal has been an ongoing issue for years.
However, it seems that lately, the Firefox team has found a way to drastically mitigate the occurrences, especially on iPads, where we (Ecosia) also received a few reports. 

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I added the `// Ecosia:` helper comments where needed
- [x] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)

[MOB-3424]: https://ecosia.atlassian.net/browse/MOB-3424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ