### PR TITLE
[MOB-3466] Fix - make snowplow instance persistent

### DIFF
--- a/firefox-ios/Ecosia/Analytics/Analytics.swift
+++ b/firefox-ios/Ecosia/Analytics/Analytics.swift
@@ -13,8 +13,13 @@ open class Analytics {
     static let inappSearchSchema = "iglu:org.ecosia/inapp_search_event/jsonschema/1-0-1"
     private static let abTestRoot = "ab_tests"
     private static let namespace = "ios_sp"
-    public static var shouldUseMicroInstance: Bool = false {
-        didSet {
+    private static let shouldUseMicroInstanceKey = "shouldUseMicroInstance"
+    public static var shouldUseMicroInstance: Bool {
+        get {
+            UserDefaults.standard.bool(forKey: shouldUseMicroInstanceKey)
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: shouldUseMicroInstanceKey)
             Analytics.updateTrackerController()
         }
     }

--- a/firefox-ios/Ecosia/Core/Environment/URLProvider.swift
+++ b/firefox-ios/Ecosia/Core/Environment/URLProvider.swift
@@ -39,7 +39,7 @@ public enum URLProvider {
 
     public var snowplowMicro: String? {
         if case .staging = self {
-            return "https://ecosia-staging.xyz/analytics-test-micro"
+            return "https://www.ecosia-staging.xyz/analytics-test-micro"
         }
         return nil
     }


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-3466]

## Context

We discovered that we needed the flag to persist across cold starts.

## Approach

Adding a UserDefault value that persists a simple bool value that checks whether a Micro instance is needed

## Other

Took the opportunity to fix the Micro URL as well 🙏 

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator
- [x] I wrote Unit Tests that confirm the expected behaviour

[MOB-3466]: https://ecosia.atlassian.net/browse/MOB-3466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ