### PR TITLE
[MOB-4246] Fix first search NTP description width

### DIFF
--- a/firefox-ios/Client/Ecosia/UI/NTP/FirstSearch/NTPFirstSearchView.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/FirstSearch/NTPFirstSearchView.swift
@@ -57,6 +57,7 @@ struct NTPFirstSearchView: View {
                             .font(.subheadline)
                             .foregroundColor(theme.textSecondary)
                             .multilineTextAlignment(.center)
+                            .fixedSize(horizontal: false, vertical: true)
 
                         // Search suggestions
                         if !suggestions.isEmpty {


### PR DESCRIPTION
[MOB-4246]

## Context

Text was cropped on specific language region configurations.

## Approach

This was caused by a SwiftUI compression issue when the pills were wider and caused more rows, consuming more vertical space.

To fix it making sure the text doesn't compress vertically.

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad

[MOB-4246]: https://ecosia.atlassian.net/browse/MOB-4246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ