### PR TITLE
[MOB-4187] Implement proactive token refresh to prevent `401` errors

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -166,7 +166,9 @@ excluded: # paths to ignore during linting. Takes precedence over `included`.
   - firefox-ios/SourcePackages
   # Ecosia: Remove Metrics.swift as part of Glean
   - Storage/Generated/Metrics.swift
-  
+  # Ecosia: Exclude Tuist-generated bundle files
+  - firefox-ios/Derived/Sources
+
 included:
   - /Users/vagrant/git
   - .

--- a/firefox-ios/Ecosia/Account/Auth/AuthError.swift
+++ b/firefox-ios/Ecosia/Account/Auth/AuthError.swift
@@ -9,8 +9,10 @@ public enum AuthError: Error, LocalizedError {
     case credentialsStorageError(Error)
     case credentialsClearingFailed
     case credentialsRenewalFailed(Error)
+    case credentialsRetrievalFailed(Error)
     case sessionClearingFailed(Error)
     case userCancelled
+    case notLoggedIn
     case authFlowConfigurationError(String)
     case authFlowSessionManagementFailed(String)
     case authFlowInvisibleTabCreationFailed
@@ -27,10 +29,14 @@ public enum AuthError: Error, LocalizedError {
             return "Failed to clear stored credentials"
         case .credentialsRenewalFailed(let error):
             return "Failed to renew credentials: \(error.localizedDescription)"
+        case .credentialsRetrievalFailed(let error):
+            return "Failed to retrieve credentials: \(error.localizedDescription)"
         case .sessionClearingFailed(let error):
             return "Failed to clear web session and credentials: \(error.localizedDescription)"
         case .userCancelled:
             return "User cancelled the authentication operation"
+        case .notLoggedIn:
+            return "User is not logged in"
         case .authFlowConfigurationError(let message):
             return "Authentication flow configuration error: \(message)"
         case .authFlowSessionManagementFailed(let message):

--- a/firefox-ios/Ecosia/Account/Auth/CredentialsManager/CredentialsManagerProtocol.swift
+++ b/firefox-ios/Ecosia/Account/Auth/CredentialsManager/CredentialsManagerProtocol.swift
@@ -20,6 +20,16 @@ public protocol CredentialsManagerProtocol {
     /// - Throws: An error if retrieving credentials fails.
     func credentials() async throws -> Credentials
 
+    /// Retrieves stored credentials asynchronously with a minimum time-to-live.
+    ///
+    /// - Parameters:
+    ///   - scope: The scope to request. If nil, uses the stored credentials' scope.
+    ///   - minTTL: The minimum time in seconds the access token should remain valid.
+    ///             If 0, returns credentials without checking expiry or refreshing.
+    /// - Returns: The stored `Credentials` object if available.
+    /// - Throws: An error if retrieving credentials fails.
+    func credentials(withScope scope: String?, minTTL: Int) async throws -> Credentials
+
     /// Clears stored credentials.
     ///
     /// - Returns: A boolean indicating whether the credentials were successfully cleared.

--- a/firefox-ios/Ecosia/Account/Auth/CredentialsManager/DefaultCredentialsManager.swift
+++ b/firefox-ios/Ecosia/Account/Auth/CredentialsManager/DefaultCredentialsManager.swift
@@ -21,6 +21,10 @@ struct DefaultCredentialsManager: CredentialsManagerProtocol {
         try await credentialManager.credentials()
     }
 
+    func credentials(withScope scope: String?, minTTL: Int) async throws -> Auth0.Credentials {
+        try await credentialManager.credentials(withScope: scope, minTTL: minTTL)
+    }
+
     func clear() -> Bool {
         credentialManager.clear()
     }

--- a/firefox-ios/Ecosia/Account/Auth/EcosiaAuthenticationService.swift
+++ b/firefox-ios/Ecosia/Account/Auth/EcosiaAuthenticationService.swift
@@ -245,8 +245,8 @@ public final class EcosiaAuthenticationService {
      expired or about to expire, ensuring the returned token is always valid.
      
      - Returns: A fresh, valid access token
-     - Throws: `AuthError.notLoggedIn` if no credentials are available,
-               `AuthError.credentialsRetrievalFailed` if credential retrieval fails
+     - Throws: `AuthError.notLoggedIn` if stored credentials do not contain a valid access token,
+               `AuthError.credentialsRetrievalFailed` if credentials cannot be retrieved or refreshed (including when no stored credentials are available)
      
      ## Use Cases
      

--- a/firefox-ios/Ecosia/Account/Auth/EcosiaAuthenticationService.swift
+++ b/firefox-ios/Ecosia/Account/Auth/EcosiaAuthenticationService.swift
@@ -260,7 +260,7 @@ public final class EcosiaAuthenticationService {
      
      ## How It Works
      
-     1. Calls Auth0's `CredentialsManager.credentials()` which checks token expiry
+     1. Calls `auth0Provider.retrieveCredentials()` (protocol implementation backed by Auth0's `CredentialsManager.credentials()`) which checks token expiry
      2. If token is expired, automatically refreshes using the refresh token
      3. Updates cached token properties with the refreshed values
      4. Returns the fresh access token

--- a/firefox-ios/Ecosia/Account/Auth/EcosiaAuthenticationService.swift
+++ b/firefox-ios/Ecosia/Account/Auth/EcosiaAuthenticationService.swift
@@ -237,6 +237,60 @@ public final class EcosiaAuthenticationService {
         }
     }
 
+    /**
+     Retrieves a fresh access token from Auth0's CredentialsManager.
+     
+     This method leverages Auth0's built-in credential management to automatically handle
+     token expiry checking and renewal. The CredentialsManager will refresh the token if it's
+     expired or about to expire, ensuring the returned token is always valid.
+     
+     - Returns: A fresh, valid access token
+     - Throws: `AuthError.notLoggedIn` if no credentials are available,
+               `AuthError.credentialsRetrievalFailed` if credential retrieval fails
+     
+     ## Use Cases
+     
+     Use this method instead of the cached `accessToken` property when making API requests
+     to avoid 401 errors from expired tokens:
+     
+     ```swift
+     let token = try await authService.getFreshAccessToken()
+     let response = try await accountsService.registerVisit(accessToken: token)
+     ```
+     
+     ## How It Works
+     
+     1. Calls Auth0's `CredentialsManager.credentials()` which checks token expiry
+     2. If token is expired, automatically refreshes using the refresh token
+     3. Updates cached token properties with the refreshed values
+     4. Returns the fresh access token
+     
+     This eliminates the need for reactive 401 error handling and retry logic.
+     */
+    public func getFreshAccessToken() async throws -> String {
+        do {
+            let credentials = try await auth0Provider.retrieveCredentials()
+            // Update cached tokens with fresh values
+            setupTokensWithCredentials(credentials, settingLoggedInStateTo: true)
+            
+            let accessToken = credentials.accessToken
+            guard !accessToken.isEmpty else {
+                EcosiaLogger.auth.error("Retrieved credentials do not contain a valid access token")
+                throw AuthError.notLoggedIn
+            }
+            
+            return accessToken
+        } catch let error as AuthError {
+            // Re-throw AuthError as-is
+            EcosiaLogger.auth.error("Failed to get fresh access token: \(error)")
+            throw error
+        } catch {
+            // Wrap other errors in credentialsRetrievalFailed
+            EcosiaLogger.auth.error("Failed to get fresh access token: \(error)")
+            throw AuthError.credentialsRetrievalFailed(error)
+        }
+    }
+
     /// Helper method to setup tokens and login flag
     private func setupTokensWithCredentials(_ credentials: Credentials?,
                                             settingLoggedInStateTo isLoggedIn: Bool = false) {

--- a/firefox-ios/Ecosia/Account/Auth/EcosiaAuthenticationService.swift
+++ b/firefox-ios/Ecosia/Account/Auth/EcosiaAuthenticationService.swift
@@ -238,34 +238,12 @@ public final class EcosiaAuthenticationService {
     }
 
     /**
-     Retrieves a fresh access token from Auth0's CredentialsManager.
-     
-     This method leverages Auth0's built-in credential management to automatically handle
-     token expiry checking and renewal. The CredentialsManager will refresh the token if it's
-     expired or about to expire, ensuring the returned token is always valid.
+     Retrieves a fresh access token, leveraging Auth0's `CredentialsManager.credentials(withScope:minTTL:parameters:headers:)`
+     to automatically handle token expiry checking and renewal.
      
      - Returns: A fresh, valid access token
      - Throws: `AuthError.notLoggedIn` if stored credentials do not contain a valid access token,
-               `AuthError.credentialsRetrievalFailed` if credentials cannot be retrieved or refreshed (including when no stored credentials are available)
-     
-     ## Use Cases
-     
-     Use this method instead of the cached `accessToken` property when making API requests
-     to avoid 401 errors from expired tokens:
-     
-     ```swift
-     let token = try await authService.getFreshAccessToken()
-     let response = try await accountsService.registerVisit(accessToken: token)
-     ```
-     
-     ## How It Works
-     
-     1. Calls `auth0Provider.retrieveCredentials()` (protocol implementation backed by Auth0's `CredentialsManager.credentials()`) which checks token expiry
-     2. If token is expired, automatically refreshes using the refresh token
-     3. Updates cached token properties with the refreshed values
-     4. Returns the fresh access token
-     
-     This eliminates the need for reactive 401 error handling and retry logic.
+               `AuthError.credentialsRetrievalFailed` if credentials cannot be retrieved or refreshed
      */
     public func getFreshAccessToken() async throws -> String {
         do {

--- a/firefox-ios/Ecosia/Account/Auth/NativeToWebSSOAuth0Provider.swift
+++ b/firefox-ios/Ecosia/Account/Auth/NativeToWebSSOAuth0Provider.swift
@@ -61,8 +61,12 @@ extension NativeToWebSSOAuth0Provider {
     ///
     /// - Returns: A `session_token` as `SessionToken` (a `String` type).
     /// - Throws: An error if the retrieval fails.
+    /// - Note: This method retrieves credentials without minTTL to avoid unnecessary token refresh
+    ///         that could invalidate the SSO session transfer token before it's used.
     public func getSSOCredentials() async throws -> SSOCredentials {
-        let credentials = try await retrieveCredentials()
+        // Retrieve credentials without triggering refresh by setting minTTL to 0
+        // This prevents the refresh token from being rotated before we use it for SSO
+        let credentials = try await credentialsManager.credentials(withScope: nil, minTTL: 0)
         guard let refreshToken = credentials.refreshToken else {
             throw NativeToWebSSOError.missingRefreshToken("Refresh token is missing. Please check your credentials.")
         }

--- a/firefox-ios/Ecosia/Core/Accounts/Service/AccountsService.swift
+++ b/firefox-ios/Ecosia/Core/Accounts/Service/AccountsService.swift
@@ -25,10 +25,6 @@ public final class AccountsService: AccountsServiceProtocol {
     }
 
     public func registerVisit(accessToken: String) async throws -> AccountVisitResponse {
-        return try await performVisitRequest(accessToken: accessToken)
-    }
-
-    private func performVisitRequest(accessToken: String) async throws -> AccountVisitResponse {
         let request = AccountVisitRequest(accessToken: accessToken)
 
         EcosiaLogger.network.info("Making accounts visit request to: \(request.baseURL.absoluteString)\(request.path)")

--- a/firefox-ios/Ecosia/Core/Accounts/Service/AccountsService.swift
+++ b/firefox-ios/Ecosia/Core/Accounts/Service/AccountsService.swift
@@ -19,33 +19,13 @@ public final class AccountsService: AccountsServiceProtocol {
     }
 
     private let client: HTTPClient
-    private let authenticationService: EcosiaAuthenticationService
 
-    public init(client: HTTPClient = URLSessionHTTPClient(),
-                authenticationService: EcosiaAuthenticationService = EcosiaAuthenticationService.shared) {
+    public init(client: HTTPClient = URLSessionHTTPClient()) {
         self.client = client
-        self.authenticationService = authenticationService
     }
 
     public func registerVisit(accessToken: String) async throws -> AccountVisitResponse {
-        do {
-            return try await performVisitRequest(accessToken: accessToken)
-        } catch Error.unauthorized {
-            EcosiaLogger.auth.info("Access token expired, attempting to renew credentials")
-            do {
-                try await authenticationService.renewCredentialsIfNeeded()
-            } catch {
-                EcosiaLogger.auth.error("Failed to renew credentials: \(error)")
-                throw Error.authenticationRequired
-            }
-
-            guard let refreshedToken = authenticationService.accessToken, !refreshedToken.isEmpty else {
-                EcosiaLogger.auth.error("Renewed credentials do not expose an access token")
-                throw Error.authenticationRequired
-            }
-
-            return try await performVisitRequest(accessToken: refreshedToken)
-        }
+        return try await performVisitRequest(accessToken: accessToken)
     }
 
     private func performVisitRequest(accessToken: String) async throws -> AccountVisitResponse {

--- a/firefox-ios/Ecosia/UI/Account/EcosiaAuthUIStateProvider.swift
+++ b/firefox-ios/Ecosia/UI/Account/EcosiaAuthUIStateProvider.swift
@@ -185,9 +185,9 @@ public class EcosiaAuthUIStateProvider: ObservableObject {
     @MainActor
     private func handleUserProfileUpdate() {
         Task { @MainActor in
-            isLoggedIn = EcosiaAuthenticationService.shared.isLoggedIn
+            isLoggedIn = authenticationService.isLoggedIn
         }
-        userProfile = EcosiaAuthenticationService.shared.userProfile
+        userProfile = authenticationService.userProfile
         username = userProfile?.name
         avatarURL = normalizedAvatarURL
     }

--- a/firefox-ios/EcosiaTests/Account/Auth/AuthTests.swift
+++ b/firefox-ios/EcosiaTests/Account/Auth/AuthTests.swift
@@ -559,7 +559,8 @@ final class AuthTests: XCTestCase {
             _ = try await auth.getFreshAccessToken()
             XCTFail("Expected getFreshAccessToken to throw but it didn't")
         } catch AuthError.notLoggedIn {
-            // Expected error
+            // Expected error - isLoggedIn must not have been set to true before validation
+            XCTAssertFalse(auth.isLoggedIn, "isLoggedIn should not be set to true when access token is empty")
         } catch {
             XCTFail("Unexpected error type: \(error)")
         }

--- a/firefox-ios/EcosiaTests/Account/Auth/AuthTests.swift
+++ b/firefox-ios/EcosiaTests/Account/Auth/AuthTests.swift
@@ -531,6 +531,9 @@ final class AuthTests: XCTestCase {
         mockProvider.storedCredentials = expiredCredentials
         mockProvider.mockCredentials = refreshedCredentials
 
+        // Reset call count before the actual test call (initialization may have called it)
+        mockProvider.retrieveCredentialsCallCount = 0
+
         // Act
         let token = try await auth.getFreshAccessToken()
 

--- a/firefox-ios/EcosiaTests/Account/Auth/AuthTests.swift
+++ b/firefox-ios/EcosiaTests/Account/Auth/AuthTests.swift
@@ -475,7 +475,7 @@ final class AuthTests: XCTestCase {
     }
 
     // MARK: - Get Fresh Access Token Tests
-    
+
     func testGetFreshAccessToken_withValidCredentials_returnsToken() async throws {
         // Arrange
         let expectedToken = "fresh-access-token"
@@ -489,20 +489,20 @@ final class AuthTests: XCTestCase {
         )
         mockProvider.mockCredentials = credentials
         mockProvider.hasStoredCredentials = true
-        
+
         // Reset call count before the actual test call (initialization may have called it)
         mockProvider.retrieveCredentialsCallCount = 0
-        
+
         // Act
         let token = try await auth.getFreshAccessToken()
-        
+
         // Assert
         XCTAssertEqual(token, expectedToken)
         XCTAssertEqual(mockProvider.retrieveCredentialsCallCount, 1)
         XCTAssertEqual(auth.accessToken, expectedToken)
         XCTAssertTrue(auth.isLoggedIn)
     }
-    
+
     func testGetFreshAccessToken_withExpiredToken_refreshesAutomatically() async throws {
         // Arrange
         let expiredToken = "expired-access-token"
@@ -540,12 +540,12 @@ final class AuthTests: XCTestCase {
         XCTAssertEqual(auth.accessToken, freshToken)
         XCTAssertEqual(mockProvider.retrieveCredentialsCallCount, 1, "Should call retrieveCredentials once to trigger auto-refresh")
     }
-    
+
     func testGetFreshAccessToken_withNoCredentials_throwsError() async throws {
         // Arrange
         mockProvider.hasStoredCredentials = false
         mockProvider.shouldFailRetrieveCredentials = true
-        
+
         // Act & Assert
         do {
             _ = try await auth.getFreshAccessToken()
@@ -556,7 +556,7 @@ final class AuthTests: XCTestCase {
             XCTFail("Unexpected error type: \(error)")
         }
     }
-    
+
     func testGetFreshAccessToken_withEmptyToken_throwsNotLoggedIn() async throws {
         // Arrange
         let credentials = Credentials(
@@ -569,7 +569,7 @@ final class AuthTests: XCTestCase {
         )
         mockProvider.mockCredentials = credentials
         mockProvider.hasStoredCredentials = true
-        
+
         // Act & Assert
         do {
             _ = try await auth.getFreshAccessToken()

--- a/firefox-ios/EcosiaTests/Account/Mocks/MockAuth0Provider.swift
+++ b/firefox-ios/EcosiaTests/Account/Mocks/MockAuth0Provider.swift
@@ -20,6 +20,7 @@ class MockAuth0Provider: Auth0ProviderProtocol {
 
     // MARK: - Mock Data
     var mockCredentials: Credentials?
+    var storedCredentials: Credentials?
     var mockError: Error?
     var hasStoredCredentials = false
 
@@ -80,7 +81,13 @@ class MockAuth0Provider: Auth0ProviderProtocol {
             throw NSError(domain: "MockAuth0Provider", code: 1006, userInfo: [NSLocalizedDescriptionKey: "No credentials were found in the store."])
         }
 
-        return mockCredentials ?? createMockCredentials()
+        // Simulate Auth0's CredentialsManager auto-refresh: when stored credentials are expired,
+        // return mockCredentials to represent the freshly refreshed token
+        if let storedCreds = storedCredentials, storedCreds.expiresIn < Date() {
+            return mockCredentials ?? createMockCredentials()
+        }
+
+        return storedCredentials ?? mockCredentials ?? createMockCredentials()
     }
 
     func clearCredentials() -> Bool {
@@ -135,6 +142,7 @@ class MockAuth0Provider: Auth0ProviderProtocol {
         clearCredentialsResult = true
 
         mockCredentials = nil
+        storedCredentials = nil
         mockError = nil
         hasStoredCredentials = false  // Clear stored credentials state
 

--- a/firefox-ios/EcosiaTests/Account/Mocks/MockCredentialsManager.swift
+++ b/firefox-ios/EcosiaTests/Account/Mocks/MockCredentialsManager.swift
@@ -38,6 +38,12 @@ final class MockCredentialsManager: CredentialsManagerProtocol {
         return mockCredentials ?? storedCredentials ?? createMockCredentials()
     }
 
+    func credentials(withScope scope: String?, minTTL: Int) async throws -> Credentials {
+        // For mock purposes, delegate to the main credentials method
+        // In a real implementation, minTTL would affect whether credentials are refreshed
+        return try await credentials()
+    }
+
     func renew() async throws -> Credentials {
         renewCallCount += 1
 

--- a/firefox-ios/EcosiaTests/Core/Accounts/AccountsServiceTests.swift
+++ b/firefox-ios/EcosiaTests/Core/Accounts/AccountsServiceTests.swift
@@ -177,7 +177,11 @@ final class AccountsServiceTests: XCTestCase {
         XCTAssertEqual(response.seedsIncrement, 3)
     }
 
-    func testRegisterVisit_UnauthorizedError() async throws {
+    func testRegisterVisit_UnauthorizedError_ThrowsAuthenticationRequired() async throws {
+        // This test verifies that a 401 Unauthorized response throws authenticationRequired error.
+        // With the new proactive token refresh approach, 401s only occur for genuine auth failures
+        // (revoked token, logged out on server, etc.) since expired tokens are refreshed before the request.
+        
         // Arrange
         mockHTTPClient.response = HTTPURLResponse(
             url: URL(string: "https://example.com")!,
@@ -190,8 +194,8 @@ final class AccountsServiceTests: XCTestCase {
         do {
             _ = try await accountsService.registerVisit(accessToken: "invalid-token")
             XCTFail("Expected unauthorized error")
-        } catch AccountsService.Error.authenticationRequired {
-            // Expected error
+        } catch AccountsService.Error.unauthorized {
+            // Expected error - 401 now indicates a genuine auth failure
         } catch {
             XCTFail("Unexpected error: \(error)")
         }

--- a/firefox-ios/EcosiaTests/Core/Accounts/AccountsServiceTests.swift
+++ b/firefox-ios/EcosiaTests/Core/Accounts/AccountsServiceTests.swift
@@ -177,8 +177,8 @@ final class AccountsServiceTests: XCTestCase {
         XCTAssertEqual(response.seedsIncrement, 3)
     }
 
-    func testRegisterVisit_UnauthorizedError_ThrowsAuthenticationRequired() async throws {
-        // This test verifies that a 401 Unauthorized response throws authenticationRequired error.
+    func testRegisterVisit_UnauthorizedError_ThrowsUnauthorized() async throws {
+        // This test verifies that a 401 Unauthorized response throws an `.unauthorized` error.
         // With the new proactive token refresh approach, 401s only occur for genuine auth failures
         // (revoked token, logged out on server, etc.) since expired tokens are refreshed before the request.
         

--- a/firefox-ios/EcosiaTests/Core/Accounts/AccountsServiceTests.swift
+++ b/firefox-ios/EcosiaTests/Core/Accounts/AccountsServiceTests.swift
@@ -181,7 +181,7 @@ final class AccountsServiceTests: XCTestCase {
         // This test verifies that a 401 Unauthorized response throws an `.unauthorized` error.
         // With the new proactive token refresh approach, 401s only occur for genuine auth failures
         // (revoked token, logged out on server, etc.) since expired tokens are refreshed before the request.
-        
+
         // Arrange
         mockHTTPClient.response = HTTPURLResponse(
             url: URL(string: "https://example.com")!,


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-4187

## Context

Previously, the app would wait for 401 responses before refreshing expired tokens, causing excessive authentication errors and poor user experience.

This change implements a proactive approach where tokens are automatically refreshed before API calls, leveraging Auth0's CredentialsManager which handles token expiry detection and refresh seamlessly.

## Approach

- Add `getFreshAccessToken()` method to `EcosiaAuthenticationService` that retrieves fresh tokens from Auth0
- Update `EcosiaAuthUIStateProvider` to use fresh tokens for API calls
- Simplify `AccountsService` by removing reactive 401 retry logic
- Add new error cases to `AuthError` enum for better error handling
- Add comprehensive tests for the new token refresh behavior
- Update `AccountsServiceTests` to reflect that 401s now indicate genuine auth failures

This approach eliminates unnecessary 401 errors and provides a more reliable authentication experience.

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I wrote Unit Tests that confirm the expected behaviour