### PR TITLE
[MOB-4049] Fix on the header VM

### DIFF
--- a/firefox-ios/Client/Ecosia/UI/NTP/Header/NTPHeaderViewModel.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/Header/NTPHeaderViewModel.swift
@@ -70,7 +70,10 @@ extension NTPHeaderViewModel: HomepageViewModelProtocol, FeatureFlaggable {
     }
 
     var isEnabled: Bool {
-        AISearchMVPExperiment.isEnabled
+        if #available(iOS 16.0, *) {
+            return AISearchMVPExperiment.isEnabled
+        }
+        return false
     }
 
     func setTheme(theme: Theme) {


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-4049]

## Context

App crashed on iOS < 16 when trying to dequeue NTPHeader cell with an empty identifier.

## Approach

### The root cause

`NTPHeaderViewModel.isEnabled` returned true on all iOS versions, causing the section to be added to the collection view even on iOS < 16 where NTPHeader is unavailable.

### Solution

Modified `NTPHeaderViewModel.isEnabled` to return `false` on iOS < 16. This makes `shouldShow` evaluate to `false`, filtering the section out before dequeue is attempted. The header section is completely excluded on devices running iOS < 16.

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad

[MOB-4049]: https://ecosia.atlassian.net/browse/MOB-4049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ