### PR TITLE
[MOB-3410] Update translations. Add ar-SA, en-CA and en-GB

### DIFF
--- a/.tx/release_notes_integration_config.yml
+++ b/.tx/release_notes_integration_config.yml
@@ -8,6 +8,8 @@ settings:
     es: es-ES
     es_MX: es-MX
     en_AU: en-AU
+    ar_SA: ar-SA
+    en_CA: en-CA
 
 filters:
 

--- a/.tx/release_notes_integration_config.yml
+++ b/.tx/release_notes_integration_config.yml
@@ -8,7 +8,6 @@ settings:
     es: es-ES
     es_MX: es-MX
     en_AU: en-AU
-    ar_SA: ar-SA
     en_CA: en-CA
 
 filters:

--- a/fastlane/metadata/ar-SA/release_notes.txt
+++ b/fastlane/metadata/ar-SA/release_notes.txt
@@ -1,0 +1,1 @@
+We fixed some bugs and added some stability improvements.

--- a/fastlane/metadata/ar-SA/release_notes.txt
+++ b/fastlane/metadata/ar-SA/release_notes.txt
@@ -1,1 +1,0 @@
-We fixed some bugs and added some stability improvements.

--- a/fastlane/metadata/en-CA/release_notes.txt
+++ b/fastlane/metadata/en-CA/release_notes.txt
@@ -1,0 +1,1 @@
+We fixed some bugs and added some stability improvements.

--- a/fastlane/metadata/en-GB/release_notes.txt
+++ b/fastlane/metadata/en-GB/release_notes.txt
@@ -1,0 +1,1 @@
+We fixed some bugs and added some stability improvements.


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-3410]

## Context

Adding new language support to our release notes automation.

## Approach

- After (unsuccessfully) checking with the marketing, I decided to pull in those new files anyway
- I also double-checked for a simple way to avoid waiting for sources (let's say en-CA and en-US) to be translated twice (which theoretically should happen automatically, but I haven't checked), but there wasn't a straightforward way to handle that
- For now, we are just adding them as in most scenarios (hope we'll change this at some point), the changelog will always be the same

💡 If we'll begin to have a different, more insightful changelog in the future, we may think of removing the transifex support for languages having 99.9% same changelog (en-CA and en-US) and provide the Github Action with a script that copies the changelog in the from the source language (let's say en-US) in the target one before uploading. We'll still be able to support en-CA with automation while having 1 less language on Transifex. 

[MOB-3333]: https://ecosia.atlassian.net/browse/MOB-3333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MOB-3410]: https://ecosia.atlassian.net/browse/MOB-3410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ