### PR TITLE
[MOB-4295] Fix iOS 16 infinite recursion on LegacyHomepage during Product Tour

### DIFF
--- a/firefox-ios/Client/Frontend/Home/HomepageViewModel.swift
+++ b/firefox-ios/Client/Frontend/Home/HomepageViewModel.swift
@@ -85,6 +85,12 @@ class HomepageViewModel: FeatureFlaggable, InjectedThemeUUIDIdentifiable {
     // Note: Should reload the view when have inconsistency between childViewModels count
     // and shownSections count in order to avoid a crash
     var shouldReloadView: Bool {
+        // Ecosia: Mirror the same Product Tour filter used in updateEnabledSections() so the counts converge
+        if ProductTourManager.shared.shouldShowProductTourHomepage {
+            return childViewModels
+                .filter { $0.sectionType.isProductTourSection && $0.shouldShow }
+                .count != shownSections.count
+        }
         return childViewModels.filter({ $0.shouldShow }).count != shownSections.count
     }
 


### PR DESCRIPTION
[MOB-4295]

Fixes a stack overflow crash affecting iOS 16 users when the Product Tour homepage is active.

## Context

**Root cause:** 

shouldReloadView compared all childViewModels where shouldShow == true against shownSections.count, but updateEnabledSections() only populates shownSections with product tour sections (returning early) when shouldShowProductTourHomepage is true. Non-product-tour sections (TopSites, News, Impact…) still return shouldShow == true, so the counts never matched and shouldReloadView was permanently true.

This caused numberOfSections(in:) to call reloadView() on every invocation. On iOS 16, invalidateLayout() synchronously triggers numberOfSections(in:), creating infinite recursion until stack overflow. iOS 17+ defers this call, which is why the crash was iOS 16-only.  

This is only an issue on the legacy homepage though - the new diffable data source structure from Firefox is more resilient for those issues as there's a redux state and no reloading data on invalidating layout.

## Approach

**Fix:** 

shouldReloadView now mirrors the same product-tour filter used in updateEnabledSections(), so the section counts converge after the first reload and the re-entry is never triggered.

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I added the `// Ecosia:` helper comments where needed

[MOB-4295]: https://ecosia.atlassian.net/browse/MOB-4295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ