### PR TITLE
Fix login/logout on Accounts and Firefox's inherited blank page bug

### DIFF
--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -585,7 +585,12 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable {
 
     func restore(_ webView: WKWebView, interactionState: Data? = nil) {
         if let url = url {
-            webView.load(URLRequest(url: url))
+            if let internalURL = InternalURL(url),
+               internalURL.isAboutHomeURL {
+                webView.load(PrivilegedRequest(url: url) as URLRequest)
+            } else {
+                webView.load(URLRequest(url: url))
+            }
         }
 
         if let interactionState = interactionState {
@@ -712,7 +717,8 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable {
             }
         }
 
-        if let webView, webView.url != nil {
+        // Do not reload from origin for homepage internal URLs
+        if let webView, webView.url != nil && !(InternalURL(webView.url)?.isAboutHomeURL ?? false) {
             webView.reloadFromOrigin()
             logger.log("Reloaded zombified tab from origin",
                        level: .debug,

--- a/firefox-ios/Ecosia/Account/Auth/NativeToWebSSOAuth0Provider.swift
+++ b/firefox-ios/Ecosia/Account/Auth/NativeToWebSSOAuth0Provider.swift
@@ -29,6 +29,7 @@ public struct NativeToWebSSOAuth0Provider: Auth0ProviderProtocol {
 
     public var webAuth: WebAuth {
         makeHttpsWebAuth()
+            .useEphemeralSession()
             .audience(environment.urlProvider.authApiAudience.absoluteString)
             .scope("openid profile email offline_access read:impact write:impact")
     }


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-####]

## Context

This PR re-integrates the concept of Ephemeral Session for Native to Web SSO as confirmed by Auth0 that this kind of SSO differs from Traditional ones and the session token gets transferred differently.

It also contains a fix brought in by Firefox v134 when sometimes the homepage opened a blank tab instead of showing the defined homepage. This happened when some homepages didn't have a UUID set for them.