### PR TITLE
Update eager linking - backport from FF

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,54 +123,6 @@ jobs:
               echo "ℹ️  No version change - pipeline complete"
             fi
 
-  manual-build-testflight-deploy:
-    <<: *environment_common
-    <<: *macos_common
-    steps:
-      - checkout
-      - run:
-          name: Check if this is a dry-run
-          command: |
-            if [[ "<< pipeline.parameters.dry-run-mode >>" == "true" ]]; then
-              echo "🧪 DRY RUN MODE: Will not actually upload to TestFlight"
-              echo "export TESTFLIGHT_DRY_RUN=true" >> $BASH_ENV
-            else
-              echo "🚀 PRODUCTION MODE: Will upload to TestFlight"
-              echo "export TESTFLIGHT_DRY_RUN=false" >> $BASH_ENV
-            fi
-      - macos/switch-ruby:
-          version: "3.2"
-      - restore_cache:
-          key: 1-gems-{{ checksum "Gemfile.lock" }}
-      - run:
-          name: Bundle install
-          command: bundle check || bundle install --path vendor/bundle
-      - save_cache:
-          key: 1-gems-{{ checksum "Gemfile.lock" }}
-          paths:
-            - vendor/bundle
-      - run:
-          name: verify github
-          command: for ip in $(dig @8.8.8.8 github.com +short); do ssh-keyscan github.com,$ip; ssh-keyscan $ip; done 2>/dev/null >> ~/.ssh/known_hosts
-      - run:
-          name: extract Production XCConfig
-          command: echo "$PRODUCTION_XCCONFIG" | base64 --decode > firefox-ios/Client/Configuration/Production.xcconfig
-      - run:
-          name: Execute bootstrap
-          command: ./bootstrap.sh
-      - run:
-          name: Build and deploy to Testflight (with dry-run support)
-          no_output_timeout: 35m
-          command: |
-            if [[ "$TESTFLIGHT_DRY_RUN" == "true" ]]; then
-              echo "🧪 DRY RUN MODE: Building app but NOT uploading to TestFlight"
-              echo "Would run: bundle exec fastlane testflight_live"
-              echo "✅ Test successful - workflow reached TestFlight deployment step"
-            else
-              echo "🚀 PRODUCTION MODE: Building and uploading to TestFlight"
-              bundle exec fastlane testflight_live
-            fi
-
   build-and-deploy-testflight-beta:
     <<: *environment_common
     <<: *macos_common
@@ -481,7 +433,7 @@ workflows:
         - << pipeline.parameters.run-release-deploy >>
         - not: << pipeline.parameters.is-release-pipeline >>
     jobs:
-      - manual-build-testflight-deploy:
+      - build-testflight-deploy:
           name: Manual Deploy release version to TestFlight
           context: napps
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,6 +123,54 @@ jobs:
               echo "ℹ️  No version change - pipeline complete"
             fi
 
+  manual-build-testflight-deploy:
+    <<: *environment_common
+    <<: *macos_common
+    steps:
+      - checkout
+      - run:
+          name: Check if this is a dry-run
+          command: |
+            if [[ "<< pipeline.parameters.dry-run-mode >>" == "true" ]]; then
+              echo "🧪 DRY RUN MODE: Will not actually upload to TestFlight"
+              echo "export TESTFLIGHT_DRY_RUN=true" >> $BASH_ENV
+            else
+              echo "🚀 PRODUCTION MODE: Will upload to TestFlight"
+              echo "export TESTFLIGHT_DRY_RUN=false" >> $BASH_ENV
+            fi
+      - macos/switch-ruby:
+          version: "3.2"
+      - restore_cache:
+          key: 1-gems-{{ checksum "Gemfile.lock" }}
+      - run:
+          name: Bundle install
+          command: bundle check || bundle install --path vendor/bundle
+      - save_cache:
+          key: 1-gems-{{ checksum "Gemfile.lock" }}
+          paths:
+            - vendor/bundle
+      - run:
+          name: verify github
+          command: for ip in $(dig @8.8.8.8 github.com +short); do ssh-keyscan github.com,$ip; ssh-keyscan $ip; done 2>/dev/null >> ~/.ssh/known_hosts
+      - run:
+          name: extract Production XCConfig
+          command: echo "$PRODUCTION_XCCONFIG" | base64 --decode > firefox-ios/Client/Configuration/Production.xcconfig
+      - run:
+          name: Execute bootstrap
+          command: ./bootstrap.sh
+      - run:
+          name: Build and deploy to Testflight (with dry-run support)
+          no_output_timeout: 35m
+          command: |
+            if [[ "$TESTFLIGHT_DRY_RUN" == "true" ]]; then
+              echo "🧪 DRY RUN MODE: Building app but NOT uploading to TestFlight"
+              echo "Would run: bundle exec fastlane testflight_live"
+              echo "✅ Test successful - workflow reached TestFlight deployment step"
+            else
+              echo "🚀 PRODUCTION MODE: Building and uploading to TestFlight"
+              bundle exec fastlane testflight_live
+            fi
+
   build-and-deploy-testflight-beta:
     <<: *environment_common
     <<: *macos_common
@@ -433,7 +481,7 @@ workflows:
         - << pipeline.parameters.run-release-deploy >>
         - not: << pipeline.parameters.is-release-pipeline >>
     jobs:
-      - build-testflight-deploy:
+      - manual-build-testflight-deploy:
           name: Manual Deploy release version to TestFlight
           context: napps
 

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -26113,7 +26113,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = Ecosia/Entitlements/Ecosia.entitlements;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				EAGER_LINKING = YES;
+				EAGER_LINKING = "$(inherited)";
 				FUSE_BUILD_SCRIPT_PHASES = YES;
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				INFOPLIST_FILE = Client/Info.plist;

--- a/firefox-ios/Client/Configuration/Common.xcconfig
+++ b/firefox-ios/Client/Configuration/Common.xcconfig
@@ -28,6 +28,7 @@ OTHER_SWIFT_FLAGS_common = -DMOZ_TARGET_CLIENT
 PRODUCT_NAME = $(TARGET_NAME)
 SDKROOT = iphoneos
 SKIP_INSTALL = YES // Overridden for Client and extensions, so they end up in the bundle
+EAGER_LINKING = NO
 SWIFT_VERSION = 5.3
 TARGETED_DEVICE_FAMILY = 1,2
 TEST_TARGET_NAME = Client


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-####]

## Context

On CI there was a surfaced issue that made all builds fail.
We didn't change anything apart from a recent machines bump so, as usual, we went over Firefox looking for similar error.

## Approach

Found the [same issue](https://github.com/mozilla-mobile/firefox-ios/pull/22554) for which Firefox applied the change of flagging `EAGER_LINKING` 's build settings OFF for the Release configuration as well. 

## Other

## Before merging

### Checklist

- [ ] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [ ] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed