### PR TITLE
[MOB-4014] Add origin to AI search URLs

### DIFF
--- a/firefox-ios/Client/Ecosia/Extensions/HomepageViewController+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/HomepageViewController+Ecosia.swift
@@ -122,6 +122,6 @@ extension LegacyHomepageViewController: NTPSeedCounterDelegate {
 
 extension LegacyHomepageViewController: NTPHeaderDelegate {
     func headerOpenAISearch() {
-        openLink(url: Environment.current.urlProvider.aiSearch)
+        openLink(url: Environment.current.urlProvider.aiSearch(origin: .ntp))
     }
 }

--- a/firefox-ios/Client/Ecosia/Extensions/SearchViewController+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/SearchViewController+Ecosia.swift
@@ -39,16 +39,10 @@ extension SearchViewController {
 
     /// Handle AI Search navigation when item is selected
     func handleAISearchSelection(_ indexPath: IndexPath) {
-        var components = URLComponents(url: Environment.current.urlProvider.aiSearch, resolvingAgainstBaseURL: false)!
+        let url = Environment.current.urlProvider.aiSearch(origin: .autocomplete)
+        let finalURL = url.appendingQueryItems([URLQueryItem(name: "q", value: viewModel.searchQuery)])
 
-        var queryItems = components.queryItems ?? []
-        queryItems.append(URLQueryItem(name: "q", value: viewModel.searchQuery))
-        components.queryItems = queryItems
-
-        if let finalURL = components.url {
-            searchDelegate?.searchViewController(self, didSelectURL: finalURL, searchTerm: viewModel.searchQuery)
-        }
-
+        searchDelegate?.searchViewController(self, didSelectURL: finalURL, searchTerm: viewModel.searchQuery)
         Analytics.shared.aiSearchAutocompleteForQuery(viewModel.searchQuery)
     }
 

--- a/firefox-ios/Ecosia/Core/Environment/URLProvider.swift
+++ b/firefox-ios/Ecosia/Core/Environment/URLProvider.swift
@@ -165,17 +165,25 @@ public enum URLProvider {
     }
 
     public var notifications: URL {
-        var components = URLComponents(url: URL(string: "https://api.ecosia.org/v1/notifications")!, resolvingAgainstBaseURL: false)!
-        components.queryItems = [
+        let url = URL(string: "https://api.ecosia.org/v1/notifications")!
+        return url.appendingQueryItems([
             .init(name: "language", value: Language.current.rawValue),
             .init(name: "market", value: User.shared.marketCode.rawValue),
             .init(name: "limit", value: "50")
-        ]
-        return components.url!
+        ])
     }
 
-    public var aiSearch: URL {
-        root.appendingPathComponent("ai-search")
+    public enum AISearchOrigin: String {
+        case ntp = "newtabbutton"
+        case autocomplete = "autocomplete_app"
+    }
+    public func aiSearch(origin: AISearchOrigin?) -> URL {
+        let baseURL = root.appendingPathComponent("ai-search")
+        guard let origin = origin else {
+            return baseURL
+        }
+
+        return baseURL.appendingQueryItems([URLQueryItem(name: "origin", value: origin.rawValue)])
     }
 
     public var storeWriteReviewPage: URL {

--- a/firefox-ios/Ecosia/Core/URL+Extensions.swift
+++ b/firefox-ios/Ecosia/Core/URL+Extensions.swift
@@ -103,7 +103,6 @@ extension URL {
                                     !User.shared.sendAnonymousUsageData
         let userId = shouldAnonymizeUserId ? UUID(uuid: UUID_NULL).uuidString : User.shared.analyticsId.uuidString
 
-        // Use the version-safe appendingQueryItems utility
         guard let urlWithoutUserId = components.url else { return self }
         return urlWithoutUserId.appendingQueryItems([Self.item(name: .userId, value: userId)])
     }
@@ -144,12 +143,14 @@ extension URL {
             url.append(queryItems: queryItems)
             return url
         } else {
-            var components = URLComponents(url: self, resolvingAgainstBaseURL: false)!
+            guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false) else {
+                return self
+            }
             if components.queryItems == nil {
                 components.queryItems = []
             }
             components.queryItems?.append(contentsOf: queryItems)
-            return components.url!
+            return components.url ?? self
         }
     }
 }

--- a/firefox-ios/Ecosia/Core/URL+Extensions.swift
+++ b/firefox-ios/Ecosia/Core/URL+Extensions.swift
@@ -86,9 +86,11 @@ extension URL {
         guard isEcosia(urlProvider),
               var components = components
         else { return self }
+
+        // Remove existing userId if present
         components.queryItems?.removeAll(where: { $0.name == EcosiaQueryItemName.userId.rawValue })
-        var items = components.queryItems ?? .init()
-        /* 
+
+        /*
          The `sendAnonymousUsageData` is set by the native UX component in settings
          that determines whether the app would send the events to Snowplow.
          To align the business logic, this parameter will also function as a condition
@@ -100,9 +102,10 @@ extension URL {
                                     !User.shared.hasAnalyticsCookieConsent ||
                                     !User.shared.sendAnonymousUsageData
         let userId = shouldAnonymizeUserId ? UUID(uuid: UUID_NULL).uuidString : User.shared.analyticsId.uuidString
-        items.append(Self.item(name: .userId, value: userId))
-        components.queryItems = items
-        return components.url!
+
+        // Use the version-safe appendingQueryItems utility
+        guard let urlWithoutUserId = components.url else { return self }
+        return urlWithoutUserId.appendingQueryItems([Self.item(name: .userId, value: userId)])
     }
 
     public var policy: Scheme.Policy {
@@ -128,5 +131,25 @@ extension URL {
 
     private static func item(name: EcosiaQueryItemName, value: String) -> URLQueryItem {
         .init(name: name.rawValue, value: value)
+    }
+
+    /// Appends query items to a URL in a version-safe way.
+    /// - Parameter queryItems: The query items to append to the URL
+    /// - Returns: A new URL with the query items appended
+    /// - Note: This method can be removed once the minimum deployment target is iOS 16+,
+    ///         as URL.append(queryItems:) is available natively from iOS 16.
+    public func appendingQueryItems(_ queryItems: [URLQueryItem]) -> URL {
+        if #available(iOS 16.0, *) {
+            var url = self
+            url.append(queryItems: queryItems)
+            return url
+        } else {
+            var components = URLComponents(url: self, resolvingAgainstBaseURL: false)!
+            if components.queryItems == nil {
+                components.queryItems = []
+            }
+            components.queryItems?.append(contentsOf: queryItems)
+            return components.url!
+        }
     }
 }

--- a/firefox-ios/EcosiaTests/Core/URLProviderDependantTests/URLProviderTests.swift
+++ b/firefox-ios/EcosiaTests/Core/URLProviderDependantTests/URLProviderTests.swift
@@ -93,4 +93,22 @@ final class URLProviderTests: XCTestCase {
 
         Language.current = def
     }
+
+    // MARK: - AI Search Tests
+
+    func testAISearchWithoutOrigin() {
+        let url = urlProvider.aiSearch(origin: nil)
+        XCTAssertTrue(url.absoluteString.hasSuffix("/ai-search"))
+        XCTAssertNil(URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems)
+    }
+
+    func testAISearchWithNTPOrigin() {
+        let url = urlProvider.aiSearch(origin: .ntp)
+        XCTAssertTrue(url.absoluteString.contains("/ai-search?origin=newtabbutton"))
+    }
+
+    func testAISearchWithAutocompleteOrigin() {
+        let url = urlProvider.aiSearch(origin: .autocomplete)
+        XCTAssertTrue(url.absoluteString.contains("/ai-search?origin=autocomplete_app"))
+    }
 }


### PR DESCRIPTION
[MOB-4014]

## Approach

Appending new `origin` parameter to ai search entry points.

## Other

Created helper for adding URL query items to URL, already taking into consideration future simplification with iOS 16 as minimum target.

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I wrote Unit Tests that confirm the expected behaviour

[MOB-4014]: https://ecosia.atlassian.net/browse/MOB-4014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ