### PR TITLE
Fix swiftlint CI failure

### DIFF
--- a/.github/workflows/swift_lint.yml
+++ b/.github/workflows/swift_lint.yml
@@ -13,4 +13,4 @@ jobs:
 
       - name: SwiftLint
         run: |
-          swiftlint lint --reporter github-actions-logging --strict --config ".swiftlint.yml"
+          swiftlint --reporter github-actions-logging --strict


### PR DESCRIPTION
## Context

On another PR (https://github.com/ecosia/ios-browser/pull/939) - noticed swiftlint is unexpectedly failing.

Example: [this run](https://github.com/ecosia/ios-browser/actions/runs/17150216851/job/48654562340?pr=939).

## Approach

Reproduced locally and noticed it is likely not using the config file. Trying to force it to use the file.