### PR TITLE
[MOB-3861] Add Unleash country field

### DIFF
--- a/firefox-ios/Ecosia/Core/FeatureManagement/Unleash/Unleash.swift
+++ b/firefox-ios/Ecosia/Core/FeatureManagement/Unleash/Unleash.swift
@@ -33,6 +33,10 @@ public enum Unleash: UnleashProtocol {
         Locale.current.regionIdentifierLowercasedWithFallbackValue
     }
 
+    static var englishCountryName: String? {
+        Locale.current.englishLocalizedCountryName
+    }
+
     public static func queryParameters(appVersion: String) -> Context {
         ["userId": userId.uuidString,
          "appName": "iOS",
@@ -41,6 +45,8 @@ public enum Unleash: UnleashProtocol {
          "environment": Environment.current.urlProvider.unleash,
          "market": User.shared.marketCode.rawValue,
          "deviceRegion": currentDeviceRegion,
+         // Mapped from device region to enabled Web flags with geo-ip based context field
+         "country": englishCountryName ?? "Unknown",
          "personalCounterSearches": "\(User.shared.searchCount)"]
     }
 

--- a/firefox-ios/Ecosia/Core/FeatureManagement/Unleash/Unleash.swift
+++ b/firefox-ios/Ecosia/Core/FeatureManagement/Unleash/Unleash.swift
@@ -29,12 +29,15 @@ public enum Unleash: UnleashProtocol {
         return queue.sync { _isLoaded }
     }
 
+    /// Locale source for dependency injection (for testing purposes)
+    static var localeSource: RegionLocatable = Locale.current
+
     static var currentDeviceRegion: String {
-        Locale.current.regionIdentifierLowercasedWithFallbackValue
+        localeSource.regionIdentifierLowercasedWithFallbackValue
     }
 
     static var englishCountryName: String? {
-        Locale.current.englishLocalizedCountryName
+        localeSource.englishLocalizedCountryName
     }
 
     public static func queryParameters(appVersion: String) -> Context {

--- a/firefox-ios/Ecosia/Core/Locale+Extensions.swift
+++ b/firefox-ios/Ecosia/Core/Locale+Extensions.swift
@@ -22,7 +22,7 @@ extension Locale {
         regionIdentifier?.lowercased() ?? "us"
     }
 
-    var englishLocalizedCountryName: String? {
+    public var englishLocalizedCountryName: String? {
         guard let regionIdentifier = regionIdentifier else { return nil }
         return Locale(identifier: "en_US").localizedString(forRegionCode: regionIdentifier)
     }

--- a/firefox-ios/Ecosia/Core/Locale+Extensions.swift
+++ b/firefox-ios/Ecosia/Core/Locale+Extensions.swift
@@ -21,6 +21,11 @@ extension Locale {
     public var regionIdentifierLowercasedWithFallbackValue: String {
         regionIdentifier?.lowercased() ?? "us"
     }
+
+    var englishLocalizedCountryName: String? {
+        guard let regionIdentifier = regionIdentifier else { return nil }
+        return Locale(identifier: "en_US").localizedString(forRegionCode: regionIdentifier)
+    }
 }
 
 extension Locale: RegionLocatable {}

--- a/firefox-ios/Ecosia/Core/RegionLocatable.swift
+++ b/firefox-ios/Ecosia/Core/RegionLocatable.swift
@@ -6,4 +6,5 @@
 /// see: `DeviceRegionChangeProvider.swift`
 public protocol RegionLocatable {
     var regionIdentifierLowercasedWithFallbackValue: String { get }
+    var englishLocalizedCountryName: String? { get }
 }

--- a/firefox-ios/EcosiaTests/Core/UnleashRefreshConfiguratorTests.swift
+++ b/firefox-ios/EcosiaTests/Core/UnleashRefreshConfiguratorTests.swift
@@ -88,14 +88,3 @@ final class UnleashRefreshConfiguratorTests: XCTestCase {
         XCTAssertTrue(Unleash.shouldRefresh, "Unleash should refresh after a device region change.")
     }
 }
-
-extension UnleashRefreshConfiguratorTests {
-
-    struct MockLocale: RegionLocatable {
-        var regionIdentifierLowercasedWithFallbackValue: String
-
-        init(_ identifier: String) {
-            self.regionIdentifierLowercasedWithFallbackValue = identifier
-        }
-    }
-}

--- a/firefox-ios/EcosiaTests/Core/UnleashTests.swift
+++ b/firefox-ios/EcosiaTests/Core/UnleashTests.swift
@@ -102,6 +102,50 @@ final class UnleashTests: XCTestCase {
         XCTAssertTrue(Unleash.isLoaded)
         XCTAssertNotEqual(Unleash.model.id, firstId, "Id should change after reset")
     }
+
+    func testQueryParametersWithMockedUser() {
+        let originalUser = User.shared
+
+        var mockUser = User()
+        mockUser.versionOnInstall = "2.5.0"
+        mockUser.marketCode = Local.make(for: .init(identifier: "de-de"))
+        mockUser.searchCount = 150
+        User.shared = mockUser
+
+        let parameters = Unleash.queryParameters(appVersion: "3.0.0")
+        XCTAssertEqual(parameters["versionOnInstall"], "2.5.0")
+        XCTAssertEqual(parameters["market"], "de-de")
+        XCTAssertEqual(parameters["personalCounterSearches"], "150")
+        XCTAssertEqual(parameters["appVersion"], "3.0.0")
+
+        User.shared = originalUser
+    }
+
+    func testQueryParametersWithMockedLocale() {
+        let originalLocaleSource = Unleash.localeSource
+
+        let mockLocale = MockLocale("fr", countryName: "France")
+        Unleash.localeSource = mockLocale
+
+        let parameters = Unleash.queryParameters(appVersion: "2.0.0")
+        XCTAssertEqual(parameters["deviceRegion"], "fr")
+        XCTAssertEqual(parameters["country"], "France")
+
+        Unleash.localeSource = originalLocaleSource
+    }
+
+    func testQueryParametersWithMockedLocaleNilCountry() {
+        let originalLocaleSource = Unleash.localeSource
+
+        let mockLocale = MockLocale("xx", countryName: nil)
+        Unleash.localeSource = mockLocale
+
+        let parameters = Unleash.queryParameters(appVersion: "1.5.0")
+        XCTAssertEqual(parameters["deviceRegion"], "xx")
+        XCTAssertEqual(parameters["country"], "Unknown")
+
+        Unleash.localeSource = originalLocaleSource
+    }
 }
 
 extension UnleashTests {

--- a/firefox-ios/EcosiaTests/Mocks/MockLocale.swift
+++ b/firefox-ios/EcosiaTests/Mocks/MockLocale.swift
@@ -1,0 +1,16 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+@testable import Ecosia
+
+struct MockLocale: RegionLocatable {
+    var regionIdentifierLowercasedWithFallbackValue: String
+    var englishLocalizedCountryName: String?
+
+    init(_ countryIdentier: String, countryName: String? = nil) {
+        self.regionIdentifierLowercasedWithFallbackValue = countryIdentier
+        self.englishLocalizedCountryName = countryName
+    }
+}


### PR DESCRIPTION
[MOB-3861]

## Context

See ticket.

## Approach

To avoid complexity, use the same `Locale.current` value but map to English localised Country name.

## Other

Refactored a bit and added tests for query parameters.

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I wrote Unit Tests that confirm the expected behaviour

[MOB-3861]: https://ecosia.atlassian.net/browse/MOB-3861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ