### PR TITLE
[MOB-3997] Updated context menu

### DIFF
--- a/firefox-ios/Client/Ecosia/Extensions/HomepageViewController+EcosiaContextMenu.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/HomepageViewController+EcosiaContextMenu.swift
@@ -81,8 +81,12 @@ extension HomepageViewController {
         ) { _ in
             store.dispatch(
                 NavigationBrowserAction(
-                    navigationDestination: NavigationDestination(.newTab, url: siteURL,
-                                                                 isPrivate: false, selectNewTab: false),
+                    navigationDestination: NavigationDestination(
+                        .newTab,
+                        url: siteURL,
+                        isPrivate: false,
+                        selectNewTab: false
+                    ),
                     windowUUID: windowUUID,
                     actionType: NavigationBrowserActionType.tapOnOpenInNewTab
                 )
@@ -95,8 +99,12 @@ extension HomepageViewController {
         ) { _ in
             store.dispatch(
                 NavigationBrowserAction(
-                    navigationDestination: NavigationDestination(.newTab, url: siteURL,
-                                                                 isPrivate: true, selectNewTab: false),
+                    navigationDestination: NavigationDestination(
+                        .newTab,
+                        url: siteURL,
+                        isPrivate: true,
+                        selectNewTab: false
+                    ),
                     windowUUID: windowUUID,
                     actionType: NavigationBrowserActionType.tapOnOpenInNewTab
                 )
@@ -145,16 +153,22 @@ extension HomepageViewController {
                 title: .UnpinTopsiteActionTitle2,
                 image: UIImage(systemName: "pin.slash")
             ) { _ in
-                store.dispatch(ContextMenuAction(site: site, windowUUID: windowUUID,
-                                                 actionType: ContextMenuActionType.tappedOnUnpinTopSite))
+                store.dispatch(ContextMenuAction(
+                    site: site,
+                    windowUUID: windowUUID,
+                    actionType: ContextMenuActionType.tappedOnUnpinTopSite
+                ))
             }
             let remove = UIAction(
                 title: .RemoveContextMenuTitle,
                 image: UIImage(systemName: "xmark"),
                 attributes: .destructive
             ) { _ in
-                store.dispatch(ContextMenuAction(site: site, windowUUID: windowUUID,
-                                                 actionType: ContextMenuActionType.tappedOnRemoveTopSite))
+                store.dispatch(ContextMenuAction(
+                    site: site,
+                    windowUUID: windowUUID,
+                    actionType: ContextMenuActionType.tappedOnRemoveTopSite
+                ))
             }
             return UIMenu(children: [
                 UIMenu(options: .displayInline, children: [unpin]),
@@ -167,16 +181,22 @@ extension HomepageViewController {
                 title: .PinTopsiteActionTitle2,
                 image: UIImage(systemName: "pin")
             ) { _ in
-                store.dispatch(ContextMenuAction(site: site, windowUUID: windowUUID,
-                                                 actionType: ContextMenuActionType.tappedOnPinTopSite))
+                store.dispatch(ContextMenuAction(
+                    site: site,
+                    windowUUID: windowUUID,
+                    actionType: ContextMenuActionType.tappedOnPinTopSite
+                ))
             }
             let remove = UIAction(
                 title: .RemoveContextMenuTitle,
                 image: UIImage(systemName: "xmark"),
                 attributes: .destructive
             ) { _ in
-                store.dispatch(ContextMenuAction(site: site, windowUUID: windowUUID,
-                                                 actionType: ContextMenuActionType.tappedOnRemoveTopSite))
+                store.dispatch(ContextMenuAction(
+                    site: site,
+                    windowUUID: windowUUID,
+                    actionType: ContextMenuActionType.tappedOnRemoveTopSite
+                ))
             }
             return UIMenu(children: [
                 UIMenu(options: .displayInline, children: [pin]),
@@ -205,8 +225,10 @@ extension HomepageViewController {
                     actionType: NavigationBrowserActionType.tapOnSettingsSection
                 )
             )
-            store.dispatch(ContextMenuAction(windowUUID: windowUUID,
-                                             actionType: ContextMenuActionType.tappedOnSettingsAction))
+            store.dispatch(ContextMenuAction(
+                windowUUID: windowUUID,
+                actionType: ContextMenuActionType.tappedOnSettingsAction
+            ))
         }
 
         let sponsoredContent = UIAction(
@@ -223,14 +245,20 @@ extension HomepageViewController {
             }
             store.dispatch(
                 NavigationBrowserAction(
-                    navigationDestination: NavigationDestination(.newTab, url: sponsorURL,
-                                                                 isPrivate: false, selectNewTab: true),
+                    navigationDestination: NavigationDestination(
+                        .newTab,
+                        url: sponsorURL,
+                        isPrivate: false,
+                        selectNewTab: true
+                    ),
                     windowUUID: windowUUID,
                     actionType: NavigationBrowserActionType.tapOnOpenInNewTab
                 )
             )
-            store.dispatch(ContextMenuAction(windowUUID: windowUUID,
-                                             actionType: ContextMenuActionType.tappedOnSponsoredAction))
+            store.dispatch(ContextMenuAction(
+                windowUUID: windowUUID,
+                actionType: ContextMenuActionType.tappedOnSponsoredAction
+            ))
         }
 
         return UIMenu(children: [

--- a/firefox-ios/Client/Ecosia/Extensions/HomepageViewController+EcosiaContextMenu.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/HomepageViewController+EcosiaContextMenu.swift
@@ -1,0 +1,242 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Redux
+import Shared
+import Storage
+import UIKit
+
+// Ecosia: Native UIContextMenuConfiguration for NTP top sites, aligning with the iOS 26 Liquid Glass design.
+// The PhotonActionSheet flow is preserved for all other homepage sections (Jump Back In, Bookmarks, Pocket).
+
+extension HomepageViewController {
+
+    // MARK: - UICollectionViewDelegate Native Context Menu (Top Sites)
+
+    // Ecosia: Returns a native UIContextMenuConfiguration for top site cells, replacing the PhotonActionSheet
+    // with the iOS 26 Liquid Glass context menu style.
+    func collectionView(
+        _ collectionView: UICollectionView,
+        contextMenuConfigurationForItemAt indexPath: IndexPath,
+        point: CGPoint
+    ) -> UIContextMenuConfiguration? {
+        guard let section = dataSource?.sectionIdentifier(for: indexPath.section),
+              case .topSites = section,
+              let item = dataSource?.itemIdentifier(for: indexPath),
+              let site = getSiteForContextMenu(for: item),
+              let sourceCell = collectionView.cellForItem(at: indexPath) as? TopSiteCell
+        else { return nil }
+
+        return UIContextMenuConfiguration(
+            identifier: indexPath as NSIndexPath,
+            previewProvider: nil,
+            actionProvider: { [weak self] _ in
+                guard let self else { return nil }
+                return self.makeTopSiteContextMenu(for: site, sourceView: sourceCell)
+            }
+        )
+    }
+
+    // Ecosia: Targets the favicon container for the highlight preview, giving a focused zoom-in effect.
+    func collectionView(
+        _ collectionView: UICollectionView,
+        previewForHighlightingContextMenuWithConfiguration configuration: UIContextMenuConfiguration
+    ) -> UITargetedPreview? {
+        return topSiteTargetedPreview(in: collectionView, for: configuration)
+    }
+
+    // Ecosia: Targets the favicon container for the dismiss animation, keeping visual consistency on menu close.
+    func collectionView(
+        _ collectionView: UICollectionView,
+        previewForDismissingContextMenuWithConfiguration configuration: UIContextMenuConfiguration
+    ) -> UITargetedPreview? {
+        return topSiteTargetedPreview(in: collectionView, for: configuration)
+    }
+
+    // Ecosia: Builds a UITargetedPreview anchored on the top site cell's favicon container.
+    private func topSiteTargetedPreview(
+        in collectionView: UICollectionView,
+        for configuration: UIContextMenuConfiguration
+    ) -> UITargetedPreview? {
+        guard let indexPath = configuration.identifier as? NSIndexPath,
+              let cell = collectionView.cellForItem(at: indexPath as IndexPath) as? TopSiteCell
+        else { return nil }
+
+        let parameters = UIPreviewParameters()
+        parameters.backgroundColor = .clear
+        return UITargetedPreview(view: cell.previewTargetView, parameters: parameters)
+    }
+
+    // Ecosia: Builds the native UIMenu for a top site, grouping actions with inline separators per the iOS 26 HIG.
+    @MainActor
+    func makeTopSiteContextMenu(for site: Site, sourceView: UIView) -> UIMenu {
+        guard let siteURL = site.url.asURL else { return UIMenu(children: []) }
+        let windowUUID = windowUUID
+
+        let openInNewTab = UIAction(
+            title: .OpenInNewTabContextMenuTitle,
+            image: UIImage(systemName: "plus")
+        ) { _ in
+            store.dispatch(
+                NavigationBrowserAction(
+                    navigationDestination: NavigationDestination(.newTab, url: siteURL,
+                                                                 isPrivate: false, selectNewTab: false),
+                    windowUUID: windowUUID,
+                    actionType: NavigationBrowserActionType.tapOnOpenInNewTab
+                )
+            )
+        }
+
+        let openInPrivateTab = UIAction(
+            title: .OpenInNewPrivateTabContextMenuTitle,
+            image: UIImage(systemName: "moon.circle")
+        ) { _ in
+            store.dispatch(
+                NavigationBrowserAction(
+                    navigationDestination: NavigationDestination(.newTab, url: siteURL,
+                                                                 isPrivate: true, selectNewTab: false),
+                    windowUUID: windowUUID,
+                    actionType: NavigationBrowserActionType.tapOnOpenInNewTab
+                )
+            )
+            store.dispatch(
+                ContextMenuAction(
+                    menuType: .topSite,
+                    windowUUID: windowUUID,
+                    actionType: ContextMenuActionType.tappedOnOpenNewPrivateTab
+                )
+            )
+        }
+
+        let navigationGroup = UIMenu(options: .displayInline, children: [openInNewTab, openInPrivateTab])
+
+        let shareConfig = ShareSheetConfiguration(
+            shareType: .site(url: siteURL),
+            shareMessage: nil,
+            sourceView: sourceView,
+            sourceRect: nil,
+            toastContainer: ecosiaToastContainer,
+            popoverArrowDirection: [.up, .down, .left]
+        )
+        let share = UIAction(
+            title: .ShareContextMenuTitle,
+            image: UIImage(systemName: "square.and.arrow.up")
+        ) { _ in
+            store.dispatch(
+                NavigationBrowserAction(
+                    navigationDestination: NavigationDestination(.shareSheet(shareConfig)),
+                    windowUUID: windowUUID,
+                    actionType: NavigationBrowserActionType.tapOnShareSheet
+                )
+            )
+        }
+
+        switch site.type {
+        case .sponsoredSite:
+            return makeTopSiteSponsoredContextMenu(
+                windowUUID: windowUUID,
+                navigationGroup: navigationGroup,
+                shareAction: share
+            )
+        case .pinnedSite:
+            let unpin = UIAction(
+                title: .UnpinTopsiteActionTitle2,
+                image: UIImage(systemName: "pin.slash")
+            ) { _ in
+                store.dispatch(ContextMenuAction(site: site, windowUUID: windowUUID,
+                                                 actionType: ContextMenuActionType.tappedOnUnpinTopSite))
+            }
+            let remove = UIAction(
+                title: .RemoveContextMenuTitle,
+                image: UIImage(systemName: "xmark"),
+                attributes: .destructive
+            ) { _ in
+                store.dispatch(ContextMenuAction(site: site, windowUUID: windowUUID,
+                                                 actionType: ContextMenuActionType.tappedOnRemoveTopSite))
+            }
+            return UIMenu(children: [
+                UIMenu(options: .displayInline, children: [unpin]),
+                navigationGroup,
+                UIMenu(options: .displayInline, children: [remove]),
+                share
+            ])
+        default:
+            let pin = UIAction(
+                title: .PinTopsiteActionTitle2,
+                image: UIImage(systemName: "pin")
+            ) { _ in
+                store.dispatch(ContextMenuAction(site: site, windowUUID: windowUUID,
+                                                 actionType: ContextMenuActionType.tappedOnPinTopSite))
+            }
+            let remove = UIAction(
+                title: .RemoveContextMenuTitle,
+                image: UIImage(systemName: "xmark"),
+                attributes: .destructive
+            ) { _ in
+                store.dispatch(ContextMenuAction(site: site, windowUUID: windowUUID,
+                                                 actionType: ContextMenuActionType.tappedOnRemoveTopSite))
+            }
+            return UIMenu(children: [
+                UIMenu(options: .displayInline, children: [pin]),
+                navigationGroup,
+                UIMenu(options: .displayInline, children: [remove]),
+                share
+            ])
+        }
+    }
+
+    // Ecosia: Builds the native UIMenu for a sponsored top site, omitting pin/unpin and adding settings and sponsored-content actions.
+    @MainActor
+    func makeTopSiteSponsoredContextMenu(
+        windowUUID: WindowUUID,
+        navigationGroup: UIMenu,
+        shareAction: UIAction
+    ) -> UIMenu {
+        let settings = UIAction(
+            title: .FirefoxHomepage.ContextualMenu.Settings,
+            image: UIImage(systemName: "gearshape")
+        ) { _ in
+            store.dispatch(
+                NavigationBrowserAction(
+                    navigationDestination: NavigationDestination(.settings(.topSites)),
+                    windowUUID: windowUUID,
+                    actionType: NavigationBrowserActionType.tapOnSettingsSection
+                )
+            )
+            store.dispatch(ContextMenuAction(windowUUID: windowUUID,
+                                             actionType: ContextMenuActionType.tappedOnSettingsAction))
+        }
+
+        let sponsoredContent = UIAction(
+            title: .FirefoxHomepage.ContextualMenu.SponsoredContent,
+            image: UIImage(systemName: "questionmark.circle")
+        ) { [weak self] _ in
+            guard let sponsorURL = SupportUtils.URLForTopic("sponsor-privacy") else {
+                self?.ecosiaLogger.log(
+                    "Unable to retrieve URL for sponsor-privacy, return early",
+                    level: .warning,
+                    category: .homepage
+                )
+                return
+            }
+            store.dispatch(
+                NavigationBrowserAction(
+                    navigationDestination: NavigationDestination(.newTab, url: sponsorURL,
+                                                                 isPrivate: false, selectNewTab: true),
+                    windowUUID: windowUUID,
+                    actionType: NavigationBrowserActionType.tapOnOpenInNewTab
+                )
+            )
+            store.dispatch(ContextMenuAction(windowUUID: windowUUID,
+                                             actionType: ContextMenuActionType.tappedOnSponsoredAction))
+        }
+
+        return UIMenu(children: [
+            navigationGroup,
+            UIMenu(options: .displayInline, children: [settings, sponsoredContent]),
+            shareAction
+        ])
+    }
+}

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
@@ -46,6 +46,10 @@ final class HomepageViewController: UIViewController,
     private var collectionView: UICollectionView?
     /// Ecosia: Exposed so Ecosia cell configuration extensions (different file) can dequeue cells.
     var homepageCollectionView: UICollectionView? { collectionView }
+    // Ecosia: Exposed for HomepageViewController+EcosiaContextMenu to anchor the share sheet.
+    var ecosiaToastContainer: UIView { toastContainer }
+    // Ecosia: Exposed for HomepageViewController+EcosiaContextMenu to log warnings.
+    var ecosiaLogger: Logger { logger }
     /* Ecosia: Update dataSource access to use Ecosia's
     private var dataSource: HomepageDiffableDataSource?
      */
@@ -876,6 +880,9 @@ final class HomepageViewController: UIViewController,
             )
             return
         }
+        // Ecosia: Top sites use native UIContextMenuConfiguration; PhotonActionSheet is skipped for this section.
+        if case .topSites = section { return }
+
         if section.canHandleLongPress {
             navigateToContextMenu(for: item, sourceView: sourceView)
         }
@@ -1024,7 +1031,8 @@ final class HomepageViewController: UIViewController,
         )
     }
 
-    private func getSiteForContextMenu(for item: HomepageItem) -> Site? {
+    // Ecosia: Internal so HomepageViewController+EcosiaContextMenu can resolve the site for context menu items.
+    func getSiteForContextMenu(for item: HomepageItem) -> Site? {
         switch item {
         case .topSite(let state, _):
             return state.site

--- a/firefox-ios/Client/Frontend/Home/Homepage/TopSites/TopSiteCell.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/TopSites/TopSiteCell.swift
@@ -142,6 +142,9 @@ class TopSiteCell: UICollectionViewCell, ReusableCell {
 
     // MARK: - Public methods
 
+    // Ecosia: Exposed for native UIContextMenuInteraction preview targeting.
+    var previewTargetView: UIView { rootContainer }
+
     func configure(_ topSite: TopSiteConfiguration,
                    position: Int,
                    theme: Theme,

--- a/firefox-ios/EcosiaTests/UI/NTP/TopSiteNativeContextMenuTests.swift
+++ b/firefox-ios/EcosiaTests/UI/NTP/TopSiteNativeContextMenuTests.swift
@@ -1,0 +1,99 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Storage
+import UIKit
+import XCTest
+
+@testable import Client
+
+// Ecosia: Tests for the native UIContextMenuConfiguration on NTP top sites (iOS 26 Liquid Glass context menu).
+@MainActor
+final class TopSiteNativeContextMenuTests: XCTestCase {
+    private var subject: HomepageViewController!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+        subject = HomepageViewController(
+            windowUUID: .XCTestDefaultUUID,
+            overlayManager: DefaultOverlayModeManager(),
+            toastContainer: UIView()
+        )
+        trackForMemoryLeaks(subject)
+    }
+
+    override func tearDown() async throws {
+        subject = nil
+        DependencyHelperMock().reset()
+        try await super.tearDown()
+    }
+
+    // MARK: - Regular top site
+
+    // Ecosia: Verifies that a regular (non-pinned) top site menu contains a Pin action as its first item.
+    func test_regularTopSite_menuContainsPinAction() {
+        let site = Site.createBasicSite(url: "https://example.com", title: "Example")
+        let menu = subject.makeTopSiteContextMenu(for: site, sourceView: UIView())
+
+        let pinGroup = menu.children.first as? UIMenu
+        let pinAction = pinGroup?.children.first as? UIAction
+        XCTAssertEqual(pinAction?.title, String.PinTopsiteActionTitle2)
+    }
+
+    // Ecosia: Verifies that the navigation group contains Open in New Tab and Open in Private Tab actions.
+    func test_regularTopSite_menuContainsNavigationActions() {
+        let site = Site.createBasicSite(url: "https://example.com", title: "Example")
+        let menu = subject.makeTopSiteContextMenu(for: site, sourceView: UIView())
+
+        let navGroup = menu.children[safe: 1] as? UIMenu
+        XCTAssertEqual(navGroup?.children.count, 2)
+
+        let openNewTab = navGroup?.children[safe: 0] as? UIAction
+        XCTAssertEqual(openNewTab?.title, String.OpenInNewTabContextMenuTitle)
+
+        let openPrivateTab = navGroup?.children[safe: 1] as? UIAction
+        XCTAssertEqual(openPrivateTab?.title, String.OpenInNewPrivateTabContextMenuTitle)
+    }
+
+    // Ecosia: Verifies that the Remove action is marked destructive so iOS renders it in red.
+    func test_regularTopSite_menuContainsDestructiveRemoveAction() {
+        let site = Site.createBasicSite(url: "https://example.com", title: "Example")
+        let menu = subject.makeTopSiteContextMenu(for: site, sourceView: UIView())
+
+        let destructiveGroup = menu.children[safe: 2] as? UIMenu
+        let removeAction = destructiveGroup?.children.first as? UIAction
+        XCTAssertEqual(removeAction?.title, String.RemoveContextMenuTitle)
+        XCTAssertTrue(removeAction?.attributes.contains(.destructive) ?? false)
+    }
+
+    // Ecosia: Verifies that Share is present as a standalone action at the bottom of the menu.
+    func test_regularTopSite_menuContainsShareAction() {
+        let site = Site.createBasicSite(url: "https://example.com", title: "Example")
+        let menu = subject.makeTopSiteContextMenu(for: site, sourceView: UIView())
+
+        let shareAction = menu.children[safe: 3] as? UIAction
+        XCTAssertEqual(shareAction?.title, String.ShareContextMenuTitle)
+    }
+
+    // MARK: - Pinned top site
+
+    // Ecosia: Verifies that a pinned top site menu shows Unpin instead of Pin.
+    func test_pinnedTopSite_menuContainsUnpinAction() {
+        let site = Site.createPinnedSite(url: "https://example.com", title: "Example", isGooglePinnedTile: false)
+        let menu = subject.makeTopSiteContextMenu(for: site, sourceView: UIView())
+
+        let pinGroup = menu.children.first as? UIMenu
+        let unpinAction = pinGroup?.children.first as? UIAction
+        XCTAssertEqual(unpinAction?.title, String.UnpinTopsiteActionTitle2)
+    }
+}
+
+// Ecosia: Safe subscript used in native context menu tests to avoid out-of-bounds crashes.
+private extension Array {
+    subscript(safe index: Index) -> Element? {
+        indices.contains(index) ? self[index] : nil
+    }
+}


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-3997]

## Context

Long-pressing a top site on the New Tab Page previously opened a custom action sheet that was visually inconsistent with the rest of the iOS experience. Top site actions (pin, remove, open in new tab, share) are now presented through the native iOS context menu, giving users the familiar Liquid Glass look and feel introduced in iOS 26.

## Approach

- Long-pressing a top site now shows a native context menu with actions grouped by intent: pin/unpin, open in new or private tab, remove, and share
- Sponsored tiles show a tailored menu: open in a new or private tab, share, learn about sponsored content, and a shortcut to top sites settings
- The favicon container is used as the visual anchor for the menu's zoom-in and zoom-out animations, keeping the interaction feeling native and precise
- All other homepage sections (Jump Back In, Bookmarks, Pocket) continue to use the existing action sheet unchanged

| Before | After |
| ------- | ------- |
| <img width="298" height="637" alt="Screenshot 2025-12-03 at 16 17 13" src="https://github.com/user-attachments/assets/2ee860e2-2464-4c32-b848-c43364a47330" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-31 at 11 19 43" src="https://github.com/user-attachments/assets/03350f5d-071c-4e4e-a082-df8b603eaf21" /> |

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the english localization source files if needed
- [x] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-3997]: https://ecosia.atlassian.net/browse/MOB-3997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ