### PR TITLE
[MOB-3583] Fix squeezed AI Search Pill

### DIFF
--- a/firefox-ios/Client/Ecosia/Extensions/SearchViewController+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/SearchViewController+Ecosia.swift
@@ -89,8 +89,8 @@ extension SearchViewController {
         pillContainer.backgroundColor = theme.colors.ecosia.buttonBackgroundPrimary
 
         let pillWidth = internalPadding + twinkleSize + spacing + aiSearchLabel.frame.width + internalPadding
-        // Make sure title's frame is calculated and not zero
-        cell.titleLabel.sizeToFit()
+        // Ensure layout is up-to-date before reading frames
+        cell.layoutIfNeeded()
         let pillHeight = cell.titleLabel.frame.height + internalPadding / 2
 
         // Calculate Y position to center pill with leftImageView

--- a/firefox-ios/Client/Ecosia/Extensions/SearchViewController+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/SearchViewController+Ecosia.swift
@@ -89,6 +89,8 @@ extension SearchViewController {
         pillContainer.backgroundColor = theme.colors.ecosia.buttonBackgroundPrimary
 
         let pillWidth = internalPadding + twinkleSize + spacing + aiSearchLabel.frame.width + internalPadding
+        // Make sure title's frame is calculated and not zero
+        cell.titleLabel.sizeToFit()
         let pillHeight = cell.titleLabel.frame.height + internalPadding / 2
 
         // Calculate Y position to center pill with leftImageView


### PR DESCRIPTION
[MOB-3583]

## Context

The AI Search Pill was getting squeezed on some cases, such as when pasting text.

## Approach

Noticed the issue was how we calculate the frame manually, instead of using constraints.

Spent more time than I care to admit trying to move to a more reliable pattern of having a separate AISearchPillView that uses constraints, but realised that there are limitations to this approach (which probably @d4r1091 had already realised when first implementing 🙈). The major ones are:
* We can't create a new section because we want it to be grouped together with search results and this is a `insetGrouped` table
* We want to use `accessoryView` to set the view instead of adding subviews, otherwise we need to manage removing them too since the cells get reused. 
* The `accessoryView` is in turn already handled and positioned within `OneLineTableViewCell` on [this line](https://github.com/ecosia/ios-browser/blob/f86a87f2abb42549964c7becde0db36901859794/firefox-ios/Client/Frontend/Widgets/OneLineTableViewCell.swift#L98), which should serve our purpose, but instead causes sequencing issues when setup without an accessory view yet. We also have problems not being able to set positioning constraints within a custom view as we don't have access to the cell.

**Conclusion:** Went with the simplest one-liner fix which is just ensuring the label which we base the height off has correct sizes when manually calculating the frame.

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad

[MOB-3583]: https://ecosia.atlassian.net/browse/MOB-3583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ