### PR TITLE
[MOB-4254] Handle same url search event

### DIFF
--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+EcosiaNavigationHandling.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+EcosiaNavigationHandling.swift
@@ -14,33 +14,19 @@ extension BrowserViewController {
     /// - Parameters:
     ///   - url: The URL being navigated to
     ///   - navigationAction: The navigation action that triggered this check
-    ///   - previousUrl: The previously loaded URL for comparison
-    /// - Returns: The URL to set as the new previousUrl
-    func ecosiaHandleNavigationAction(
-        url: URL,
-        navigationAction: WKNavigationAction,
-        previousUrl: URL?
-    ) -> URL {
+    func ecosiaHandleNavigationAction(url: URL, navigationAction: WKNavigationAction) {
         // Clear any stale pending tracking from a previous navigation
         pendingInappSearchUrl = nil
 
-        guard url.isEcosiaSearchVertical() else {
-            return url
-        }
+        guard url.isEcosiaSearchVertical() else { return }
 
-        // Tab restoration (e.g. switching back to a memory-evicted tab) fires with navigationType
-        // .other and the same URL. Genuine user navigations (.linkActivated, .reload, etc.)
-        // should always be tracked, even for the same URL (matching web behaviour).
-        let isBackForward = navigationAction.navigationType == .backForward
-        let isTabRestore = url == previousUrl && navigationAction.navigationType == .other
-        guard !isBackForward && !isTabRestore else {
-            return url
-        }
+        // Back/forward navigations are suppressed: on web, bfcache keeps the page mounted so
+        // Vue never refires. Tab switching doesn't reach this delegate at all, so any other
+        // navigation type arriving here is a genuine user action and should always track.
+        guard navigationAction.navigationType != .backForward else { return }
 
         // Store the URL; the event fires in ecosiaHandleDidCommit when content starts rendering
         pendingInappSearchUrl = url
-
-        return url
     }
 
     /// Fires the in-app search event when the web content starts to be received (didCommit).

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+EcosiaNavigationHandling.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+EcosiaNavigationHandling.swift
@@ -28,11 +28,12 @@ extension BrowserViewController {
             return url
         }
 
-        // Only process if not navigating back/forward and either URL changed or it's a reload
-        let urlChanged = url != previousUrl
-        let isReload = navigationAction.navigationType == .reload
+        // Tab restoration (e.g. switching back to a memory-evicted tab) fires with navigationType
+        // .other and the same URL. Genuine user navigations (.linkActivated, .reload, etc.)
+        // should always be tracked, even for the same URL (matching web behaviour).
         let isBackForward = navigationAction.navigationType == .backForward
-        guard !isBackForward && (urlChanged || isReload) else {
+        let isTabRestore = url == previousUrl && navigationAction.navigationType == .other
+        guard !isBackForward && !isTabRestore else {
             return url
         }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -607,11 +607,7 @@ extension BrowserViewController: WKNavigationDelegate {
             }
 
             // Ecosia: Handle navigation tracking
-            previousUrl = ecosiaHandleNavigationAction(
-                url: url,
-                navigationAction: navigationAction,
-                previousUrl: previousUrl
-            )
+            ecosiaHandleNavigationAction(url: url, navigationAction: navigationAction)
 
             decisionHandler(.allow)
             return

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -35,10 +35,6 @@ class BrowserViewController: UIViewController,
                              AddressToolbarContainerDelegate,
                              FeatureFlaggable {
 
-    // Ecosia: Tracks the last committed search URL to detect tab restoration
-    // (same URL + navigationType .other), which should not fire an event.
-    var previousUrl: URL?
-
     // Ecosia: Bridges eligibility (checked in decidePolicyFor, where WKNavigationAction
     // and its navigationType are available) to the actual tracking call in didCommit.
     // Set when eligible, cleared on commit or on the next navigation.

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -35,8 +35,8 @@ class BrowserViewController: UIViewController,
                              AddressToolbarContainerDelegate,
                              FeatureFlaggable {
 
-    // Ecosia: Used inside webview delegate to decide if search should be tracked
-    // (for now this is not cleared across sections or tabs, but shouldn't be an issue)
+    // Ecosia: Tracks the last committed search URL to detect tab restoration
+    // (same URL + navigationType .other), which should not fire an event.
     var previousUrl: URL?
 
     // Ecosia: Bridges eligibility (checked in decidePolicyFor, where WKNavigationAction

--- a/firefox-ios/EcosiaTests/Analytics/AnalyticsSpyTests.swift
+++ b/firefox-ios/EcosiaTests/Analytics/AnalyticsSpyTests.swift
@@ -636,7 +636,7 @@ final class AnalyticsSpyTests: XCTestCase {
             ("https://www.example.org", false, "Does not track external URLs"),
             ("\(rootURL)", false, "Does not track index page"),
             ("\(rootURL)/search?q=test", true, "Tracks search query"),
-            ("\(rootURL)/search?q=test", false, "Does not track tab restoration (same URL, .other type)"),
+            ("\(rootURL)/search?q=test", true, "Tracks same URL again with .other type"),
             ("\(rootURL)/images?q=test1", true, "Tracks images query"),
             ("\(rootURL)/news?q=test2&p=1", true, "Tracks news query"),
             ("\(rootURL)/videos?q=test3", true, "Tracks videos query"),
@@ -674,8 +674,8 @@ final class AnalyticsSpyTests: XCTestCase {
         let rootURL = EcosiaEnvironment.current.urlProvider.root
         let testCases = [
             (WKNavigationType.other, "\(rootURL)/search?q=test", true, "Tracks regular navigation"),
-            (WKNavigationType.reload, "\(rootURL)/search?q=test", true, "Tracks reload (with unchanged url)"),
-            (WKNavigationType.backForward, "\(rootURL)/search?q=test1", false, "Does not track back forward"),
+            (WKNavigationType.reload, "\(rootURL)/search?q=test", true, "Tracks reload"),
+            (WKNavigationType.backForward, "\(rootURL)/search?q=test", false, "Does not track back/forward"),
         ]
 
         for (type, urlString, shouldTrack, message) in testCases {
@@ -706,7 +706,7 @@ final class AnalyticsSpyTests: XCTestCase {
         let rootURL = EcosiaEnvironment.current.urlProvider.root
         let url = URL(string: "\(rootURL)/search?q=test")!
 
-        // Load the URL once so previousUrl is set
+        // Load the URL once to establish it as the current page
         let firstAction = FakeNavigationAction(url: url, navigationType: .other)
         browser.webView(makeWebView(), decidePolicyFor: firstAction) { _ in }
         browser.ecosiaHandleDidCommit(url: url)

--- a/firefox-ios/EcosiaTests/Analytics/AnalyticsSpyTests.swift
+++ b/firefox-ios/EcosiaTests/Analytics/AnalyticsSpyTests.swift
@@ -636,7 +636,7 @@ final class AnalyticsSpyTests: XCTestCase {
             ("https://www.example.org", false, "Does not track external URLs"),
             ("\(rootURL)", false, "Does not track index page"),
             ("\(rootURL)/search?q=test", true, "Tracks search query"),
-            ("\(rootURL)/search?q=test", false, "Does not track if url did not change"),
+            ("\(rootURL)/search?q=test", false, "Does not track tab restoration (same URL, .other type)"),
             ("\(rootURL)/images?q=test1", true, "Tracks images query"),
             ("\(rootURL)/news?q=test2&p=1", true, "Tracks news query"),
             ("\(rootURL)/videos?q=test3", true, "Tracks videos query"),
@@ -699,6 +699,28 @@ final class AnalyticsSpyTests: XCTestCase {
             analyticsSpy = nil
             Analytics.shared = Analytics()
         }
+    }
+
+    func testWebViewDelegateTracksSearchEventOnSameURLWhenLinkActivated() {
+        let browser = BrowserViewController(profile: profileMock, tabManager: tabManagerMock)
+        let rootURL = EcosiaEnvironment.current.urlProvider.root
+        let url = URL(string: "\(rootURL)/search?q=test")!
+
+        // Load the URL once so previousUrl is set
+        let firstAction = FakeNavigationAction(url: url, navigationType: .other)
+        browser.webView(makeWebView(), decidePolicyFor: firstAction) { _ in }
+        browser.ecosiaHandleDidCommit(url: url)
+
+        // Navigate to the same URL again via link activation (e.g. tapping the same search vertical)
+        analyticsSpy = AnalyticsSpy()
+        Analytics.shared = analyticsSpy
+        let secondAction = FakeNavigationAction(url: url, navigationType: .linkActivated)
+        browser.webView(makeWebView(), decidePolicyFor: secondAction) { _ in }
+        browser.ecosiaHandleDidCommit(url: url)
+
+        XCTAssertEqual(analyticsSpy.inappSearchUrlCalled?.absoluteString,
+                       url.absoluteString,
+                       "Should track same URL when navigated via link activation, not treated as tab restore")
     }
 
     func testEcosiaHandleDidCommitDoesNotFireWhenURLDoesNotMatchPending() {


### PR DESCRIPTION
[MOB-4254]

## Context

The `previousUrl` check was introduced to prevent tab switching from re-firing the inapp search event. In practice, tab switching never reaches `didCommit` — WKWebView handles it at the view level without     
  triggering navigation delegates. The check was solving a phantom problem, and as a side effect was incorrectly suppressing legitimate same-URL navigations (e.g. tapping a search vertical you're already on).

Depends on https://github.com/ecosia/ios-browser/pull/1083 being merged first ❗

## Approach

Remove url check and simplified logic.

The only guard retained is `!isBackForward`, matching web behaviour where bfcache keeps the page mounted across back/forward so Vue never refires.

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I added the `// Ecosia:` helper comments where needed

[MOB-4254]: https://ecosia.atlassian.net/browse/MOB-4254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ