### PR TITLE
[NOTICKET] pinned swiftlint

### DIFF
--- a/.github/workflows/swift_lint.yml
+++ b/.github/workflows/swift_lint.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/realm/swiftlint:0.59.1
+      image: ghcr.io/realm/swiftlint:0.63.2
 
     steps:
       - uses: actions/checkout@v4

--- a/docs/decisions/0001-swiftlint-configuration-for-upstream-fork.md
+++ b/docs/decisions/0001-swiftlint-configuration-for-upstream-fork.md
@@ -17,7 +17,7 @@ The Ecosia iOS browser is a fork of Mozilla's Firefox iOS browser. As a fork, we
 * Firefox core codebase has existing lint violations that are outside our control
 * Need consistent SwiftLint version across team members and CI environment
 * We want to maintain a zero-violation policy for most of the year
-* we might have a time after the merge of upstream with violations
+* We might have a time after the merge of upstream with violations
 
 ## Decision Outcome
 
@@ -112,7 +112,7 @@ This pinning strategy ensures that violations introduced by Firefox upstream are
 
 ## Resolved Issues
 
-* by pinning the version of swiftlint we introduce some consistency
+* By pinning the version of swiftlint we introduce some consistency
 * the baseline offers an option to *temporarely* ignore swiftlint issues
 
 

--- a/docs/decisions/0001-swiftlint-configuration-for-upstream-fork.md
+++ b/docs/decisions/0001-swiftlint-configuration-for-upstream-fork.md
@@ -59,7 +59,7 @@ python3 -m json.tool --sort-keys swiftlint_baseline.json > swiftlint_baseline.tm
 
 ### Negative Consequences
 
-* Firefox core files retain existing lint violations (but they're baselined)
+* Firefox core files _could_ retain existing lint violations (but they're baselined)
 * Baseline file requires manual regeneration after upstream merges
 * Version pinning requires coordination when upgrading SwiftLint
 
@@ -146,5 +146,5 @@ It mentions `Done correcting 1 file!` but the file has not been fixed and had to
 * [SwiftLint Configuration](../../.swiftlint.yml) - Current SwiftLint rules and exclusions
 * [SwiftLint Baseline](../../swiftlint_baseline.json) - Baseline file capturing existing violations
 * [SwiftLint CI Workflow](../../.github/workflows/swift_lint.yml) - GitHub Actions workflow with version specification
-* [Ecosia README - SwiftLint Section](../../firefox-ios/Ecosia/Ecosia.docc/Ecosia.md#-swiftlint) - Setup instructions for developers
+* [Ecosia README - SwiftLint Section](../../firefox-ios/Ecosia/Ecosia.docc/Ecosia.md) - Setup instructions for developers
 * [Firefox iOS Repository](https://github.com/mozilla-mobile/firefox-ios) - Upstream repository

--- a/docs/decisions/0001-swiftlint-configuration-for-upstream-fork.md
+++ b/docs/decisions/0001-swiftlint-configuration-for-upstream-fork.md
@@ -3,6 +3,7 @@
 * Status: accepted
 * Deciders: Ecosia iOS Team
 * Date: 2026-02-03
+* Updated: 2026-02-10 (version pinning implementation)
 
 ## Context and Problem Statement
 
@@ -14,16 +15,31 @@ The Ecosia iOS browser is a fork of Mozilla's Firefox iOS browser. As a fork, we
 * Need to minimize merge conflicts when incorporating Firefox upstream changes
 * Want to use SwiftLint's `--fix` option for automatic code formatting
 * Firefox core codebase has existing lint violations that are outside our control
-
-## Considered Options
-
-* **Option 1**: Fix all Firefox upstream lint issues in our fork
-* **Option 2**: Exclude Firefox core files from linting entirely
-* **Option 3**: Lint all files but do not auto-fix Firefox core files (current approach)
+* Need consistent SwiftLint version across team members and CI environment
+* We want to maintain a zero-violation policy for most of the year
+* we might have a time after the merge of upstream with violations
 
 ## Decision Outcome
 
-Chosen option: **Option 3 - Lint all files but do not auto-fix Firefox core files**, because it allows us to maintain visibility of code quality across the entire codebase while avoiding merge conflicts that would arise from auto-fixing upstream code.
+### Implementation
+
+This decision has been implemented using SwiftLint's baseline feature:
+
+1. **Version Pinning**: SwiftLint is pinned to **version 0.63.2** across all environments:
+   - Local development: `brew install swiftlint && brew pin swiftlint`
+   - CI environment: Specified in [`.github/workflows/swift_lint.yml`](/.github/workflows/swift_lint.yml) using `ghcr.io/realm/swiftlint:0.63.2`
+   - These versions must match to ensure consistent linting behavior
+
+2. **Baseline Configuration**: A baseline file (`swiftlint_baseline.json`) captures all existing violations as of 2026-02-10:
+   - Configured in `.swiftlint.yml`: `baseline: swiftlint_baseline.json`
+   - SwiftLint only reports *new* violations not present in the baseline
+   - This allows us to enforce standards on new code without fixing all historical violations
+
+3. **Regenerating the Baseline**: When intentionally accepting new violations (e.g., after upstream merges):
+   ```bash
+   swiftlint --write-baseline swiftlint_baseline.json
+   python3 -m json.tool --sort-keys swiftlint_baseline.json > swiftlint_baseline.tmp && mv swiftlint_baseline.tmp swiftlint_baseline.json
+   ```
 
 To ensure we can work with the file, the JSON is pretty printed and json-key-sorted
 
@@ -34,45 +50,70 @@ python3 -m json.tool --sort-keys swiftlint_baseline.json > swiftlint_baseline.tm
 ### Positive Consequences
 
 * Merge conflicts with upstream Firefox are minimized
+* New code must be lint-clean, preventing technical debt accumulation
 * Ecosia-specific code can still benefit from `swiftlint --fix` automatic corrections
 * Lint warnings in Firefox core files remain visible for awareness
 * Easier to stay synchronized with Mozilla's upstream changes
+* Consistent linting behavior across all developers and CI
+* Baseline can be regenerated after major upstream merges to accept new Firefox violations
 
 ### Negative Consequences
 
-* Firefox core files retain existing lint violations
-* Currently no automated way to selectively apply `--fix` only to Ecosia team files
-* Manual discipline required to not accidentally auto-fix Firefox files
+* Firefox core files retain existing lint violations (but they're baselined)
+* Baseline file requires manual regeneration after upstream merges
+* Version pinning requires coordination when upgrading SwiftLint
 
 ## Pros and Cons of the Options
-
-### Option 1: Fix all Firefox upstream lint issues
-
-* Good, because it would result in a completely clean lint output
-* Good, because it enforces consistent code style across the entire codebase
-* Bad, because it would cause significant merge conflicts on every upstream merge
-* Bad, because it requires ongoing effort to re-fix issues after each upstream sync
-
-### Option 2: Exclude Firefox core files from linting entirely
-
-* Good, because it eliminates noise from Firefox lint violations
-* Good, because it focuses lint output only on Ecosia code
-* Bad, because we lose visibility into code quality issues in files we may need to modify
-* Bad, because it could mask potential issues when Ecosia code interacts with Firefox code
-
-### Option 3: Lint all files but do not auto-fix Firefox core files
 
 * Good, because it maintains visibility of all lint issues
 * Good, because it minimizes merge conflicts with upstream
 * Good, because Ecosia code can still be auto-fixed
 * Bad, because there is currently no built-in SwiftLint mechanism to selectively apply `--fix`
 
-## Open Issues
+## Implementation Details
 
-* **Selective auto-fix**: Currently, there is no straightforward way to tell SwiftLint to `--fix` only files changed by the Ecosia team while leaving Firefox core files untouched. A potential solution would involve:
-  - Creating a script that identifies Ecosia-owned files (possibly based on file paths or git history)
-  - Running `swiftlint --fix` only on those specific files
-  - Integrating this into the CI/CD pipeline or pre-commit hooks
+### Version Consistency
+
+**Upstream Firefox** enforces a strict zero violations policy on their main branch, which means their codebase is clean against their SwiftLint configuration. However, Firefox does not pin SwiftLint versions - they use whatever the latest version is at the time.
+
+**Ecosia's approach** differs: we pin SwiftLint to ensure consistency across our team and CI:
+
+* **Current Version**: 0.63.2 (selected at time of last upstream merge in Feb 2026)
+* **Why we pin**: Unlike Firefox, we need consistent linting behavior across all developers and CI runs to avoid "works on my machine" issues with different SwiftLint versions
+
+When performing Firefox upstream merges, we evaluate whether to update our pinned SwiftLint version:
+
+* **Upgrade Process**:
+  1. During upstream merge, assume Firefox is using the latest stable SwiftLint available at that time
+  2. Consider upgrading to that version (or latest stable) to align with Firefox's codebase expectations
+  3. Update both CI and local development instructions with the new version
+  4. Regenerate the baseline with the new version to capture any new rule behavior
+
+To ensure consistent linting results across environments:
+
+* **CI**: Version is specified in `.github/workflows/swift_lint.yml` (line 9): `image: ghcr.io/realm/swiftlint:0.63.2`
+* **Local**: Developers pin the version using Homebrew: `brew pin swiftlint`
+* **Documentation**: Setup instructions in `firefox-ios/Ecosia/Ecosia.docc/Ecosia.md`
+
+This pinning strategy ensures that violations introduced by Firefox upstream are minimal (since Mozilla maintains zero violations), while giving us predictable, consistent linting behavior across the team.
+
+### Baseline Workflow
+
+1. **Normal Development**: Developers only see lint violations in code they've added or modified
+2. **After Upstream Merge**: If Firefox introduces new violations:
+   - Review the violations to ensure they're from upstream (not our changes)
+   - Regenerate the baseline to accept Firefox's violations
+   - Commit the updated `swiftlint_baseline.json`
+3. **Version Upgrades**: When upgrading SwiftLint:
+   - Update the version in `.github/workflows/swift_lint.yml`
+   - Update local installations: `brew unpin swiftlint && brew upgrade swiftlint && brew pin swiftlint`
+   - Regenerate the baseline (new versions may detect different violations)
+   - Update documentation in `firefox-ios/Ecosia/Ecosia.docc/Ecosia.md`
+
+## Resolved Issues
+
+* by pinning the version of swiftlint we introduce some consistency
+* the baseline offers an option to *temporarely* ignore swiftlint issues
 
 
 for some reason running `swiftlint --fix firefox-ios/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift` for instance would not work out of the box:
@@ -102,5 +143,8 @@ It mentions `Done correcting 1 file!` but the file has not been fixed and had to
 
 ## Links
 
-* [SwiftLint Configuration](.swiftlint.yml) - Current SwiftLint rules and exclusions
+* [SwiftLint Configuration](../../.swiftlint.yml) - Current SwiftLint rules and exclusions
+* [SwiftLint Baseline](../../swiftlint_baseline.json) - Baseline file capturing existing violations
+* [SwiftLint CI Workflow](../../.github/workflows/swift_lint.yml) - GitHub Actions workflow with version specification
+* [Ecosia README - SwiftLint Section](../../firefox-ios/Ecosia/Ecosia.docc/Ecosia.md#-swiftlint) - Setup instructions for developers
 * [Firefox iOS Repository](https://github.com/mozilla-mobile/firefox-ios) - Upstream repository

--- a/firefox-ios/Ecosia/Ecosia.docc/Ecosia.md
+++ b/firefox-ios/Ecosia/Ecosia.docc/Ecosia.md
@@ -74,9 +74,35 @@ We use [Tuist](https://tuist.dev) to generate the Xcode project and manage the b
 
 We use [SwiftLint](https://github.com/realm/SwiftLint) to enforce Swift style and conventions. Make sure to install it so that linting runs correctly when building.
 
+#### Installation & Version Pinning
+
+We pin SwiftLint to **version 0.63.2** to ensure consistent linting behavior across all developers and CI. This version is specified in [`.github/workflows/swift_lint.yml`](/.github/workflows/swift_lint.yml).
+
 ```shell
 brew install swiftlint
+brew pin swiftlint
 ```
+
+The `brew pin` command prevents SwiftLint from being automatically upgraded when you run `brew upgrade`. This ensures everyone on the team uses version 0.63.2.
+
+**To verify the pinned version:**
+```shell
+swiftlint version
+brew list --pinned
+```
+
+#### Baseline Approach
+
+We use SwiftLint's baseline feature (`swiftlint_baseline.json`) to handle existing violations in Firefox core files while enforcing standards on new code. This means:
+- ✅ New code you write must be lint-clean
+- ⚠️ Existing violations in Firefox core files are baselined (won't block builds)
+- 🔄 The baseline is regenerated after upstream Firefox merges
+
+#### Version Updates
+
+SwiftLint version is evaluated during upstream Firefox merges. Since Firefox doesn't pin versions (they use the latest), we assess whether to upgrade when merging their changes.
+
+**For more details**, see the Architecture Decision Record: [SwiftLint Configuration for Upstream Firefox Fork](../../../docs/decisions/0001-swiftlint-configuration-for-upstream-fork.md)
 
 We have a baseline. We will attempt to not add new swiftlint violations. Some violations may be in the firefox base.
 

--- a/firefox-ios/Ecosia/Ecosia.docc/Ecosia.md
+++ b/firefox-ios/Ecosia/Ecosia.docc/Ecosia.md
@@ -93,25 +93,16 @@ brew list --pinned
 
 #### Baseline Approach
 
-We use SwiftLint's baseline feature (`swiftlint_baseline.json`) to handle existing violations in Firefox core files while enforcing standards on new code. This means:
-- ✅ New code you write must be lint-clean
-- ⚠️ Existing violations in Firefox core files are baselined (won't block builds)
-- 🔄 The baseline is regenerated after upstream Firefox merges
+SwiftLint's baseline feature (`swiftlint_baseline.json`) is used **temporarily** during Firefox upstream merges when SwiftLint version updates introduce new violations. Key principles:
+- ✅ **Main branch must have an empty baseline** — all violations must be fixed before the upgrade is complete
+- ⚠️ The baseline is only for Ecosia files during the transition period when updating SwiftLint versions
+- 🔄 New code you write must always be lint-clean, regardless of baseline state
 
 #### Version Updates
 
 SwiftLint version is evaluated during upstream Firefox merges. Since Firefox doesn't pin versions (they use the latest), we assess whether to upgrade when merging their changes.
 
-**For more details**, see the Architecture Decision Record: [SwiftLint Configuration for Upstream Firefox Fork](../../../docs/decisions/0001-swiftlint-configuration-for-upstream-fork.md)
-
-We have a baseline. We will attempt to not add new swiftlint violations. Some violations may be in the firefox base.
-
-here is how you update the baseline (please only commit the pretty printed version):
-```
-rm swiftlint_baseline.json
-swiftlint --write-baseline swiftlint_baseline.json
-python3 -m json.tool --sort-keys swiftlint_baseline.json > swiftlint_baseline.tmp && mv swiftlint_baseline.tmp swiftlint_baseline.json
-````
+**For more details on baseline workflow and version updates**, see the Architecture Decision Record: [SwiftLint Configuration for Upstream Firefox Fork](../../../docs/decisions/0001-swiftlint-configuration-for-upstream-fork.md)
 
 ### First-time setup and building
 

--- a/firefox-ios/Ecosia/Ecosia.docc/Ecosia.md
+++ b/firefox-ios/Ecosia/Ecosia.docc/Ecosia.md
@@ -106,7 +106,7 @@ SwiftLint version is evaluated during upstream Firefox merges. Since Firefox doe
 
 We have a baseline. We will attempt to not add new swiftlint violations. Some violations may be in the firefox base.
 
-here is is how you update the baseline (please only commit the pretty printed version):
+here is how you update the baseline (please only commit the pretty printed version):
 ```
 rm swiftlint_baseline.json
 swiftlint --write-baseline swiftlint_baseline.json


### PR DESCRIPTION
## Context

  We need to formalize our SwiftLint version management strategy to ensure consistent linting behavior across all developers and CI. Currently, we're using SwiftLint 0.59.1 in CI but the version isn't documented or pinned for local development, leading to "works (different) on my machine" issues.

As a fork of Firefox iOS, we face the challenge of maintaining code quality while minimizing merge conflicts with upstream. Firefox enforces a strict zero violations policy but doesn't pin SwiftLint versions (they use latest).

  ## Approach

  This PR implements a comprehensive SwiftLint version pinning strategy:

  1. **Upgrade CI from 0.59.1 to 0.63.2**: Update `.github/workflows/swift_lint.yml` to use SwiftLint 0.63.2, aligning with current stable version

  2. **Document version pinning strategy in ADR**: Update the existing Architecture Decision Record to include:
     - Version pinning implementation using Homebrew's `brew pin`
     - Baseline approach for handling existing violations
     - Upstream Firefox alignment strategy (they use latest, we pin for consistency)
     - Upgrade process during Firefox upstream merges
     - Baseline regeneration workflow
     - Cross-references to related files

  3. **Update developer documentation**: Enhance the Ecosia README SwiftLint section with:
     - Installation and version pinning instructions
     - Explanation of the baseline approach
     - Version update policy
     - Link to ADR for detailed rationale

  4. **Cross-link documents**: Ensure ADR and README reference each other and related configuration files

  ## Benefits

  - ✅ Consistent linting behavior across all developers and CI
  - ✅ Clear documentation of our SwiftLint strategy
  - ✅ Reduced "works on my machine" issues
  - ✅ Better onboarding for new developers
  - ✅ Documented process for version upgrades
  - ✅ Alignment with upstream Firefox while maintaining consistency

  ## Other

  - Version 0.63.2 selected as it's the current stable version at time of this work
  - Baseline feature allows us to enforce lint-clean new code while not blocking on Firefox core violations
  - The pinning strategy is designed to work with our upstream merge workflow

  ## Before merging

  ### Checklist

  - [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
    - N/A - Documentation and CI configuration changes only
  - [x] I wrote Unit Tests that confirm the expected behaviour
    - N/A - No code changes requiring tests
  - [x] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
    - N/A - No localization changes
  - [x] I added the `// Ecosia:` helper comments where needed
    - N/A - No code changes
  - [x] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
    - N/A - No analytics changes
  - [x] I included documentation updates to the coding standards or Confluence doc, when needed
    - ✅ Updated ADR and Ecosia README with comprehensive SwiftLint documentation
