### PR TITLE
[MOB-3493] Seed Account Balance in Snowplow Context

### DIFF
--- a/firefox-ios/Ecosia/Analytics/Analytics.swift
+++ b/firefox-ios/Ecosia/Analytics/Analytics.swift
@@ -10,6 +10,7 @@ open class Analytics {
     private static let abTestSchema = "iglu:org.ecosia/abtest_context/jsonschema/1-0-1"
     private static let consentSchema = "iglu:org.ecosia/eccc_context/jsonschema/1-0-2"
     private static let feedbackSchema = "iglu:org.ecosia/ios_feedback_event/jsonschema/1-0-0"
+    static let impactBalanceSchema = "iglu:org.ecosia/impact_balance/jsonschema/1-0-0"
     private static let abTestRoot = "ab_tests"
     private static let namespace = "ios_sp"
     static let installSchema = "iglu:org.ecosia/ios_install_event/jsonschema/1-0-0"

--- a/firefox-ios/Ecosia/Analytics/Analytics.swift
+++ b/firefox-ios/Ecosia/Analytics/Analytics.swift
@@ -497,7 +497,7 @@ extension Analytics {
 
     private func addUserSeedCountContext(to event: Structured) {
         let consentContext = SelfDescribingJson(schema: Self.impactBalanceSchema,
-                                                andDictionary: ["impact-balance": User.shared.seedCount])
+                                                andDictionary: ["amount": User.shared.seedCount])
         event.entities.append(consentContext)
     }
 }

--- a/firefox-ios/Ecosia/Analytics/Analytics.swift
+++ b/firefox-ios/Ecosia/Analytics/Analytics.swift
@@ -76,7 +76,7 @@ open class Analytics {
                                action: action.rawValue)
             .label(Analytics.Label.Navigation.inapp.rawValue)
 
-        appendTestContextIfNeeded(action, event) { [weak self] in
+        appendContextIfNeeded(action, event) { [weak self] in
             self?.track(event)
         }
     }
@@ -448,7 +448,7 @@ open class Analytics {
 }
 
 extension Analytics {
-    func appendTestContextIfNeeded(_ action: Analytics.Action.Activity, _ event: Structured, completion: @escaping () -> Void) {
+    func appendContextIfNeeded(_ action: Analytics.Action.Activity, _ event: Structured, completion: @escaping () -> Void) {
         switch action {
         case .resume, .launch:
             addABTestContexts(to: event, toggles: [.brazeIntegration])

--- a/firefox-ios/Ecosia/Analytics/Analytics.swift
+++ b/firefox-ios/Ecosia/Analytics/Analytics.swift
@@ -455,6 +455,7 @@ extension Analytics {
             addCookieConsentContext(to: event)
             addUserStateContext(to: event, completion: completion)
         }
+        addUserSeedCountContext(to: event)
     }
 
     private func addABTestContexts(to event: Structured, toggles: [Unleash.Toggle.Name]) {
@@ -481,6 +482,12 @@ extension Analytics {
             event.entities.append(userContext)
             completion()
         }
+    }
+    
+    private func addUserSeedCountContext(to event: Structured) {
+        let consentContext = SelfDescribingJson(schema: Self.impactBalanceSchema,
+                                                andDictionary: ["impact-balance": User.shared.seedCount])
+        event.entities.append(consentContext)
     }
 }
 

--- a/firefox-ios/Ecosia/Core/Cookie/Cookie.swift
+++ b/firefox-ios/Ecosia/Core/Cookie/Cookie.swift
@@ -44,7 +44,7 @@ public enum Cookie: String, CaseIterable {
     /// - Parameters:
     ///   - cookie: HTTPCookie
     init?(_ cookie: HTTPCookie) {
-        let ecosiaDomain = Cookie.urlProvider.domain ?? ""
+        let ecosiaDomain = Cookie.urlProvider.domain
         guard cookie.domain == ".\(ecosiaDomain)" else {
             return nil
         }

--- a/firefox-ios/Ecosia/Core/Cookie/CookieHandler.swift
+++ b/firefox-ios/Ecosia/Core/Cookie/CookieHandler.swift
@@ -36,7 +36,7 @@ class BaseCookieHandler: CookieHandler {
         let urlProvider = Cookie.urlProvider
         return HTTPCookie(properties: [
             .name: cookieName,
-            .domain: ".\(urlProvider.domain ?? "")",
+            .domain: ".\(urlProvider.domain)",
             .path: "/",
             .value: value
         ])

--- a/firefox-ios/Ecosia/Core/User.swift
+++ b/firefox-ios/Ecosia/Core/User.swift
@@ -58,6 +58,9 @@ public struct User: Codable, Equatable {
     public var news = Date.distantPast
     public var migrated = false
     public var referrals = Referrals.Model()
+    public var seedCount: Int {
+        EcosiaAuthUIStateProvider.shared.seedCount
+    }
     public internal(set) var id: String?
     public var whatsNewItemsVersionsShown = Set<String>()
     public internal(set) var analyticsUserState = AnalyticsStateContext()

--- a/firefox-ios/EcosiaTests/Analytics/AnalyticsSpyTests.swift
+++ b/firefox-ios/EcosiaTests/Analytics/AnalyticsSpyTests.swift
@@ -846,7 +846,7 @@ final class AnalyticsSpyTests: XCTestCase {
                                action: Analytics.Action.Activity.resume.rawValue)
 
         // Act
-        analyticsSpy.appendTestContextIfNeeded(.resume, event) {
+        analyticsSpy.appendContextIfNeeded(.resume, event) {
             expectation.fulfill()
         }
         waitForExpectations(timeout: 1.0, handler: nil)
@@ -867,7 +867,7 @@ final class AnalyticsSpyTests: XCTestCase {
                                action: Analytics.Action.Activity.launch.rawValue)
 
         // Act
-        analyticsSpy.appendTestContextIfNeeded(.resume, event) {
+        analyticsSpy.appendContextIfNeeded(.resume, event) {
             expectation.fulfill()
         }
         waitForExpectations(timeout: 1.0, handler: nil)

--- a/firefox-ios/EcosiaTests/Analytics/AnalyticsSpyTests.swift
+++ b/firefox-ios/EcosiaTests/Analytics/AnalyticsSpyTests.swift
@@ -924,7 +924,7 @@ final class AnalyticsSpyTests: XCTestCase {
         XCTAssertEqual(analyticsSpy.activityActionCalled, .resume)
         XCTAssertEqual(analyticsSpy.trackedEvents.count, 1, "Should have tracked one resume event")
 
-        if let structuredEvent = analyticsSpy.trackedEvents.first as? Structured {
+        if let structuredEvent = analyticsSpy.trackedEvents.first(where: { ($0 as? Structured)?.action == Analytics.Action.Activity.resume.rawValue }) {
             let seedCountContext = structuredEvent.entities.first { $0.schema == Analytics.impactBalanceSchema }
             XCTAssertNotNil(seedCountContext, "User seed count context must be added to resume event")
             if let seedCountContext = seedCountContext {

--- a/firefox-ios/EcosiaTests/Analytics/AnalyticsSpyTests.swift
+++ b/firefox-ios/EcosiaTests/Analytics/AnalyticsSpyTests.swift
@@ -880,6 +880,48 @@ final class AnalyticsSpyTests: XCTestCase {
         }
     }
 
+    func testAddUserSeedCountContextOnResumeEvent() {
+        // Arrange
+        let analyticsSpy = makeAnalyticsSpyContextSUT()
+        let expectation = self.expectation(description: "Event tracked")
+        let event = Structured(category: "",
+                               action: Analytics.Action.Activity.resume.rawValue)
+
+        // Act
+        analyticsSpy.appendContextIfNeeded(.resume, event) {
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1.0, handler: nil)
+
+        // Assert
+        let seedCountContext = event.entities.first { $0.schema == Analytics.impactBalanceSchema }
+        XCTAssertNotNil(seedCountContext, "User seed count context not found in event entities")
+        if let seedCountContext = seedCountContext {
+            XCTAssertEqual(seedCountContext.data["impact-balance"] as? Int, User.shared.seedCount)
+        }
+    }
+
+    func testAddUserSeedCountContextOnLaunchEvent() {
+        // Arrange
+        let analyticsSpy = makeAnalyticsSpyContextSUT()
+        let expectation = self.expectation(description: "Event tracked")
+        let event = Structured(category: "",
+                               action: Analytics.Action.Activity.launch.rawValue)
+
+        // Act
+        analyticsSpy.appendContextIfNeeded(.launch, event) {
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1.0, handler: nil)
+
+        // Assert
+        let seedCountContext = event.entities.first { $0.schema == Analytics.impactBalanceSchema }
+        XCTAssertNotNil(seedCountContext, "User seed count context not found in event entities")
+        if let seedCountContext = seedCountContext {
+            XCTAssertEqual(seedCountContext.data["impact-balance"] as? Int, User.shared.seedCount)
+        }
+    }
+
     // MARK: Analytics Private Data clearance
 
     func testClearPrivateDataTracksEvent() {

--- a/firefox-ios/EcosiaTests/Analytics/AnalyticsSpyTests.swift
+++ b/firefox-ios/EcosiaTests/Analytics/AnalyticsSpyTests.swift
@@ -903,7 +903,7 @@ final class AnalyticsSpyTests: XCTestCase {
         let seedCountContext = event.entities.first { $0.schema == Analytics.impactBalanceSchema }
         XCTAssertNotNil(seedCountContext, "User seed count context must be added to the structured event")
         if let seedCountContext = seedCountContext {
-            XCTAssertEqual(seedCountContext.data["impact-balance"] as? Int, User.shared.seedCount)
+            XCTAssertEqual(seedCountContext.data["amount"] as? Int, User.shared.seedCount)
         }
     }
 
@@ -928,7 +928,7 @@ final class AnalyticsSpyTests: XCTestCase {
             let seedCountContext = structuredEvent.entities.first { $0.schema == Analytics.impactBalanceSchema }
             XCTAssertNotNil(seedCountContext, "User seed count context must be added to resume event")
             if let seedCountContext = seedCountContext {
-                XCTAssertEqual(seedCountContext.data["impact-balance"] as? Int, User.shared.seedCount)
+                XCTAssertEqual(seedCountContext.data["amount"] as? Int, User.shared.seedCount)
             }
         } else {
             XCTFail("Tracked event should be a Structured event")


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-3493]

## Context

We want to bring the implementation done in [JO-3004](https://ecosia.atlassian.net/browse/JO-3004) as part of our Native side analytics. All analytics must get the new context in.

## Approach

- Revisit how we enrich events with additional context
- Add the new `impact_balance` schema
- Improve tests to make sure we send the new context for retention events as well
- Found a middle-ground to further improve our `AnalyticsSpy` and achieve real-world events testing without triggering them to Snowplow mini.

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I wrote Unit Tests that confirm the expected behaviour
- [x] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)

[MOB-3493]: https://ecosia.atlassian.net/browse/MOB-3493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[JO-3004]: https://ecosia.atlassian.net/browse/JO-3004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ