### PR TITLE
[MOB-4251] Move inapp search to webView didCommit

### DIFF
--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+EcosiaNavigationHandling.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+EcosiaNavigationHandling.swift
@@ -10,6 +10,7 @@ import Ecosia
 extension BrowserViewController {
 
     /// Handles any Ecosia-specific tracking when a navigation action is allowed.
+    /// Stores a pending URL to be tracked at didCommit.
     /// - Parameters:
     ///   - url: The URL being navigated to
     ///   - navigationAction: The navigation action that triggered this check
@@ -20,6 +21,9 @@ extension BrowserViewController {
         navigationAction: WKNavigationAction,
         previousUrl: URL?
     ) -> URL {
+        // Clear any stale pending tracking from a previous navigation
+        pendingInappSearchUrl = nil
+
         guard url.isEcosiaSearchVertical() else {
             return url
         }
@@ -32,9 +36,19 @@ extension BrowserViewController {
             return url
         }
 
-        Analytics.shared.inappSearch(url: url)
+        // Store the URL; the event fires in ecosiaHandleDidCommit when content starts rendering
+        pendingInappSearchUrl = url
 
         return url
+    }
+
+    /// Fires the in-app search event when the web content starts to be received (didCommit).
+    /// This matches the timing of Vue's mounted event on web (DOM ready, before full page load).
+    /// - Parameter url: The URL that just committed
+    func ecosiaHandleDidCommit(url: URL) {
+        guard url == pendingInappSearchUrl else { return }
+        pendingInappSearchUrl = nil
+        Analytics.shared.inappSearch(url: url)
     }
 
     /// Handles any tasks that should run after a page finishes loading.

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -881,6 +881,11 @@ extension BrowserViewController: WKNavigationDelegate {
               let metadataManager = tab.metadataManager
         else { return }
 
+        // Ecosia: Fire in-app search event at commit time (closest to Vue's mounted on web)
+        if let url = webView.url {
+            ecosiaHandleDidCommit(url: url)
+        }
+
         searchTelemetry?.trackTabAndTopSiteSAP(tab, webView: webView)
         webviewTelemetry.start()
         tab.url = webView.url

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -39,6 +39,11 @@ class BrowserViewController: UIViewController,
     // (for now this is not cleared across sections or tabs, but shouldn't be an issue)
     var previousUrl: URL?
 
+    // Ecosia: Bridges eligibility (checked in decidePolicyFor, where WKNavigationAction
+    // and its navigationType are available) to the actual tracking call in didCommit.
+    // Set when eligible, cleared on commit or on the next navigation.
+    var pendingInappSearchUrl: URL?
+
     private enum UX {
         static let ShowHeaderTapAreaHeight: CGFloat = 32
         static let ActionSheetTitleMaxLength = 120

--- a/firefox-ios/EcosiaTests/Analytics/AnalyticsSpyTests.swift
+++ b/firefox-ios/EcosiaTests/Analytics/AnalyticsSpyTests.swift
@@ -648,12 +648,13 @@ final class AnalyticsSpyTests: XCTestCase {
             analyticsSpy = AnalyticsSpy()
             Analytics.shared = analyticsSpy
             let url = URL(string: urlString)!
-            var action = FakeNavigationAction(url: url,
-                                              navigationType: .other)
+            let action = FakeNavigationAction(url: url, navigationType: .other)
             browser.webView(makeWebView(),
                             decidePolicyFor: action) { policy in
                 XCTAssertEqual(policy, .allow, "Should allow independent of tracking behavior")
             }
+            // inappSearch is now fired at didCommit, not decidePolicyFor
+            browser.ecosiaHandleDidCommit(url: url)
 
             if shouldTrack {
                 XCTAssertEqual(analyticsSpy.inappSearchUrlCalled?.absoluteString,
@@ -681,12 +682,12 @@ final class AnalyticsSpyTests: XCTestCase {
             analyticsSpy = AnalyticsSpy()
             Analytics.shared = analyticsSpy
             let url = URL(string: urlString)!
-            var action = FakeNavigationAction(url: url,
-                                              navigationType: type)
+            let action = FakeNavigationAction(url: url, navigationType: type)
             browser.webView(makeWebView(),
                             decidePolicyFor: action) { policy in
                 XCTAssertEqual(policy, .allow, "Should allow independent of tracking behavior")
             }
+            browser.ecosiaHandleDidCommit(url: url)
 
             if shouldTrack {
                 XCTAssertEqual(analyticsSpy.inappSearchUrlCalled?.absoluteString,
@@ -698,6 +699,26 @@ final class AnalyticsSpyTests: XCTestCase {
             analyticsSpy = nil
             Analytics.shared = Analytics()
         }
+    }
+
+    func testEcosiaHandleDidCommitDoesNotFireWhenURLDoesNotMatchPending() {
+        let browser = BrowserViewController(profile: profileMock, tabManager: tabManagerMock)
+        analyticsSpy = AnalyticsSpy()
+        Analytics.shared = analyticsSpy
+
+        let rootURL = EcosiaEnvironment.current.urlProvider.root
+        let searchUrl = URL(string: "\(rootURL)/search?q=test")!
+        let differentUrl = URL(string: "\(rootURL)/images?q=test")!
+
+        // Simulate decidePolicyFor setting the pending URL to searchUrl
+        let action = FakeNavigationAction(url: searchUrl, navigationType: .other)
+        browser.webView(makeWebView(), decidePolicyFor: action) { _ in }
+
+        // didCommit fires with a different URL (e.g. a redirect landed elsewhere)
+        browser.ecosiaHandleDidCommit(url: differentUrl)
+
+        XCTAssertNil(analyticsSpy.inappSearchUrlCalled,
+                     "Should not track when committed URL does not match pending URL")
     }
 
     // MARK: - Analytics Context Tests


### PR DESCRIPTION
[MOB-4251]

## Context

See ticket

## Approach

Move trigger to webView `didCommit` since that is much closer to web behaviour.

Had to still use the navigation type properties from `decidePolicyFor` as they are not present on `didCommit`, so introducing a bridge variable.

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I added the `// Ecosia:` helper comments where needed

[MOB-4251]: https://ecosia.atlassian.net/browse/MOB-4251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ