### PR TITLE
[MOB-3627] feat: update `MOZ_BUNDLE_DISPLAY_NAME` into `Ecosia`

### DIFF
--- a/firefox-ios/Client/Configuration/Ecosia.xcconfig
+++ b/firefox-ios/Client/Configuration/Ecosia.xcconfig
@@ -6,6 +6,7 @@
 #include "Release.xcconfig"
 #include "Production.xcconfig"
 
+MOZ_PRODUCT_NAME = Ecosia
 MOZ_BUNDLE_DISPLAY_NAME = Ecosia
 MOZ_BUNDLE_ID = com.ecosia.ecosiaapp
 CODE_SIGN_ENTITLEMENTS = Ecosia/Entitlements/Ecosia.entitlements

--- a/firefox-ios/Client/Configuration/EcosiaBeta.xcconfig
+++ b/firefox-ios/Client/Configuration/EcosiaBeta.xcconfig
@@ -9,6 +9,7 @@
 #include "Staging.xcconfig"
 
 MOZ_BUNDLE_DISPLAY_NAME = Ecosia Beta
+MOZ_PRODUCT_NAME = Ecosia
 MOZ_BUNDLE_ID = com.ecosia.ecosiaapp.firefox
 CODE_SIGN_ENTITLEMENTS = Ecosia/Entitlements/EcosiaBeta.entitlements
 OTHER_SWIFT_FLAGS = $(OTHER_SWIFT_FLAGS_common) -DMOZ_CHANNEL_BETA

--- a/firefox-ios/Client/Configuration/EcosiaBetaDebug.xcconfig
+++ b/firefox-ios/Client/Configuration/EcosiaBetaDebug.xcconfig
@@ -10,6 +10,7 @@
 
 INFOPLIST_FILE = Client/Info.plist
 MOZ_BUNDLE_DISPLAY_NAME = Ecosia Beta
+MOZ_PRODUCT_NAME = Ecosia
 MOZ_BUNDLE_ID = com.ecosia.ecosiaapp.firefox
 INCLUDE_SETTINGS_BUNDLE = YES
 LEANPLUM_ENVIRONMENT = development

--- a/firefox-ios/Client/Configuration/EcosiaDebug.xcconfig
+++ b/firefox-ios/Client/Configuration/EcosiaDebug.xcconfig
@@ -10,6 +10,7 @@
 #include "Staging.xcconfig"
 
 INFOPLIST_FILE = Client/Info.plist
+MOZ_PRODUCT_NAME = Ecosia
 MOZ_BUNDLE_DISPLAY_NAME = Ecosia
 MOZ_BUNDLE_ID = com.ecosia.ecosiaapp
 INCLUDE_SETTINGS_BUNDLE = YES


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-3627]

## Context

As part of the Auth0 implementation, we noticed that the product name is Client, which should be Ecosia when displayed in the popup.

## Approach

- Investigate how the whole xcconfig process worked
- Found `MOZ_PRODUCT_NAME`
- updated into `Ecosia`

Added screen in the [jira ticket](https://ecosia.atlassian.net/browse/MOB-3627)

[MOB-3627]: https://ecosia.atlassian.net/browse/MOB-3627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ