### PR TITLE
[MOB-3801] Request APN consent only after status refresh

### DIFF
--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -148,10 +148,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
          */
         Task {
             await FeatureManagement.fetchConfiguration()
-            // Ecosia: Braze Service Initialization after feature flags are fetched
+            // Ecosia: Braze Service Initialization after feature flags are fetched for conditional initialization
             BrazeService.shared.initialize()
-            // Ecosia: Directly ask for consent
-            await APNConsent.requestIfNeeded()
             // Ecosia: Lifecycle tracking. Needs to happen after Unleash start so that the flags are correctly added to the analytics context.
             Analytics.shared.activity(.launch)
         }

--- a/firefox-ios/Ecosia/Braze/APNConsent.swift
+++ b/firefox-ios/Ecosia/Braze/APNConsent.swift
@@ -7,13 +7,8 @@ import Foundation
 public struct APNConsent {
     private init() {}
 
-    private static var isEnabled: Bool {
-        // Depends on Braze Integration being enabled
-        BrazeIntegrationExperiment.isEnabled
-    }
-
     public static func requestIfNeeded() async {
-        guard isEnabled, BrazeService.shared.notificationAuthorizationStatus == .notDetermined else {
+        guard BrazeService.shared.notificationAuthorizationStatus == .notDetermined else {
             return
         }
         Analytics.shared.apnConsent(.view)

--- a/firefox-ios/Ecosia/Braze/BrazeService.swift
+++ b/firefox-ios/Ecosia/Braze/BrazeService.swift
@@ -40,6 +40,7 @@ public final class BrazeService: NSObject {
             try initBraze(userId: userId)
             Task {
                 await refreshAPNRegistrationIfNeeded()
+                await APNConsent.requestIfNeeded()
             }
         } catch {
             debugPrint(error)


### PR DESCRIPTION
[MOB-3801]

## Context

Follow-up to https://github.com/ecosia/ios-browser/pull/952 since I noticed push consent was no longer being asked.

## Approach

Move APN consent request inside Braze and ensuring it only happens after the notification status is updated.

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad

[MOB-3801]: https://ecosia.atlassian.net/browse/MOB-3801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ