### PR TITLE
[MOB-3926] Fix Snapshot Tests

### DIFF
--- a/.github/workflows/snapshot_tests.yml
+++ b/.github/workflows/snapshot_tests.yml
@@ -1,6 +1,9 @@
 name: Snapshot Tests
 
 on:
+  push:
+    branches:
+      - dc-mob-3926-fix-snapshot-tests
   pull_request:
     paths:
       - 'firefox-ios/Client/Configuration/Common.xcconfig'
@@ -21,13 +24,13 @@ jobs:
         run: sh ./check_marketing_version.sh
 
       - name: Prepare environment
-        if : ( steps.check_marketing_version.outputs.skipnext  != 'true' )
+        # if : ( steps.check_marketing_version.outputs.skipnext  != 'true' )
         uses: ./.github/actions/prepare_environment
         with:
           core-token: ${{ secrets.IOS_CORE_TOKEN }}
 
       - name: Perform Snapshot Tests and Publish Test reports
-        if : ( steps.check_marketing_version.outputs.skipnext  != 'true' )
+        # if : ( steps.check_marketing_version.outputs.skipnext  != 'true' )
         id: perform-snapshot-tests
         uses: ./.github/actions/perform_snapshot_tests
         with:

--- a/.github/workflows/snapshot_tests.yml
+++ b/.github/workflows/snapshot_tests.yml
@@ -1,9 +1,6 @@
 name: Snapshot Tests
 
 on:
-  push:
-    branches:
-      - dc-mob-3926-fix-snapshot-tests
   pull_request:
     paths:
       - 'firefox-ios/Client/Configuration/Common.xcconfig'
@@ -25,13 +22,13 @@ jobs:
         run: sh ./check_marketing_version.sh
 
       - name: Prepare environment
-        # if : ( steps.check_marketing_version.outputs.skipnext  != 'true' )
+        if : ( steps.check_marketing_version.outputs.skipnext  != 'true' )
         uses: ./.github/actions/prepare_environment
         with:
           core-token: ${{ secrets.IOS_CORE_TOKEN }}
 
       - name: Perform Snapshot Tests and Publish Test reports
-        # if : ( steps.check_marketing_version.outputs.skipnext  != 'true' )
+        if : ( steps.check_marketing_version.outputs.skipnext  != 'true' )
         id: perform-snapshot-tests
         uses: ./.github/actions/perform_snapshot_tests
         with:

--- a/.github/workflows/snapshot_tests.yml
+++ b/.github/workflows/snapshot_tests.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          lfs: true
           submodules: true    
 
       - name: Check for MARKETING_VERSION change

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -9563,6 +9563,7 @@
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				SnapshotTests/DeviceType.swift,
+				SnapshotTests/environment.json,
 				SnapshotTests/LocaleRetriever.swift,
 				SnapshotTests/LocalizationOverrideTestingBundle.swift,
 				SnapshotTests/NTP/NTPComponentTests.swift,
@@ -9583,6 +9584,7 @@
 				Mocks/EcosiaMockThemeManager.swift,
 				Mocks/MockWelcomeDelegate.swift,
 				SnapshotTests/DeviceType.swift,
+				SnapshotTests/environment.json,
 				SnapshotTests/LocaleRetriever.swift,
 				SnapshotTests/LocalizationOverrideTestingBundle.swift,
 				SnapshotTests/NTP/NTPComponentTests.swift,

--- a/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -185,8 +185,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "revision" : "f5bfff796ee8e3bc9a685b7ffba1bf20663eb370",
-        "version" : "1.18.0"
+        "revision" : "a8b7c5e0ed33d8ab8887d1654d9b59f2cbad529b",
+        "version" : "1.18.7"
       }
     },
     {

--- a/firefox-ios/EcosiaTests/SnapshotTests/DeviceType.swift
+++ b/firefox-ios/EcosiaTests/SnapshotTests/DeviceType.swift
@@ -9,10 +9,10 @@ import UIKit
 enum DeviceType: String, CaseIterable {
     case iPhoneSE_Portrait
     case iPhoneSE_Landscape
-    case iPhone15Pro_Portrait
-    case iPhone15Pro_Landscape
-    case iPhone15ProMax_Portrait
-    case iPhone15ProMax_Landscape
+    case iPhone16Pro_Portrait
+    case iPhone16Pro_Landscape
+    case iPhone16ProMax_Portrait
+    case iPhone16ProMax_Landscape
     case iPadPro_Portrait
     case iPadPro_Landscape
 
@@ -22,13 +22,13 @@ enum DeviceType: String, CaseIterable {
             return ViewImageConfig.iPhone8(.portrait)
         case .iPhoneSE_Landscape:
             return ViewImageConfig.iPhone8(.landscape)
-        case .iPhone15Pro_Portrait:
+        case .iPhone16Pro_Portrait:
             return ViewImageConfig.iPhone13Pro(.portrait)
-        case .iPhone15Pro_Landscape:
+        case .iPhone16Pro_Landscape:
             return ViewImageConfig.iPhone13Pro(.landscape)
-        case .iPhone15ProMax_Portrait:
+        case .iPhone16ProMax_Portrait:
             return ViewImageConfig.iPhone13ProMax(.portrait)
-        case .iPhone15ProMax_Landscape:
+        case .iPhone16ProMax_Landscape:
             return ViewImageConfig.iPhone13ProMax(.landscape)
         case .iPadPro_Portrait:
             return ViewImageConfig.iPadPro11(.portrait)
@@ -41,10 +41,10 @@ enum DeviceType: String, CaseIterable {
         switch self {
         case .iPhoneSE_Portrait, .iPhoneSE_Landscape:
             return "iPhone SE (3rd generation)"
-        case .iPhone15Pro_Portrait, .iPhone15Pro_Landscape:
-            return "iPhone 15 Pro"
-        case .iPhone15ProMax_Portrait, .iPhone15ProMax_Landscape:
-            return "iPhone 15 Pro Max"
+        case .iPhone16Pro_Portrait, .iPhone16Pro_Landscape:
+            return "iPhone 16 Pro"
+        case .iPhone16ProMax_Portrait, .iPhone16ProMax_Landscape:
+            return "iPhone 16 Pro Max"
         case .iPadPro_Portrait, .iPadPro_Landscape:
             return "iPad Pro 11-inch (M4)"
         }
@@ -63,13 +63,13 @@ enum DeviceType: String, CaseIterable {
         case ("iPhone SE (3rd generation)", "landscape"):
             return .iPhoneSE_Landscape
         case ("iPhone 16 Pro", "portrait"):
-            return .iPhone15Pro_Portrait
+            return .iPhone16Pro_Portrait
         case ("iPhone 16 Pro", "landscape"):
-            return .iPhone15Pro_Landscape
+            return .iPhone16Pro_Landscape
         case ("iPhone 16 Pro Max", "portrait"):
-            return .iPhone15ProMax_Portrait
+            return .iPhone16ProMax_Portrait
         case ("iPhone 16 Pro Max", "landscape"):
-            return .iPhone15ProMax_Landscape
+            return .iPhone16ProMax_Landscape
         case ("iPad Pro 11-inch (M4)", "portrait"):
             return .iPadPro_Portrait
         case ("iPad Pro 11-inch (M4)", "landscape"):

--- a/firefox-ios/EcosiaTests/SnapshotTests/DeviceType.swift
+++ b/firefox-ios/EcosiaTests/SnapshotTests/DeviceType.swift
@@ -62,13 +62,13 @@ enum DeviceType: String, CaseIterable {
             return .iPhoneSE_Portrait
         case ("iPhone SE (3rd generation)", "landscape"):
             return .iPhoneSE_Landscape
-        case ("iPhone 15 Pro", "portrait"):
+        case ("iPhone 16 Pro", "portrait"):
             return .iPhone15Pro_Portrait
-        case ("iPhone 15 Pro", "landscape"):
+        case ("iPhone 16 Pro", "landscape"):
             return .iPhone15Pro_Landscape
-        case ("iPhone 15 Pro Max", "portrait"):
+        case ("iPhone 16 Pro Max", "portrait"):
             return .iPhone15ProMax_Portrait
-        case ("iPhone 15 Pro Max", "landscape"):
+        case ("iPhone 16 Pro Max", "landscape"):
             return .iPhone15ProMax_Landscape
         case ("iPad Pro 11-inch (M4)", "portrait"):
             return .iPadPro_Portrait

--- a/firefox-ios/EcosiaTests/SnapshotTests/SnapshotTestHelper.swift
+++ b/firefox-ios/EcosiaTests/SnapshotTests/SnapshotTestHelper.swift
@@ -139,7 +139,7 @@ final class SnapshotTestHelper {
 
     /// Swaps the main bundle to use a custom bundle for localization override during testing.
     private static func swizzleMainBundle() {
-        object_setClass(Bundle.main, LocalizationOverrideTestingBundle.self)
+        object_setClass(Bundle.ecosia, LocalizationOverrideTestingBundle.self)
     }
 
     /// Updates the window with newly initialized content and makes it visible.

--- a/firefox-ios/EcosiaTests/SnapshotTests/SnapshotTests.xctestplan
+++ b/firefox-ios/EcosiaTests/SnapshotTests/SnapshotTests.xctestplan
@@ -16,6 +16,9 @@
       "parallelizable" : true,
       "skippedTests" : [
         "NTPTests",
+        "OnboardingTests",
+        "OnboardingTests\/testWelcomeScreen()",
+        "OnboardingTests\/testWelcomeStepsScreens()",
         "SnapshotBaseTests"
       ],
       "target" : {

--- a/firefox-ios/EcosiaTests/SnapshotTests/environment.json
+++ b/firefox-ios/EcosiaTests/SnapshotTests/environment.json
@@ -5,12 +5,8 @@
     "orientation": "portrait"
   },
   {
-    "name": "iPhone 15 Pro",
+    "name": "iPhone 16 Pro",
     "orientation": "portrait"
-  },
-  {
-    "name": "iPhone 15 Pro Max",
-    "orientation": "landscape"
   },
   {
     "name": "iPad Pro 11-inch (M4)",
@@ -24,5 +20,5 @@
   "es",
   "nl"
 ],
-    "SIMULATOR_DEVICE_NAME": "iPhone 15 Pro"
+    "SIMULATOR_DEVICE_NAME": "iPhone 16 Pro"
   }

--- a/firefox-ios/EcosiaTests/SnapshotTests/snapshot_configuration.json
+++ b/firefox-ios/EcosiaTests/SnapshotTests/snapshot_configuration.json
@@ -31,11 +31,6 @@
       "name": "EcosiaSnapshotTests",
       "testClasses": [
         {
-          "name": "OnboardingTests",
-          "devices": ["all", "portrait"],
-          "locales": ["all"]
-        },
-        {
           "name": "NTPComponentTests",
           "devices": ["iPhone 16 Pro"],
           "locales": ["all"]

--- a/firefox-ios/EcosiaTests/SnapshotTests/snapshot_configuration.json
+++ b/firefox-ios/EcosiaTests/SnapshotTests/snapshot_configuration.json
@@ -12,13 +12,13 @@
       "orientation": "portrait"
     },
     {
-      "name": "iPhone 15 Pro",
+      "name": "iPhone 16 Pro",
       "orientation": "portrait",
-      "os": "17.5",
+      "os": "18.6",
       "isDefaultTestDevice": true
     },
     {
-      "name": "iPhone 15 Pro Max",
+      "name": "iPhone 16 Pro Max",
       "orientation": "landscape"
     },
     {
@@ -37,7 +37,7 @@
         },
         {
           "name": "NTPComponentTests",
-          "devices": ["iPhone 15 Pro"],
+          "devices": ["iPhone 16 Pro"],
           "locales": ["all"]
         }
       ]

--- a/perform_snapshot_tests.sh
+++ b/perform_snapshot_tests.sh
@@ -454,6 +454,14 @@ if [ "${#xcresult_files[@]}" -eq 0 ]; then
   exit 1
 fi
 
+# Check if xcresult is one
+if [ "${#xcresult_files[@]}" -eq 1 ]; then
+  echo "Only one xcresult file found. Copying to combined result path."
+  cp -R "${xcresult_files[0]}" "$combined_result_path"
+  echo "Combined xcresult created at: $combined_result_path"
+  exit 0
+fi
+
 # Merge the xcresult files into one
 $xcresulttool_path merge "${xcresult_files[@]}" --output-path "$combined_result_path"
 

--- a/perform_snapshot_tests.sh
+++ b/perform_snapshot_tests.sh
@@ -434,7 +434,7 @@ combined_result_path="$results_dir/all_tests.xcresult"
 
 # Define the Xcode path based on the CI environment variable
 if [ "${CI:-false}" = "true" ]; then
-    xcresulttool_path="/Applications/Xcode_15.4.app/Contents/Developer/usr/bin/xcresulttool"
+    xcresulttool_path="/Applications/Xcode_16.4.app/Contents/Developer/usr/bin/xcresulttool"
 else
     xcresulttool_path="/Applications/Xcode.app/Contents/Developer/usr/bin/xcresulttool"
 fi


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-3926]

## Context

We realised Snapshot tests were failing because of the Simulator mismatch and unavailability.

## Approach

We took the occasion to review the current implementation and update it to match the current state of Simulator availability.

- Removed onboarding screenshots as not available
- Removed old screenshots
- Updated new screenshots for the AI brand
- Fixed bundle reference for localisation

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed

[MOB-3926]: https://ecosia.atlassian.net/browse/MOB-3926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ