### PR TITLE
[MOB-3466] Snowplow Micro Analytics Tests

### DIFF
--- a/firefox-ios/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
@@ -155,13 +155,17 @@ extension AppSettingsTableViewController {
             ChangeSearchCount(settings: self),
             ResetSearchCount(settings: self),
             ResetDefaultBrowserNudgeCard(settings: self),
-            AnalyticsIdentifierSetting(settings: self),
             FasterInactiveTabs(settings: self, settingsDelegate: self),
+            UnleashSeedCounterNTPSetting(settings: self),
             UnleashBrazeIntegrationSetting(settings: self),
             UnleashAPNConsent(settings: self),
+            AnalyticsIdentifierSetting(settings: self),
             UnleashNativeSRPVAnalyticsSetting(settings: self),
-            UnleashSeedCounterNTPSetting(settings: self),
         ]
+
+        if Environment.current == .staging {
+            hiddenDebugSettings.append(AnalyticsStagingUrlSetting(settings: self))
+        }
 
         if SeedCounterNTPExperiment.isEnabled {
             hiddenDebugSettings.append(AddOneSeedSetting(settings: self,

--- a/firefox-ios/Client/Ecosia/Settings/EcosiaDebugSettings.swift
+++ b/firefox-ios/Client/Ecosia/Settings/EcosiaDebugSettings.swift
@@ -301,3 +301,21 @@ final class AnalyticsIdentifierSetting: HiddenSetting {
         UIPasteboard.general.string = analyticsIdentifier
     }
 }
+
+final class AnalyticsStagingUrlSetting: HiddenSetting {
+
+    override var title: NSAttributedString? {
+        return NSAttributedString(string: "Debug: Toggle - Swap Analytics Staging URL", attributes: [NSAttributedString.Key.foregroundColor: theme.colors.ecosia.tableViewRowText])
+    }
+
+    override var status: NSAttributedString? {
+        let isOn = Analytics.shouldUseMicroInstance
+        let snowplowInstance = isOn ? "Micro" : "Mini"
+        return NSAttributedString(string: "\(snowplowInstance) instance (Click to toggle)", attributes: [NSAttributedString.Key.foregroundColor: theme.colors.ecosia.tableViewRowText])
+    }
+
+    override func onClick(_ navigationController: UINavigationController?) {
+        Analytics.shouldUseMicroInstance.toggle()
+        settings.tableView.reloadData()
+    }
+}

--- a/firefox-ios/Ecosia/Analytics/Analytics.swift
+++ b/firefox-ios/Ecosia/Analytics/Analytics.swift
@@ -370,8 +370,9 @@ extension Analytics {
     /// including authentication headers if using a micro instance.
     ///
     /// - Returns: A configured `NetworkConfiguration` object.
-    static func makeNetworkConfig() -> NetworkConfiguration {
-        let urlProvider = Environment.current.urlProvider
+    /// - Parameters:
+    ///   - urlProvider: The urlProvider in use. Useful for testing purposes.
+    static func makeNetworkConfig(urlProvider: URLProvider = Environment.current.urlProvider) -> NetworkConfiguration {
         let endpoint = shouldUseMicroInstance ? urlProvider.snowplowMicro : urlProvider.snowplow
         var networkConfig = NetworkConfiguration(endpoint: endpoint!)
 

--- a/firefox-ios/Ecosia/Analytics/Analytics.swift
+++ b/firefox-ios/Ecosia/Analytics/Analytics.swift
@@ -13,15 +13,10 @@ open class Analytics {
     static let inappSearchSchema = "iglu:org.ecosia/inapp_search_event/jsonschema/1-0-1"
     private static let abTestRoot = "ab_tests"
     private static let namespace = "ios_sp"
-
-    private static var tracker: TrackerController {
-
-        return Snowplow.createTracker(namespace: namespace,
-                                      network: .init(endpoint: Environment.current.urlProvider.snowplow),
-                                      configurations: [Self.trackerConfiguration,
-                                                       Self.subjectConfiguration,
-                                                       Self.appInstallTrackingPluginConfiguration,
-                                                       Self.appResumeDailyTrackingPluginConfiguration])
+    public static var shouldUseMicroInstance: Bool = false {
+        didSet {
+            Analytics.updateTrackerController()
+        }
     }
 
     public static var shared = Analytics()
@@ -29,7 +24,7 @@ open class Analytics {
     private let notificationCenter: AnalyticsUserNotificationCenterProtocol
 
     internal init(notificationCenter: AnalyticsUserNotificationCenterProtocol = AnalyticsUserNotificationCenterWrapper()) {
-        tracker = Self.tracker
+        tracker = Self.makeTracker()
         tracker.installAutotracking = true
         tracker.screenViewAutotracking = false
         tracker.lifecycleAutotracking = false
@@ -44,6 +39,10 @@ open class Analytics {
         _ = tracker.track(event)
     }
 
+    private static func updateTrackerController() {
+        Analytics.shared.tracker = makeTracker()
+    }
+
     private static func getTestContext(from toggle: Unleash.Toggle.Name) -> SelfDescribingJson? {
         let variant = Unleash.getVariant(toggle).name
         guard variant != "disabled" else { return nil }
@@ -55,7 +54,7 @@ open class Analytics {
 
     public func reset() {
         User.shared.analyticsId = .init()
-        tracker = Self.tracker
+        tracker = Self.makeTracker()
     }
 
     // MARK: App events
@@ -349,5 +348,43 @@ extension Analytics {
             event.entities.append(userContext)
             completion()
         }
+    }
+}
+
+extension Analytics {
+
+    /// Creates and configures a new instance of `TrackerController` using Snowplow.
+    ///
+    /// - Returns: A configured `TrackerController` instance, which in non-release builds can either point to mini or micro Snowplow instance.
+    private static func makeTracker() -> TrackerController {
+        return Snowplow.createTracker(namespace: namespace,
+                                      network: makeNetworkConfig(),
+                                      configurations: [
+                                        Self.trackerConfiguration,
+                                        Self.subjectConfiguration,
+                                        Self.appInstallTrackingPluginConfiguration,
+                                        Self.appResumeDailyTrackingPluginConfiguration])
+    }
+
+    /// Factory that builds the `NetworkConfiguration` for the Snowplow tracker, optionally
+    /// including authentication headers if using a micro instance.
+    ///
+    /// - Returns: A configured `NetworkConfiguration` object.
+    static func makeNetworkConfig() -> NetworkConfiguration {
+        let urlProvider = Environment.current.urlProvider
+        let endpoint = shouldUseMicroInstance ? urlProvider.snowplowMicro : urlProvider.snowplow
+        var networkConfig = NetworkConfiguration(endpoint: endpoint!)
+
+        if shouldUseMicroInstance,
+           urlProvider.snowplowMicro != nil,
+           let auth = Environment.current.auth {
+            networkConfig = networkConfig
+                .requestHeaders([
+                    CloudflareKeyProvider.clientId: auth.id,
+                    CloudflareKeyProvider.clientSecret: auth.secret
+                ])
+        }
+
+        return networkConfig
     }
 }

--- a/firefox-ios/Ecosia/Analytics/Analytics.swift
+++ b/firefox-ios/Ecosia/Analytics/Analytics.swift
@@ -377,7 +377,6 @@ extension Analytics {
         var networkConfig = NetworkConfiguration(endpoint: endpoint!)
 
         if shouldUseMicroInstance,
-           urlProvider.snowplowMicro != nil,
            let auth = Environment.current.auth {
             networkConfig = networkConfig
                 .requestHeaders([

--- a/firefox-ios/Ecosia/Core/Environment/URLProvider.swift
+++ b/firefox-ios/Ecosia/Core/Environment/URLProvider.swift
@@ -37,6 +37,13 @@ public enum URLProvider {
         }
     }
 
+    public var snowplowMicro: String? {
+        if case .staging = self {
+            return "https://ecosia-staging.xyz/analytics-test-micro"
+        }
+        return nil
+    }
+
     public var snowplow: String {
         switch self {
         case .production:

--- a/firefox-ios/EcosiaTests/Analytics/AnalyticsTests.swift
+++ b/firefox-ios/EcosiaTests/Analytics/AnalyticsTests.swift
@@ -163,14 +163,14 @@ final class AnalyticsTests: XCTestCase {
         XCTAssertEqual(config.requestHeaders?.keys.contains(CloudflareKeyProvider.clientId), true)
         XCTAssertEqual(config.requestHeaders?.keys.contains(CloudflareKeyProvider.clientSecret), true)
     }
-    
+
     func test_makeNetworkConfig_usesProductionEndpoint_whenShouldUseMicroIsFalse_andUrlProvider_isProduction() {
         Analytics.shouldUseMicroInstance = false
         let mockUrlProvider: URLProvider = .production
         let config = Analytics.makeNetworkConfig(urlProvider: mockUrlProvider)
         XCTAssertEqual(mockUrlProvider.snowplow, "sp.ecosia.org")
         XCTAssertEqual(mockUrlProvider.snowplow, config.endpoint?.asURL?.host)
-        XCTAssertEqual(config.requestHeaders?.keys.contains(CloudflareKeyProvider.clientId), false)
-        XCTAssertEqual(config.requestHeaders?.keys.contains(CloudflareKeyProvider.clientSecret), false)
+        XCTAssertNil(config.requestHeaders?.keys.contains(CloudflareKeyProvider.clientId))
+        XCTAssertNil(config.requestHeaders?.keys.contains(CloudflareKeyProvider.clientSecret))
     }
 }

--- a/firefox-ios/EcosiaTests/Analytics/AnalyticsTests.swift
+++ b/firefox-ios/EcosiaTests/Analytics/AnalyticsTests.swift
@@ -146,4 +146,19 @@ final class AnalyticsTests: XCTestCase {
 
         // Then: The result should be false because it's an upgrade
         XCTAssertFalse(result, "The first install should return FALSE when it's an upgrade")
-    }}
+    }
+
+    func test_makeNetworkConfig_usesStandardEndpoint_whenShouldUseMicroIsFalse() {
+        Analytics.shouldUseMicroInstance = false
+        let config = Analytics.makeNetworkConfig()
+        XCTAssertEqual(Environment.current.urlProvider.snowplow, config.endpoint)
+    }
+
+    func test_makeNetworkConfig_usesMicroEndpoint_whenShouldUseMicroIsTrue() {
+        Analytics.shouldUseMicroInstance = false
+        let config = Analytics.makeNetworkConfig()
+        XCTAssertEqual(Environment.current.urlProvider.snowplowMicro, config.endpoint)
+        XCTAssertEqual(config.requestHeaders?.keys.contains(CloudflareKeyProvider.clientId), true)
+        XCTAssertEqual(config.requestHeaders?.keys.contains(CloudflareKeyProvider.clientSecret), true)
+    }
+}

--- a/firefox-ios/EcosiaTests/Analytics/AnalyticsTests.swift
+++ b/firefox-ios/EcosiaTests/Analytics/AnalyticsTests.swift
@@ -150,15 +150,27 @@ final class AnalyticsTests: XCTestCase {
 
     func test_makeNetworkConfig_usesStandardEndpoint_whenShouldUseMicroIsFalse() {
         Analytics.shouldUseMicroInstance = false
-        let config = Analytics.makeNetworkConfig()
-        XCTAssertEqual(Environment.current.urlProvider.snowplow, config.endpoint)
+        let mockUrlProvider: URLProvider = .staging
+        let config = Analytics.makeNetworkConfig(urlProvider: mockUrlProvider)
+        XCTAssertEqual(mockUrlProvider.snowplow, config.endpoint?.asURL?.host)
     }
 
     func test_makeNetworkConfig_usesMicroEndpoint_whenShouldUseMicroIsTrue() {
-        Analytics.shouldUseMicroInstance = false
-        let config = Analytics.makeNetworkConfig()
-        XCTAssertEqual(Environment.current.urlProvider.snowplowMicro, config.endpoint)
+        Analytics.shouldUseMicroInstance = true
+        let mockUrlProvider: URLProvider = .staging
+        let config = Analytics.makeNetworkConfig(urlProvider: mockUrlProvider)
+        XCTAssertEqual(mockUrlProvider.snowplowMicro, config.endpoint)
         XCTAssertEqual(config.requestHeaders?.keys.contains(CloudflareKeyProvider.clientId), true)
         XCTAssertEqual(config.requestHeaders?.keys.contains(CloudflareKeyProvider.clientSecret), true)
+    }
+    
+    func test_makeNetworkConfig_usesProductionEndpoint_whenShouldUseMicroIsFalse_andUrlProvider_isProduction() {
+        Analytics.shouldUseMicroInstance = false
+        let mockUrlProvider: URLProvider = .production
+        let config = Analytics.makeNetworkConfig(urlProvider: mockUrlProvider)
+        XCTAssertEqual(mockUrlProvider.snowplow, "sp.ecosia.org")
+        XCTAssertEqual(mockUrlProvider.snowplow, config.endpoint?.asURL?.host)
+        XCTAssertEqual(config.requestHeaders?.keys.contains(CloudflareKeyProvider.clientId), false)
+        XCTAssertEqual(config.requestHeaders?.keys.contains(CloudflareKeyProvider.clientSecret), false)
     }
 }


### PR DESCRIPTION
Minor improvements on how we handle the tracker creation

<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-3466]

## Context

This ticket aims to complete the investigation performed as part of this branch https://github.com/ecosia/ios-browser/tree/ls-mob-3355-snowplow-micro-staging and complete the implementation.

## Approach

After some thinking, I realised that the best approach (given our open-source codebase) would be to:
- Simply save a flag that determines which Snowplow mini instance to use.
- This flag will reset whenever we open the app at a cold start.
- The hidden setting will not be available for release builds. 

## Other

Took the opportunity to review how we create the tracker, adding factory methods for both the tracker and the network config.

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I wrote Unit Tests that confirm the expected behaviour
- [x] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)

[MOB-3466]: https://ecosia.atlassian.net/browse/MOB-3466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ