### PR TITLE
[MOB-4222]: Use Firefox's SettingsViewController with Ecosia Customizations

### DIFF
--- a/firefox-ios/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
@@ -7,46 +7,19 @@ import UIKit
 import Shared
 import Ecosia
 
-extension AppSettingsTableViewController {
-
-    func getEcosiaSettingsSectionsShowingDebug(_ isDebugSectionEnabled: Bool) -> [SettingSection] {
-        var sections = [
-            getSearchSection(),
-            getCustomizationSection(),
-            getEcosiaGeneralSection(),
-            getEcosiaPrivacySection(),
-            getEcosiaSupportSection(),
-            getEcosiaAboutSection()
-        ]
-
-        if User.shared.shouldShowDefaultBrowserSettingNudgeCard {
-            sections.insert(getEcosiaDefaultBrowserSection(), at: 0)
-        }
-
-        if isDebugSectionEnabled {
-            sections.append(getEcosiaDebugSupportSection())
-            sections.append(getEcosiaDebugUnleashSection())
-            sections.append(getEcosiaDebugAccountsSection())
-        }
-
-        return sections
-    }
-}
+// MARK: - Ecosia Settings Sections
+// These sections are called from generateSettings() in AppSettingsTableViewController.swift
+// to integrate Ecosia-specific settings into Firefox's settings flow.
 
 extension AppSettingsTableViewController {
 
-    // We need this section as a placeholder for the default browser nudge card.
-    private func getEcosiaDefaultBrowserSection() -> SettingSection {
-        .init(children: [DefaultBrowserSetting(theme: themeManager.getCurrentTheme(for: windowUUID))])
-    }
-
-    private func getSearchSection() -> SettingSection {
+    func getSearchSection() -> [SettingSection] {
         guard let profile else {
-            return .init(title: .init(string: .localized(.search)), children: [
+            return [SettingSection(title: .init(string: .localized(.search)), children: [
                 EcosiaDefaultBrowserSettings(),
                 SearchAreaSetting(settings: self),
                 SafeSearchSettings(settings: self)
-            ])
+            ])]
         }
         let theme = themeManager.getCurrentTheme(for: windowUUID)
         let settings: [Setting] = [
@@ -58,11 +31,11 @@ extension AppSettingsTableViewController {
             AIOverviewsSearchSettings(prefs: profile.prefs, theme: theme)
         ]
 
-        return .init(title: .init(string: .localized(.search)),
-                     children: settings)
+        return [SettingSection(title: .init(string: .localized(.search)),
+                               children: settings)]
     }
 
-    private func getCustomizationSection() -> SettingSection {
+    func getCustomizationSection() -> [SettingSection] {
         var customizationSettings: [Setting] = [
             HomepageSettings(settings: self, settingsDelegate: settingsDelegate)
         ]
@@ -78,92 +51,16 @@ extension AppSettingsTableViewController {
             customizationSettings.append(SearchBarSetting(settings: self, profile: profile, settingsDelegate: parentCoordinator))
         }
 
-        return .init(title: .init(string: .localized(.customization)),
-                     children: customizationSettings)
+        return [SettingSection(title: .init(string: .localized(.customization)),
+                               children: customizationSettings)]
     }
+}
 
-    private func getEcosiaGeneralSection() -> SettingSection {
-        guard let profile else {
-            return .init(title: .init(string: .SettingsGeneralSectionTitle),
-                         children: [
-                            ThemeSetting(settings: self, settingsDelegate: parentCoordinator),
-                            SiriPageSetting(settings: self, settingsDelegate: parentCoordinator)
-                         ])
-        }
-        let theme = themeManager.getCurrentTheme(for: windowUUID)
-        /* Ecosia: OpenWithSetting expects BrowsingSettingsDelegate; parentCoordinator is SettingsFlowDelegate so pass nil */
-        let generalSettings: [Setting] = [
-            OpenWithSetting(settings: self, settingsDelegate: nil),
-            ThemeSetting(settings: self, settingsDelegate: parentCoordinator),
-            SiriPageSetting(settings: self, settingsDelegate: parentCoordinator),
-            BlockPopupSetting(prefs: profile.prefs),
-            NoImageModeSetting(profile: profile),
-            BoolSetting(
-                prefs: profile.prefs,
-                theme: theme,
-                prefKey: "showClipboardBar",
-                defaultValue: false,
-                titleText: .SettingsOfferClipboardBarTitle,
-                statusText: String(format: .SettingsOfferClipboardBarStatus, AppName.shortName.rawValue)
-            ),
-            BoolSetting(
-                prefs: profile.prefs,
-                theme: theme,
-                prefKey: PrefsKeys.ContextMenuShowLinkPreviews,
-                defaultValue: true,
-                titleText: .SettingsShowLinkPreviewsTitle,
-                statusText: .SettingsShowLinkPreviewsStatus
-            )
-        ]
+// MARK: - Ecosia Debug Sections
 
-        return .init(title: .init(string: .SettingsGeneralSectionTitle),
-                     children: generalSettings)
-    }
+extension AppSettingsTableViewController {
 
-    private func getEcosiaSupportSection() -> SettingSection {
-        let helpCenterSetting = HelpCenterSetting()
-        let sendFeedbackSetting = EcosiaSendFeedbackSetting(settings: self)
-
-        return .init(title: NSAttributedString(string: .AppSettingsSupport),
-                     children: [helpCenterSetting, sendFeedbackSetting])
-    }
-
-    private func getEcosiaPrivacySection() -> SettingSection {
-        let theme = themeManager.getCurrentTheme(for: windowUUID)
-        var privacySettings: [Setting] = [
-            PasswordManagerSetting(settings: self, settingsDelegate: parentCoordinator),
-            ClearPrivateDataSetting(settings: self, settingsDelegate: parentCoordinator),
-            ContentBlockerSetting(settings: self, settingsDelegate: parentCoordinator),
-            EcosiaPrivacyPolicySetting(settings: self),
-            EcosiaTermsSetting(settings: self)
-        ]
-        if let profile {
-            privacySettings.insert(EcosiaSendAnonymousUsageDataSetting(prefs: profile.prefs, theme: theme), at: 2)
-            privacySettings.insert(BoolSetting(prefs: profile.prefs,
-                                               theme: theme,
-                                               prefKey: PrefsKeys.Settings.closePrivateTabs,
-                                               // Ecosia: Default value is different from Firefox
-                                               defaultValue: PrefsKeysDefaultValues.Settings.closePrivateTabs,
-                                               titleText: .AppSettingsClosePrivateTabsTitle,
-                                               statusText: .AppSettingsClosePrivateTabsDescription), at: 3)
-        }
-
-        return .init(title: NSAttributedString(string: .AppSettingsPrivacyTitle),
-                     children: privacySettings)
-    }
-
-    private func getEcosiaAboutSection() -> SettingSection {
-        let aboutSettings = [
-            AppStoreReviewSetting(settingsDelegate: parentCoordinator),
-            VersionSetting(settingsDelegate: self),
-            LicenseAndAcknowledgementsSetting(settingsDelegate: parentCoordinator),
-        ]
-
-        return .init(title: NSAttributedString(string: .AppSettingsAbout),
-                     children: aboutSettings)
-    }
-
-    private func getEcosiaDebugSupportSection() -> SettingSection {
+    func getEcosiaDebugSupportSection() -> SettingSection {
         /* Ecosia: FasterInactiveTabs removed in Firefox upgrade; re-add if type is restored */
         var hiddenDebugSettings: [Setting] = [
             ExportBrowserDataSetting(settings: self),
@@ -193,7 +90,7 @@ extension AppSettingsTableViewController {
         return SettingSection(title: NSAttributedString(string: "Debug"), children: hiddenDebugSettings)
     }
 
-    private func getEcosiaDebugUnleashSection() -> SettingSection {
+    func getEcosiaDebugUnleashSection() -> SettingSection {
         let unleashSettings: [Setting] = [
             UnleashBrazeIntegrationSetting(settings: self),
             UnleashNativeSRPVAnalyticsSetting(settings: self),
@@ -205,7 +102,7 @@ extension AppSettingsTableViewController {
         return SettingSection(title: NSAttributedString(string: "Debug - Unleash"), children: unleashSettings)
     }
 
-    private func getEcosiaDebugAccountsSection() -> SettingSection {
+    func getEcosiaDebugAccountsSection() -> SettingSection {
         let accountSettings: [Setting] = [
             ResetAccountImpactNudgeCard(settings: self),
             DebugAddSeedsLoggedOut(settings: self),

--- a/firefox-ios/Client/Ecosia/Settings/EcosiaSettings.swift
+++ b/firefox-ios/Client/Ecosia/Settings/EcosiaSettings.swift
@@ -21,6 +21,16 @@ func ecosiaDisclosureIndicator(theme: Theme) -> UIImageView {
     return disclosureIndicator
 }
 
+/// Hidden placeholder used by the nudge card section.
+/// Carries the accessibility identifier so `isDefaultBrowserCell` can identify the section,
+/// but `hidden = true` ensures no row is rendered.
+final class EcosiaDefaultBrowserNudgeCardPlaceholder: Setting {
+    override var hidden: Bool { true }
+    override var accessibilityIdentifier: String? {
+        AccessibilityIdentifiers.Settings.DefaultBrowser.defaultBrowser
+    }
+}
+
 final class EcosiaDefaultBrowserSettings: Setting {
 
     override var accessoryView: UIImageView? {

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -6,6 +6,7 @@ import Common
 import UIKit
 import Shared
 import Glean
+import Ecosia // Ecosia
 
 import struct MozillaAppServices.VisitObservation
 
@@ -322,17 +323,27 @@ class AppSettingsTableViewController: SettingsTableViewController,
     // MARK: - Generate Settings
 
     override func generateSettings() -> [SettingSection] {
-        setupDataSettings()
+        // Ecosia: removed setupDataSettings() — Ecosia does not use Firefox data-collection settings
         var settings = [SettingSection]()
-        settings += getDefaultBrowserSetting()
-        settings += getAccountSetting()
+
+        // Ecosia: conditionally show default browser nudge card
+        if User.shared.shouldShowDefaultBrowserSettingNudgeCard {
+            settings += getDefaultBrowserSetting()
+        }
+
+        // Ecosia: removed getAccountSetting() — no sign-in / accounts feature
+        settings += getSearchSection()          // Ecosia: search settings section
+        settings += getCustomizationSection()   // Ecosia: customization section
         settings += getGeneralSettings()
         settings += getPrivacySettings()
         settings += getSupportSettings()
         settings += getAboutSettings()
 
         if showDebugSettings {
-            settings += getDebugSettings()
+            // Ecosia: use Ecosia-specific debug sections
+            settings.append(getEcosiaDebugSupportSection())
+            settings.append(getEcosiaDebugUnleashSection())
+            settings.append(getEcosiaDebugAccountsSection())
         }
 
         return settings
@@ -369,44 +380,39 @@ class AppSettingsTableViewController: SettingsTableViewController,
     }
 
     private func getGeneralSettings() -> [SettingSection] {
-        var generalSettings: [Setting] = [
-            BrowsingSetting(settings: self, settingsDelegate: parentCoordinator),
-            SearchSetting(
-                settingsDelegate: parentCoordinator,
-                searchEnginesManager: searchEnginesManager,
-                theme: themeManager.getCurrentTheme(for: windowUUID)
+        // Ecosia: replaced Firefox general items (Browsing, Search, NewTab, Home, AppIcon,
+        // Summarize, Translation, SearchBar) with Ecosia-specific general settings.
+        // Items moved to Search section or Customization section are handled there.
+        guard let profile else {
+            return [SettingSection(title: NSAttributedString(string: .SettingsGeneralSectionTitle),
+                                   children: [
+                                    ThemeSetting(settings: self, settingsDelegate: parentCoordinator),
+                                    SiriPageSetting(settings: self, settingsDelegate: parentCoordinator)
+                                   ])]
+        }
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
+        let generalSettings: [Setting] = [
+            OpenWithSetting(settings: self, settingsDelegate: nil), // Ecosia: BrowsingSettingsDelegate not available here
+            ThemeSetting(settings: self, settingsDelegate: parentCoordinator),
+            SiriPageSetting(settings: self, settingsDelegate: parentCoordinator),
+            BlockPopupSetting(prefs: profile.prefs),
+            NoImageModeSetting(profile: profile),
+            BoolSetting(
+                prefs: profile.prefs,
+                theme: theme,
+                prefKey: "showClipboardBar",
+                defaultValue: false,
+                titleText: .SettingsOfferClipboardBarTitle,
+                statusText: String(format: .SettingsOfferClipboardBarStatus, AppName.shortName.rawValue)
             ),
-            NewTabPageSetting(settings: self, settingsDelegate: parentCoordinator),
-            HomeSetting(settings: self, settingsDelegate: parentCoordinator),
-            ThemeSetting(settings: self, settingsDelegate: parentCoordinator)
-        ]
-
-        if isSearchBarLocationFeatureEnabled, let profile {
-            generalSettings.append(
-                SearchBarSetting(settings: self, profile: profile, settingsDelegate: parentCoordinator)
+            BoolSetting(
+                prefs: profile.prefs,
+                theme: theme,
+                prefKey: PrefsKeys.ContextMenuShowLinkPreviews,
+                defaultValue: true,
+                titleText: .SettingsShowLinkPreviewsTitle,
+                statusText: .SettingsShowLinkPreviewsStatus
             )
-        }
-
-        // For users whose devices support alternate app icons, add the App Icon setting
-        if UIApplication.shared.supportsAlternateIcons {
-            generalSettings.append(
-                AppIconSetting(
-                    theme: themeManager.getCurrentTheme(for: windowUUID),
-                    settingsDelegate: parentCoordinator
-                )
-            )
-        }
-
-        if summarizerNimbusUtils.isSummarizeFeatureEnabled {
-            generalSettings.append(SummarizeSetting(settings: self, settingsDelegate: parentCoordinator))
-        }
-
-        if featureFlags.isFeatureEnabled(.translation, checking: .buildOnly) {
-            generalSettings.append(TranslationSetting(settings: self, settingsDelegate: parentCoordinator))
-        }
-
-        generalSettings += [
-            SiriPageSetting(settings: self, settingsDelegate: parentCoordinator)
         ]
 
         return [SettingSection(title: NSAttributedString(string: .SettingsGeneralSectionTitle),
@@ -414,94 +420,53 @@ class AppSettingsTableViewController: SettingsTableViewController,
     }
 
     private func getPrivacySettings() -> [SettingSection] {
-        var privacySettings = [Setting]()
-
-        privacySettings.append(AutofillPasswordSetting(settings: self, settingsDelegate: parentCoordinator))
-
-        privacySettings.append(ClearPrivateDataSetting(settings: self, settingsDelegate: parentCoordinator))
+        // Ecosia: replaced AutofillPasswordSetting with PasswordManagerSetting,
+        // added EcosiaSendAnonymousUsageDataSetting, removed NotificationsSetting,
+        // replaced PrivacyPolicySetting with Ecosia equivalents, added EcosiaTermsSetting
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
+        var privacySettings: [Setting] = [
+            PasswordManagerSetting(settings: self, settingsDelegate: parentCoordinator),
+            ClearPrivateDataSetting(settings: self, settingsDelegate: parentCoordinator),
+        ]
 
         if let profile {
-            privacySettings.append(
-                BoolSetting(
-                    prefs: profile.prefs,
-                    theme: themeManager.getCurrentTheme(for: windowUUID),
-                    prefKey: PrefsKeys.Settings.closePrivateTabs,
-                    defaultValue: true,
-                    titleText: .AppSettingsClosePrivateTabsTitle,
-                    statusText: .AppSettingsClosePrivateTabsDescription
-                ) { _ in
-                    let action = TabTrayAction(windowUUID: self.windowUUID,
-                                               actionType: TabTrayActionType.closePrivateTabsSettingToggled)
-                    store.dispatch(action)
-                }
-            )
+            privacySettings.append(EcosiaSendAnonymousUsageDataSetting(prefs: profile.prefs, theme: theme))
+            privacySettings.append(BoolSetting(
+                prefs: profile.prefs,
+                theme: theme,
+                prefKey: PrefsKeys.Settings.closePrivateTabs,
+                // Ecosia: default value is different from Firefox
+                defaultValue: PrefsKeysDefaultValues.Settings.closePrivateTabs,
+                titleText: .AppSettingsClosePrivateTabsTitle,
+                statusText: .AppSettingsClosePrivateTabsDescription
+            ))
         }
 
         privacySettings.append(ContentBlockerSetting(settings: self, settingsDelegate: parentCoordinator))
-
-        if let profile {
-            privacySettings.append(NotificationsSetting(theme: themeManager.getCurrentTheme(for: windowUUID),
-                                                        profile: profile,
-                                                        settingsDelegate: parentCoordinator))
-        }
-
-        privacySettings.append(PrivacyPolicySetting(theme: themeManager.getCurrentTheme(for: windowUUID),
-                                                    settingsDelegate: parentCoordinator))
+        privacySettings.append(EcosiaPrivacyPolicySetting(settings: self))
+        privacySettings.append(EcosiaTermsSetting(settings: self))
 
         return [SettingSection(title: NSAttributedString(string: .AppSettingsPrivacyTitle),
                                children: privacySettings)]
     }
 
     private func getSupportSettings() -> [SettingSection] {
-        var supportSettings = [
-            ShowIntroductionSetting(settings: self, settingsDelegate: self),
-            SendFeedbackSetting(settingsDelegate: parentCoordinator),
+        // Ecosia: replaced Firefox support items with Ecosia Help Center and Send Feedback
+        let supportSettings: [Setting] = [
+            HelpCenterSetting(),
+            EcosiaSendFeedbackSetting(settings: self)
         ]
-
-        // Only add this toggle to the Settings if Sent from Firefox feature flag is enabled from Nimbus
-        if featureFlags.isFeatureEnabled(.sentFromFirefox, checking: .buildOnly), let profile {
-            supportSettings.append(
-                SentFromFirefoxSetting(
-                    prefs: profile.prefs,
-                    delegate: settingsDelegate,
-                    theme: themeManager.getCurrentTheme(for: windowUUID),
-                    settingsDelegate: parentCoordinator
-                )
-            )
-        }
-
-        guard let sendTechnicalDataSetting,
-              let sendDailyUsagePingSetting,
-              let studiesToggleSetting,
-              let rolloutsToggleSetting,
-              let sendCrashReportsSetting else {
-            return []
-        }
-
-        supportSettings.append(contentsOf: [
-            sendTechnicalDataSetting,
-            studiesToggleSetting,
-            rolloutsToggleSetting,
-            sendDailyUsagePingSetting,
-            sendCrashReportsSetting
-        ])
-
-        supportSettings.append(contentsOf: [
-            OpenSupportPageSetting(delegate: settingsDelegate,
-                                   theme: themeManager.getCurrentTheme(for: windowUUID),
-                                   settingsDelegate: parentCoordinator),
-        ])
 
         return [SettingSection(title: NSAttributedString(string: .AppSettingsSupport),
                                children: supportSettings)]
     }
 
     private func getAboutSettings() -> [SettingSection] {
+        // Ecosia: removed YourRightsSetting
         let aboutSettings = [
             AppStoreReviewSetting(settingsDelegate: parentCoordinator),
             VersionSetting(settingsDelegate: self),
             LicenseAndAcknowledgementsSetting(settingsDelegate: parentCoordinator),
-            YourRightsSetting(settingsDelegate: parentCoordinator)
         ]
 
         return [SettingSection(title: NSAttributedString(string: .AppSettingsAbout),

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -123,6 +123,12 @@ class AppSettingsTableViewController: SettingsTableViewController,
         tableView.register(cellType: ThemedLearnMoreTableViewCell.self)
         setupNavigationBar()
         configureAccessibilityIdentifiers()
+
+        // Ecosia: Register Nudge Card if needed
+        if User.shared.shouldShowDefaultBrowserSettingNudgeCard {
+            tableView.register(DefaultBrowserSettingsNudgeCardHeaderView.self,
+                               forHeaderFooterViewReuseIdentifier: DefaultBrowserSettingsNudgeCardHeaderView.cellIdentifier)
+        }
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -350,11 +356,12 @@ class AppSettingsTableViewController: SettingsTableViewController,
     }
 
     private func getDefaultBrowserSetting() -> [SettingSection] {
-        let footerTitle = NSAttributedString(
-            string: String.FirefoxHomepage.HomeTabBanner.EvergreenMessage.HomeTabBannerDescription)
-
-        return [SettingSection(footerTitle: footerTitle,
-                               children: [DefaultBrowserSetting(theme: themeManager.getCurrentTheme(for: windowUUID))])]
+        // Ecosia: hidden placeholder section for the nudge card header.
+        // The nudge card header view is displayed via viewForHeaderInSection.
+        // The placeholder Setting carries the accessibility identifier used by isDefaultBrowserCell()
+        // but is hidden so no row is rendered — only the nudge card header is visible.
+        let placeholder = EcosiaDefaultBrowserNudgeCardPlaceholder()
+        return [SettingSection(children: [placeholder])]
     }
 
     private func getAccountSetting() -> [SettingSection] {
@@ -596,6 +603,20 @@ class AppSettingsTableViewController: SettingsTableViewController,
     // MARK: - UITableViewDelegate
 
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        // Ecosia: Show nudge card header for default browser section
+        if shouldShowDefaultBrowserNudgeCardInSection(section),
+           let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: DefaultBrowserSettingsNudgeCardHeaderView.cellIdentifier) as? DefaultBrowserSettingsNudgeCardHeaderView {
+            header.configure(theme: themeManager.getCurrentTheme(for: windowUUID))
+            header.onDismiss = { [weak self] in
+                User.shared.hideDefaultBrowserSettingNudgeCard()
+                self?.hideDefaultBrowserNudgeCardInSection(section)
+            }
+            header.onTap = { [weak self] in
+                self?.showDefaultBrowserDetailView()
+            }
+            return header
+        }
+
         guard let headerView = super.tableView(
             tableView,
             viewForHeaderInSection: section

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -329,24 +329,36 @@ class AppSettingsTableViewController: SettingsTableViewController,
     // MARK: - Generate Settings
 
     override func generateSettings() -> [SettingSection] {
-        // Ecosia: removed setupDataSettings() — Ecosia does not use Firefox data-collection settings
+        /* Ecosia: Replace Firefox settings structure with Ecosia settings
+        setupDataSettings()
         var settings = [SettingSection]()
-
-        // Ecosia: conditionally show default browser nudge card
-        if User.shared.shouldShowDefaultBrowserSettingNudgeCard {
-            settings += getDefaultBrowserSetting()
-        }
-
-        // Ecosia: removed getAccountSetting() — no sign-in / accounts feature
-        settings += getSearchSection()          // Ecosia: search settings section
-        settings += getCustomizationSection()   // Ecosia: customization section
+        settings += getDefaultBrowserSetting()
+        settings += getAccountSetting()
         settings += getGeneralSettings()
         settings += getPrivacySettings()
         settings += getSupportSettings()
         settings += getAboutSettings()
 
         if showDebugSettings {
-            // Ecosia: use Ecosia-specific debug sections
+            settings += getDebugSettings()
+        }
+
+        return settings
+        */
+        var settings = [SettingSection]()
+
+        if User.shared.shouldShowDefaultBrowserSettingNudgeCard {
+            settings += getDefaultBrowserSetting()
+        }
+
+        settings += getSearchSection()
+        settings += getCustomizationSection()
+        settings += getGeneralSettings()
+        settings += getPrivacySettings()
+        settings += getSupportSettings()
+        settings += getAboutSettings()
+
+        if showDebugSettings {
             settings.append(getEcosiaDebugSupportSection())
             settings.append(getEcosiaDebugUnleashSection())
             settings.append(getEcosiaDebugAccountsSection())
@@ -356,10 +368,13 @@ class AppSettingsTableViewController: SettingsTableViewController,
     }
 
     private func getDefaultBrowserSetting() -> [SettingSection] {
-        // Ecosia: hidden placeholder section for the nudge card header.
-        // The nudge card header view is displayed via viewForHeaderInSection.
-        // The placeholder Setting carries the accessibility identifier used by isDefaultBrowserCell()
-        // but is hidden so no row is rendered — only the nudge card header is visible.
+        /* Ecosia: Replace Firefox default browser banner with nudge card placeholder
+        let footerTitle = NSAttributedString(
+            string: String.FirefoxHomepage.HomeTabBanner.EvergreenMessage.HomeTabBannerDescription)
+
+        return [SettingSection(footerTitle: footerTitle,
+                               children: [DefaultBrowserSetting(theme: themeManager.getCurrentTheme(for: windowUUID))])]
+        */
         let placeholder = EcosiaDefaultBrowserNudgeCardPlaceholder()
         return [SettingSection(children: [placeholder])]
     }
@@ -387,9 +402,50 @@ class AppSettingsTableViewController: SettingsTableViewController,
     }
 
     private func getGeneralSettings() -> [SettingSection] {
-        // Ecosia: replaced Firefox general items (Browsing, Search, NewTab, Home, AppIcon,
-        // Summarize, Translation, SearchBar) with Ecosia-specific general settings.
-        // Items moved to Search section or Customization section are handled there.
+        /* Ecosia: Replace Firefox general settings with Ecosia general settings
+        var generalSettings: [Setting] = [
+            BrowsingSetting(settings: self, settingsDelegate: parentCoordinator),
+            SearchSetting(
+                settingsDelegate: parentCoordinator,
+                searchEnginesManager: searchEnginesManager,
+                theme: themeManager.getCurrentTheme(for: windowUUID)
+            ),
+            NewTabPageSetting(settings: self, settingsDelegate: parentCoordinator),
+            HomeSetting(settings: self, settingsDelegate: parentCoordinator),
+            ThemeSetting(settings: self, settingsDelegate: parentCoordinator)
+        ]
+
+        if isSearchBarLocationFeatureEnabled, let profile {
+            generalSettings.append(
+                SearchBarSetting(settings: self, profile: profile, settingsDelegate: parentCoordinator)
+            )
+        }
+
+        // For users whose devices support alternate app icons, add the App Icon setting
+        if UIApplication.shared.supportsAlternateIcons {
+            generalSettings.append(
+                AppIconSetting(
+                    theme: themeManager.getCurrentTheme(for: windowUUID),
+                    settingsDelegate: parentCoordinator
+                )
+            )
+        }
+
+        if summarizerNimbusUtils.isSummarizeFeatureEnabled {
+            generalSettings.append(SummarizeSetting(settings: self, settingsDelegate: parentCoordinator))
+        }
+
+        if featureFlags.isFeatureEnabled(.translation, checking: .buildOnly) {
+            generalSettings.append(TranslationSetting(settings: self, settingsDelegate: parentCoordinator))
+        }
+
+        generalSettings += [
+            SiriPageSetting(settings: self, settingsDelegate: parentCoordinator)
+        ]
+
+        return [SettingSection(title: NSAttributedString(string: .SettingsGeneralSectionTitle),
+                               children: generalSettings)]
+        */
         guard let profile else {
             return [SettingSection(title: NSAttributedString(string: .SettingsGeneralSectionTitle),
                                    children: [
@@ -399,7 +455,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
         }
         let theme = themeManager.getCurrentTheme(for: windowUUID)
         let generalSettings: [Setting] = [
-            OpenWithSetting(settings: self, settingsDelegate: nil), // Ecosia: BrowsingSettingsDelegate not available here
+            OpenWithSetting(settings: self, settingsDelegate: nil),
             ThemeSetting(settings: self, settingsDelegate: parentCoordinator),
             SiriPageSetting(settings: self, settingsDelegate: parentCoordinator),
             BlockPopupSetting(prefs: profile.prefs),
@@ -427,9 +483,44 @@ class AppSettingsTableViewController: SettingsTableViewController,
     }
 
     private func getPrivacySettings() -> [SettingSection] {
-        // Ecosia: replaced AutofillPasswordSetting with PasswordManagerSetting,
-        // added EcosiaSendAnonymousUsageDataSetting, removed NotificationsSetting,
-        // replaced PrivacyPolicySetting with Ecosia equivalents, added EcosiaTermsSetting
+        /* Ecosia: Replace Firefox privacy settings with Ecosia privacy settings
+        var privacySettings = [Setting]()
+
+        privacySettings.append(AutofillPasswordSetting(settings: self, settingsDelegate: parentCoordinator))
+
+        privacySettings.append(ClearPrivateDataSetting(settings: self, settingsDelegate: parentCoordinator))
+
+        if let profile {
+            privacySettings.append(
+                BoolSetting(
+                    prefs: profile.prefs,
+                    theme: themeManager.getCurrentTheme(for: windowUUID),
+                    prefKey: PrefsKeys.Settings.closePrivateTabs,
+                    defaultValue: true,
+                    titleText: .AppSettingsClosePrivateTabsTitle,
+                    statusText: .AppSettingsClosePrivateTabsDescription
+                ) { _ in
+                    let action = TabTrayAction(windowUUID: self.windowUUID,
+                                               actionType: TabTrayActionType.closePrivateTabsSettingToggled)
+                    store.dispatch(action)
+                }
+            )
+        }
+
+        privacySettings.append(ContentBlockerSetting(settings: self, settingsDelegate: parentCoordinator))
+
+        if let profile {
+            privacySettings.append(NotificationsSetting(theme: themeManager.getCurrentTheme(for: windowUUID),
+                                                        profile: profile,
+                                                        settingsDelegate: parentCoordinator))
+        }
+
+        privacySettings.append(PrivacyPolicySetting(theme: themeManager.getCurrentTheme(for: windowUUID),
+                                                    settingsDelegate: parentCoordinator))
+
+        return [SettingSection(title: NSAttributedString(string: .AppSettingsPrivacyTitle),
+                               children: privacySettings)]
+        */
         let theme = themeManager.getCurrentTheme(for: windowUUID)
         var privacySettings: [Setting] = [
             PasswordManagerSetting(settings: self, settingsDelegate: parentCoordinator),
@@ -442,7 +533,6 @@ class AppSettingsTableViewController: SettingsTableViewController,
                 prefs: profile.prefs,
                 theme: theme,
                 prefKey: PrefsKeys.Settings.closePrivateTabs,
-                // Ecosia: default value is different from Firefox
                 defaultValue: PrefsKeysDefaultValues.Settings.closePrivateTabs,
                 titleText: .AppSettingsClosePrivateTabsTitle,
                 statusText: .AppSettingsClosePrivateTabsDescription
@@ -458,7 +548,49 @@ class AppSettingsTableViewController: SettingsTableViewController,
     }
 
     private func getSupportSettings() -> [SettingSection] {
-        // Ecosia: replaced Firefox support items with Ecosia Help Center and Send Feedback
+        /* Ecosia: Replace Firefox support settings with Ecosia support settings
+        var supportSettings = [
+            ShowIntroductionSetting(settings: self, settingsDelegate: self),
+            SendFeedbackSetting(settingsDelegate: parentCoordinator),
+        ]
+
+        // Only add this toggle to the Settings if Sent from Firefox feature flag is enabled from Nimbus
+        if featureFlags.isFeatureEnabled(.sentFromFirefox, checking: .buildOnly), let profile {
+            supportSettings.append(
+                SentFromFirefoxSetting(
+                    prefs: profile.prefs,
+                    delegate: settingsDelegate,
+                    theme: themeManager.getCurrentTheme(for: windowUUID),
+                    settingsDelegate: parentCoordinator
+                )
+            )
+        }
+
+        guard let sendTechnicalDataSetting,
+              let sendDailyUsagePingSetting,
+              let studiesToggleSetting,
+              let rolloutsToggleSetting,
+              let sendCrashReportsSetting else {
+            return []
+        }
+
+        supportSettings.append(contentsOf: [
+            sendTechnicalDataSetting,
+            studiesToggleSetting,
+            rolloutsToggleSetting,
+            sendDailyUsagePingSetting,
+            sendCrashReportsSetting
+        ])
+
+        supportSettings.append(contentsOf: [
+            OpenSupportPageSetting(delegate: settingsDelegate,
+                                   theme: themeManager.getCurrentTheme(for: windowUUID),
+                                   settingsDelegate: parentCoordinator),
+        ])
+
+        return [SettingSection(title: NSAttributedString(string: .AppSettingsSupport),
+                               children: supportSettings)]
+        */
         let supportSettings: [Setting] = [
             HelpCenterSetting(),
             EcosiaSendFeedbackSetting(settings: self)
@@ -469,11 +601,13 @@ class AppSettingsTableViewController: SettingsTableViewController,
     }
 
     private func getAboutSettings() -> [SettingSection] {
-        // Ecosia: removed YourRightsSetting
         let aboutSettings = [
             AppStoreReviewSetting(settingsDelegate: parentCoordinator),
             VersionSetting(settingsDelegate: self),
             LicenseAndAcknowledgementsSetting(settingsDelegate: parentCoordinator),
+            /* Ecosia: Remove YourRightsSetting
+            YourRightsSetting(settingsDelegate: parentCoordinator)
+            */
         ]
 
         return [SettingSection(title: NSAttributedString(string: .AppSettingsAbout),

--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -6,7 +6,7 @@ import Common
 import UIKit
 import Shared
 import Glean
-import Ecosia // Ecosia
+import Ecosia
 
 import struct MozillaAppServices.VisitObservation
 


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-4222] Use Firefox's SettingsViewController with Ecosia Customizations
-->

[MOB-4222]

## Context

Re-integrates Ecosia Customizations to Firefox's AppSettingsTableViewController

| | | |
|---|---|---|
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-03-18 at 16 05 04" src="https://github.com/user-attachments/assets/95c33b82-d413-40db-b2a5-5d375886ade8" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-03-18 at 16 05 11" src="https://github.com/user-attachments/assets/7e1e4d0f-f7d1-4b5c-a1ac-2dd2a7baaf07" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-03-18 at 16 05 16" src="https://github.com/user-attachments/assets/7d39366b-16d1-48e2-9fca-2d8378399880" /> |

## Approach

## Other

## Before merging

### Checklist

- [ ] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [ ] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4222]: https://ecosia.atlassian.net/browse/MOB-4222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ