### PR TITLE
[MOB-3597] Braze Push delegates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,6 +369,7 @@ workflows:
               only: 
                 - main
                 - /^main-\d+$/
+                - ls-mob-3597-braze-push-delegate
           context: napps
 
       # Check if version was bumped and conditionally continue to release pipeline

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,7 +369,6 @@ workflows:
               only: 
                 - main
                 - /^main-\d+$/
-                - ls-mob-3597-braze-push-delegate
           context: napps
 
       # Check if version was bumped and conditionally continue to release pipeline

--- a/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/braze-inc/braze-swift-sdk",
       "state" : {
-        "revision" : "b509705fb11fe1788a813b2310847c166203f744",
-        "version" : "11.6.0"
+        "revision" : "6c7bcbd58e36b4776f235260398fa1817244160d",
+        "version" : "11.9.0"
       }
     },
     {

--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -366,10 +366,16 @@ extension AppDelegate {
     }
 }
 
-// Ecosia: Register the APN device token
-
+// Ecosia: Register the APN device token and handle background notifications
 extension AppDelegate {
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         BrazeService.shared.registerDeviceToken(deviceToken)
+    }
+
+    func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable: Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
+        if BrazeService.shared.handleBackgroundNotification(userInfo: userInfo, completionHandler: completionHandler) {
+            return
+        }
+        completionHandler(.noData)
     }
 }

--- a/firefox-ios/Ecosia/Braze/BrazeService.swift
+++ b/firefox-ios/Ecosia/Braze/BrazeService.swift
@@ -161,7 +161,7 @@ extension BrazeService: BrazeInAppMessageUIDelegate {
 
 extension BrazeService: UNUserNotificationCenterDelegate {
     public func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
-        if let braze = braze, braze.notifications.handleUserNotification(
+        if let braze, braze.notifications.handleUserNotification(
             response: response,
             withCompletionHandler: completionHandler
         ) {
@@ -171,7 +171,7 @@ extension BrazeService: UNUserNotificationCenterDelegate {
     }
 
     public func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
-        if let braze = braze {
+        if let braze {
             braze.notifications.handleForegroundNotification(notification: notification)
         }
         completionHandler([.list, .banner, .sound, .badge])
@@ -181,7 +181,7 @@ extension BrazeService: UNUserNotificationCenterDelegate {
 // Exposing Braze logic to be used inside `application(_:didReceiveRemoteNotification:fetchCompletionHandler:)`
 extension BrazeService {
     public func handleBackgroundNotification(userInfo: [AnyHashable: Any], completionHandler: @escaping (UIBackgroundFetchResult) -> Void) -> Bool {
-        guard let braze = braze else { return false }
+        guard let braze else { return false }
         return braze.notifications.handleBackgroundNotification(userInfo: userInfo, fetchCompletionHandler: completionHandler)
     }
 }

--- a/firefox-ios/Ecosia/Braze/BrazeService.swift
+++ b/firefox-ios/Ecosia/Braze/BrazeService.swift
@@ -174,8 +174,7 @@ extension BrazeService: UNUserNotificationCenterDelegate {
         if let braze = braze {
             braze.notifications.handleForegroundNotification(notification: notification)
         }
-
-        completionHandler([.list, .banner])
+        completionHandler([.list, .banner, .sound, .badge])
     }
 }
 

--- a/firefox-ios/Ecosia/Braze/BrazeService.swift
+++ b/firefox-ios/Ecosia/Braze/BrazeService.swift
@@ -159,4 +159,30 @@ extension BrazeService: BrazeInAppMessageUIDelegate {
     }
 }
 
-extension BrazeService: UNUserNotificationCenterDelegate {}
+extension BrazeService: UNUserNotificationCenterDelegate {
+    public func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+        if let braze = braze, braze.notifications.handleUserNotification(
+            response: response,
+            withCompletionHandler: completionHandler
+        ) {
+            return
+        }
+        completionHandler()
+    }
+
+    public func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        if let braze = braze {
+            braze.notifications.handleForegroundNotification(notification: notification)
+        }
+
+        completionHandler([.list, .banner])
+    }
+}
+
+// Exposing Braze logic to be used inside `application(_:didReceiveRemoteNotification:fetchCompletionHandler:)`
+extension BrazeService {
+    public func handleBackgroundNotification(userInfo: [AnyHashable: Any], completionHandler: @escaping (UIBackgroundFetchResult) -> Void) -> Bool {
+        guard let braze = braze else { return false }
+        return braze.notifications.handleBackgroundNotification(userInfo: userInfo, fetchCompletionHandler: completionHandler)
+    }
+}


### PR DESCRIPTION
[MOB-3597]

## Context

Push delegates were not yet implemented, even if there was an impression they were (see ticket).

## Approach

Follow [this Braze guide](https://www.braze.com/docs/developer_guide/push_notifications/?tab=manual&sdktab=swift&redirected=3#swift_step-33-enable-push-handling) to forward handling of background and foreground notifications to Braze.

## Other

Also bumped Braze's minor version as a good practice (we're also two majors behind but that can contain breaking changes, so to be reviewed)

## Before merging

Revert temporary changes
- [x] Firebase deploy of feature branch

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I added the `// Ecosia:` helper comments where needed

[MOB-3597]: https://ecosia.atlassian.net/browse/MOB-3597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ