### PR TITLE
[MOB-3902] Adjust CIE behaviour with product tour

### DIFF
--- a/firefox-ios/Ecosia/UI/Account/EcosiaAuthUIStateProvider.swift
+++ b/firefox-ios/Ecosia/UI/Account/EcosiaAuthUIStateProvider.swift
@@ -79,10 +79,9 @@ public class EcosiaAuthUIStateProvider: ObservableObject {
         self.username = userProfile?.name
 
         // If logged out, ensure seed count is loaded (already done in property initializer)
-        // If logged in, seed count will be updated from API in initializeState()
+        // If logged in, seed count will be updated from API when the NTP header appears
 
         setupAuthStateMonitoring()
-        initializeState()
     }
 
     deinit {
@@ -155,13 +154,6 @@ public class EcosiaAuthUIStateProvider: ObservableObject {
             Task {
                 await self?.handleSeedProgressUpdate()
             }
-        }
-    }
-
-    /// Initializes the state based on authentication status.
-    private func initializeState() {
-        Task {
-            await refreshSeedState()
         }
     }
 


### PR DESCRIPTION
[MOB-3902]

## Context

We hide the header during the product tour for logged out users (done on https://github.com/ecosia/ios-browser/pull/1074), so we want to make sure the animation is only triggered when the NTP header appears.

## Approach

Apparently simply avoiding the seed refresh on initialisation is enough to achieve that.

The seeds will refresh than only 1. when NTP appears or 2. when login state change.

[MOB-3902]: https://ecosia.atlassian.net/browse/MOB-3902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ