### PR TITLE
[MOB-4179] Update Seeds with balance account

### DIFF
--- a/firefox-ios/Ecosia/Core/Accounts/Service/AccountsService.swift
+++ b/firefox-ios/Ecosia/Core/Accounts/Service/AccountsService.swift
@@ -78,7 +78,7 @@ public final class AccountsService: AccountsServiceProtocol {
 
         do {
             let decodedResponse = try JSONDecoder().decode(AccountVisitResponse.self, from: data)
-            EcosiaLogger.network.info("Accounts visit successful: seeds=\(decodedResponse.seeds.totalAmount), seedsModified=\(decodedResponse.seeds.isModified), level=\(decodedResponse.growthPoints.level.number), levelUp=\(decodedResponse.didLevelUp)")
+            EcosiaLogger.network.info("Accounts visit successful: seeds=\(decodedResponse.seeds.balanceAmount), seedsModified=\(decodedResponse.seeds.isModified), level=\(decodedResponse.growthPoints.level.number), levelUp=\(decodedResponse.didLevelUp)")
             return decodedResponse
         } catch {
             EcosiaLogger.network.error("Accounts visit response decoding failed: \(error.localizedDescription)")

--- a/firefox-ios/Ecosia/UI/Account/EcosiaAccountAvatarViewModel.swift
+++ b/firefox-ios/Ecosia/UI/Account/EcosiaAccountAvatarViewModel.swift
@@ -88,7 +88,7 @@ public final class EcosiaAccountAvatarViewModel: ObservableObject {
 
     /// Updates avatar progress based on AccountVisitResponse
     public func updateFromBalanceResponse(_ response: AccountVisitResponse) {
-        let newSeedCount = response.seeds.totalAmount
+        let newSeedCount = response.seeds.balanceAmount
         let newLevelNumber = response.growthPoints.level.number
         let newProgress = response.progressToNextLevel
 

--- a/firefox-ios/Ecosia/UI/Account/EcosiaAuthUIStateProvider.swift
+++ b/firefox-ios/Ecosia/UI/Account/EcosiaAuthUIStateProvider.swift
@@ -243,7 +243,7 @@ public class EcosiaAuthUIStateProvider: ObservableObject {
 
     @MainActor
     private func updateBalance(_ response: AccountVisitResponse) {
-        let newSeedCount = response.seeds.totalAmount
+        let newSeedCount = response.seeds.balanceAmount
         let newLevelNumber = response.growthPoints.level.number
         let newProgress = response.progressToNextLevel
 


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-4179]

## Context

We noticed an out-of-sync behaviour between iOS native and Web.

After an investigation, JOU noticed that with the Collectibles release, they switched from displaying seeds total (all seeds ever earned) to seeds balance (current seeds value available to spend after buying collectibles).

## Approach

- Move from seeds.totalAmount to seeds.balanceAmount

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad

[MOB-4179]: https://ecosia.atlassian.net/browse/MOB-4179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ