### PR TITLE
[MOB-3924] Accounts Unleash flag

### DIFF
--- a/firefox-ios/Client/Ecosia/UI/NTP/Header/NTPHeader.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/Header/NTPHeader.swift
@@ -85,21 +85,23 @@ struct NTPHeaderView: View {
                     onTap: handleAISearchTap
                 )
             }
-            ZStack(alignment: .topLeading) {
-                EcosiaAccountNavButton(
-                    seedCount: viewModel.seedCount,
-                    avatarURL: viewModel.userAvatarURL,
-                    enableAnimation: !reduceMotion,
-                    windowUUID: windowUUID,
-                    onTap: handleTap
-                )
-
-                if let increment = viewModel.balanceIncrement {
-                    BalanceIncrementAnimationView(
-                        increment: increment,
-                        windowUUID: windowUUID
+            if AccountFeatureExperiment.isEnabled {
+                ZStack(alignment: .topLeading) {
+                    EcosiaAccountNavButton(
+                        seedCount: viewModel.seedCount,
+                        avatarURL: viewModel.userAvatarURL,
+                        enableAnimation: !reduceMotion,
+                        windowUUID: windowUUID,
+                        onTap: handleTap
                     )
-                    .offset(x: 20, y: -10)
+
+                    if let increment = viewModel.balanceIncrement {
+                        BalanceIncrementAnimationView(
+                            increment: increment,
+                            windowUUID: windowUUID
+                        )
+                        .offset(x: 20, y: -10)
+                    }
                 }
             }
         }

--- a/firefox-ios/Ecosia/Core/FeatureManagement/Unleash/Unleash.Model.swift
+++ b/firefox-ios/Ecosia/Core/FeatureManagement/Unleash/Unleash.Model.swift
@@ -26,6 +26,7 @@ extension Unleash {
             case nativeSRPVAnalytics = "mob_ios_native_srpv_analytics"
             case newsletterCard = "mob_ios_newsletter_card"
             case aiSearchMVP = "ai2-67-ai-search-mvp"
+            case accountsFeaturesHoldoutGroup = "accounts_features_holdout_group"
         }
 
         public let name: String

--- a/firefox-ios/Ecosia/Core/Navigation/EcosiaURLInterceptor.swift
+++ b/firefox-ios/Ecosia/Core/Navigation/EcosiaURLInterceptor.swift
@@ -16,6 +16,12 @@ public enum EcosiaInterceptedURLType {
     ///   - path: The URL path (lowercased recommended)
     ///   - urlProvider: The URL provider containing path patterns
     public init(path: String, urlProvider: URLProvider) {
+#if !TESTING
+        if AccountFeatureExperiment.isEnabled {
+            self = .none
+            return
+        }
+#endif
         if urlProvider.loginURL.relativePath == path {
             self = .signIn
         } else if urlProvider.logoutURL.relativePath == path {

--- a/firefox-ios/Ecosia/Experiments/Unleash/AccountFeatureExperiment.swift
+++ b/firefox-ios/Ecosia/Experiments/Unleash/AccountFeatureExperiment.swift
@@ -1,0 +1,23 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+public struct AccountFeatureExperiment {
+
+    private init() {}
+
+    public static var isEnabled: Bool {
+        Unleash.isEnabled(.accountsFeaturesHoldoutGroup) && !isControl
+    }
+
+    private static var variant: Unleash.Variant {
+        Unleash.getVariant(.accountsFeaturesHoldoutGroup)
+    }
+
+    private static let controlVariantName: String = "st_accounts_features_holdout"
+    public static var isControl: Bool {
+        variant.name == controlVariantName
+    }
+}

--- a/firefox-ios/Ecosia/Experiments/Unleash/AccountFeatureExperiment.swift
+++ b/firefox-ios/Ecosia/Experiments/Unleash/AccountFeatureExperiment.swift
@@ -9,7 +9,7 @@ public struct AccountFeatureExperiment {
     private init() {}
 
     public static var isEnabled: Bool {
-        Unleash.isEnabled(.accountsFeaturesHoldoutGroup) && !isControl
+        Unleash.isEnabled(.accountsFeaturesHoldoutGroup) && !isHoldout
     }
 
     private static var variant: Unleash.Variant {
@@ -17,7 +17,7 @@ public struct AccountFeatureExperiment {
     }
 
     private static let controlVariantName: String = "st_accounts_features_holdout"
-    private static var isControl: Bool {
+    private static var isHoldout: Bool {
         variant.name == controlVariantName
     }
 }

--- a/firefox-ios/Ecosia/Experiments/Unleash/AccountFeatureExperiment.swift
+++ b/firefox-ios/Ecosia/Experiments/Unleash/AccountFeatureExperiment.swift
@@ -17,7 +17,7 @@ public struct AccountFeatureExperiment {
     }
 
     private static let controlVariantName: String = "st_accounts_features_holdout"
-    public static var isControl: Bool {
+    private static var isControl: Bool {
         variant.name == controlVariantName
     }
 }


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-3924]

## Context

We got the confirmation that we'd need the Accounts feature under the same feature flag, which is currently being used by Web.
We could confirm that the flag is also being retrieved from iOS on Staging, and the variant that enables the experiment.

## Approach

- Integrate the flag the usual way
- Make sure the Account's entry point visibility depends on the flag
- Make sure the URLs we detect that trigger any native flow aren't fired in case of experiment is disabled (huge help from our centralised interceptor)

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad

[MOB-3924]: https://ecosia.atlassian.net/browse/MOB-3924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ