### PR TITLE
[MOB-3451] Skip tests and update `EcosiaHomeViewModelTests`

### DIFF
--- a/firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/EcosiaBeta.xcscheme
+++ b/firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/EcosiaBeta.xcscheme
@@ -103,6 +103,24 @@
                   Identifier = "HistoryHighlightsDataAdaptorTests/testReloadDataOnNotification()">
                </Test>
                <Test
+                  Identifier = "MainMenuStateTests">
+               </Test>
+               <Test
+                  Identifier = "MainMenuStateTests/testCloseAction()">
+               </Test>
+               <Test
+                  Identifier = "MainMenuStateTests/testInitialization()">
+               </Test>
+               <Test
+                  Identifier = "MainMenuStateTests/testNavigation_AllCases()">
+               </Test>
+               <Test
+                  Identifier = "MainMenuStateTests/testToggleUserAgentAction()">
+               </Test>
+               <Test
+                  Identifier = "MainMenuStateTests/testUpdatingCurrentTabInfo()">
+               </Test>
+               <Test
                   Identifier = "SearchTests/testURIFixupPunyCode()">
                </Test>
                <Test
@@ -310,6 +328,11 @@
                BlueprintName = "EcosiaTests"
                ReferencedContainer = "container:Client.xcodeproj">
             </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "NewsTests/testNeedsUpdateAfterLoading()">
+               </Test>
+            </SkippedTests>
          </TestableReference>
       </Testables>
    </TestAction>

--- a/firefox-ios/EcosiaTests/EcosiaHomeViewModelTests.swift
+++ b/firefox-ios/EcosiaTests/EcosiaHomeViewModelTests.swift
@@ -36,8 +36,8 @@ class EcosiaHomeViewModelTests: XCTestCase {
         let viewModel = HomepageViewModel(profile: profile,
                                           isPrivate: false,
                                           tabManager: MockTabManager(),
-                                          referrals: .init(),
                                           theme: EcosiaLightTheme())
+        User.shared.showClimateImpact = true
 
         XCTAssertEqual(viewModel.shownSections.count, 4)
         XCTAssertEqual(viewModel.shownSections[0], HomepageSectionType.homepageHeader)


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-3451]

## Context

As a result of the work done to investigate flaky tests, we realised that some tests are still affected by some flakiness.
Firefox is constantly reviewing those, but it would be nice to review them too. However, we agreed to skip the notably flaky ones on our end and review the Firefox ones in the next upgrade.

## Approach

#### Before opening the PR, I wanted to make sure of multiple successful runs locally. We know, though, that would not necessarily mean that everything will go well on CI.

- Skipped our flaky ones
- Reviewed the `testNumberOfSection_withoutUpdatingData_has4Sections` explicitly adding the `User.shared.showClimateImpact = true`. This shared `User` instance was something that has always been flagged as one of the causes of test instability (expected from a shared instance after all). Would love to think of a migration strategy, especially now that we are including some of the Accounts functionalities.

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator

[MOB-3451]: https://ecosia.atlassian.net/browse/MOB-3451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ