### PR TITLE
[MOB-3538] Add debug features for seed and level-up animations

### DIFF
--- a/firefox-ios/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
@@ -170,6 +170,13 @@ extension AppSettingsTableViewController {
             SimulateImpactAPIErrorSetting(settings: self)
         ]
 
+        hiddenDebugSettings.append(contentsOf: [
+            DebugAddSeedsLoggedOut(settings: self),
+            DebugAddSeedsLoggedIn(settings: self),
+            DebugForceLevelUp(settings: self),
+            DebugAddCustomSeeds(settings: self)
+        ])
+
         if EcosiaEnvironment.current == .staging {
             hiddenDebugSettings.append(AnalyticsStagingUrlSetting(settings: self))
         }

--- a/firefox-ios/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
@@ -25,6 +25,8 @@ extension AppSettingsTableViewController {
 
         if isDebugSectionEnabled {
             sections.append(getEcosiaDebugSupportSection())
+            sections.append(getEcosiaDebugUnleashSection())
+            sections.append(getEcosiaDebugAccountsSection())
         }
 
         return sections
@@ -144,8 +146,7 @@ extension AppSettingsTableViewController {
     }
 
     private func getEcosiaDebugSupportSection() -> SettingSection {
-
-        var hiddenDebugSettings = [
+        var hiddenDebugSettings: [Setting] = [
             ExportBrowserDataSetting(settings: self),
             ForceCrashSetting(settings: self),
             PushBackInstallation(settings: self),
@@ -159,29 +160,40 @@ extension AppSettingsTableViewController {
             ChangeSearchCount(settings: self),
             ResetSearchCount(settings: self),
             ResetDefaultBrowserNudgeCard(settings: self),
-            ResetAccountImpactNudgeCard(settings: self),
             FasterInactiveTabs(settings: self, settingsDelegate: self),
-            UnleashBrazeIntegrationSetting(settings: self),
-            UnleashNativeSRPVAnalyticsSetting(settings: self),
-            UnleashAISearchMVPSetting(settings: self),
-            UnleashIdentifierSetting(settings: self),
             AnalyticsIdentifierSetting(settings: self),
-            SimulateAuthErrorSetting(settings: self),
-            SimulateImpactAPIErrorSetting(settings: self)
         ]
-
-        hiddenDebugSettings.append(contentsOf: [
-            DebugAddSeedsLoggedOut(settings: self),
-            DebugAddSeedsLoggedIn(settings: self),
-            DebugForceLevelUp(settings: self),
-            DebugAddCustomSeeds(settings: self)
-        ])
 
         if EcosiaEnvironment.current == .staging {
             hiddenDebugSettings.append(AnalyticsStagingUrlSetting(settings: self))
         }
 
         return SettingSection(title: NSAttributedString(string: "Debug"), children: hiddenDebugSettings)
+    }
+
+    private func getEcosiaDebugUnleashSection() -> SettingSection {
+        let unleashSettings: [Setting] = [
+            UnleashBrazeIntegrationSetting(settings: self),
+            UnleashNativeSRPVAnalyticsSetting(settings: self),
+            UnleashAISearchMVPSetting(settings: self),
+            UnleashIdentifierSetting(settings: self)
+        ]
+
+        return SettingSection(title: NSAttributedString(string: "Debug - Unleash"), children: unleashSettings)
+    }
+
+    private func getEcosiaDebugAccountsSection() -> SettingSection {
+        let accountSettings: [Setting] = [
+            ResetAccountImpactNudgeCard(settings: self),
+            DebugAddSeedsLoggedOut(settings: self),
+            DebugAddSeedsLoggedIn(settings: self),
+            DebugAddCustomSeeds(settings: self),
+            DebugForceLevelUp(settings: self),
+            SimulateAuthErrorSetting(settings: self),
+            SimulateImpactAPIErrorSetting(settings: self)
+        ]
+
+        return SettingSection(title: NSAttributedString(string: "Debug - Accounts"), children: accountSettings)
     }
 }
 

--- a/firefox-ios/Client/Ecosia/Settings/EcosiaDebugSettings.swift
+++ b/firefox-ios/Client/Ecosia/Settings/EcosiaDebugSettings.swift
@@ -451,7 +451,7 @@ final class DebugAddSeedsLoggedOut: HiddenSetting {
     override func onClick(_ navigationController: UINavigationController?) {
         let currentSeeds = UserDefaultsSeedProgressManager.loadTotalSeedsCollected()
         let maxSeeds = UserDefaultsSeedProgressManager.maxSeedsForLoggedOutUsers
-        
+
         // Check if already at cap
         if currentSeeds >= maxSeeds {
             let alert = AlertController(
@@ -463,7 +463,7 @@ final class DebugAddSeedsLoggedOut: HiddenSetting {
             navigationController?.topViewController?.present(alert, animated: true)
             return
         }
-        
+
         let alert = AlertController(
             title: "Seed Queued ✅",
             message: "Navigate to home or open Account Impact within 10 seconds to see animation",

--- a/firefox-ios/Client/Ecosia/UI/NTP/Header/NTPHeader.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/Header/NTPHeader.swift
@@ -69,7 +69,6 @@ final class NTPHeader: UICollectionViewCell, ReusableCell {
 @available(iOS 16.0, *)
 struct NTPHeaderView: View {
     @ObservedObject var viewModel: NTPHeaderViewModel
-    @ObservedObject private var authStateProvider = EcosiaAuthUIStateProvider.shared
     let windowUUID: WindowUUID
     // Use explicit SwiftUI.Environment to avoid ambiguity
     @SwiftUI.Environment(\.themeManager) var themeManager: any ThemeManager

--- a/firefox-ios/Client/Ecosia/UI/NTP/Header/NTPHeaderViewModel.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/Header/NTPHeaderViewModel.swift
@@ -23,7 +23,7 @@ final class NTPHeaderViewModel: ObservableObject {
     var onTapAction: ((UIButton) -> Void)?
     private let authStateProvider = EcosiaAuthUIStateProvider.shared
     private var cancellables = Set<AnyCancellable>()
-    
+
     var seedCount: Int { authStateProvider.seedCount }
     var isLoggedIn: Bool { authStateProvider.isLoggedIn }
     var userAvatarURL: URL? { authStateProvider.avatarURL }
@@ -40,7 +40,7 @@ final class NTPHeaderViewModel: ObservableObject {
         self.windowUUID = windowUUID
         self.auth = auth
         self.delegate = delegate
-        
+
         // Forward objectWillChange notifications from authStateProvider
         // This ensures SwiftUI knows to update the view when auth state changes
         authStateProvider.objectWillChange

--- a/firefox-ios/Ecosia/UI/Account/EcosiaAccountImpactView.swift
+++ b/firefox-ios/Ecosia/UI/Account/EcosiaAccountImpactView.swift
@@ -15,6 +15,7 @@ public struct EcosiaAccountImpactView: View {
     @State private var theme = EcosiaAccountImpactViewTheme()
     @State private var showSeedsCounterInfoWebView = false
     @State private var showProfileWebView = false
+    @State private var showSparkles = false
 
     /// Layout configuration optimized for account impact cards
     private var impactCardLayout: NudgeCardLayout {
@@ -60,9 +61,12 @@ public struct EcosiaAccountImpactView: View {
                 EcosiaAccountProgressAvatar(
                     avatarURL: viewModel.avatarURL,
                     progress: viewModel.levelProgress,
-                    showSparkles: viewModel.shouldShowLevelUpAnimation,
+                    showSparkles: showSparkles,
                     showProgress: !authStateProvider.hasRegisterVisitError,
-                    windowUUID: windowUUID
+                    windowUUID: windowUUID,
+                    onLevelUpAnimationComplete: {
+                        showSparkles = false
+                    }
                 )
 
                 VStack(alignment: .leading, spacing: .ecosia.space._1s) {
@@ -122,6 +126,9 @@ public struct EcosiaAccountImpactView: View {
             }
         }
         .ecosiaThemed(windowUUID, $theme)
+        .onReceive(NotificationCenter.default.publisher(for: .EcosiaAccountLevelUp)) { _ in
+            showSparkles = true
+        }
         .sheet(isPresented: $showSeedsCounterInfoWebView) {
             EcosiaWebViewModal(
                 url: EcosiaEnvironment.current.urlProvider.seedCounterInfo,

--- a/firefox-ios/Ecosia/UI/Account/EcosiaAccountImpactViewModel.swift
+++ b/firefox-ios/Ecosia/UI/Account/EcosiaAccountImpactViewModel.swift
@@ -27,7 +27,7 @@ public class EcosiaAccountImpactViewModel: ObservableObject {
         self.onLoginAction = onLogin
         self.onDismissAction = onDismiss
         self.authStateProvider = EcosiaAuthUIStateProvider.shared
-        
+
         // Forward objectWillChange notifications from authStateProvider
         // This ensures SwiftUI knows to update the view when auth state changes
         authStateProvider.objectWillChange
@@ -124,10 +124,5 @@ extension EcosiaAccountImpactViewModel {
     /// Progress for the avatar (0.0 to 1.0)
     public var levelProgress: Double {
         authStateProvider.levelProgress
-    }
-
-    /// Whether to show level-up animation (from centralized provider)
-    public var shouldShowLevelUpAnimation: Bool {
-        authStateProvider.shouldShowLevelUpAnimation
     }
 }

--- a/firefox-ios/Ecosia/UI/Account/EcosiaAccountProgressAvatar.swift
+++ b/firefox-ios/Ecosia/UI/Account/EcosiaAccountProgressAvatar.swift
@@ -13,6 +13,7 @@ public struct EcosiaAccountProgressAvatar: View {
     private let showProgress: Bool
     private let size: CGFloat
     private let windowUUID: WindowUUID
+    private let onLevelUpAnimationComplete: (() -> Void)?
 
     public init(
         avatarURL: URL?,
@@ -20,7 +21,8 @@ public struct EcosiaAccountProgressAvatar: View {
         showSparkles: Bool = false,
         showProgress: Bool = false,
         size: CGFloat = .ecosia.space._7l,
-        windowUUID: WindowUUID
+        windowUUID: WindowUUID,
+        onLevelUpAnimationComplete: (() -> Void)? = nil
     ) {
         self.avatarURL = avatarURL
         self.progress = max(0.0, min(1.0, progress))
@@ -28,6 +30,7 @@ public struct EcosiaAccountProgressAvatar: View {
         self.showProgress = showProgress
         self.size = size
         self.windowUUID = windowUUID
+        self.onLevelUpAnimationComplete = onLevelUpAnimationComplete
     }
 
     public var body: some View {
@@ -52,7 +55,8 @@ public struct EcosiaAccountProgressAvatar: View {
                 EcosiaSparkleAnimation(
                     isVisible: showSparkles,
                     containerSize: sparkleContainerSize,
-                    sparkleSize: sparkleSize
+                    sparkleSize: sparkleSize,
+                    onComplete: onLevelUpAnimationComplete
                 )
             }
         }

--- a/firefox-ios/Ecosia/UI/Account/EcosiaAuthUIStateProvider.swift
+++ b/firefox-ios/Ecosia/UI/Account/EcosiaAuthUIStateProvider.swift
@@ -30,6 +30,9 @@ public class EcosiaAuthUIStateProvider: ObservableObject {
     /// Balance increment for animations (temporary state)
     @Published public private(set) var balanceIncrement: Int?
 
+    /// Level-up animation trigger (temporary state, auto-resets)
+    @Published public private(set) var shouldShowLevelUpAnimation: Bool = false
+
     /// Current level number (from API for logged-in users, 1 for logged-out)
     @Published private var currentLevelNumber: Int = 1
 
@@ -43,6 +46,7 @@ public class EcosiaAuthUIStateProvider: ObservableObject {
 
     private var authStateObserver: NSObjectProtocol?
     private var userProfileObserver: NSObjectProtocol?
+    private var seedProgressObserver: NSObjectProtocol?
     private let accountsProvider: AccountsProviderProtocol
     private static var seedProgressManagerType: SeedProgressManagerProtocol.Type = UserDefaultsSeedProgressManager.self
 
@@ -65,6 +69,9 @@ public class EcosiaAuthUIStateProvider: ObservableObject {
             NotificationCenter.default.removeObserver(observer)
         }
         if let observer = userProfileObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        if let observer = seedProgressObserver {
             NotificationCenter.default.removeObserver(observer)
         }
     }
@@ -115,6 +122,17 @@ public class EcosiaAuthUIStateProvider: ObservableObject {
         ) { [weak self] _ in
             Task {
                 await self?.handleUserProfileUpdate()
+            }
+        }
+
+        // Listen for seed progress updates (for logged-out users)
+        seedProgressObserver = NotificationCenter.default.addObserver(
+            forName: UserDefaultsSeedProgressManager.progressUpdatedNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task {
+                await self?.handleSeedProgressUpdate()
             }
         }
     }
@@ -173,6 +191,23 @@ public class EcosiaAuthUIStateProvider: ObservableObject {
         }
     }
 
+    @MainActor
+    private func handleSeedProgressUpdate() {
+        // Only handle for logged-out users
+        guard !isLoggedIn else { return }
+
+        let newSeedCount = Self.seedProgressManagerType.loadTotalSeedsCollected()
+
+        // If seed count increased, show animation
+        if newSeedCount > seedCount {
+            let increment = newSeedCount - seedCount
+            EcosiaLogger.accounts.info("Seed progress updated for logged-out user: \(seedCount) → \(newSeedCount) (+\(increment))")
+            animateBalanceChange(from: seedCount, to: newSeedCount, increment: increment)
+        } else {
+            seedCount = newSeedCount
+        }
+    }
+
     // MARK: - Seed Count Management
 
     private func registerVisitIfNeeded() {
@@ -213,6 +248,12 @@ public class EcosiaAuthUIStateProvider: ObservableObject {
         currentLevelNumber = newLevelNumber
         currentProgress = newProgress
 
+        // Trigger level-up animation if user leveled up
+        if response.didLevelUp {
+            EcosiaLogger.accounts.info("Level up detected: triggering animation for level \(newLevelNumber)")
+            triggerLevelUpAnimation()
+        }
+
         if let increment = response.seedsIncrement {
             EcosiaLogger.accounts.info("Balance updated with animation: \(seedCount) → \(newSeedCount) (+\(increment)), level=\(newLevelNumber), progress=\(newProgress)")
             animateBalanceChange(from: seedCount, to: newSeedCount, increment: increment)
@@ -240,6 +281,16 @@ public class EcosiaAuthUIStateProvider: ObservableObject {
     }
 
     @MainActor
+    private func triggerLevelUpAnimation() {
+        shouldShowLevelUpAnimation = true
+        
+        // Auto-reset after animation completes
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+            self.shouldShowLevelUpAnimation = false
+        }
+    }
+
+    @MainActor
     private func resetToLocalSeedCollection() {
         EcosiaLogger.accounts.info("Resetting to local seed collection system")
         Self.seedProgressManagerType.resetCounter()
@@ -262,5 +313,36 @@ public class EcosiaAuthUIStateProvider: ObservableObject {
         } else {
             seedCount = newSeedCount
         }
+    }
+
+    // MARK: - Debug Methods
+
+    /// Debug method to simulate balance updates for testing animations
+    /// This allows QA to test seed addition and level-up animations without server calls
+    /// Available in all builds, accessible through hidden debug menu
+    @MainActor
+    public func debugUpdateBalance(_ response: AccountVisitResponse) {
+        updateBalance(response)
+        EcosiaLogger.accounts.info("Debug: Balance updated via debug method")
+    }
+    
+    /// Debug method to directly trigger level-up animation without mock data
+    /// This allows QA to test the level-up sparkle animation independently
+    /// Available in all builds, accessible through hidden debug menu
+    @MainActor
+    public func debugTriggerLevelUpAnimation() {
+        triggerLevelUpAnimation()
+        EcosiaLogger.accounts.info("Debug: Level-up animation triggered directly")
+    }
+    
+    /// Debug method to directly add seeds with animation for logged-in users
+    /// This allows QA to test seed increment animations without mock responses
+    /// Available in all builds, accessible through hidden debug menu
+    @MainActor
+    public func debugAddSeeds(_ count: Int) {
+        let currentSeeds = seedCount
+        let newSeeds = currentSeeds + count
+        animateBalanceChange(from: currentSeeds, to: newSeeds, increment: count)
+        EcosiaLogger.accounts.info("Debug: Added \(count) seeds for logged-in user (\(currentSeeds) → \(newSeeds))")
     }
 }

--- a/firefox-ios/Ecosia/UI/Account/EcosiaAuthUIStateProvider.swift
+++ b/firefox-ios/Ecosia/UI/Account/EcosiaAuthUIStateProvider.swift
@@ -30,9 +30,6 @@ public class EcosiaAuthUIStateProvider: ObservableObject {
     /// Balance increment for animations (temporary state)
     @Published public private(set) var balanceIncrement: Int?
 
-    /// Level-up animation trigger (temporary state, auto-resets)
-    @Published public private(set) var shouldShowLevelUpAnimation: Bool = false
-
     /// Current level number (from API for logged-in users, 1 for logged-out)
     @Published private var currentLevelNumber: Int = 1
 
@@ -282,12 +279,10 @@ public class EcosiaAuthUIStateProvider: ObservableObject {
 
     @MainActor
     private func triggerLevelUpAnimation() {
-        shouldShowLevelUpAnimation = true
-        
-        // Auto-reset after animation completes
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-            self.shouldShowLevelUpAnimation = false
-        }
+        EcosiaAccountNotificationCenter.postLevelUp(
+            newLevel: currentLevelNumber,
+            newProgress: currentProgress
+        )
     }
 
     @MainActor
@@ -325,7 +320,7 @@ public class EcosiaAuthUIStateProvider: ObservableObject {
         updateBalance(response)
         EcosiaLogger.accounts.info("Debug: Balance updated via debug method")
     }
-    
+
     /// Debug method to directly trigger level-up animation without mock data
     /// This allows QA to test the level-up sparkle animation independently
     /// Available in all builds, accessible through hidden debug menu
@@ -334,7 +329,7 @@ public class EcosiaAuthUIStateProvider: ObservableObject {
         triggerLevelUpAnimation()
         EcosiaLogger.accounts.info("Debug: Level-up animation triggered directly")
     }
-    
+
     /// Debug method to directly add seeds with animation for logged-in users
     /// This allows QA to test seed increment animations without mock responses
     /// Available in all builds, accessible through hidden debug menu

--- a/firefox-ios/Ecosia/UI/Account/EcosiaSparkleAnimation.swift
+++ b/firefox-ios/Ecosia/UI/Account/EcosiaSparkleAnimation.swift
@@ -73,7 +73,7 @@ public struct EcosiaSparkleAnimation: View {
     private func startSparkleAnimation() {
         generateSparkles()
         animateSparkles()
-        
+
         // Run for animationDuration, then gracefully fade out
         DispatchQueue.main.asyncAfter(deadline: .now() + animationDuration) {
             stopSparkleAnimation()

--- a/firefox-ios/Ecosia/UI/Account/EcosiaSparkleAnimation.swift
+++ b/firefox-ios/Ecosia/UI/Account/EcosiaSparkleAnimation.swift
@@ -10,6 +10,7 @@ public struct EcosiaSparkleAnimation: View {
     private let containerSize: CGFloat
     private let sparkleSize: CGFloat
     private let animationDuration: Double
+    private let onComplete: (() -> Void)?
 
     @State private var sparkles: [SparkleData] = []
 
@@ -31,12 +32,14 @@ public struct EcosiaSparkleAnimation: View {
         isVisible: Bool,
         containerSize: CGFloat = .ecosia.space._6l,
         sparkleSize: CGFloat = 24,
-        animationDuration: Double = 6.0
+        animationDuration: Double = 6.0,
+        onComplete: (() -> Void)? = nil
     ) {
         self.isVisible = isVisible
         self.containerSize = containerSize
         self.sparkleSize = sparkleSize
         self.animationDuration = animationDuration
+        self.onComplete = onComplete
     }
 
     public var body: some View {
@@ -70,6 +73,11 @@ public struct EcosiaSparkleAnimation: View {
     private func startSparkleAnimation() {
         generateSparkles()
         animateSparkles()
+        
+        // Run for animationDuration, then gracefully fade out
+        DispatchQueue.main.asyncAfter(deadline: .now() + animationDuration) {
+            stopSparkleAnimation()
+        }
     }
 
     private func stopSparkleAnimation() {
@@ -81,6 +89,7 @@ public struct EcosiaSparkleAnimation: View {
 
         DispatchQueue.main.asyncAfter(deadline: .now() + UX.fadeOutDuration) {
             sparkles.removeAll()
+            onComplete?()
         }
     }
 

--- a/firefox-ios/Ecosia/UI/Account/SeedProgressManager/UserDefaultsSeedProgressManager.swift
+++ b/firefox-ios/Ecosia/UI/Account/SeedProgressManager/UserDefaultsSeedProgressManager.swift
@@ -30,10 +30,10 @@ import Foundation
 public final class UserDefaultsSeedProgressManager: SeedProgressManagerProtocol {
 
     private static let className = String(describing: UserDefaultsSeedProgressManager.self)
-    public static var progressUpdatedNotification: Notification.Name { .init("\(className).SeedProgressUpdated") }
-    public static var levelUpNotification: Notification.Name { .init("\(className).SeedLevelUp") }
     private static let numberOfSeedsAtStart = 1
     public static let maxSeedsForLoggedOutUsers = 3
+    public static var progressUpdatedNotification: Notification.Name { .init("\(className).SeedProgressUpdated") }
+    public static var levelUpNotification: Notification.Name { .init("\(className).SeedLevelUp") }
 
     // UserDefaults keys
     private static let totalSeedsCollectedKey = "TotalSeedsCollected"
@@ -123,45 +123,21 @@ public final class UserDefaultsSeedProgressManager: SeedProgressManagerProtocol 
         let effectiveMaxLevel = maxCappedLevel ?? seedLevels.count
         var effectiveMaxRequiredSeeds = maxCappedSeeds ?? standardMaxRequiredSeeds
 
-        // Apply seed cap for logged-out users (permanent rule)
-        // Logged-out users can only collect a maximum of maxSeedsForLoggedOutUsers seeds
         effectiveMaxRequiredSeeds = maxSeedsForLoggedOutUsers
         EcosiaLogger.accounts.info("Seed cap enforced for logged-out user: max \(maxSeedsForLoggedOutUsers) seeds")
 
-        // Early exit if the maximum number of seeds is already collected
         if totalSeeds >= effectiveMaxRequiredSeeds {
             return
         }
 
-        var currentLevel = loadCurrentLevel()
-
-        let thresholdForNextLevel = requiredSeedsForLevel(currentLevel + 1)
-
         totalSeeds += count
 
-        /* 
-         If the number of seeds being added (e.g. via "add 5 seeds" debug function) exceeds the max required seeds
-         cap the totalSeeds to the maximum required.
-         This is useful in case of a seeds multiplier when the configuration has the `maxCappedSeeds` evaluted.
-         */
         if totalSeeds >= effectiveMaxRequiredSeeds {
             totalSeeds = effectiveMaxRequiredSeeds
         }
 
-        var leveledUp = false
-        // Only level up if the total seeds is equal or exceed the threshold for the level we are reaching to
-        if totalSeeds >= thresholdForNextLevel && currentLevel < effectiveMaxLevel {
-                currentLevel += 1
-                leveledUp = true
-        }
-
-        // Save progress with updated total seeds and current level
-        saveProgress(totalSeeds: totalSeeds, currentLevel: currentLevel, lastAppOpenDate: date)
-
-        // Notify listeners if leveled up
-        if leveledUp {
-            NotificationCenter.default.post(name: levelUpNotification, object: nil)
-        }
+        saveProgress(totalSeeds: totalSeeds, currentLevel: 1, lastAppOpenDate: date)
+        NotificationCenter.default.post(name: progressUpdatedNotification, object: nil)
     }
 
     // Reset the counter to the initial state

--- a/firefox-ios/Ecosia/UI/Account/SeedProgressManager/UserDefaultsSeedProgressManager.swift
+++ b/firefox-ios/Ecosia/UI/Account/SeedProgressManager/UserDefaultsSeedProgressManager.swift
@@ -33,6 +33,7 @@ public final class UserDefaultsSeedProgressManager: SeedProgressManagerProtocol 
     public static var progressUpdatedNotification: Notification.Name { .init("\(className).SeedProgressUpdated") }
     public static var levelUpNotification: Notification.Name { .init("\(className).SeedLevelUp") }
     private static let numberOfSeedsAtStart = 1
+    public static let maxSeedsForLoggedOutUsers = 3
 
     // UserDefaults keys
     private static let totalSeedsCollectedKey = "TotalSeedsCollected"
@@ -106,7 +107,7 @@ public final class UserDefaultsSeedProgressManager: SeedProgressManagerProtocol 
     }
 
     // Add seeds to the counter and handle level progression
-    static func addSeeds(_ count: Int) {
+    public static func addSeeds(_ count: Int) {
         addSeeds(count, relativeToDate: loadLastAppOpenDate())
     }
 
@@ -120,7 +121,12 @@ public final class UserDefaultsSeedProgressManager: SeedProgressManagerProtocol 
 
         // Determine the effective max seeds and level to enforce (capped or classic)
         let effectiveMaxLevel = maxCappedLevel ?? seedLevels.count
-        let effectiveMaxRequiredSeeds = maxCappedSeeds ?? standardMaxRequiredSeeds
+        var effectiveMaxRequiredSeeds = maxCappedSeeds ?? standardMaxRequiredSeeds
+
+        // Apply seed cap for logged-out users (permanent rule)
+        // Logged-out users can only collect a maximum of maxSeedsForLoggedOutUsers seeds
+        effectiveMaxRequiredSeeds = maxSeedsForLoggedOutUsers
+        EcosiaLogger.accounts.info("Seed cap enforced for logged-out user: max \(maxSeedsForLoggedOutUsers) seeds")
 
         // Early exit if the maximum number of seeds is already collected
         if totalSeeds >= effectiveMaxRequiredSeeds {

--- a/firefox-ios/Ecosia/UI/Account/SeedProgressManager/UserDefaultsSeedProgressManager.swift
+++ b/firefox-ios/Ecosia/UI/Account/SeedProgressManager/UserDefaultsSeedProgressManager.swift
@@ -113,27 +113,19 @@ public final class UserDefaultsSeedProgressManager: SeedProgressManagerProtocol 
 
     // Add seeds to the counter with a specific date
     public static func addSeeds(_ count: Int, relativeToDate date: Date) {
-        // Load total seeds and current level from User Defaults
+        // Load total seeds
         var totalSeeds = loadTotalSeedsCollected()
 
-        // Fetch the maximum seeds required for the current progression context
-        let standardMaxRequiredSeeds = seedLevels.last?.requiredSeeds ?? 0
-
-        // Determine the effective max seeds and level to enforce (capped or classic)
-        let effectiveMaxLevel = maxCappedLevel ?? seedLevels.count
-        var effectiveMaxRequiredSeeds = maxCappedSeeds ?? standardMaxRequiredSeeds
-
-        effectiveMaxRequiredSeeds = maxSeedsForLoggedOutUsers
         EcosiaLogger.accounts.info("Seed cap enforced for logged-out user: max \(maxSeedsForLoggedOutUsers) seeds")
 
-        if totalSeeds >= effectiveMaxRequiredSeeds {
+        if totalSeeds >= maxSeedsForLoggedOutUsers {
             return
         }
 
         totalSeeds += count
 
-        if totalSeeds >= effectiveMaxRequiredSeeds {
-            totalSeeds = effectiveMaxRequiredSeeds
+        if totalSeeds >= maxSeedsForLoggedOutUsers {
+            totalSeeds = maxSeedsForLoggedOutUsers
         }
 
         saveProgress(totalSeeds: totalSeeds, currentLevel: 1, lastAppOpenDate: date)

--- a/firefox-ios/EcosiaTests/ClimateImpactCounter/UserDefaultsSeedProgressManagerTests.swift
+++ b/firefox-ios/EcosiaTests/ClimateImpactCounter/UserDefaultsSeedProgressManagerTests.swift
@@ -22,8 +22,8 @@ final class UserDefaultsSeedProgressManagerTests: XCTestCase {
             maxCappedLevel: nil,
             maxCappedSeeds: nil,
             levels: [
-                SeedCounterConfig.SeedLevel(level: 1, requiredSeeds: 5),
-                SeedCounterConfig.SeedLevel(level: 2, requiredSeeds: 10)
+                SeedCounterConfig.SeedLevel(level: 1, requiredSeeds: 2),
+                SeedCounterConfig.SeedLevel(level: 2, requiredSeeds: 3)
             ]
         )
     }
@@ -37,108 +37,137 @@ final class UserDefaultsSeedProgressManagerTests: XCTestCase {
         XCTAssertEqual(totalSeedsCollected, 1, "Initial totalSeedsCollected should be 1")
     }
 
-    // Test adding seeds, make sure the user stays on level 1 until the required seeds to reach next level are added
-    func test_add_seeds_progress_to_next_level() {
-        UserDefaultsSeedProgressManager.addSeeds(4)
-
-        var level = UserDefaultsSeedProgressManager.loadCurrentLevel()
-        var totalSeedsCollected = UserDefaultsSeedProgressManager.loadTotalSeedsCollected()
-
-        // User should still be in level 1 after collecting exactly 5 seeds
-        XCTAssertEqual(level, 1, "User should still be in level 1 after collecting 5 seeds")
-        XCTAssertEqual(totalSeedsCollected, 5, "Total seeds should be 5")
-
-        // Add 5 more seeds, now the user should progress to level 2, as 10 seeds total reached
-        UserDefaultsSeedProgressManager.addSeeds(5)
-
-        level = UserDefaultsSeedProgressManager.loadCurrentLevel()
-        totalSeedsCollected = UserDefaultsSeedProgressManager.loadTotalSeedsCollected()
-
-        XCTAssertEqual(level, 2, "User should progress to level 2 after collecting the 10th seed")
-        XCTAssertEqual(totalSeedsCollected, 10, "Total seeds should be 10")
-    }
-
-    // Test adding seeds beyond level 1 and keep accumulating for level 2
-    func test_add_seeds_beyond_level_1() {
-        // Collect 5 seeds, stay in level 1 (4+1)
-        UserDefaultsSeedProgressManager.addSeeds(4)
-
-        // Add 2 more seeds, stays at level 1
+    // Test that logged-out users never level up
+    func test_logged_out_users_never_level_up() {
+        // Given
         UserDefaultsSeedProgressManager.addSeeds(2)
 
-        let level = UserDefaultsSeedProgressManager.loadCurrentLevel()
-        let totalSeedsCollected = UserDefaultsSeedProgressManager.loadTotalSeedsCollected()
+        // When / Then
+        var level = UserDefaultsSeedProgressManager.loadCurrentLevel()
+        var totalSeedsCollected = UserDefaultsSeedProgressManager.loadTotalSeedsCollected()
+        
+        XCTAssertEqual(level, 1)
+        XCTAssertEqual(totalSeedsCollected, 3)
 
-        XCTAssertEqual(level, 1, "User should still be in level 1 after adding 2 more seed beyond the first level threshold")
-        XCTAssertEqual(totalSeedsCollected, 7, "Total seeds should accumulate across levels (6 new added + 1 accumulated at the start")
-    }
+        // When: Try to add more seeds
+        UserDefaultsSeedProgressManager.addSeeds(10)
 
-    // Test inner progress calculation for Level 2
-    func test_calculate_inner_progress_for_level_2() {
-        UserDefaultsSeedProgressManager.addSeeds(6)  // Collect 7 (1+6) seeds, which puts the user progressing to level 2
-
-        let innerProgress = UserDefaultsSeedProgressManager.calculateInnerProgress()
-        XCTAssertEqual(innerProgress, 0.4, accuracy: 0.01, "Inner progress should reflect 40% progress for level 2 after collecting 7 seeds total out of 10")
+        // Then: Level remains 1, seeds capped at 3
+        level = UserDefaultsSeedProgressManager.loadCurrentLevel()
+        totalSeedsCollected = UserDefaultsSeedProgressManager.loadTotalSeedsCollected()
+        
+        XCTAssertEqual(level, 1)
+        XCTAssertEqual(totalSeedsCollected, 3)
     }
 
     // Test resetting the progress to the initial state
     func test_reset_counter() {
-        UserDefaultsSeedProgressManager.addSeeds(10)
+        // Given
+        UserDefaultsSeedProgressManager.addSeeds(2)
+        
+        // When
         UserDefaultsSeedProgressManager.resetCounter()
 
+        // Then
         let level = UserDefaultsSeedProgressManager.loadCurrentLevel()
         let totalSeedsCollected = UserDefaultsSeedProgressManager.loadTotalSeedsCollected()
-        let innerProgress = UserDefaultsSeedProgressManager.calculateInnerProgress()
 
-        XCTAssertEqual(level, 1, "Reset should set the level to 1")
-        XCTAssertEqual(totalSeedsCollected, 1, "Reset should set totalSeedsCollected to 1")
-        XCTAssertEqual(innerProgress, 0.2, "Reset should set progress to 20%")
+        XCTAssertEqual(level, 1)
+        XCTAssertEqual(totalSeedsCollected, 1)
     }
 
     // Test collecting a seed once per day
     func test_collect_seed_once_per_day() {
-        UserDefaultsSeedProgressManager.collectDailySeed()  // First seed collection today
+        // Given / When
+        UserDefaultsSeedProgressManager.collectDailySeed()
         let totalSeedsAfterFirstCollect = UserDefaultsSeedProgressManager.loadTotalSeedsCollected()
 
-        UserDefaultsSeedProgressManager.collectDailySeed()  // Try collecting another seed today
+        UserDefaultsSeedProgressManager.collectDailySeed()
         let totalSeedsAfterSecondCollect = UserDefaultsSeedProgressManager.loadTotalSeedsCollected()
 
-        XCTAssertEqual(totalSeedsAfterFirstCollect, 1, "Should collect one seed on first open")
-        XCTAssertEqual(totalSeedsAfterSecondCollect, 1, "Should not collect more than one seed in a day")
+        // Then
+        XCTAssertEqual(totalSeedsAfterFirstCollect, 1)
+        XCTAssertEqual(totalSeedsAfterSecondCollect, 1)
     }
 
-    // Test that a seed can be collected the next day
-    func test_collect_seed_next_day() {
+    // Test that a seed can be collected the next day but stays at level 1
+    func test_collect_seed_next_day_stays_level_1() {
+        // Given
         let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: Date())
         UserDefaults.standard.set(yesterday, forKey: "LastAppOpenDate")
 
-        UserDefaultsSeedProgressManager.collectDailySeed()  // Simulate collecting seed today
+        // When
+        UserDefaultsSeedProgressManager.collectDailySeed()
 
+        // Then
         let totalSeedsCollected = UserDefaultsSeedProgressManager.loadTotalSeedsCollected()
-        XCTAssertEqual(totalSeedsCollected, 2, "User should be able to collect a seed on a new day")
+        let level = UserDefaultsSeedProgressManager.loadCurrentLevel()
+        
+        XCTAssertEqual(totalSeedsCollected, 2)
+        XCTAssertEqual(level, 1)
     }
 
-    // Test that adding seeds beyond the maximum level stops at the maximum seeds for the last level.
-    func test_add_seeds_beyond_maximum_level_stops_at_max_seeds_for_last_level() {
-        // Add enough seeds to reach level 2
-        UserDefaultsSeedProgressManager.addSeeds(9) // +9 seeds; total: 10 seeds (5 from level 1, 5 from level 2)
+    // Test that logged-out users are capped at 3 seeds and always remain at level 1
+    func test_logged_out_users_capped_at_max_seeds_and_level_1() {
+        // Given
+        let initialSeeds = UserDefaultsSeedProgressManager.loadTotalSeedsCollected()
+        let initialLevel = UserDefaultsSeedProgressManager.loadCurrentLevel()
+        XCTAssertEqual(initialSeeds, 1)
+        XCTAssertEqual(initialLevel, 1)
 
-        // Ensure user is at level 2 and has 10 seeds
-        var totalSeedsCollected = UserDefaultsSeedProgressManager.loadTotalSeedsCollected()
-        var currentLevel = UserDefaultsSeedProgressManager.loadCurrentLevel()
+        // When
+        UserDefaultsSeedProgressManager.addSeeds(2)
 
-        XCTAssertEqual(currentLevel, 2, "User should be at level 2 after collecting 10 seeds.")
-        XCTAssertEqual(totalSeedsCollected, 10, "Total seeds should be exactly 10 after reaching level 2.")
+        // Then
+        var totalSeeds = UserDefaultsSeedProgressManager.loadTotalSeedsCollected()
+        var level = UserDefaultsSeedProgressManager.loadCurrentLevel()
+        XCTAssertEqual(totalSeeds, UserDefaultsSeedProgressManager.maxSeedsForLoggedOutUsers)
+        XCTAssertEqual(level, 1)
 
-        // Now, try to add more seeds beyond the maximum allowed seeds for level 2
-        UserDefaultsSeedProgressManager.addSeeds(5) // Try adding +5 seeds
+        // When
+        UserDefaultsSeedProgressManager.addSeeds(5)
 
-        // Reload the values after adding seeds
-        totalSeedsCollected = UserDefaultsSeedProgressManager.loadTotalSeedsCollected()
-        currentLevel = UserDefaultsSeedProgressManager.loadCurrentLevel()
+        // Then
+        totalSeeds = UserDefaultsSeedProgressManager.loadTotalSeedsCollected()
+        level = UserDefaultsSeedProgressManager.loadCurrentLevel()
+        XCTAssertEqual(totalSeeds, UserDefaultsSeedProgressManager.maxSeedsForLoggedOutUsers)
+        XCTAssertEqual(level, 1)
+    }
 
-        // Ensure user is still at level 2, and total seeds should be capped at 10
-        XCTAssertEqual(currentLevel, 2, "User should remain at level 2, as it's the last level.")
-        XCTAssertEqual(totalSeedsCollected, 10, "Total seeds should be capped at 10 (the maximum for level 2) even after adding more seeds.")
+    // Test that bulk seed addition caps at 3 seeds and level remains 1
+    func test_logged_out_users_bulk_addition_caps_at_3_seeds_level_1() {
+        // Given
+        let initialSeeds = UserDefaultsSeedProgressManager.loadTotalSeedsCollected()
+        XCTAssertEqual(initialSeeds, 1)
+
+        // When
+        UserDefaultsSeedProgressManager.addSeeds(10)
+
+        // Then
+        let totalSeeds = UserDefaultsSeedProgressManager.loadTotalSeedsCollected()
+        let level = UserDefaultsSeedProgressManager.loadCurrentLevel()
+        XCTAssertEqual(totalSeeds, UserDefaultsSeedProgressManager.maxSeedsForLoggedOutUsers)
+        XCTAssertEqual(level, 1)
+    }
+
+    // Test that daily seed collection respects cap and level remains 1
+    func test_logged_out_users_daily_seed_respects_cap_and_level_1() {
+        // Given
+        UserDefaultsSeedProgressManager.addSeeds(2)
+        var totalSeeds = UserDefaultsSeedProgressManager.loadTotalSeedsCollected()
+        var level = UserDefaultsSeedProgressManager.loadCurrentLevel()
+        XCTAssertEqual(totalSeeds, 3)
+        XCTAssertEqual(level, 1)
+
+        // When
+        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: Date())
+        UserDefaults.standard.set(yesterday, forKey: "LastAppOpenDate")
+        UserDefaultsSeedProgressManager.collectDailySeed()
+
+        // Then
+        totalSeeds = UserDefaultsSeedProgressManager.loadTotalSeedsCollected()
+        level = UserDefaultsSeedProgressManager.loadCurrentLevel()
+        XCTAssertEqual(totalSeeds, UserDefaultsSeedProgressManager.maxSeedsForLoggedOutUsers)
+        XCTAssertEqual(level, 1)
     }
 }

--- a/firefox-ios/EcosiaTests/ClimateImpactCounter/UserDefaultsSeedProgressManagerTests.swift
+++ b/firefox-ios/EcosiaTests/ClimateImpactCounter/UserDefaultsSeedProgressManagerTests.swift
@@ -45,7 +45,7 @@ final class UserDefaultsSeedProgressManagerTests: XCTestCase {
         // When / Then
         var level = UserDefaultsSeedProgressManager.loadCurrentLevel()
         var totalSeedsCollected = UserDefaultsSeedProgressManager.loadTotalSeedsCollected()
-        
+
         XCTAssertEqual(level, 1)
         XCTAssertEqual(totalSeedsCollected, 3)
 
@@ -55,7 +55,7 @@ final class UserDefaultsSeedProgressManagerTests: XCTestCase {
         // Then: Level remains 1, seeds capped at 3
         level = UserDefaultsSeedProgressManager.loadCurrentLevel()
         totalSeedsCollected = UserDefaultsSeedProgressManager.loadTotalSeedsCollected()
-        
+
         XCTAssertEqual(level, 1)
         XCTAssertEqual(totalSeedsCollected, 3)
     }
@@ -64,7 +64,7 @@ final class UserDefaultsSeedProgressManagerTests: XCTestCase {
     func test_reset_counter() {
         // Given
         UserDefaultsSeedProgressManager.addSeeds(2)
-        
+
         // When
         UserDefaultsSeedProgressManager.resetCounter()
 
@@ -102,7 +102,7 @@ final class UserDefaultsSeedProgressManagerTests: XCTestCase {
         // Then
         let totalSeedsCollected = UserDefaultsSeedProgressManager.loadTotalSeedsCollected()
         let level = UserDefaultsSeedProgressManager.loadCurrentLevel()
-        
+
         XCTAssertEqual(totalSeedsCollected, 2)
         XCTAssertEqual(level, 1)
     }


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-3538]

## Context

Throughout testing the Account's feature main branch, we realised that some hidden debug settings were needed to test the Seed Addition and Levelling Up animations.

## Approach

- Implement debug settings to test seed addition and level-up animations
- Add custom seed input debug setting for logged-in users
- Specify a 3-seed cap for logged-out users
- Create debug methods in EcosiaAuthUIStateProvider to test animations directly
- Fix notification handling like done in other classes via `cancellables`
- Review local seeds implementation, removing the level handling as there is no level up happening, and simplify its implementation

ℹ️ Regarding how sparkles animate, given the newly detailed approach to animation in [Figma's Global Components](https://www.figma.com/design/s1beHaK0d7VU3UpE4YAg11/%F0%9F%A7%AC-Global-Components?node-id=11558-10440&m=dev), the animation will be reviewed as part of the dedicated design changes feature branch.

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I wrote Unit Tests that confirm the expected behaviour

[MOB-3538]: https://ecosia.atlassian.net/browse/MOB-3538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ