### PR TITLE
[MOB-3995] Always show last opened page via Ecosia middleware

### DIFF
--- a/firefox-ios/Client/Ecosia/UI/StartAtHome/EcosiaStartAtHomeMiddleware.swift
+++ b/firefox-ios/Client/Ecosia/UI/StartAtHome/EcosiaStartAtHomeMiddleware.swift
@@ -1,0 +1,39 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Redux
+import Shared
+
+@MainActor
+final class EcosiaStartAtHomeMiddleware {
+    private let windowManager: WindowManager
+    private let logger: Logger
+    private let prefs: Prefs
+    private let dateProvider: DateProvider
+
+    init(profile: Profile = AppContainer.shared.resolve(),
+         windowManager: WindowManager = AppContainer.shared.resolve(),
+         logger: Logger = DefaultLogger.shared,
+         dateProvider: DateProvider = SystemDateProvider()) {
+        self.windowManager = windowManager
+        self.logger = logger
+        self.prefs = profile.prefs
+        self.dateProvider = dateProvider
+    }
+
+    lazy var startAtHomeProvider: Middleware<AppState> = { state, action in
+        switch action.actionType {
+        case StartAtHomeActionType.didBrowserBecomeActive:
+            store.dispatch(
+                StartAtHomeAction(
+                    shouldStartAtHome: false,
+                    windowUUID: action.windowUUID,
+                    actionType: StartAtHomeMiddlewareActionType.startAtHomeCheckCompleted
+                )
+            )
+        default: break
+        }
+    }
+}

--- a/firefox-ios/Client/Redux/GlobalState/AppState.swift
+++ b/firefox-ios/Client/Redux/GlobalState/AppState.swift
@@ -82,7 +82,10 @@ let middlewares = [
     WallpaperMiddleware().wallpaperProvider,
     BookmarksMiddleware().bookmarksProvider,
     HomepageMiddleware(notificationCenter: NotificationCenter.default).homepageProvider,
+    /* Ecosia: Use Ecosia's start at home middleware to disable the feature
     StartAtHomeMiddleware().startAtHomeProvider,
+    */
+    EcosiaStartAtHomeMiddleware().startAtHomeProvider,
     ShortcutsLibraryMiddleware().shortcutsLibraryProvider,
     SummarizerMiddleware().summarizerProvider,
     TermsOfUseMiddleware().termsOfUseProvider,

--- a/firefox-ios/EcosiaTests/EcosiaStartAtHomeMiddlewareTests.swift
+++ b/firefox-ios/EcosiaTests/EcosiaStartAtHomeMiddlewareTests.swift
@@ -1,0 +1,220 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+@testable import Client
+
+import Common
+import Redux
+import Shared
+import XCTest
+
+final class EcosiaStartAtHomeMiddlewareTests: XCTestCase, StoreTestUtility {
+    private var mockProfile: MockProfile!
+    private var mockTabManager: MockTabManager!
+    private var mockWindowManager: MockWindowManager!
+    private var mockStore: MockStoreForMiddleware<AppState>!
+    private var appState: AppState!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+        mockProfile = MockProfile()
+        mockTabManager = MockTabManager()
+        mockTabManager.tabRestoreHasFinished = true
+        mockWindowManager = MockWindowManager(
+            wrappedManager: WindowManagerImplementation(),
+            tabManager: mockTabManager
+        )
+        DependencyHelperMock().bootstrapDependencies(injectedWindowManager: mockWindowManager)
+        LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: mockProfile)
+        setupStore()
+        appState = setupAppState()
+    }
+
+    override func tearDown() async throws {
+        mockProfile = nil
+        mockWindowManager = nil
+        DependencyHelperMock().reset()
+        resetStore()
+        try await super.tearDown()
+    }
+
+    @MainActor
+    func test_didBrowserBecomeActiveAction_alwaysReturnsFalse_withAfterFourHoursSetting() throws {
+        mockProfile.prefs.setString(StartAtHome.afterFourHours.rawValue, forKey: PrefsKeys.FeatureFlags.StartAtHome)
+        let subject = createSubject(with: mockProfile)
+        let action = StartAtHomeAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: StartAtHomeActionType.didBrowserBecomeActive
+        )
+
+        let expectation = XCTestExpectation(description: "Start At Home action should be dispatched")
+
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
+
+        subject.startAtHomeProvider(appState, action)
+
+        wait(for: [expectation])
+
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? StartAtHomeAction)
+        let actionType = try XCTUnwrap(actionCalled.actionType as? StartAtHomeMiddlewareActionType)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        XCTAssertEqual(actionType, StartAtHomeMiddlewareActionType.startAtHomeCheckCompleted)
+        XCTAssertEqual(actionCalled.shouldStartAtHome, false)
+    }
+
+    @MainActor
+    func test_didBrowserBecomeActiveAction_alwaysReturnsFalse_withAlwaysSetting() throws {
+        mockProfile.prefs.setString(StartAtHome.always.rawValue, forKey: PrefsKeys.FeatureFlags.StartAtHome)
+        let subject = createSubject(with: mockProfile)
+        let action = StartAtHomeAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: StartAtHomeActionType.didBrowserBecomeActive
+        )
+
+        let expectation = XCTestExpectation(description: "Start At Home action should be dispatched")
+
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
+
+        subject.startAtHomeProvider(appState, action)
+
+        wait(for: [expectation])
+
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? StartAtHomeAction)
+        let actionType = try XCTUnwrap(actionCalled.actionType as? StartAtHomeMiddlewareActionType)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        XCTAssertEqual(actionType, StartAtHomeMiddlewareActionType.startAtHomeCheckCompleted)
+        XCTAssertEqual(actionCalled.shouldStartAtHome, false)
+    }
+
+    @MainActor
+    func test_didBrowserBecomeActiveAction_alwaysReturnsFalse_withDisabledSetting() throws {
+        mockProfile.prefs.setString(StartAtHome.disabled.rawValue, forKey: PrefsKeys.FeatureFlags.StartAtHome)
+        let subject = createSubject(with: mockProfile)
+        let action = StartAtHomeAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: StartAtHomeActionType.didBrowserBecomeActive
+        )
+
+        let expectation = XCTestExpectation(description: "Start At Home action should be dispatched")
+
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
+
+        subject.startAtHomeProvider(appState, action)
+
+        wait(for: [expectation])
+
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? StartAtHomeAction)
+        let actionType = try XCTUnwrap(actionCalled.actionType as? StartAtHomeMiddlewareActionType)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        XCTAssertEqual(actionType, StartAtHomeMiddlewareActionType.startAtHomeCheckCompleted)
+        XCTAssertEqual(actionCalled.shouldStartAtHome, false)
+    }
+
+    @MainActor
+    func test_didBrowserBecomeActiveAction_alwaysReturnsFalse_withNoSetting() throws {
+        let subject = createSubject(with: mockProfile)
+        let action = StartAtHomeAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: StartAtHomeActionType.didBrowserBecomeActive
+        )
+
+        let expectation = XCTestExpectation(description: "Start At Home action should be dispatched")
+
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
+
+        subject.startAtHomeProvider(appState, action)
+
+        wait(for: [expectation])
+
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? StartAtHomeAction)
+        let actionType = try XCTUnwrap(actionCalled.actionType as? StartAtHomeMiddlewareActionType)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        XCTAssertEqual(actionType, StartAtHomeMiddlewareActionType.startAtHomeCheckCompleted)
+        XCTAssertEqual(actionCalled.shouldStartAtHome, false)
+    }
+
+    @MainActor
+    func test_didBrowserBecomeActiveAction_alwaysReturnsFalse_withPrivateTab() throws {
+        mockProfile.prefs.setString(StartAtHome.always.rawValue, forKey: PrefsKeys.FeatureFlags.StartAtHome)
+        let privateTab = mockTabManager.addTab(isPrivate: true)
+        mockTabManager.selectTab(privateTab)
+        
+        let subject = createSubject(with: mockProfile)
+        let action = StartAtHomeAction(
+            windowUUID: .XCTestDefaultUUID,
+            actionType: StartAtHomeActionType.didBrowserBecomeActive
+        )
+
+        let expectation = XCTestExpectation(description: "Start At Home action should be dispatched")
+
+        mockStore.dispatchCalled = {
+            expectation.fulfill()
+        }
+
+        subject.startAtHomeProvider(appState, action)
+
+        wait(for: [expectation])
+
+        let actionCalled = try XCTUnwrap(mockStore.dispatchedActions.first as? StartAtHomeAction)
+        let actionType = try XCTUnwrap(actionCalled.actionType as? StartAtHomeMiddlewareActionType)
+
+        XCTAssertEqual(mockStore.dispatchedActions.count, 1)
+        XCTAssertEqual(actionType, StartAtHomeMiddlewareActionType.startAtHomeCheckCompleted)
+        XCTAssertEqual(actionCalled.shouldStartAtHome, false)
+    }
+
+    // MARK: - Helpers
+    private func createSubject(with mockProfile: Profile = MockProfile()) -> EcosiaStartAtHomeMiddleware {
+        let testDate = Date(timeIntervalSince1970: 1_000_065_600)
+        let lastSessionDate = Calendar.current.date(
+            byAdding: .hour,
+            value: -5,
+            to: testDate
+        )!
+        UserDefaults.standard.setValue(lastSessionDate, forKey: "LastActiveTimestamp")
+        return EcosiaStartAtHomeMiddleware(
+            profile: mockProfile,
+            windowManager: mockWindowManager,
+            dateProvider: MockDateProvider(fixedDate: testDate))
+    }
+
+    // MARK: StoreTestUtility
+    func setupAppState() -> Client.AppState {
+        let appState = AppState(
+            activeScreens: ActiveScreensState(
+                screens: [
+                    .browserViewController(
+                        BrowserViewControllerState(
+                            windowUUID: .XCTestDefaultUUID
+                        )
+                    )
+                ]
+            )
+        )
+        self.appState = appState
+        return appState
+    }
+
+    func setupStore() {
+        mockStore = MockStoreForMiddleware(state: setupAppState())
+        StoreTestUtilityHelper.setupStore(with: mockStore)
+    }
+
+    func resetStore() {
+        StoreTestUtilityHelper.resetStore()
+    }
+}

--- a/firefox-ios/EcosiaTests/EcosiaStartAtHomeMiddlewareTests.swift
+++ b/firefox-ios/EcosiaTests/EcosiaStartAtHomeMiddlewareTests.swift
@@ -152,7 +152,7 @@ final class EcosiaStartAtHomeMiddlewareTests: XCTestCase, StoreTestUtility {
         mockProfile.prefs.setString(StartAtHome.always.rawValue, forKey: PrefsKeys.FeatureFlags.StartAtHome)
         let privateTab = mockTabManager.addTab(isPrivate: true)
         mockTabManager.selectTab(privateTab)
-        
+
         let subject = createSubject(with: mockProfile)
         let action = StartAtHomeAction(
             windowUUID: .XCTestDefaultUUID,


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-3995]

## Context

We want the app to restore the last visited page when the app reopens.
Currently, Firefox has an option that will let the user choose the logic of the "home page".

## Approach

- Make a middleware and swap it so we own the logic

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I wrote Unit Tests that confirm the expected behaviour
- [x] I added the `// Ecosia:` helper comments where needed

[MOB-3995]: https://ecosia.atlassian.net/browse/MOB-3995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ