### PR TITLE
[MOB-3333] Add correct image identifier to ReadingList view

### DIFF
--- a/firefox-ios/Client/Ecosia/UI/EmptyReadingListView.swift
+++ b/firefox-ios/Client/Ecosia/UI/EmptyReadingListView.swift
@@ -39,7 +39,7 @@ final class EmptyReadingListView: UIView, Themeable {
     }
     var readerModeImageView: UIImageView = .build { imageView in
         imageView.contentMode = .scaleAspectFit
-        imageView.image = UIImage(named: "ReaderModeCircle")?.withRenderingMode(.alwaysTemplate)
+        imageView.image = UIImage(named: StandardImageIdentifiers.Large.readerView)?.withRenderingMode(.alwaysTemplate)
     }
     var readingListLabel: UILabel = .build { label in
         label.text = .ReaderPanelReadingListDescription
@@ -48,7 +48,7 @@ final class EmptyReadingListView: UIView, Themeable {
     }
     var readingListImageView: UIImageView = .build { imageView in
         imageView.contentMode = .scaleAspectFit
-        imageView.image = UIImage(named: "AddToReadingListCircle")?.withRenderingMode(.alwaysTemplate)
+        imageView.image = UIImage(named: StandardImageIdentifiers.Large.readingListAdd)?.withRenderingMode(.alwaysTemplate)
     }
 
     // MARK: - Init


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-3333]

## Context

As an upgrade regression, we found out that the Empty State's reading list items were missing.

## Approach

- Found out the root cause by comparing with the [Firefox's empty state view](https://github.com/mozilla-mobile/firefox-ios/blob/release/v133/firefox-ios/Client/Frontend/Library/Reader/ReaderPanelEmptyStateView.swift)
- Apply the correct image identifiers

## Other

I didn't want to copy the images in our Ecosia Framework and reference them from there, otherwise, we would have ended up having a double reference for the same image and likely a size increase in the resulting package.

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator

[MOB-3333]: https://ecosia.atlassian.net/browse/MOB-3333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ