### PR TITLE
[MOB-4000] Address bar stick to bottom

### DIFF
--- a/firefox-ios/Client/Application/AppLaunchUtil.swift
+++ b/firefox-ios/Client/Application/AppLaunchUtil.swift
@@ -99,7 +99,10 @@ final class AppLaunchUtil: Sendable {
         }
 
         // Save toolbar position to user prefs
+        /* Ecosia: Use Ecosia's search bar location saver
         SearchBarLocationSaver().saveUserSearchBarLocation(profile: profile)
+        */
+        EcosiaSearchBarLocationSaver().saveUserSearchBarLocation(profile: profile)
         let deviceName = UIDevice.current.name
 
         NotificationCenter.default.addObserver(

--- a/firefox-ios/Client/Ecosia/Toolbars/EcosiaSearchBarLocationSaver.swift
+++ b/firefox-ios/Client/Ecosia/Toolbars/EcosiaSearchBarLocationSaver.swift
@@ -1,0 +1,20 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Shared
+import Ecosia
+
+struct EcosiaSearchBarLocationSaver: SearchBarLocationProvider, FeatureFlaggable, SearchBarLocationSaverProtocol {
+    @MainActor
+    func saveUserSearchBarLocation(profile: Profile,
+                                   userInterfaceIdiom: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) {
+        let hasSearchBarPosition = profile.prefs.stringForKey(PrefsKeys.FeatureFlags.SearchBarPosition) != nil
+        
+        guard !hasSearchBarPosition else { return }
+        
+        if User.shared.firstTime {
+            featureFlags.set(feature: .searchBarPosition, to: SearchBarPosition.bottom)
+        }
+    }
+}

--- a/firefox-ios/Client/Ecosia/Toolbars/EcosiaSearchBarLocationSaver.swift
+++ b/firefox-ios/Client/Ecosia/Toolbars/EcosiaSearchBarLocationSaver.swift
@@ -10,9 +10,9 @@ struct EcosiaSearchBarLocationSaver: SearchBarLocationProvider, FeatureFlaggable
     func saveUserSearchBarLocation(profile: Profile,
                                    userInterfaceIdiom: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom) {
         let hasSearchBarPosition = profile.prefs.stringForKey(PrefsKeys.FeatureFlags.SearchBarPosition) != nil
-        
+
         guard !hasSearchBarPosition else { return }
-        
+
         if User.shared.firstTime {
             featureFlags.set(feature: .searchBarPosition, to: SearchBarPosition.bottom)
         }

--- a/firefox-ios/EcosiaTests/EcosiaSearchBarLocationSaverTests.swift
+++ b/firefox-ios/EcosiaTests/EcosiaSearchBarLocationSaverTests.swift
@@ -1,0 +1,75 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+@testable import Client
+
+import Common
+import Shared
+import Ecosia
+import XCTest
+
+class EcosiaSearchBarLocationSaverTests: XCTestCase {
+    private var profile: MockProfile!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        profile = MockProfile()
+        await DependencyHelperMock().bootstrapDependencies()
+        LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
+        User.shared.firstTime = true
+    }
+
+    override func tearDown() async throws {
+        profile.shutdown()
+        profile = nil
+        User.shared.firstTime = true
+        DependencyHelperMock().reset()
+        try await super.tearDown()
+    }
+
+    @MainActor
+    func test_saveSearchBarLocation_withFirstTimeUser_setsPositionToBottom() async throws {
+        let subject = createSubject()
+        User.shared.firstTime = true
+
+        subject.saveUserSearchBarLocation(profile: profile, userInterfaceIdiom: .phone)
+        let searchBarPosition = profile.prefs.stringForKey(PrefsKeys.FeatureFlags.SearchBarPosition)
+        XCTAssertEqual(searchBarPosition, SearchBarPosition.bottom.rawValue)
+    }
+
+    @MainActor
+    func test_saveSearchBarLocation_withExistingUser_doesNotSetPosition() async throws {
+        let subject = createSubject()
+        User.shared.firstTime = false
+
+        subject.saveUserSearchBarLocation(profile: profile, userInterfaceIdiom: .phone)
+        let searchBarPosition = profile.prefs.stringForKey(PrefsKeys.FeatureFlags.SearchBarPosition)
+        XCTAssertNil(searchBarPosition)
+    }
+
+    @MainActor
+    func test_saveSearchBarLocation_withExistingPosition_keepsPosition() async throws {
+        let subject = createSubject()
+        User.shared.firstTime = true
+        profile.prefs.setString(SearchBarPosition.top.rawValue, forKey: PrefsKeys.FeatureFlags.SearchBarPosition)
+
+        subject.saveUserSearchBarLocation(profile: profile, userInterfaceIdiom: .phone)
+        let searchBarPosition = profile.prefs.stringForKey(PrefsKeys.FeatureFlags.SearchBarPosition)
+        XCTAssertEqual(searchBarPosition, SearchBarPosition.top.rawValue)
+    }
+
+    @MainActor
+    func test_saveSearchBarLocation_oniPad_withFirstTimeUser_setsPositionToBottom() async throws {
+        let subject = createSubject()
+        User.shared.firstTime = true
+
+        subject.saveUserSearchBarLocation(profile: profile, userInterfaceIdiom: .pad)
+        let searchBarPosition = profile.prefs.stringForKey(PrefsKeys.FeatureFlags.SearchBarPosition)
+        XCTAssertEqual(searchBarPosition, SearchBarPosition.bottom.rawValue)
+    }
+
+    private func createSubject() -> EcosiaSearchBarLocationSaver {
+        return EcosiaSearchBarLocationSaver()
+    }
+}


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-4000]

## Context

Design decision for the current Address Bar behaviour.

## Approach

- Made our own `EcosiaSearchBarLocationSaver`
- Applied the wanted rules
- Swapped in `AppLaunchUtil`

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I wrote Unit Tests that confirm the expected behaviour
- [x] I added the `// Ecosia:` helper comments where needed

[MOB-4000]: https://ecosia.atlassian.net/browse/MOB-4000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ