### PR TITLE
Noticket/tree counter

### DIFF
--- a/Ecosia/Core/Statistics/Statistics.swift
+++ b/Ecosia/Core/Statistics/Statistics.swift
@@ -38,15 +38,16 @@ public actor Statistics {
     }
 
     public static let shared = Statistics()
-    public internal(set) var treesPlanted = Double(113016418)
-    public internal(set) var treesPlantedLastUpdated = Date(timeIntervalSince1970: 1604671200)
-    public internal(set) var timePerTree = Double(1.3)
+    // Ecosia: defaults updated from live API on 2026-02-26 (previously Nov 2020 hardcoded values)
+    public internal(set) var treesPlanted = Double(244_418_472)                                    // "2025-12-01T16:34:00.0Z"
+    public internal(set) var treesPlantedLastUpdated = Date(timeIntervalSince1970: 1_764_606_840)  // 2025-12-01T16:34:00Z
+    public internal(set) var timePerTree = Double(2.2)
     public internal(set) var searchesPerTree = Double(50)
     public internal(set) var activeUsers = Double(20000000)
     public internal(set) var eurToUsdMultiplier = Double(1.08)
-    public internal(set) var investmentPerSecond = Double(0.35)
-    public internal(set) var totalInvestments = Double(76776000)
-    public internal(set) var totalInvestmentsLastUpdated = Date(timeIntervalSince1970: 1685404800)
+    public internal(set) var investmentPerSecond = Double(0.25)
+    public internal(set) var totalInvestments = Double(88_666_760)                                 // "2024-10-08T00:00:00.000000Z"
+    public internal(set) var totalInvestmentsLastUpdated = Date(timeIntervalSince1970: 1_728_345_600) // 2024-10-08T00:00:00Z
 
     init() { }
 

--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -8,6 +8,7 @@ import UIKit
 import Common
 import Glean
 import TabDataStore
+import Ecosia
 
 import class MozillaAppServices.Viaduct
 
@@ -158,6 +159,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, FeatureFlaggable {
         }
 
         metricKitWrapper.beginObservingMXPayloads()
+
+        // Ecosia: fetching statistics before they are used
+        Task.detached {
+            try? await Statistics.shared.fetchAndUpdate()
+        }
 
         let topSitesProvider = TopSitesProviderImplementation(
             placesFetcher: profile.places,

--- a/firefox-ios/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
@@ -180,6 +180,7 @@ extension AppSettingsTableViewController {
             ResetSearchCount(settings: self),
             ResetDefaultBrowserNudgeCard(settings: self),
             AnalyticsIdentifierSetting(settings: self),
+            RefreshStatisticsSetting(settings: self),
         ]
 
         if EcosiaEnvironment.current == .staging {

--- a/firefox-ios/Client/Ecosia/Frontend/Home/EcosiaHomepageAdapter.swift
+++ b/firefox-ios/Client/Ecosia/Frontend/Home/EcosiaHomepageAdapter.swift
@@ -198,10 +198,6 @@ final class EcosiaHomepageAdapter {
     func viewWillAppear() {
         impactViewModel?.subscribeToProjections()
         // News automatically subscribes on init
-        // Ecosia: Fetch latest statistics so the tree counter reflects live data from CloudFront
-        Task.detached {
-            try? await Statistics.shared.fetchAndUpdate()
-        }
     }
     
     func viewDidDisappear() {

--- a/firefox-ios/Client/Ecosia/Frontend/Home/EcosiaHomepageAdapter.swift
+++ b/firefox-ios/Client/Ecosia/Frontend/Home/EcosiaHomepageAdapter.swift
@@ -198,6 +198,10 @@ final class EcosiaHomepageAdapter {
     func viewWillAppear() {
         impactViewModel?.subscribeToProjections()
         // News automatically subscribes on init
+        // Ecosia: Fetch latest statistics so the tree counter reflects live data from CloudFront
+        Task.detached {
+            try? await Statistics.shared.fetchAndUpdate()
+        }
     }
     
     func viewDidDisappear() {

--- a/firefox-ios/Client/Ecosia/Settings/EcosiaDebugSettings.swift
+++ b/firefox-ios/Client/Ecosia/Settings/EcosiaDebugSettings.swift
@@ -673,3 +673,68 @@ final class DebugAddCustomSeeds: HiddenSetting {
         }
     }
 }
+
+// MARK: - Statistics Refresh
+
+@MainActor
+final class RefreshStatisticsSetting: HiddenSetting {
+    override var title: NSAttributedString? {
+        NSAttributedString(string: "Debug: Refresh Statistics (Tree Counter)", attributes: [:])
+    }
+
+    override var status: NSAttributedString? {
+        let trees = Int(Statistics.shared.treesPlanted)
+        let formatted = NumberFormatter.localizedString(from: NSNumber(value: trees), number: .decimal)
+        return NSAttributedString(string: "Current: \(formatted) trees", attributes: [:])
+    }
+
+    override func onClick(_ navigationController: UINavigationController?) {
+        let trees = Int(Statistics.shared.treesPlanted)
+        let formatted = NumberFormatter.localizedString(from: NSNumber(value: trees), number: .decimal)
+
+        let confirmAlert = AlertController(
+            title: "Refresh Statistics?",
+            message: "Current trees planted: \(formatted)\n\nFetch latest data from CloudFront?",
+            preferredStyle: .alert
+        )
+
+        confirmAlert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        confirmAlert.addAction(UIAlertAction(title: "Refresh", style: .default) { [weak self] _ in
+            self?.performFetch(navigationController: navigationController)
+        })
+
+        navigationController?.topViewController?.present(confirmAlert, animated: true)
+    }
+
+    private func performFetch(navigationController: UINavigationController?) {
+        Task {
+            do {
+                try await Statistics.shared.fetchAndUpdate()
+                let newTrees = Int(Statistics.shared.treesPlanted)
+                let formatted = NumberFormatter.localizedString(from: NSNumber(value: newTrees), number: .decimal)
+
+                let successAlert = AlertController(
+                    title: "Statistics Refreshed ✅",
+                    message: "Trees planted: \(formatted)",
+                    preferredStyle: .alert
+                )
+                navigationController?.topViewController?.present(successAlert, animated: true) {
+                    // Ecosia: Task + sleep instead of DispatchQueue for strict concurrency
+                    Task { @MainActor in
+                        try? await Task.sleep(nanoseconds: 2_000_000_000)
+                        successAlert.dismiss(animated: true)
+                    }
+                }
+                self.settings.tableView.reloadData()
+            } catch {
+                let errorAlert = AlertController(
+                    title: "Refresh Failed ❌",
+                    message: error.localizedDescription,
+                    preferredStyle: .alert
+                )
+                errorAlert.addAction(UIAlertAction(title: "OK", style: .default))
+                navigationController?.topViewController?.present(errorAlert, animated: true)
+            }
+        }
+    }
+}

--- a/firefox-ios/Ecosia/Core/Statistics/Statistics.swift
+++ b/firefox-ios/Ecosia/Core/Statistics/Statistics.swift
@@ -37,15 +37,16 @@ public final class Statistics {
     }
 
     public static let shared = Statistics()
-    public internal(set) var treesPlanted = Double(113016418)
-    public internal(set) var treesPlantedLastUpdated = Date(timeIntervalSince1970: 1604671200)
-    public internal(set) var timePerTree = Double(1.3)
+    // Ecosia: defaults updated from live API on 2026-02-26 (previously Nov 2020 hardcoded values)
+    public internal(set) var treesPlanted = Double(244_418_472)                                    // "2025-12-01T16:34:00.0Z"
+    public internal(set) var treesPlantedLastUpdated = Date(timeIntervalSince1970: 1_764_606_840)  // 2025-12-01T16:34:00Z
+    public internal(set) var timePerTree = Double(2.2)
     public internal(set) var searchesPerTree = Double(50)
     public internal(set) var activeUsers = Double(20000000)
     public internal(set) var eurToUsdMultiplier = Double(1.08)
-    public internal(set) var investmentPerSecond = Double(0.35)
-    public internal(set) var totalInvestments = Double(76776000)
-    public internal(set) var totalInvestmentsLastUpdated = Date(timeIntervalSince1970: 1685404800)
+    public internal(set) var investmentPerSecond = Double(0.25)
+    public internal(set) var totalInvestments = Double(88_666_760)                                 // "2024-10-08T00:00:00.000000Z"
+    public internal(set) var totalInvestmentsLastUpdated = Date(timeIntervalSince1970: 1_728_345_600) // 2024-10-08T00:00:00Z
 
     init() { }
 

--- a/firefox-ios/EcosiaTests/Core/StatisticsTests.swift
+++ b/firefox-ios/EcosiaTests/Core/StatisticsTests.swift
@@ -90,29 +90,29 @@ final class StatisticsTests: XCTestCase {
         XCTAssertEqual(trees, 247_000_000)
     }
 
-    // MARK: - Stale-defaults regression
+    // MARK: - Default-values regression
 
-    /// Documents the root cause of MOB-XXXX: the default treesPlanted base is from Nov 2020.
-    /// Without calling fetchAndUpdate(), the projection drifts ~6M below the live value by 2026.
-    /// This test pins the defaults and confirms the formula produces a stale-but-calculable count.
-    func testDefaultValuesProduceKnownStaleProjection() async {
+    /// Pins the default values to the Dec 2025 API snapshot so any accidental change breaks this test.
+    /// Without calling fetchAndUpdate(), the hardcoded defaults now project within ~3.5M of live (vs. ~6M gap with Nov 2020 base).
+    func testDefaultValuesProduceKnownProjection() async {
         let freshStats = Statistics()
         let base = await freshStats.treesPlanted
         let baseDate = await freshStats.treesPlantedLastUpdated
         let timePerTree = await freshStats.timePerTree
 
-        // Base values must still be the Nov 2020 defaults
-        XCTAssertEqual(base, 113_016_418, "Default treesPlanted baseline changed — update docs/fix")
-        XCTAssertEqual(baseDate, Date(timeIntervalSince1970: 1_604_671_200), "Default base date changed — update docs/fix")
+        // Base values must match the Dec 2025 API snapshot
+        XCTAssertEqual(base, 244_418_472, "Default treesPlanted baseline changed — update from live API and update docs/fix")
+        XCTAssertEqual(baseDate, Date(timeIntervalSince1970: 1_764_606_840), "Default base date changed — update docs/fix") // 2025-12-01T16:34:00Z
+        XCTAssertEqual(timePerTree, 2.2, "Default timePerTree changed — update from live API and update docs/fix")
 
-        // Projection for a fixed reference point (2026-02-26) should equal ~241.8M
-        let referenceDate = Date(timeIntervalSince1970: 1_740_614_400) // 2026-02-26 00:00 UTC
+        // Projection for a fixed reference point (2026-02-26 00:00 UTC = 1_772_064_000)
+        let referenceDate = Date(timeIntervalSince1970: 1_772_064_000) // 2026-02-26 00:00 UTC
         let elapsed = referenceDate.timeIntervalSince(baseDate)
         let projected = Int(elapsed / timePerTree + base - 1)
 
-        // Stale projection < live value: document the gap is ~6M
-        XCTAssertGreaterThan(projected, 240_000_000, "Projection from defaults should exceed 240M by 2026")
-        XCTAssertLessThan(projected, 245_000_000, "Projection from defaults should be below live ~247M")
+        // Projection from Dec 2025 defaults should be ~247.8M on 2026-02-26
+        XCTAssertGreaterThan(projected, 246_000_000, "Projection from defaults should exceed 246M by Feb 2026")
+        XCTAssertLessThan(projected, 250_000_000, "Projection from defaults should be below 250M by Feb 2026")
     }
 
     /// When fetchAndUpdate succeeds with live data, the subsequent projection matches the live count.

--- a/firefox-ios/EcosiaTests/Core/StatisticsTests.swift
+++ b/firefox-ios/EcosiaTests/Core/StatisticsTests.swift
@@ -134,8 +134,11 @@ final class StatisticsTests: XCTestCase {
 
         // Assert – projection from today should be ≥ live base
         let projection = await TreesProjection.shared.treesAt(Date())
-        XCTAssertGreaterThanOrEqual(projection, Int(liveBase),
-            "After fetching live data, projection should be ≥ the fetched base")
+        XCTAssertGreaterThanOrEqual(
+            projection,
+            Int(liveBase),
+            "After fetching live data, projection should be ≥ the fetched base"
+        )
     }
 }
 

--- a/firefox-ios/EcosiaTests/Core/StatisticsTests.swift
+++ b/firefox-ios/EcosiaTests/Core/StatisticsTests.swift
@@ -42,4 +42,107 @@ final class StatisticsTests: XCTestCase {
         XCTAssertEqual(statistics.totalInvestments, 2345678)
         XCTAssertEqual(statistics.totalInvestmentsLastUpdated, Date(timeIntervalSince1970: 1690675200))
     }
+
+    // MARK: - Failure resilience
+
+    /// When the network request fails, all existing values must be preserved unchanged.
+    func testFetchAndUpdatePreservesValuesOnNetworkFailure() async throws {
+        // Arrange – seed with known live-like values
+        await statistics.setTreesPlanted(247_000_000)
+        await statistics.setTreesPlantedLastUpdated(Date(timeIntervalSince1970: 1_740_000_000))
+        await statistics.setTimePerTree(1.3)
+
+        // Act – simulate a network error
+        let failingSession = ThrowingMockURLSession()
+        do {
+            try await statistics.fetchAndUpdate(urlSession: failingSession)
+            XCTFail("Expected fetchAndUpdate to throw on network failure")
+        } catch {
+            // Expected path
+        }
+
+        // Assert – values unchanged
+        let trees = await statistics.treesPlanted
+        let lastUpdated = await statistics.treesPlantedLastUpdated
+        let timePerTree = await statistics.timePerTree
+        XCTAssertEqual(trees, 247_000_000)
+        XCTAssertEqual(lastUpdated, Date(timeIntervalSince1970: 1_740_000_000))
+        XCTAssertEqual(timePerTree, 1.3)
+    }
+
+    /// When the response contains malformed JSON, all existing values must be preserved.
+    func testFetchAndUpdatePreservesValuesOnMalformedJSON() async throws {
+        // Arrange
+        await statistics.setTreesPlanted(247_000_000)
+
+        mockURLSession.data = Data("not valid json".utf8)
+
+        // Act
+        do {
+            try await statistics.fetchAndUpdate(urlSession: mockURLSession)
+            XCTFail("Expected fetchAndUpdate to throw on malformed JSON")
+        } catch {
+            // Expected path
+        }
+
+        // Assert
+        let trees = await statistics.treesPlanted
+        XCTAssertEqual(trees, 247_000_000)
+    }
+
+    // MARK: - Stale-defaults regression
+
+    /// Documents the root cause of MOB-XXXX: the default treesPlanted base is from Nov 2020.
+    /// Without calling fetchAndUpdate(), the projection drifts ~6M below the live value by 2026.
+    /// This test pins the defaults and confirms the formula produces a stale-but-calculable count.
+    func testDefaultValuesProduceKnownStaleProjection() async {
+        let freshStats = Statistics()
+        let base = await freshStats.treesPlanted
+        let baseDate = await freshStats.treesPlantedLastUpdated
+        let timePerTree = await freshStats.timePerTree
+
+        // Base values must still be the Nov 2020 defaults
+        XCTAssertEqual(base, 113_016_418, "Default treesPlanted baseline changed — update docs/fix")
+        XCTAssertEqual(baseDate, Date(timeIntervalSince1970: 1_604_671_200), "Default base date changed — update docs/fix")
+
+        // Projection for a fixed reference point (2026-02-26) should equal ~241.8M
+        let referenceDate = Date(timeIntervalSince1970: 1_740_614_400) // 2026-02-26 00:00 UTC
+        let elapsed = referenceDate.timeIntervalSince(baseDate)
+        let projected = Int(elapsed / timePerTree + base - 1)
+
+        // Stale projection < live value: document the gap is ~6M
+        XCTAssertGreaterThan(projected, 240_000_000, "Projection from defaults should exceed 240M by 2026")
+        XCTAssertLessThan(projected, 245_000_000, "Projection from defaults should be below live ~247M")
+    }
+
+    /// When fetchAndUpdate succeeds with live data, the subsequent projection matches the live count.
+    func testFetchAndUpdateProducesAccurateProjection() async throws {
+        // Arrange – simulate a live API response with a recent base
+        let liveBase = 247_000_000.0
+        let liveBaseTimestamp = "2026-02-25T00:00:00.000000Z"
+        mockURLSession.data = Data("""
+            {
+                "results": [
+                    {"name": "Total Trees Planted", "value": "\(Int(liveBase))", "last_updated": "\(liveBaseTimestamp)"},
+                    {"name": "Time per tree (seconds)", "value": "1.3"}
+                ]
+            }
+        """.utf8)
+
+        // Act
+        try await statistics.fetchAndUpdate(urlSession: mockURLSession)
+
+        // Assert – projection from today should be ≥ live base
+        let projection = await TreesProjection.shared.treesAt(Date())
+        XCTAssertGreaterThanOrEqual(projection, Int(liveBase),
+            "After fetching live data, projection should be ≥ the fetched base")
+    }
+}
+
+// MARK: - Test helpers
+
+private final class ThrowingMockURLSession: URLSessionProtocol {
+    func data(from url: URL) async throws -> (Data, URLResponse) {
+        throw URLError(.notConnectedToInternet)
+    }
 }


### PR DESCRIPTION
Tree counter was showing ~241M instead of the live ~247M from CloudFront.

**Root cause:** `Statistics.shared.fetchAndUpdate()` was never called on this branch. The projection always ran from hardcoded defaults from November 2020 — projecting those forward to 2026 gives ~241M, not the live ~247M. (This call was already added to `main`'s `AppDelegate` in a separate commit; this PR brings the same fix to this branch and adds the debug tool + tests.)

In addition, the hardcoded fallback defaults themselves were stale (Nov 2020 baseline). These have been updated to the Dec 2025 API snapshot, reducing the cold-start gap from ~6M to <1M trees.

## Context

| before | after |
| - | - |
| Tree counter stuck at ~241M (defaults from Nov 2020) | Tree counter reflects live CloudFront data (~247M) |
|  <img src="https://github.com/user-attachments/assets/bf91a61c-e850-4289-b4ab-b932a1eeb1a7" /> | <img  src="https://github.com/user-attachments/assets/4e483489-59fd-4923-9d2e-eb9712eed46c" />  |

## Approach

- **`AppDelegate.didFinishLaunchingWithOptions`** — call `Statistics.shared.fetchAndUpdate()` once at app launch as a fire-and-forget `Task.detached`. This is identical to how `main` already handles it; the call was missing on this branch.
- **`RefreshStatisticsSetting`** (debug menu) — manual trigger in Settings → Debug: shows current tree count, confirmation dialog, then success ✅ (with updated count, auto-dismisses) or failure ❌ (with error message + OK).
- **Updated fallback defaults** — both `Statistics.swift` files updated from the 2020 baseline to the 2025-12-01 API snapshot:
  - `treesPlanted`: 113M → 244.4M
  - `timePerTree`: 1.3s → 2.2s
  - `investmentPerSecond`: 0.35 → 0.25
  - `totalInvestments`: 76.8M → 88.7M

## Other

4 new tests in `StatisticsTests.swift`:
- Network failure preserves existing values
- Malformed JSON preserves existing values
- Default-values regression pin (guards against silently changing the fallback defaults)
- Accurate projection after a live fetch

## Note: two `Statistics.swift` files

This PR edits both `firefox-ios/Ecosia/Core/Statistics/Statistics.swift` and `Ecosia/Core/Statistics/Statistics.swift`. Here's presumably why they both exist:

- The top-level `Ecosia/` directory is presumably a standalone Ecosia Framework — presumably intended to be a self-contained, independently testable module separate from the Firefox fork. It uses `public actor` (Swift 6.2 concurrency model) and is presumably what `EcosiaTests` imports via `@testable import Ecosia`.
- `firefox-ios/Ecosia/` is the version actually compiled into the app. It uses `@MainActor public final class` — presumably to stay compatible with Firefox's UI-heavy calling patterns — and is the only one referenced by Tuist's build config.
- The two files appear to be diverged copies of the same logic that need to be kept in sync manually, presumably as a transitional state while a framework extraction (MOB-3113?) is in progress.
- The presumably intended end state is for the app to depend on the top-level `Ecosia/` framework as a proper module, but that migration is presumably not yet complete.

In the meantime, any change to `Statistics.swift` defaults or logic needs to be applied to both files.

## Before merging

### Checklist

- [ ] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I wrote Unit Tests that confirm the expected behaviour
- [x] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [x] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed