### PR TITLE
Fix BoolSetting's constructor `BoolSetting` typo

### DIFF
--- a/firefox-ios/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
@@ -141,7 +141,7 @@ extension AppSettingsTableViewController {
             privacySettings.insert(EcosiaSendAnonymousUsageDataSetting(prefs: profile.prefs, theme: theme), at: 2)
             privacySettings.insert(BoolSetting(prefs: profile.prefs,
                                                theme: theme,
-                                               refKey: PrefsKeys.Settings.closePrivateTabs,
+                                               prefKey: PrefsKeys.Settings.closePrivateTabs,
                                                // Ecosia: Default value is different from Firefox
                                                defaultValue: PrefsKeysDefaultValues.Settings.closePrivateTabs,
                                                titleText: .AppSettingsClosePrivateTabsTitle,


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[NOTICKET]

## Context

When working on the [MOB-4002](https://ecosia.atlassian.net/browse/MOB-4002) ticket, I realised the `develop` branch was in an unstable state.

## Approach

- Fix the typo
- Make this PR independent from the ticket 

## Other
⚠️
I noticed a few SwiftLint errors, but I guess these issues will be solved by https://github.com/ecosia/ios-browser/pull/1036 

[MOB-4002]: https://ecosia.atlassian.net/browse/MOB-4002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ