### PR TITLE
[MOB-3424] Fix Paypal UA regression by reintroducing Firefox's UA

### DIFF
--- a/firefox-ios/Shared/UserAgent.swift
+++ b/firefox-ios/Shared/UserAgent.swift
@@ -136,11 +136,16 @@ struct CustomUserAgentConstant {
     private static let customDesktopUA = UserAgentBuilder.defaultDesktopUserAgent().clone(extensions: "Version/\(AppInfo.appVersion) \(UserAgent.uaBitSafari)")
 
     static let customMobileUAForDomain = [
+        // Ecosia: Re-introduce paypal UA so it uses the Firefox one
+        "paypal.com": UserAgentBuilder.defaultFirefoxMobileUserAgent().userAgent(),
         "disneyplus.com": customDesktopUA
     ]
 
     static let customDesktopUAForDomain = [
+        /* Ecosia: Update paypal UA so it uses the Firefox one
         "paypal.com": defaultMobileUA,
+        */
+        "paypal.com": UserAgentBuilder.defaultFirefoxMobileUserAgent().userAgent(),
         "firefox.com": defaultMobileUA,
         // Ecosia: Add Ecosia URLs
         Ecosia.URLProvider.production.domain: UserAgent.ecosiaDesktopUA,
@@ -223,7 +228,7 @@ public struct UserAgentBuilder {
     }
 }
 
-// Ecosia: Ecosia Mobile UA
+// Ecosia: Ecosia Mobile UA + Firefox
 extension UserAgentBuilder {
 
     public static func ecosiaMobileUserAgent() -> UserAgentBuilder {
@@ -232,5 +237,14 @@ extension UserAgentBuilder {
                          platform: UserAgent.platform,
                          platformDetails: UserAgent.platformDetails,
                          extensions: "\(UserAgent.uaBitVersion) \(UserAgent.uaBitMobile) \(UserAgent.uaBitSafari) \(UserAgent.uaBitEcosia)")
+    }
+
+    // This is what Firefox uses on production
+    public static func defaultFirefoxMobileUserAgent() -> UserAgentBuilder {
+        UserAgentBuilder(product: UserAgent.product,
+                         systemInfo: "(\(UIDevice.current.model); CPU iPhone OS \(UIDevice.current.systemVersion.replacingOccurrences(of: ".", with: "_")) like Mac OS X)",
+                         platform: UserAgent.platform,
+                         platformDetails: UserAgent.platformDetails,
+                         extensions: "FxiOS/\(AppInfo.appVersion)  \(UserAgent.uaBitMobile) \(UserAgent.uaBitSafari)")
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/SharedTests/UserAgentTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/SharedTests/UserAgentTests.swift
@@ -25,13 +25,19 @@ final class UserAgentTests: XCTestCase {
 
     func testGetUserAgentDesktop_withPaypalDomain_returnMobileUserAgent() {
         let paypalDomain = "paypal.com"
+        /* Ecosia: Use default Firefox UA instead
         XCTAssertEqual(UserAgent.mobileUserAgent(),
+         */
+        XCTAssertEqual(UserAgentBuilder.defaultFirefoxMobileUserAgent().userAgent(),
                        UserAgent.getUserAgent(domain: paypalDomain, platform: .Desktop))
     }
 
     func testGetUserAgentMobile_withPaypalDomain_returnProperUserAgent() {
         let paypalDomain = "paypal.com"
+        /* Ecosia: Use default Firefox UA instead
         XCTAssertEqual(UserAgent.mobileUserAgent(),
+         */
+        XCTAssertEqual(UserAgentBuilder.defaultFirefoxMobileUserAgent().userAgent(),
                        UserAgent.getUserAgent(domain: paypalDomain, platform: .Mobile))
     }
 }


### PR DESCRIPTION
[MOB-3424]

## Context

On https://github.com/ecosia/ios-browser/pull/905 we cherry-picked some Firefox's Paypal fixes.

⚠️ This introduced a regression error related to UserAgents -> see this [ticket comment](https://ecosia.atlassian.net/browse/MOB-3424?focusedCommentId=104689).

## Approach

Figure out the issue originates from the fact we don't use Firefox's UA for Paypal and revert that.

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I wrote Unit Tests that confirm the expected behaviour
- [x] I added the `// Ecosia:` helper comments where needed

[MOB-3424]: https://ecosia.atlassian.net/browse/MOB-3424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ