### PR TITLE
Update copilot instructions with new guidelines

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -39,14 +39,6 @@ when modifying Firefox code for Ecosia customizations, follow these commenting c
    let appVersionPredicate = (appVersionString?.contains("Ecosia") ?? false) == true
    ```
 
-## Building and Dependencies
-
-ensure SwiftLint is installed and used for linting: `brew install swiftlint`
-
-after cloning or when updating dependencies, run `./bootstrap.sh` to install Node.js dependencies, build user scripts, and update content blockers
-
-the project uses Swift Package Manager (SPM). If you encounter dependency issues, try: Xcode -> File -> Packages -> Reset Package Caches
-
 ## User Scripts
 
 User Scripts (JavaScript injected into WKWebView) are compiled, concatenated, and minified using webpack

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,7 +12,7 @@ also add MOB-XXXX with the correct ticket name into the branch name so we can li
 issues that don't reference a ticket should use `NOTICKET` in the PR name and `noticket` in the branch name
 
 
-consider a architecture descision record based on this template
+consider a architecture decision record based on this template
 https://github.com/joelparkerhenderson/architecture-decision-record/tree/main/locales/en/templates/decision-record-template-of-the-madr-project is a good template
 request other considerations needed to implement a feature
 document unsolved issues in the architecture decision record

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,20 @@
+always consider this codebase is mixed with firefox-ios and our modifications
+
+write comprehensive tests
+
+keep `firefox-ios/Ecosia/Ecosia.docc/Ecosia.md` up to date
+
+don't update the `/README.md` file as it is part of the `firefox-ios` core
+
+name pull requests "[MOB-XXXX] {name of the feature}"
+[MOB-XXXX] is the ticket reference, it should be provided as part of the PR/Ticket/Instructions
+also add MOB-XXXX with the correct ticket name into the branch name so we can link tickets and branches and pull requests by this identifier
+issues that don't reference a ticket should use `NOTICKET` in the PR name and `noticket` in the branch name
+
+
+consider a architecture descision record based on this template
+https://github.com/joelparkerhenderson/architecture-decision-record/tree/main/locales/en/templates/decision-record-template-of-the-madr-project is a good template
+request other considerations that to implement a feature
+document unsolved issues in the architecture decision record
+
+consider adding readme.md files into folders that are created or touched heavily during feature development so that folders represent features and have some documentation

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,7 +14,7 @@ issues that don't reference a ticket should use `NOTICKET` in the PR name and `n
 
 consider a architecture descision record based on this template
 https://github.com/joelparkerhenderson/architecture-decision-record/tree/main/locales/en/templates/decision-record-template-of-the-madr-project is a good template
-request other considerations that to implement a feature
+request other considerations needed to implement a feature
 document unsolved issues in the architecture decision record
 ADRs should be stored in `docs/decisions/` and the readme `docs/decisions/README.md` should be updated to have an up-to-date list
 `docs/decisions/0001-swiftlint-configuration-for-upstream-fork.md` is a good name for the ADR

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,3 +20,59 @@ ADRs should be stored in  `docs/decisions/` and the readme `docs/decisions/READM
 `docs/decisions/0001-swiftlint-configuration-for-upstream-fork.md` is a good name for the ADR
 
 consider adding readme.md files into folders that are created or touched heavily during feature development so that folders represent features and have some documentation
+
+## Commenting Guidelines for Ecosia Code in Firefox
+
+when modifying Firefox code for Ecosia customizations, follow these commenting conventions:
+
+1. **One-liner Comments**: Use `//` for introducing new code or brief explanations.
+   ```swift
+   // Ecosia: Update appversion predicate
+   let appVersionPredicate = (appVersionString?.contains("Ecosia") ?? false) == true
+   ```
+
+2. **Block Comments**: Use `/* */` when commenting out existing Firefox code for easier readability and conflict resolution.
+   ```swift
+   /* Ecosia: Update appversion predicate
+   let appVersionPredicate = (appVersionString?.contains("Firefox") ?? false) == true
+   */
+   let appVersionPredicate = (appVersionString?.contains("Ecosia") ?? false) == true
+   ```
+
+## Building and Dependencies
+
+ensure SwiftLint is installed and used for linting: `brew install swiftlint`
+
+after cloning or when updating dependencies, run `./bootstrap.sh` to install Node.js dependencies, build user scripts, and update content blockers
+
+the project uses Swift Package Manager (SPM). If you encounter dependency issues, try: Xcode -> File -> Packages -> Reset Package Caches
+
+## User Scripts
+
+User Scripts (JavaScript injected into WKWebView) are compiled, concatenated, and minified using webpack
+
+when adding or editing User Scripts in `/Client/Frontend/UserContent/UserScripts/`, recompile them by running `npm run build` in the project root
+
+the compiled outputs are checked into the repository at `/Client/Assets/` with names like `AllFramesAtDocumentEnd.js`, `MainFrameAtDocumentStart.js`, etc.
+
+## Ecosia Framework Structure
+
+the Ecosia Framework (`firefox-ios/Ecosia/`) is a wrapper for Ecosia-specific implementation and logic
+
+some Ecosia codebase still lives under `Client/Ecosia`, but new Ecosia-specific code should be added to the Ecosia Framework when possible
+
+## Translations
+
+translations are managed via Transifex
+
+when adding new strings, add them to `Client/Ecosia/L10N/en.lproj/Ecosia.strings`
+
+## Snapshot Testing
+
+use `SnapshotTestHelper` for UI snapshot testing
+
+snapshot tests support multiple themes, devices, and localizations
+
+reference images are compared to detect unintended UI changes
+
+see `SNAPSHOT_TESTING_WIKI.md` for more details

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,7 +16,7 @@ consider a architecture descision record based on this template
 https://github.com/joelparkerhenderson/architecture-decision-record/tree/main/locales/en/templates/decision-record-template-of-the-madr-project is a good template
 request other considerations that to implement a feature
 document unsolved issues in the architecture decision record
-ADRs should be stored in  `docs/decisions/` and the readme `docs/decisions/README.md` should be updated to have an up to date list
+ADRs should be stored in `docs/decisions/` and the readme `docs/decisions/README.md` should be updated to have an up-to-date list
 `docs/decisions/0001-swiftlint-configuration-for-upstream-fork.md` is a good name for the ADR
 
 consider adding readme.md files into folders that are created or touched heavily during feature development so that folders represent features and have some documentation

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,5 +16,7 @@ consider a architecture descision record based on this template
 https://github.com/joelparkerhenderson/architecture-decision-record/tree/main/locales/en/templates/decision-record-template-of-the-madr-project is a good template
 request other considerations that to implement a feature
 document unsolved issues in the architecture decision record
+ADRs should be stored in  `docs/decisions/` and the readme `docs/decisions/README.md` should be updated to have an up to date list
+`docs/decisions/0001-swiftlint-configuration-for-upstream-fork.md` is a good name for the ADR
 
 consider adding readme.md files into folders that are created or touched heavily during feature development so that folders represent features and have some documentation


### PR DESCRIPTION
## Pull request overview

This PR adds a new Copilot instructions file to provide guidelines for AI-assisted development in this codebase. The file establishes conventions for testing, documentation, pull request naming, and architecture decision records (ADRs).

**Changes:**
- Creates `.github/copilot-instructions.md` with development guidelines including testing practices, documentation requirements, PR naming conventions, and ADR templates


---

💡 <a href="/ecosia/ios-browser/new/main/.github/instructions?filename=*.instructions.md" class="Link--inTextBlock" target="_blank" rel="noopener noreferrer">Add Copilot custom instructions</a> for smarter, more guided reviews. <a href="https://docs.github.com/en/copilot/customizing-copilot/adding-repository-custom-instructions-for-github-copilot" class="Link--inTextBlock" target="_blank" rel="noopener noreferrer">Learn how to get started</a>.


## Context

we want to document tribe knowledge and enable AI

## Approach

## Other

## Before merging

### Checklist

- [ ] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [ ] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed