### PR TITLE
[MOB-4002] Update Theme to dark/light even if incognito

### DIFF
--- a/firefox-ios/Client/Ecosia/UI/Theme/EcosiaThemeManager.swift
+++ b/firefox-ios/Client/Ecosia/UI/Theme/EcosiaThemeManager.swift
@@ -102,7 +102,7 @@ public final class EcosiaThemeManager: ThemeManager, Notifiable {
     }
 
     public func resolvedTheme(with shouldShowPrivateTheme: Bool) -> Theme {
-        return shouldShowPrivateTheme ? PrivateModeTheme() : getThemeFrom(type: determineUserTheme())
+        return getThemeFrom(type: determineUserTheme())
     }
 
     @MainActor
@@ -205,7 +205,6 @@ public final class EcosiaThemeManager: ThemeManager, Notifiable {
     }
 
     private func determineThemeType(for window: WindowUUID) -> ThemeType {
-        if getPrivateThemeIsOn(for: window) { return .privateMode }
         return determineUserTheme()
     }
 
@@ -244,7 +243,7 @@ public final class EcosiaThemeManager: ThemeManager, Notifiable {
         case .nightMode:
             return EcosiaDarkTheme()
         case .privateMode:
-            return PrivateModeTheme()
+            return EcosiaDarkTheme()
         }
     }
 

--- a/firefox-ios/EcosiaTests/Mocks/EcosiaMockThemeManager.swift
+++ b/firefox-ios/EcosiaTests/Mocks/EcosiaMockThemeManager.swift
@@ -86,6 +86,12 @@ final class EcosiaMockThemeManager: ThemeManager {
 
     func getUserManualTheme() -> ThemeType { return currentThemeStorage.type }
 
+    func resolvedTheme(with shouldShowPrivateTheme: Bool) -> Theme {
+        return currentThemeStorage
+    }
+
+    var isNewAppearanceMenuOn: Bool { return false }
+
     func reloadTheme(for window: UUID) { }
 
     func setWindow(_ window: UIWindow, for uuid: UUID) { }

--- a/firefox-ios/EcosiaTests/UI/Themable/ThemableMockThemeManager.swift
+++ b/firefox-ios/EcosiaTests/UI/Themable/ThemableMockThemeManager.swift
@@ -25,6 +25,13 @@ final class ThemeableMockThemeManager: ThemeManager {
     func setSystemTheme(isOn: Bool) {}
     func setManualTheme(to newTheme: ThemeType) {}
     func getUserManualTheme() -> ThemeType { return .light }
+    
+    func resolvedTheme(with shouldShowPrivateTheme: Bool) -> Theme {
+        return currentTheme
+    }
+    
+    var isNewAppearanceMenuOn: Bool { return false }
+    
     func setAutomaticBrightness(isOn: Bool) {}
     func setAutomaticBrightnessValue(_ value: Float) {}
     func applyThemeUpdatesToWindows() {}

--- a/firefox-ios/EcosiaTests/UI/Themable/ThemableMockThemeManager.swift
+++ b/firefox-ios/EcosiaTests/UI/Themable/ThemableMockThemeManager.swift
@@ -25,13 +25,13 @@ final class ThemeableMockThemeManager: ThemeManager {
     func setSystemTheme(isOn: Bool) {}
     func setManualTheme(to newTheme: ThemeType) {}
     func getUserManualTheme() -> ThemeType { return .light }
-    
+
     func resolvedTheme(with shouldShowPrivateTheme: Bool) -> Theme {
         return currentTheme
     }
-    
+
     var isNewAppearanceMenuOn: Bool { return false }
-    
+
     func setAutomaticBrightness(isOn: Bool) {}
     func setAutomaticBrightnessValue(_ value: Float) {}
     func applyThemeUpdatesToWindows() {}


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-4002]

## Context

Firefox added a "private mode" theme.
We currently don’t provide any themes besides light and dark mode; therefore, we should force the mode to keep using light or dark depending on the user’s settings.

## Approach

- Make our `EcosiaThemeManager` stick to dark/light (current theme) for Incognito too

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I wrote Unit Tests that confirm the expected behaviour

[MOB-4002]: https://ecosia.atlassian.net/browse/MOB-4002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ