### PR TITLE
[MOB-4318] Fix Singular on upgrade (and bonus fixes!)

### DIFF
--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -48,6 +48,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, FeatureFlaggable {
     private var shutdownWebServer: DispatchSourceTimer?
     private var webServerUtil: WebServerUtil?
     private var appLaunchUtil: AppLaunchUtil?
+    // Ecosia: Searches counter
+    private let searchesCounter = SearchesCounter()
     private var backgroundWorkUtility: BackgroundFetchAndProcessingUtility?
     private var suggestBackgroundUtility: BackgroundFirefoxSuggestIngestUtility?
     private var suggestBackgroundTaskID: UIBackgroundTaskIdentifier = .invalid
@@ -251,6 +253,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate, FeatureFlaggable {
 
         DispatchQueue.global().async { [weak profile] in
             profile?.pollCommands(forcePoll: false)
+        }
+
+        // Ecosia: Track MMP notifications
+        MMP.sendSession()
+        searchesCounter.subscribe(self) { searchCount in
+            MMP.handleSearchEvent(searchCount)
         }
 
         updateWallpaperMetadata()

--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -255,6 +255,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate, FeatureFlaggable {
             profile?.pollCommands(forcePoll: false)
         }
 
+        // Ecosia: Refresh flags on foreground. The launch call in didFinishLaunchingWithOptions
+        // loads from disk to unblock startup; this one picks up stale flags when returning from background.
+        // No-op if the cache is fresh.
+        Task {
+            await FeatureManagement.fetchConfiguration()
+            Analytics.shared.activity(.resume)
+        }
+
         // Ecosia: Track MMP notifications
         MMP.sendSession()
         searchesCounter.subscribe(self) { searchCount in

--- a/firefox-ios/Client/Frontend/Browser/SearchEngines/OpenSearchEngine.swift
+++ b/firefox-ios/Client/Frontend/Browser/SearchEngines/OpenSearchEngine.swift
@@ -140,7 +140,10 @@ final class OpenSearchEngine: NSObject, NSSecureCoding, Sendable, TrendingSearch
 
     /// Returns the search URL for the given query.
     func searchURLForQuery(_ query: String) -> URL? {
+        /* Ecosia: Use environment-aware URL builder instead of hardcoded template
         return getURLFromTemplate(searchTemplate, query: query)
+        */
+        return URL.ecosiaSearchWithQuery(query)
     }
 
     /// Returns the search suggestion URL for the given query.

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -667,7 +667,15 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
             if let url = request.url, url.isFileURL, request.isPrivileged {
                 return webView.loadFileURL(url, allowingReadAccessTo: url)
             }
+            /* Ecosia: Inject CloudFlare auth headers and language region header for search requests
             return webView.load(request)
+            */
+            var ecosiaUpdatedRequest = request
+            ecosiaUpdatedRequest = ecosiaUpdatedRequest.withCloudFlareAuthParameters()
+            if ecosiaUpdatedRequest.url?.isEcosiaSearchQuery() == true {
+                ecosiaUpdatedRequest.addLanguageRegionHeader()
+            }
+            return webView.load(ecosiaUpdatedRequest)
         }
         return nil
     }

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Ecosia
 import Foundation
 import TabDataStore
 import Storage
@@ -140,6 +141,9 @@ class TabManagerImplementation: NSObject,
         super.init()
 
         GlobalTabEventHandlers.configure(with: profile)
+
+        // Ecosia: Cookie observing
+        WKWebsiteDataStore.default().httpCookieStore.add(self)
 
         startObservingNotifications(
             withNotificationCenter: notificationCenter,
@@ -1250,5 +1254,16 @@ extension TabManagerImplementation: WindowSimpleTabsProvider {
                                     activeTabId: self.selectedTabUUID ?? UUID(),
                                     tabData: self.generateTabDataForSaving())
         return SimpleTab.convertToSimpleTabs(windowData.tabData)
+    }
+}
+
+// Ecosia: Cookie observer
+extension TabManagerImplementation: WKHTTPCookieStoreObserver {
+    func cookiesDidChange(in cookieStore: WKHTTPCookieStore) {
+        cookieStore.getAllCookies { cookies in
+            DispatchQueue.main.async {
+                Cookie.received(cookies, in: cookieStore)
+            }
+        }
     }
 }

--- a/firefox-ios/Ecosia/Core/MMP/MMP.swift
+++ b/firefox-ios/Ecosia/Core/MMP/MMP.swift
@@ -16,6 +16,8 @@ public struct MMP {
 
     private init() {}
 
+    nonisolated(unsafe) public static var provider: MMPProvider = Singular(includeSKAN: true)
+
     static var appDeviceInfo: AppDeviceInfo {
         /// We are hardcoding `iOS` as per the platform parameter
         /// as `Singular` MMP doesn't currently support others like `iPadOS`
@@ -38,8 +40,7 @@ public struct MMP {
 
         Task {
             do {
-                let mmpProvider: MMPProvider = Singular(includeSKAN: true)
-                try await mmpProvider.sendSessionInfo(appDeviceInfo: appDeviceInfo)
+                try await provider.sendSessionInfo(appDeviceInfo: appDeviceInfo)
             } catch {
                 debugPrint(error)
             }
@@ -51,8 +52,7 @@ public struct MMP {
 
         Task { [event] in
             do {
-                let mmpProvider: MMPProvider = Singular(includeSKAN: true)
-                try await mmpProvider.sendEvent(event, appDeviceInfo: appDeviceInfo)
+                try await provider.sendEvent(event, appDeviceInfo: appDeviceInfo)
             } catch {
                 debugPrint(error)
             }

--- a/firefox-ios/EcosiaTests/IntegrationTests/AppDelegateMMPIntegrationTests.swift
+++ b/firefox-ios/EcosiaTests/IntegrationTests/AppDelegateMMPIntegrationTests.swift
@@ -1,0 +1,74 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import Client
+@testable import Ecosia
+
+final class AppDelegateMMPIntegrationTests: XCTestCase, @unchecked Sendable {
+    var appDelegate: AppDelegate!
+    var mockProvider: MockMMPProvider!
+    var savedUser: User!
+
+    override func setUp() {
+        super.setUp()
+        MainActor.assumeIsolated {
+            appDelegate = AppDelegate()
+            DependencyHelperMock().bootstrapDependencies()
+        }
+        savedUser = User.shared
+        User.shared.sendAnonymousUsageData = true
+        User.shared.searchCount = 0
+        mockProvider = MockMMPProvider()
+        MMP.provider = mockProvider
+    }
+
+    override func tearDown() {
+        User.shared = savedUser
+        MMP.provider = Singular(includeSKAN: true)
+        super.tearDown()
+    }
+
+    func testSessionIsSentOnBecomeActive() {
+        MainActor.assumeIsolated { appDelegate.applicationDidBecomeActive(UIApplication.shared) }
+        wait(1)
+        XCTAssertTrue(mockProvider.didSendSession)
+    }
+
+    func testSessionIsNotSentWhenAnonymousDataDisabled() {
+        User.shared.sendAnonymousUsageData = false
+        MainActor.assumeIsolated { appDelegate.applicationDidBecomeActive(UIApplication.shared) }
+        wait(1)
+        XCTAssertFalse(mockProvider.didSendSession)
+    }
+
+    func testFirstSearchMilestoneTriggersEvent() {
+        MainActor.assumeIsolated { appDelegate.applicationDidBecomeActive(UIApplication.shared) }
+        User.shared.searchCount = 1
+        wait(1)
+        XCTAssertEqual(mockProvider.receivedEvents, [.firstSearch])
+    }
+
+    func testNonMilestoneSearchCountDoesNotTriggerEvent() {
+        MainActor.assumeIsolated { appDelegate.applicationDidBecomeActive(UIApplication.shared) }
+        User.shared.searchCount = 3
+        wait(1)
+        XCTAssertTrue(mockProvider.receivedEvents.isEmpty)
+    }
+}
+
+// MARK: - MockMMPProvider
+
+final class MockMMPProvider: MMPProvider, @unchecked Sendable {
+    var didSendSession = false
+    var receivedEvents: [MMPEvent] = []
+
+    func sendSessionInfo(appDeviceInfo: AppDeviceInfo) async throws {
+        didSendSession = true
+    }
+
+    func sendEvent(_ event: MMPEvent, appDeviceInfo: AppDeviceInfo) async throws {
+        receivedEvents.append(event)
+    }
+}


### PR DESCRIPTION
[MOB-4318]

## Context

Singular requests were not being made.

## Approach

Re-added MMP calls.

Wrote integration Unit tests for this, similar to existing Unleash (FeatureManagement) ones - this were not yet checked since tests are broken though, but I'm handling that on [this separate ticket](https://ecosia.atlassian.net/browse/MOB-4320).

To fix search count notifications I also had to do some bonus fixes:
* Reintroduced Cookie handling on the tab management
* Fixed usage of the correct search URL based on environment
* Fixed Cloudflare injection for search URL

## Other

* Re-added missing Unleash and Analytics calls from `didBecomeActive`

* Noticed tests are not actually runnable now both locally and on CI, fixing that on a separate PR (some of the fixes were unit tested like the Unleash integration, so fixing them might show other issues).

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I wrote Unit Tests that confirm the expected behaviour
- [x] I added the `// Ecosia:` helper comments where needed

[MOB-4318]: https://ecosia.atlassian.net/browse/MOB-4318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ