### PR TITLE
[MOB-3548] Fix vertical spacing in Default Browser Dialog

### DIFF
--- a/firefox-ios/Client/Ecosia/UI/NTP/DefaultBrowserViewController.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/DefaultBrowserViewController.swift
@@ -199,7 +199,7 @@ final class DefaultBrowserViewController: UIViewController, Themeable {
             triviaView.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
             triviaView.trailingAnchor.constraint(equalTo: titleLabel.trailingAnchor),
 
-            actionButton.topAnchor.constraint(equalTo: triviaView.bottomAnchor, constant: .ecosia.space._1l).priority(.defaultLow),
+            actionButton.topAnchor.constraint(equalTo: triviaView.bottomAnchor, constant: .ecosia.space._1l),
             actionButton.heightAnchor.constraint(greaterThanOrEqualToConstant: UX.buttonHeight),
             actionButton.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
             actionButton.trailingAnchor.constraint(equalTo: titleLabel.trailingAnchor),


### PR DESCRIPTION
[MOB-3548: Default Browser modal UI is broken on iPad](https://ecosia.atlassian.net/browse/MOB-3548)

This is how it now looks like on iPad and iPhone:

<img width="1640" height="2360" alt="MOB-3548_pad" src="https://github.com/user-attachments/assets/9563ddd6-d67b-46bf-9885-e2f2c2f302ce" />

------

<img width="1206" height="2622" alt="MOB-3548_phone" src="https://github.com/user-attachments/assets/9339f9a1-f2ef-43fd-8abb-5e1d552b0e6e" />
