### PR TITLE
[MOB-4146] Update Snowplow Mini Staging URL

### DIFF
--- a/firefox-ios/Ecosia/Analytics/Analytics.swift
+++ b/firefox-ios/Ecosia/Analytics/Analytics.swift
@@ -519,16 +519,18 @@ extension Analytics {
     }
 
     /// Factory that builds the `NetworkConfiguration` for the Snowplow tracker, optionally
-    /// including authentication headers if using a micro instance.
+    /// including authentication headers when the environment provides Cloudflare credentials.
     ///
-    /// - Returns: A configured `NetworkConfiguration` object.
     /// - Parameters:
-    ///   - urlProvider: The urlProvider in use. Useful for testing purposes.
-    static func makeNetworkConfig(urlProvider: URLProvider = EcosiaEnvironment.current.urlProvider) -> NetworkConfiguration {
+    ///   - environment: The environment to use for resolving the endpoint and authentication.
+    ///                  Defaults to `EcosiaEnvironment.current`. Pass a specific value in tests.
+    /// - Returns: A configured `NetworkConfiguration` object.
+    static func makeNetworkConfig(environment: EcosiaEnvironment = .current) -> NetworkConfiguration {
+        let urlProvider = environment.urlProvider
         let endpoint = shouldUseMicroInstance ? urlProvider.snowplowMicro : urlProvider.snowplow
         var networkConfig = NetworkConfiguration(endpoint: endpoint!)
 
-        if let auth = EcosiaEnvironment.current.cloudFlareAuth {
+        if let auth = environment.cloudFlareAuth {
             networkConfig = networkConfig
                 .requestHeaders([
                     CloudflareKeyProvider.clientId: auth.id,

--- a/firefox-ios/Ecosia/Analytics/Analytics.swift
+++ b/firefox-ios/Ecosia/Analytics/Analytics.swift
@@ -528,8 +528,8 @@ extension Analytics {
         let endpoint = shouldUseMicroInstance ? urlProvider.snowplowMicro : urlProvider.snowplow
         var networkConfig = NetworkConfiguration(endpoint: endpoint!)
 
-        if shouldUseMicroInstance,
-           let auth = EcosiaEnvironment.current.cloudFlareAuth {
+        // TODO: Check if we really need the auth header now and why it still doesn't work (302 redirect to login page)
+        if let auth = EcosiaEnvironment.current.cloudFlareAuth {
             networkConfig = networkConfig
                 .requestHeaders([
                     CloudflareKeyProvider.clientId: auth.id,

--- a/firefox-ios/Ecosia/Analytics/Analytics.swift
+++ b/firefox-ios/Ecosia/Analytics/Analytics.swift
@@ -528,7 +528,6 @@ extension Analytics {
         let endpoint = shouldUseMicroInstance ? urlProvider.snowplowMicro : urlProvider.snowplow
         var networkConfig = NetworkConfiguration(endpoint: endpoint!)
 
-        // TODO: Check if we really need the auth header now and why it still doesn't work (302 redirect to login page)
         if let auth = EcosiaEnvironment.current.cloudFlareAuth {
             networkConfig = networkConfig
                 .requestHeaders([

--- a/firefox-ios/Ecosia/Core/Environment/URLProvider.swift
+++ b/firefox-ios/Ecosia/Core/Environment/URLProvider.swift
@@ -40,10 +40,10 @@ public enum URLProvider {
 
     public var snowplow: String {
         switch self {
-        case .production:
+        case .production, .debug:
             return "sp.ecosia.org"
-        case .staging, .debug:
-            return "org-ecosia-prod1.mini.snplow.net"
+        case .staging:
+            return "https://osc.ecosia-dev.xyz"
         }
     }
 

--- a/firefox-ios/Ecosia/Core/Environment/URLProvider.swift
+++ b/firefox-ios/Ecosia/Core/Environment/URLProvider.swift
@@ -43,7 +43,7 @@ public enum URLProvider {
         case .production, .debug:
             return "sp.ecosia.org"
         case .staging:
-            return "https://osc.ecosia-dev.xyz"
+            return "https://osc.ecosia-staging.xyz"
         }
     }
 

--- a/firefox-ios/EcosiaTests/Analytics/AnalyticsTests.swift
+++ b/firefox-ios/EcosiaTests/Analytics/AnalyticsTests.swift
@@ -150,27 +150,23 @@ final class AnalyticsTests: XCTestCase {
 
     func test_makeNetworkConfig_usesStandardEndpoint_whenShouldUseMicroIsFalse() {
         Analytics.shouldUseMicroInstance = false
-        let mockUrlProvider: URLProvider = .staging
-        let config = Analytics.makeNetworkConfig(urlProvider: mockUrlProvider)
-        XCTAssertEqual(mockUrlProvider.snowplow, config.endpoint?.asURL?.host)
+        let config = Analytics.makeNetworkConfig(environment: .staging)
+        let expectedHost = URLProvider.staging.snowplow.asURL?.host
+        XCTAssertEqual(expectedHost, config.endpoint?.asURL?.host)
     }
 
     func test_makeNetworkConfig_usesMicroEndpoint_whenShouldUseMicroIsTrue() {
         Analytics.shouldUseMicroInstance = true
-        let mockUrlProvider: URLProvider = .staging
-        let config = Analytics.makeNetworkConfig(urlProvider: mockUrlProvider)
-        XCTAssertEqual(mockUrlProvider.snowplowMicro, config.endpoint)
+        let config = Analytics.makeNetworkConfig(environment: .staging)
+        XCTAssertEqual(URLProvider.staging.snowplowMicro, config.endpoint)
         XCTAssertEqual(config.requestHeaders?.keys.contains(CloudflareKeyProvider.clientId), true)
         XCTAssertEqual(config.requestHeaders?.keys.contains(CloudflareKeyProvider.clientSecret), true)
     }
 
-    func test_makeNetworkConfig_usesProductionEndpoint_whenShouldUseMicroIsFalse_andUrlProvider_isProduction() {
+    func test_makeNetworkConfig_usesProductionEndpoint_whenShouldUseMicroIsFalse_andEnvironment_isProduction() {
         Analytics.shouldUseMicroInstance = false
-        let mockUrlProvider: URLProvider = .production
-        let config = Analytics.makeNetworkConfig(urlProvider: mockUrlProvider)
-        XCTAssertEqual(mockUrlProvider.snowplow, "sp.ecosia.org")
-        XCTAssertEqual(mockUrlProvider.snowplow, config.endpoint?.asURL?.host)
-        XCTAssertNil(config.requestHeaders?.keys.contains(CloudflareKeyProvider.clientId))
-        XCTAssertNil(config.requestHeaders?.keys.contains(CloudflareKeyProvider.clientSecret))
+        let config = Analytics.makeNetworkConfig(environment: .production)
+        XCTAssertEqual(config.endpoint?.asURL?.host, "sp.ecosia.org")
+        XCTAssertNil(config.requestHeaders, "Production environment should not include Cloudflare authentication headers")
     }
 }

--- a/firefox-ios/EcosiaTests/Core/URLProviderDependantTests/URLProviderTests.swift
+++ b/firefox-ios/EcosiaTests/Core/URLProviderDependantTests/URLProviderTests.swift
@@ -108,19 +108,16 @@ final class URLProviderTests: XCTestCase {
         // Debug should follow production for these properties
         XCTAssertEqual(debugProvider.root, productionProvider.root)
         XCTAssertEqual(debugProvider.apiRoot, productionProvider.apiRoot)
+        XCTAssertEqual(debugProvider.snowplow, productionProvider.snowplow)
         XCTAssertEqual(debugProvider.snowplowMicro, productionProvider.snowplowMicro)
         XCTAssertEqual(debugProvider.unleash, productionProvider.unleash)
         XCTAssertEqual(debugProvider.brazeEndpoint, productionProvider.brazeEndpoint)
         XCTAssertEqual(debugProvider.statistics, productionProvider.statistics)
     }
 
-    func testDebugSnowplowFollowsStaging() {
-        let debugProvider = URLProvider.debug
-        let stagingProvider = URLProvider.staging
-
-        // Debug should follow staging only for snowplow
-        XCTAssertEqual(debugProvider.snowplow, stagingProvider.snowplow)
-        XCTAssertEqual(debugProvider.snowplow, "org-ecosia-prod1.mini.snplow.net")
+    func testSnowplowStaging() {
+        let provider = URLProvider.staging
+        XCTAssertEqual(provider.snowplow, "https://osc.ecosia-staging.xyz")
     }
 
     func testTrees() {


### PR DESCRIPTION
[MOB-4146]

## Context

Using new URL from BI migration.

## Approach

Updating URLProvider and removing micro condition from existing Cloudflare header Snowplow configuration.

Checked events are coming to the dashboard 🎉 
<img width="1481" height="702" alt="Screenshot 2026-03-02 at 16 53 10" src="https://github.com/user-attachments/assets/5d4b26ec-c194-4ac7-8e60-d22aeab683ba" />

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)

[MOB-4146]: https://ecosia.atlassian.net/browse/MOB-4146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ