### PR TITLE
[MOB-4042] Handle links meant to be opened in a new tab in `EcosiaWebViewModal`

### DIFF
--- a/firefox-ios/EcosiaTests/EcosiaHomeViewModelTests.swift
+++ b/firefox-ios/EcosiaTests/EcosiaHomeViewModelTests.swift
@@ -48,11 +48,10 @@ class EcosiaHomeViewModelTests: XCTestCase {
                                           auth: EcosiaAuth(browserViewController: BrowserViewController(profile: profile, tabManager: tabManager)))
         User.shared.showClimateImpact = true
 
-        XCTAssertEqual(viewModel.shownSections.count, 5)
-        XCTAssertEqual(viewModel.shownSections[0], HomepageSectionType.header)
-        XCTAssertEqual(viewModel.shownSections[1], HomepageSectionType.homepageHeader)
-        XCTAssertEqual(viewModel.shownSections[2], HomepageSectionType.libraryShortcuts)
-        XCTAssertEqual(viewModel.shownSections[3], HomepageSectionType.impact)
-        XCTAssertEqual(viewModel.shownSections[4], HomepageSectionType.ntpCustomization)
+        XCTAssertEqual(viewModel.shownSections.count, 4)
+        XCTAssertEqual(viewModel.shownSections[0], HomepageSectionType.homepageHeader)
+        XCTAssertEqual(viewModel.shownSections[1], HomepageSectionType.libraryShortcuts)
+        XCTAssertEqual(viewModel.shownSections[2], HomepageSectionType.impact)
+        XCTAssertEqual(viewModel.shownSections[3], HomepageSectionType.ntpCustomization)
     }
 }

--- a/firefox-ios/EcosiaTests/UI/Account/EcosiaWebViewModalTests.swift
+++ b/firefox-ios/EcosiaTests/UI/Account/EcosiaWebViewModalTests.swift
@@ -1,0 +1,396 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import WebKit
+@testable import Ecosia
+
+@available(iOS 16.0, *)
+final class EcosiaWebViewModalCoordinatorTests: XCTestCase {
+
+    private var coordinator: MockCoordinator!
+    private var mockWebView: MockWKWebView!
+    private var mockParent: MockWebViewRepresentable!
+
+    override func setUp() {
+        super.setUp()
+        mockWebView = MockWKWebView()
+        mockParent = MockWebViewRepresentable()
+        coordinator = MockCoordinator(parent: mockParent)
+    }
+
+    override func tearDown() {
+        coordinator = nil
+        mockWebView = nil
+        mockParent = nil
+        super.tearDown()
+    }
+
+    // MARK: - WKUIDelegate Tests
+
+    func testCreateWebViewWith_targetBlankLink_loadsInModal() {
+        // Given
+        let blankURL = URL(string: "https://example.com/blank-page")!
+        let currentURL = URL(string: "https://example.com/origin")!
+        mockWebView.mockURL = currentURL
+
+        let navigationAction = MockNavigationAction(
+            request: URLRequest(url: blankURL),
+            targetFrame: nil
+        )
+
+        // When
+        let result = coordinator.webView(
+            mockWebView,
+            createWebViewWith: WKWebViewConfiguration(),
+            for: navigationAction,
+            windowFeatures: WKWindowFeatures()
+        )
+
+        // Then
+        XCTAssertNil(result, "Should return nil to prevent new window creation")
+        XCTAssertEqual(mockWebView.loadedRequests.count, 1)
+        XCTAssertEqual(mockWebView.loadedRequests.first?.url, blankURL)
+        XCTAssertTrue(coordinator.blankTargetURLs.contains(currentURL.absoluteString))
+    }
+
+    func testCreateWebViewWith_noTargetFrame_recordsOriginURL() {
+        // Given
+        let originURL = URL(string: "https://example.com/page1")!
+        mockWebView.mockURL = originURL
+
+        let blankURL = URL(string: "https://example.com/blank")!
+        let navigationAction = MockNavigationAction(
+            request: URLRequest(url: blankURL),
+            targetFrame: nil
+        )
+
+        // When
+        _ = coordinator.webView(
+            mockWebView,
+            createWebViewWith: WKWebViewConfiguration(),
+            for: navigationAction,
+            windowFeatures: WKWindowFeatures()
+        )
+
+        // Then
+        XCTAssertTrue(coordinator.blankTargetURLs.contains(originURL.absoluteString))
+    }
+
+    func testCreateWebViewWith_noURL_returnsNil() {
+        // Given
+        let navigationAction = MockNavigationAction(
+            request: URLRequest(url: URL(string: "about:blank")!),
+            targetFrame: nil
+        )
+        navigationAction.mockRequestURL = nil
+
+        // When
+        let result = coordinator.webView(
+            mockWebView,
+            createWebViewWith: WKWebViewConfiguration(),
+            for: navigationAction,
+            windowFeatures: WKWindowFeatures()
+        )
+
+        // Then
+        XCTAssertNil(result)
+        XCTAssertEqual(mockWebView.loadedRequests.count, 0)
+    }
+
+    // MARK: - Back Navigation Prevention Tests
+
+    func testDecidePolicyFor_backToBlankTargetOrigin_preventsNavigation() {
+        // Given
+        let originURL = URL(string: "https://example.com/origin")!
+        coordinator.blankTargetURLs.insert(originURL.absoluteString)
+
+        let navigationAction = MockNavigationAction(
+            request: URLRequest(url: originURL),
+            navigationType: .backForward
+        )
+
+        let expectation = XCTestExpectation(description: "Decision handler called")
+        var capturedPolicy: WKNavigationActionPolicy?
+
+        // When
+        coordinator.webView(mockWebView, decidePolicyFor: navigationAction) { policy in
+            capturedPolicy = policy
+            expectation.fulfill()
+        }
+
+        // Then
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(capturedPolicy, .cancel)
+        XCTAssertEqual(mockWebView.goBackCallCount, 1)
+    }
+
+    func testDecidePolicyFor_backToBlankTargetOrigin_cannotGoBack_reloadsInitialURL() {
+        // Given
+        let originURL = URL(string: "https://example.com/origin")!
+        let initialURL = URL(string: "https://example.com/initial")!
+        mockParent.mockURL = initialURL
+        mockWebView.mockCanGoBack = false
+        coordinator.blankTargetURLs.insert(originURL.absoluteString)
+
+        let navigationAction = MockNavigationAction(
+            request: URLRequest(url: originURL),
+            navigationType: .backForward
+        )
+
+        let expectation = XCTestExpectation(description: "Decision handler called")
+
+        // When
+        coordinator.webView(mockWebView, decidePolicyFor: navigationAction) { _ in
+            expectation.fulfill()
+        }
+
+        // Then
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(mockWebView.loadedRequests.count, 1)
+        XCTAssertEqual(mockWebView.loadedRequests.first?.url, initialURL)
+        XCTAssertTrue(coordinator.blankTargetURLs.isEmpty, "Should clear tracked URLs")
+    }
+
+    func testDecidePolicyFor_normalBackNavigation_allowsNavigation() {
+        // Given
+        let url = URL(string: "https://example.com/page")!
+        let navigationAction = MockNavigationAction(
+            request: URLRequest(url: url),
+            navigationType: .backForward
+        )
+
+        let expectation = XCTestExpectation(description: "Decision handler called")
+        var capturedPolicy: WKNavigationActionPolicy?
+
+        // When
+        coordinator.webView(mockWebView, decidePolicyFor: navigationAction) { policy in
+            capturedPolicy = policy
+            expectation.fulfill()
+        }
+
+        // Then
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(capturedPolicy, .allow)
+        XCTAssertEqual(mockWebView.goBackCallCount, 0)
+    }
+
+    func testDecidePolicyFor_nonBackForwardNavigation_allowsNavigation() {
+        // Given
+        let originURL = URL(string: "https://example.com/origin")!
+        coordinator.blankTargetURLs.insert(originURL.absoluteString)
+
+        let navigationAction = MockNavigationAction(
+            request: URLRequest(url: originURL),
+            navigationType: .linkActivated
+        )
+
+        let expectation = XCTestExpectation(description: "Decision handler called")
+        var capturedPolicy: WKNavigationActionPolicy?
+
+        // When
+        coordinator.webView(mockWebView, decidePolicyFor: navigationAction) { policy in
+            capturedPolicy = policy
+            expectation.fulfill()
+        }
+
+        // Then
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(capturedPolicy, .allow)
+    }
+
+    // MARK: - Multiple Blank Target URLs Tests
+
+    func testMultipleBlankTargetURLs_tracksAll() {
+        // Given
+        let url1 = URL(string: "https://example.com/page1")!
+        let url2 = URL(string: "https://example.com/page2")!
+        let url3 = URL(string: "https://example.com/page3")!
+
+        mockWebView.mockURL = url1
+        let action1 = MockNavigationAction(
+            request: URLRequest(url: URL(string: "https://example.com/blank1")!),
+            targetFrame: nil
+        )
+        _ = coordinator.webView(mockWebView, createWebViewWith: WKWebViewConfiguration(), for: action1, windowFeatures: WKWindowFeatures())
+
+        mockWebView.mockURL = url2
+        let action2 = MockNavigationAction(
+            request: URLRequest(url: URL(string: "https://example.com/blank2")!),
+            targetFrame: nil
+        )
+        _ = coordinator.webView(mockWebView, createWebViewWith: WKWebViewConfiguration(), for: action2, windowFeatures: WKWindowFeatures())
+
+        mockWebView.mockURL = url3
+        let action3 = MockNavigationAction(
+            request: URLRequest(url: URL(string: "https://example.com/blank3")!),
+            targetFrame: nil
+        )
+        _ = coordinator.webView(mockWebView, createWebViewWith: WKWebViewConfiguration(), for: action3, windowFeatures: WKWindowFeatures())
+
+        // Then
+        XCTAssertEqual(coordinator.blankTargetURLs.count, 3)
+        XCTAssertTrue(coordinator.blankTargetURLs.contains(url1.absoluteString))
+        XCTAssertTrue(coordinator.blankTargetURLs.contains(url2.absoluteString))
+        XCTAssertTrue(coordinator.blankTargetURLs.contains(url3.absoluteString))
+    }
+
+    func testBlankTargetURLs_clearedWhenReloadingInitial() {
+        // Given
+        let originURL = URL(string: "https://example.com/origin")!
+        coordinator.blankTargetURLs.insert(originURL.absoluteString)
+        coordinator.blankTargetURLs.insert("https://example.com/other")
+        mockWebView.mockCanGoBack = false
+        mockParent.mockURL = URL(string: "https://example.com/initial")!
+
+        let navigationAction = MockNavigationAction(
+            request: URLRequest(url: originURL),
+            navigationType: .backForward
+        )
+
+        let expectation = XCTestExpectation(description: "Decision handler called")
+
+        // When
+        coordinator.webView(mockWebView, decidePolicyFor: navigationAction) { _ in
+            expectation.fulfill()
+        }
+
+        // Then
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertTrue(coordinator.blankTargetURLs.isEmpty)
+    }
+}
+
+// MARK: - Mock Classes
+
+@available(iOS 16.0, *)
+private class MockCoordinator: NSObject, WKNavigationDelegate, WKUIDelegate {
+    let parent: MockWebViewRepresentable
+    var blankTargetURLs: Set<String> = []
+
+    init(parent: MockWebViewRepresentable) {
+        self.parent = parent
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        createWebViewWith configuration: WKWebViewConfiguration,
+        for navigationAction: WKNavigationAction,
+        windowFeatures: WKWindowFeatures
+    ) -> WKWebView? {
+        guard navigationAction.targetFrame == nil,
+              let url = navigationAction.request.url else {
+            return nil
+        }
+
+        if let currentURL = webView.url {
+            blankTargetURLs.insert(currentURL.absoluteString)
+        }
+
+        webView.load(URLRequest(url: url))
+        return nil
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationAction: WKNavigationAction,
+        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+    ) {
+        guard let url = navigationAction.request.url else {
+            decisionHandler(.allow)
+            return
+        }
+
+        if navigationAction.navigationType == .backForward,
+           blankTargetURLs.contains(url.absoluteString) {
+            decisionHandler(.cancel)
+
+            if webView.canGoBack {
+                webView.goBack()
+            } else {
+                webView.load(URLRequest(url: parent.mockURL))
+                blankTargetURLs.removeAll()
+            }
+            return
+        }
+
+        decisionHandler(.allow)
+    }
+}
+
+@available(iOS 16.0, *)
+private class MockWebViewRepresentable {
+    var mockURL: URL = URL(string: "https://example.com")!
+}
+
+@available(iOS 16.0, *)
+private class MockWKWebView: WKWebView {
+    var mockURL: URL?
+    var mockCanGoBack = true
+    var loadedRequests: [URLRequest] = []
+    var goBackCallCount = 0
+
+    override var url: URL? {
+        return mockURL
+    }
+
+    override var canGoBack: Bool {
+        return mockCanGoBack
+    }
+
+    override func load(_ request: URLRequest) -> WKNavigation? {
+        loadedRequests.append(request)
+        return nil
+    }
+
+    override func goBack() -> WKNavigation? {
+        goBackCallCount += 1
+        return nil
+    }
+}
+
+@available(iOS 16.0, *)
+private class MockNavigationAction: WKNavigationAction {
+    private let mockRequest: URLRequest
+    private let mockTargetFrame: WKFrameInfo?
+    private let mockNavigationType: WKNavigationType
+    private var shouldOverrideURL = false
+    var mockRequestURL: URL? {
+        didSet {
+            shouldOverrideURL = true
+        }
+    }
+
+    init(request: URLRequest, targetFrame: WKFrameInfo? = nil, navigationType: WKNavigationType = .other) {
+        self.mockRequest = request
+        self.mockTargetFrame = targetFrame
+        self.mockNavigationType = navigationType
+        self.mockRequestURL = request.url
+    }
+
+    override var request: URLRequest {
+        guard shouldOverrideURL else {
+            return mockRequest
+        }
+        var modifiedRequest = mockRequest
+        modifiedRequest.url = mockRequestURL
+        return modifiedRequest
+    }
+
+    override var targetFrame: WKFrameInfo? {
+        return mockTargetFrame
+    }
+
+    override var navigationType: WKNavigationType {
+        return mockNavigationType
+    }
+}
+
+@available(iOS 16.0, *)
+private class MockFrameInfo: WKFrameInfo {
+    override var isMainFrame: Bool {
+        return true
+    }
+}
+

--- a/firefox-ios/EcosiaTests/UI/Account/EcosiaWebViewModalTests.swift
+++ b/firefox-ios/EcosiaTests/UI/Account/EcosiaWebViewModalTests.swift
@@ -321,7 +321,7 @@ private class MockCoordinator: NSObject, WKNavigationDelegate, WKUIDelegate {
 
 @available(iOS 16.0, *)
 private class MockWebViewRepresentable {
-    var mockURL: URL = URL(string: "https://example.com")!
+    var mockURL = URL(string: "https://example.com")!
 }
 
 @available(iOS 16.0, *)
@@ -393,4 +393,3 @@ private class MockFrameInfo: WKFrameInfo {
         return true
     }
 }
-

--- a/firefox-ios/EcosiaTests/UI/Account/EcosiaWebViewModalTests.swift
+++ b/firefox-ios/EcosiaTests/UI/Account/EcosiaWebViewModalTests.swift
@@ -7,7 +7,7 @@ import WebKit
 @testable import Ecosia
 
 @available(iOS 16.0, *)
-final class EcosiaWebViewModalCoordinatorTests: XCTestCase {
+final class EcosiaWebViewModalTests: XCTestCase {
 
     private var coordinator: MockCoordinator!
     private var mockWebView: MockWKWebView!


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-4042]

## Context

We noticed that some links meant to be opened in a new tab within our `EcosiaWebViewModal` weren't working.
We don't, in fact, handle tabs or special navigation in this modal view.

## Approach

We wanted to implement the simplest approach possible that wouldn't interfere much with a convoluted UX or the Firefox code.

#### Problem: Handle target="_blank" links in profile modal.
#### Attempts:
1. Callback-based → Failed: Closure retention issues through SwiftUI struct hierarchy
2. Load directly → Partial: Caused infinite back-navigation loops
3. Track navigation history ✅ Success: Record origin pages, skip them on back navigation

## Other

We also removed some callbacks we identified not working.

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad

[MOB-4042]: https://ecosia.atlassian.net/browse/MOB-4042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ