### PR TITLE
[MOB-4275] Anonymise inapp search incognito

### DIFF
--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+EcosiaNavigationHandling.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+EcosiaNavigationHandling.swift
@@ -31,11 +31,13 @@ extension BrowserViewController {
 
     /// Fires the in-app search event when the web content starts to be received (didCommit).
     /// This matches the timing of Vue's mounted event on web (DOM ready, before full page load).
-    /// - Parameter url: The URL that just committed
-    func ecosiaHandleDidCommit(url: URL) {
+    /// - Parameters:
+    ///   - url: The URL that just committed
+    ///   - isPrivate: Whether the tab is in private browsing mode
+    func ecosiaHandleDidCommit(url: URL, isPrivate: Bool) {
         guard url == pendingInappSearchUrl else { return }
         pendingInappSearchUrl = nil
-        Analytics.shared.inappSearch(url: url)
+        Analytics.shared.inappSearch(url: url, isPrivate: isPrivate)
     }
 
     /// Handles any tasks that should run after a page finishes loading.

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -879,7 +879,7 @@ extension BrowserViewController: WKNavigationDelegate {
 
         // Ecosia: Fire in-app search event at commit time (closest to Vue's mounted on web)
         if let url = webView.url {
-            ecosiaHandleDidCommit(url: url)
+            ecosiaHandleDidCommit(url: url, isPrivate: tab.isPrivate)
         }
 
         searchTelemetry?.trackTabAndTopSiteSAP(tab, webView: webView)

--- a/firefox-ios/Ecosia/Analytics/Analytics+Configuration.swift
+++ b/firefox-ios/Ecosia/Analytics/Analytics+Configuration.swift
@@ -25,6 +25,20 @@ extension Analytics {
     static let subjectConfiguration = SubjectConfiguration()
         .userId(User.shared.analyticsId.uuidString)
 
+    /// Tracker configuration for private browsing sessions.
+    /// - Identical to `trackerConfiguration` but with `userAnonymisation` enabled,
+    ///   which strips userId, session userId, previousSessionId, and IDFA/IDFV from all events.
+    static let privateTrackerConfiguration = TrackerConfiguration()
+        .appId(Bundle.version)
+        .sessionContext(true)
+        .applicationContext(true)
+        .platformContext(true)
+        .platformContextProperties([.appleIdfv])
+        .geoLocationContext(true)
+        .deepLinkContext(false)
+        .screenContext(false)
+        .userAnonymisation(true)
+
     /// Configuration for the daily tracking plugin.
     /// - This plugin filters events based on whether a day has passed since the last check for a specific identifier.
     /// - It specifically filters structured events related to in-app navigation and resume actions.

--- a/firefox-ios/Ecosia/Analytics/Analytics+Configuration.swift
+++ b/firefox-ios/Ecosia/Analytics/Analytics+Configuration.swift
@@ -25,19 +25,10 @@ extension Analytics {
     static let subjectConfiguration = SubjectConfiguration()
         .userId(User.shared.analyticsId.uuidString)
 
-    /// Tracker configuration for private browsing sessions.
-    /// - Identical to `trackerConfiguration` but with `userAnonymisation` enabled,
-    ///   which strips userId, session userId, previousSessionId, and IDFA/IDFV from all events.
-    static let privateTrackerConfiguration = TrackerConfiguration()
-        .appId(Bundle.version)
-        .sessionContext(true)
-        .applicationContext(true)
-        .platformContext(true)
-        .platformContextProperties([.appleIdfv])
-        .geoLocationContext(true)
-        .deepLinkContext(false)
-        .screenContext(false)
-        .userAnonymisation(true)
+    /// Subject configuration for private browsing sessions.
+    /// - Sets the userId to a null UUID so the field is present but carries no identifying value.
+    static let privateSubjectConfiguration = SubjectConfiguration()
+        .userId(UUID(uuid: UUID_NULL).uuidString)
 
     /// Configuration for the daily tracking plugin.
     /// - This plugin filters events based on whether a day has passed since the last check for a specific identifier.

--- a/firefox-ios/Ecosia/Analytics/Analytics.swift
+++ b/firefox-ios/Ecosia/Analytics/Analytics.swift
@@ -13,6 +13,7 @@ open class Analytics {
     static let impactBalanceSchema = "iglu:org.ecosia/impact_balance/jsonschema/1-0-0"
     private static let abTestRoot = "ab_tests"
     private static let namespace = "ios_sp"
+    private static let privateNamespace = "ios_sp_private"
     static let installSchema = "iglu:org.ecosia/ios_install_event/jsonschema/1-0-0"
     static let userSchema = "iglu:org.ecosia/app_user_state_context/jsonschema/1-0-0"
     static let inappSearchSchema = "iglu:org.ecosia/inapp_search_event/jsonschema/1-0-1"
@@ -29,6 +30,7 @@ open class Analytics {
 
     public static var shared = Analytics()
     private var tracker: TrackerController
+    private var privateTracker: TrackerController
     private let notificationCenter: AnalyticsUserNotificationCenterProtocol
 
     internal init(notificationCenter: AnalyticsUserNotificationCenterProtocol = AnalyticsUserNotificationCenterWrapper()) {
@@ -39,21 +41,23 @@ open class Analytics {
         tracker.screenEngagementAutotracking = false
         tracker.exceptionAutotracking = false
         tracker.diagnosticAutotracking = false
+        privateTracker = Self.makePrivateTracker()
         self.notificationCenter = notificationCenter
     }
 
-    internal func track(_ event: SnowplowTracker.Event) {
+    internal func track(_ event: SnowplowTracker.Event, isPrivate: Bool = false) {
         guard User.shared.sendAnonymousUsageData else { return }
         if let structuredEvent = event as? Structured {
             appendContextIfNeeded(to: structuredEvent)
         }
 #if !TESTING
-        _ = tracker.track(event)
+        _ = (isPrivate ? privateTracker : tracker).track(event)
 #endif
     }
 
     private static func updateTrackerController() {
         Analytics.shared.tracker = makeTracker()
+        Analytics.shared.privateTracker = makePrivateTracker()
     }
 
     private static func getTestContext(from toggle: Unleash.Toggle.Name) -> SelfDescribingJson? {
@@ -68,6 +72,7 @@ open class Analytics {
     public func reset() {
         User.shared.analyticsId = .init()
         tracker = Self.makeTracker()
+        privateTracker = Self.makePrivateTracker()
     }
 
     // MARK: App events
@@ -306,7 +311,7 @@ open class Analytics {
     }
 
     // MARK: In-App Search
-    public func inappSearch(url: URL) {
+    public func inappSearch(url: URL, isPrivate: Bool = false) {
         // Note: This functionality was previously guarded/throttled by the mob_ios_native_srpv_analytics feature flag
         // and has been permanently enabled/unthrottled as part of MOB-4040
         guard let query = url.getEcosiaSearchQuery() else {
@@ -320,7 +325,8 @@ open class Analytics {
             "search_type": url.getEcosiaSearchVerticalPath()
         ]
         track(SelfDescribing(schema: Self.inappSearchSchema,
-                             payload: payload.compactMapValues({ $0 })))
+                             payload: payload.compactMapValues({ $0 })),
+              isPrivate: isPrivate)
     }
 
     // MARK: Settings
@@ -536,6 +542,24 @@ extension Analytics {
                                         Self.subjectConfiguration,
                                         Self.appInstallTrackingPluginConfiguration,
                                         Self.appResumeDailyTrackingPluginConfiguration])
+    }
+
+    /// Creates and configures a tracker for private browsing.
+    /// Uses `userAnonymisation` to strip all user identifiers (userId, session userId, IDFA/IDFV).
+    /// No subject configuration is applied, so no `userId` is ever set.
+    private static func makePrivateTracker() -> TrackerController {
+        let controller = Snowplow.createTracker(namespace: privateNamespace,
+                                                network: makeNetworkConfig(),
+                                                configurations: [
+                                                    Self.privateTrackerConfiguration,
+                                                    Self.appResumeDailyTrackingPluginConfiguration])
+        controller.installAutotracking = false
+        controller.screenViewAutotracking = false
+        controller.lifecycleAutotracking = false
+        controller.screenEngagementAutotracking = false
+        controller.exceptionAutotracking = false
+        controller.diagnosticAutotracking = false
+        return controller
     }
 
     /// Factory that builds the `NetworkConfiguration` for the Snowplow tracker, optionally

--- a/firefox-ios/Ecosia/Analytics/Analytics.swift
+++ b/firefox-ios/Ecosia/Analytics/Analytics.swift
@@ -13,7 +13,7 @@ open class Analytics {
     static let impactBalanceSchema = "iglu:org.ecosia/impact_balance/jsonschema/1-0-0"
     private static let abTestRoot = "ab_tests"
     private static let namespace = "ios_sp"
-    private static let privateNamespace = "ios_sp_private"
+    private static let privateNamespace = "ios_sp_anonymous"
     static let installSchema = "iglu:org.ecosia/ios_install_event/jsonschema/1-0-0"
     static let userSchema = "iglu:org.ecosia/app_user_state_context/jsonschema/1-0-0"
     static let inappSearchSchema = "iglu:org.ecosia/inapp_search_event/jsonschema/1-0-1"

--- a/firefox-ios/Ecosia/Analytics/Analytics.swift
+++ b/firefox-ios/Ecosia/Analytics/Analytics.swift
@@ -35,12 +35,6 @@ open class Analytics {
 
     internal init(notificationCenter: AnalyticsUserNotificationCenterProtocol = AnalyticsUserNotificationCenterWrapper()) {
         tracker = Self.makeTracker()
-        tracker.installAutotracking = true
-        tracker.screenViewAutotracking = false
-        tracker.lifecycleAutotracking = false
-        tracker.screenEngagementAutotracking = false
-        tracker.exceptionAutotracking = false
-        tracker.diagnosticAutotracking = false
         privateTracker = Self.makePrivateTracker()
         self.notificationCenter = notificationCenter
     }
@@ -535,31 +529,37 @@ extension Analytics {
     ///
     /// - Returns: A configured `TrackerController` instance, which in non-release builds can either point to mini or micro Snowplow instance.
     private static func makeTracker() -> TrackerController {
-        return Snowplow.createTracker(namespace: namespace,
-                                      network: makeNetworkConfig(),
-                                      configurations: [
-                                        Self.trackerConfiguration,
-                                        Self.subjectConfiguration,
-                                        Self.appInstallTrackingPluginConfiguration,
-                                        Self.appResumeDailyTrackingPluginConfiguration])
+        let controller = Snowplow.createTracker(namespace: namespace,
+                                                network: makeNetworkConfig(),
+                                                configurations: [
+                                                    Self.trackerConfiguration,
+                                                    Self.subjectConfiguration,
+                                                    Self.appInstallTrackingPluginConfiguration,
+                                                    Self.appResumeDailyTrackingPluginConfiguration])
+        configure(controller, installAutotracking: true)
+        return controller
     }
 
     /// Creates and configures a tracker for private browsing.
-    /// Uses `userAnonymisation` to strip all user identifiers (userId, session userId, IDFA/IDFV).
-    /// No subject configuration is applied, so no `userId` is ever set.
+    /// Sets userId to an all-zeros UUID so the field is present but carries no identifying value.
     private static func makePrivateTracker() -> TrackerController {
         let controller = Snowplow.createTracker(namespace: privateNamespace,
                                                 network: makeNetworkConfig(),
                                                 configurations: [
-                                                    Self.privateTrackerConfiguration,
+                                                    Self.trackerConfiguration,
+                                                    Self.privateSubjectConfiguration,
                                                     Self.appResumeDailyTrackingPluginConfiguration])
-        controller.installAutotracking = false
-        controller.screenViewAutotracking = false
-        controller.lifecycleAutotracking = false
-        controller.screenEngagementAutotracking = false
-        controller.exceptionAutotracking = false
-        controller.diagnosticAutotracking = false
+        configure(controller, installAutotracking: false)
         return controller
+    }
+
+    private static func configure(_ tracker: TrackerController, installAutotracking: Bool) {
+        tracker.installAutotracking = installAutotracking
+        tracker.screenViewAutotracking = false
+        tracker.lifecycleAutotracking = false
+        tracker.screenEngagementAutotracking = false
+        tracker.exceptionAutotracking = false
+        tracker.diagnosticAutotracking = false
     }
 
     /// Factory that builds the `NetworkConfiguration` for the Snowplow tracker, optionally

--- a/firefox-ios/EcosiaTests/Analytics/AnalyticsSpyTests.swift
+++ b/firefox-ios/EcosiaTests/Analytics/AnalyticsSpyTests.swift
@@ -20,8 +20,8 @@ final class AnalyticsSpy: Analytics {
 
     var trackedEvents: [SnowplowTracker.Event] = []
 
-    override func track(_ event: SnowplowTracker.Event) {
-        super.track(event)
+    override func track(_ event: SnowplowTracker.Event, isPrivate: Bool = false) {
+        super.track(event, isPrivate: isPrivate)
         trackedEvents.append(event)
     }
 
@@ -118,8 +118,10 @@ final class AnalyticsSpy: Analytics {
     }
 
     var inappSearchUrlCalled: URL?
-    override func inappSearch(url: URL) {
+    var inappSearchIsPrivateCalled: Bool?
+    override func inappSearch(url: URL, isPrivate: Bool = false) {
         inappSearchUrlCalled = url
+        inappSearchIsPrivateCalled = isPrivate
     }
 
     var ntpTopSiteActionCalled: Action.TopSite?
@@ -654,7 +656,7 @@ final class AnalyticsSpyTests: XCTestCase {
                 XCTAssertEqual(policy, .allow, "Should allow independent of tracking behavior")
             }
             // inappSearch is now fired at didCommit, not decidePolicyFor
-            browser.ecosiaHandleDidCommit(url: url)
+            browser.ecosiaHandleDidCommit(url: url, isPrivate: false)
 
             if shouldTrack {
                 XCTAssertEqual(analyticsSpy.inappSearchUrlCalled?.absoluteString,
@@ -687,7 +689,7 @@ final class AnalyticsSpyTests: XCTestCase {
                             decidePolicyFor: action) { policy in
                 XCTAssertEqual(policy, .allow, "Should allow independent of tracking behavior")
             }
-            browser.ecosiaHandleDidCommit(url: url)
+            browser.ecosiaHandleDidCommit(url: url, isPrivate: false)
 
             if shouldTrack {
                 XCTAssertEqual(analyticsSpy.inappSearchUrlCalled?.absoluteString,
@@ -709,14 +711,14 @@ final class AnalyticsSpyTests: XCTestCase {
         // Load the URL once to establish it as the current page
         let firstAction = FakeNavigationAction(url: url, navigationType: .other)
         browser.webView(makeWebView(), decidePolicyFor: firstAction) { _ in }
-        browser.ecosiaHandleDidCommit(url: url)
+        browser.ecosiaHandleDidCommit(url: url, isPrivate: false)
 
         // Navigate to the same URL again via link activation (e.g. tapping the same search vertical)
         analyticsSpy = AnalyticsSpy()
         Analytics.shared = analyticsSpy
         let secondAction = FakeNavigationAction(url: url, navigationType: .linkActivated)
         browser.webView(makeWebView(), decidePolicyFor: secondAction) { _ in }
-        browser.ecosiaHandleDidCommit(url: url)
+        browser.ecosiaHandleDidCommit(url: url, isPrivate: false)
 
         XCTAssertEqual(analyticsSpy.inappSearchUrlCalled?.absoluteString,
                        url.absoluteString,
@@ -737,10 +739,36 @@ final class AnalyticsSpyTests: XCTestCase {
         browser.webView(makeWebView(), decidePolicyFor: action) { _ in }
 
         // didCommit fires with a different URL (e.g. a redirect landed elsewhere)
-        browser.ecosiaHandleDidCommit(url: differentUrl)
+        browser.ecosiaHandleDidCommit(url: differentUrl, isPrivate: false)
 
         XCTAssertNil(analyticsSpy.inappSearchUrlCalled,
                      "Should not track when committed URL does not match pending URL")
+    }
+
+    func testInappSearchPrivateFlagIsForwardedCorrectly() {
+        let browser = BrowserViewController(profile: profileMock, tabManager: tabManagerMock)
+
+        let rootURL = EcosiaEnvironment.current.urlProvider.root
+        let url = URL(string: "\(rootURL)/search?q=test")!
+        let action = FakeNavigationAction(url: url, navigationType: .other)
+
+        // Non-private
+        analyticsSpy = AnalyticsSpy()
+        Analytics.shared = analyticsSpy
+        browser.webView(makeWebView(), decidePolicyFor: action) { _ in }
+        browser.ecosiaHandleDidCommit(url: url, isPrivate: false)
+        XCTAssertEqual(analyticsSpy.inappSearchIsPrivateCalled,
+                       false,
+                       "Should forward isPrivate: false for normal tabs")
+
+        // Private
+        analyticsSpy = AnalyticsSpy()
+        Analytics.shared = analyticsSpy
+        browser.webView(makeWebView(), decidePolicyFor: action) { _ in }
+        browser.ecosiaHandleDidCommit(url: url, isPrivate: true)
+        XCTAssertEqual(analyticsSpy.inappSearchIsPrivateCalled,
+                       true,
+                       "Should forward isPrivate: true for private tabs")
     }
 
     // MARK: - Analytics Context Tests


### PR DESCRIPTION
[MOB-4275]

## Context

See ticket.

## Approach

Create a second Snowplow tracker instance dedicated to private browsing, configured with a null UUID as user id.                                                                                                                                                                                                                                                             
              
A second tracker was chosen over nulling userId around the track() call because the SDK dispatches through an internal queue — there is no guarantee the event is built before the flag is restored, making the toggle approach prone to race conditions.

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I wrote Unit Tests that confirm the expected behaviour
- [x] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)

[MOB-4275]: https://ecosia.atlassian.net/browse/MOB-4275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ