### PR TITLE
[MOB-3801] Open Braze Ecosia links on new tab

### DIFF
--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -12,6 +12,8 @@ import Glean
  */
 import TabDataStore
 import Ecosia
+// Ecosia: Import Braze
+import BrazeKit
 
 import class MozillaAppServices.Viaduct
 
@@ -116,6 +118,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                    level: .info,
                    category: .lifecycle)
 
+        // Ecosia: Allow Braze to be initialized after feature management
+        Braze.prepareForDelayedInitialization()
+
         // Ecosia: pushNotificationSetup()
         appLaunchUtil?.setUpPostLaunchDependencies()
         /* Ecosia: Do not intialize Background sync
@@ -145,8 +150,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
          */
         Task {
             await FeatureManagement.fetchConfiguration()
-            // Ecosia: Braze Service Initialization helper
-            await BrazeService.shared.initialize()
+            // Ecosia: Braze Service Initialization after feature flags are fetched
+            BrazeService.shared.initialize()
             // Ecosia: Directly ask for consent
             await APNConsent.requestIfNeeded()
             // Ecosia: Lifecycle tracking. Needs to happen after Unleash start so that the flags are correctly added to the analytics context.

--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -12,8 +12,6 @@ import Glean
  */
 import TabDataStore
 import Ecosia
-// Ecosia: Import Braze
-import BrazeKit
 
 import class MozillaAppServices.Viaduct
 
@@ -119,7 +117,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                    category: .lifecycle)
 
         // Ecosia: Allow Braze to be initialized after feature management
-        Braze.prepareForDelayedInitialization()
+        BrazeService.prepareForDelayedInitialization()
 
         // Ecosia: pushNotificationSetup()
         appLaunchUtil?.setUpPostLaunchDependencies()

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -1123,7 +1123,7 @@ extension BrowserCoordinator: BrazeBrowserDelegate {
         if tabManager.isRestoringTabs {
             // On cold start we need to wait for tab restoration to finish
             AppEventQueue.wait(for: .tabRestoration(windowUUID)) { [weak self] in
-                self?.openURLinNewTab(url)
+                self?.openURLInNewTab(url)
             }
         } else {
             openURLInNewTab(url)

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -1114,3 +1114,10 @@ extension BrowserCoordinator {
         return true
     }
 }
+
+// Ecosia: Set BrowserCoordinator as Braze's browserDelegate to handle push urls
+extension BrowserCoordinator: BrazeBrowserDelegate {
+    func openBrazeURLInNewTab(_ url: URL?) {
+        openURLInNewTab(url)
+    }
+}

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -1118,6 +1118,8 @@ extension BrowserCoordinator {
 // Ecosia: Set BrowserCoordinator as Braze's browserDelegate to handle push urls
 extension BrowserCoordinator: BrazeBrowserDelegate {
     func openBrazeURLInNewTab(_ url: URL?) {
+        // TODO: Check why from Cold start this results in an additional blank tab in focus (besides the one with the url)
+        // Probably has to do with out Tab setup from cold start creating this new tab after we execute this method
         openURLInNewTab(url)
     }
 }

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -1118,8 +1118,15 @@ extension BrowserCoordinator {
 // Ecosia: Set BrowserCoordinator as Braze's browserDelegate to handle push urls
 extension BrowserCoordinator: BrazeBrowserDelegate {
     func openBrazeURLInNewTab(_ url: URL?) {
-        // TODO: Check why from Cold start this results in an additional blank tab in focus (besides the one with the url)
-        // Probably has to do with out Tab setup from cold start creating this new tab after we execute this method
-        openURLInNewTab(url)
+        guard let url = url else { return }
+
+        if tabManager.isRestoringTabs {
+            // On cold start we need to wait for tab restoration to finish
+            AppEventQueue.wait(for: .tabRestoration(windowUUID)) { [weak self] in
+                self?.openURLinNewTab(url)
+            }
+        } else {
+            openURLInNewTab(url)
+        }
     }
 }

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -1118,7 +1118,7 @@ extension BrowserCoordinator {
 // Ecosia: Set BrowserCoordinator as Braze's browserDelegate to handle push urls
 extension BrowserCoordinator: BrazeBrowserDelegate {
     func openBrazeURLInNewTab(_ url: URL?) {
-        guard let url = url else { return }
+        guard let url else { return }
 
         if tabManager.isRestoringTabs {
             // On cold start we need to wait for tab restoration to finish

--- a/firefox-ios/Client/Coordinators/Scene/SceneCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Scene/SceneCoordinator.swift
@@ -130,6 +130,9 @@ class SceneCoordinator: BaseCoordinator, LaunchCoordinatorDelegate, LaunchFinish
                                                     screenshotService: screenshotService,
                                                     tabManager: tabManager)
 
+        // Ecosia: Set BrowserCoordinator as Braze's browserDelegate to handle push urls
+        BrazeService.shared.browserDelegate = browserCoordinator
+
         let windowInfo = AppWindowInfo(tabManager: tabManager, sceneCoordinator: self)
         windowManager.newBrowserWindowConfigured(windowInfo, uuid: windowUUID)
 

--- a/firefox-ios/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
@@ -162,7 +162,6 @@ extension AppSettingsTableViewController {
             FasterInactiveTabs(settings: self, settingsDelegate: self),
             UnleashSeedCounterNTPSetting(settings: self),
             UnleashBrazeIntegrationSetting(settings: self),
-            UnleashAPNConsent(settings: self),
             UnleashNativeSRPVAnalyticsSetting(settings: self),
             UnleashAISearchMVPSetting(settings: self),
             UnleashIdentifierSetting(settings: self),

--- a/firefox-ios/Client/Ecosia/Settings/EcosiaDebugSettings.swift
+++ b/firefox-ios/Client/Ecosia/Settings/EcosiaDebugSettings.swift
@@ -265,16 +265,6 @@ final class UnleashBrazeIntegrationSetting: UnleashVariantResetSetting {
     }
 }
 
-final class UnleashAPNConsent: UnleashVariantResetSetting {
-    override var titleName: String? {
-        "APN Consent Feature Rollout"
-    }
-
-    override var variant: Unleash.Variant? {
-        Unleash.getVariant(.apnConsent)
-    }
-}
-
 final class UnleashNativeSRPVAnalyticsSetting: UnleashVariantResetSetting {
     override var titleName: String? {
         "Native SRPV Analytics"

--- a/firefox-ios/Ecosia/Braze/APNConsent.swift
+++ b/firefox-ios/Ecosia/Braze/APNConsent.swift
@@ -7,13 +7,9 @@ import Foundation
 public struct APNConsent {
     private init() {}
 
-    private static var toggleName: Unleash.Toggle.Name {
-        .apnConsent
-    }
-
     private static var isEnabled: Bool {
-        // Depends on Braze Integration being enabled - we should make sure targets on Unleash match
-        Unleash.isEnabled(toggleName) && BrazeIntegrationExperiment.isEnabled
+        // Depends on Braze Integration being enabled
+        BrazeIntegrationExperiment.isEnabled
     }
 
     public static func requestIfNeeded() async {

--- a/firefox-ios/Ecosia/Braze/BrazeService.swift
+++ b/firefox-ios/Ecosia/Braze/BrazeService.swift
@@ -34,6 +34,8 @@ public final class BrazeService: NSObject {
     }
 
     public func initialize() {
+        guard BrazeIntegrationExperiment.isEnabled else { return }
+        
         do {
             try initBraze(userId: userId)
             Task {

--- a/firefox-ios/Ecosia/Braze/BrazeService.swift
+++ b/firefox-ios/Ecosia/Braze/BrazeService.swift
@@ -92,6 +92,14 @@ extension BrazeService {
 }
 
 extension BrazeService {
+    // MARK: - Braze proxy function
+
+    public static func prepareForDelayedInitialization() {
+        Braze.prepareForDelayedInitialization()
+    }
+}
+
+extension BrazeService {
     // MARK: - Notification Center
 
     private func makeNotificationCenter() -> UNUserNotificationCenter {

--- a/firefox-ios/Ecosia/Braze/BrazeService.swift
+++ b/firefox-ios/Ecosia/Braze/BrazeService.swift
@@ -35,7 +35,7 @@ public final class BrazeService: NSObject {
 
     public func initialize() {
         guard BrazeIntegrationExperiment.isEnabled else { return }
-        
+
         do {
             try initBraze(userId: userId)
             Task {

--- a/firefox-ios/Ecosia/Core/FeatureManagement/Unleash/Unleash.Model.swift
+++ b/firefox-ios/Ecosia/Core/FeatureManagement/Unleash/Unleash.Model.swift
@@ -20,7 +20,6 @@ extension Unleash {
 
     public struct Toggle: Codable, Hashable {
         public enum Name: String {
-            case apnConsent = "mob_ios_apn_consent_on_launch_rollout"
             case brazeIntegration = "mob_ios_braze_integration"
             case configTest = "mob_ios_staging_config"
             case seedCounterNTP = "mob_ios_seed_counter_ntp"


### PR DESCRIPTION
[MOB-3801]

## Context

See ticket.

## Approach

Use Braze delegate for custom link handling like [exemplified here](https://www.braze.com/docs/developer_guide/push_notifications/deep_linking#swift_brazedelegate).

## Other

- Simplified `BrazeService.initialize` async usage 

- Added support to Braze delayed initialisation like [described here](https://www.braze.com/docs/developer_guide/sdk_integration?sdktab=swift#swift_step-2-set-up-delayed-initialization-optional)

- Includes feature flag restriction fix for [MOB-3853]

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] ~~I wrote Unit Tests that confirm the expected behaviour~~ Had some issue with mocking braze objects - given our BrazeService is not fully tested at the moment, will leave this as tech debt for the sake of time
- [x] I added the `// Ecosia:` helper comments where needed

[MOB-3801]: https://ecosia.atlassian.net/browse/MOB-3801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MOB-3853]: https://ecosia.atlassian.net/browse/MOB-3853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ