### PR TITLE
[MOB-4331] Remove sponsored and homepage section in settings

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -74,16 +74,11 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
         let customizeFirefoxHomeSection = customizeFirefoxSettingSection()
         let startAtHomeSection = setupStartAtHomeSection()
 
-        #if ECOSIA
         /* Ecosia: The new tab page is always Ecosia's NTP; remove "Current homepage" / custom URL section (MOB-4331).
         let customizeHomePageSection = customizeHomeSettingSection()
         return [startAtHomeSection, customizeFirefoxHomeSection, customizeHomePageSection]
         */
         return [startAtHomeSection, customizeFirefoxHomeSection]
-        #else
-        let customizeHomePageSection = customizeHomeSettingSection()
-        return [startAtHomeSection, customizeFirefoxHomeSection, customizeHomePageSection]
-        #endif
     }
 
     private func customizeHomeSettingSection() -> SettingSection {

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -75,7 +75,9 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
         let startAtHomeSection = setupStartAtHomeSection()
 
         #if ECOSIA
-        // MOB-4331: New tab is always Ecosia’s NTP; hide “Current homepage” / custom URL choice.
+        // Ecosia: The new tab page is always Ecosia's NTP; remove "Current homepage" / custom URL section (MOB-4331).
+        /* let customizeHomePageSection = customizeHomeSettingSection()
+        return [startAtHomeSection, customizeFirefoxHomeSection, customizeHomePageSection] */
         return [startAtHomeSection, customizeFirefoxHomeSection]
         #else
         let customizeHomePageSection = customizeHomeSettingSection()

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -77,7 +77,8 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
         #if ECOSIA
         /* Ecosia: The new tab page is always Ecosia's NTP; remove "Current homepage" / custom URL section (MOB-4331).
         let customizeHomePageSection = customizeHomeSettingSection()
-        return [startAtHomeSection, customizeFirefoxHomeSection, customizeHomePageSection] */
+        return [startAtHomeSection, customizeFirefoxHomeSection, customizeHomePageSection]
+        */
         return [startAtHomeSection, customizeFirefoxHomeSection]
         #else
         let customizeHomePageSection = customizeHomeSettingSection()

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -72,10 +72,15 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
     // MARK: - Methods
     override func generateSettings() -> [SettingSection] {
         let customizeFirefoxHomeSection = customizeFirefoxSettingSection()
-        let customizeHomePageSection = customizeHomeSettingSection()
         let startAtHomeSection = setupStartAtHomeSection()
 
+        #if ECOSIA
+        // MOB-4331: New tab is always Ecosia’s NTP; hide “Current homepage” / custom URL choice.
+        return [startAtHomeSection, customizeFirefoxHomeSection]
+        #else
+        let customizeHomePageSection = customizeHomeSettingSection()
         return [startAtHomeSection, customizeFirefoxHomeSection, customizeHomePageSection]
+        #endif
     }
 
     private func customizeHomeSettingSection() -> SettingSection {

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -75,8 +75,8 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
         let startAtHomeSection = setupStartAtHomeSection()
 
         #if ECOSIA
-        // Ecosia: The new tab page is always Ecosia's NTP; remove "Current homepage" / custom URL section (MOB-4331).
-        /* let customizeHomePageSection = customizeHomeSettingSection()
+        /* Ecosia: The new tab page is always Ecosia's NTP; remove "Current homepage" / custom URL section (MOB-4331).
+        let customizeHomePageSection = customizeHomeSettingSection()
         return [startAtHomeSection, customizeFirefoxHomeSection, customizeHomePageSection] */
         return [startAtHomeSection, customizeFirefoxHomeSection]
         #else

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesRowCountSettingsController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesRowCountSettingsController.swift
@@ -9,7 +9,10 @@ import Shared
 class TopSitesRowCountSettingsController: SettingsTableViewController, FeatureFlaggable {
     let prefs: Prefs
     var numberOfRows: Int32
+    /* Ecosia: Shortcuts are always displayed in a single row (MOB-4331).
     nonisolated static let defaultNumberOfRows: Int32 = 2
+    */
+    nonisolated static let defaultNumberOfRows: Int32 = 1
 
     init(prefs: Prefs, windowUUID: WindowUUID) {
         self.prefs = prefs

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
@@ -87,15 +87,18 @@ final class TopSitesSettingsViewController: SettingsTableViewController, Feature
         return sections
     }
 
+    /* Ecosia: Only called by the sponsored toggle which is removed (MOB-4331).
     private func deleteUserRequest(contextId: String) {
         Task {
             let remover = UnifiedAdsUserDataRemover()
             try await remover.deleteUserData(contextID: contextId)
         }
     }
+    */
 }
 
 // MARK: - TopSitesSettings
+/* Ecosia: RowSettings is only used by the row-count picker which is removed (MOB-4331).
 extension TopSitesSettingsViewController {
     class RowSettings: Setting {
         let profile: Profile?
@@ -142,3 +145,4 @@ extension TopSitesSettingsViewController {
         }
     }
 }
+*/

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
@@ -31,46 +31,51 @@ final class TopSitesSettingsViewController: SettingsTableViewController, Feature
         var sections: [SettingSection] = []
 
         if let profile {
-            let toggleSettings = [
-                BoolSetting(
-                    prefs: profile.prefs,
-                    theme: themeManager.getCurrentTheme(for: windowUUID),
-                    prefKey: PrefsKeys.UserFeatureFlagPrefs.TopSiteSection,
-                    defaultValue: true,
-                    titleText: .Settings.Homepage.Shortcuts.ShortcutsToggle
-                ) { isOn in
-                    store.dispatch(
-                        TopSitesAction(
-                            isEnabled: isOn,
-                            windowUUID: self.windowUUID,
-                            actionType: TopSitesActionType.toggleShowSectionSetting
-                        )
+            let shortcutsToggle = BoolSetting(
+                prefs: profile.prefs,
+                theme: themeManager.getCurrentTheme(for: windowUUID),
+                prefKey: PrefsKeys.UserFeatureFlagPrefs.TopSiteSection,
+                defaultValue: true,
+                titleText: .Settings.Homepage.Shortcuts.ShortcutsToggle
+            ) { isOn in
+                store.dispatch(
+                    TopSitesAction(
+                        isEnabled: isOn,
+                        windowUUID: self.windowUUID,
+                        actionType: TopSitesActionType.toggleShowSectionSetting
                     )
-                },
-                BoolSetting(
-                    prefs: profile.prefs,
-                    theme: themeManager.getCurrentTheme(for: windowUUID),
-                    prefKey: PrefsKeys.FeatureFlags.SponsoredShortcuts,
-                    defaultValue: featureFlags.isFeatureEnabled(.hntSponsoredShortcuts, checking: .userOnly),
-                    titleText: .Settings.Homepage.Shortcuts.SponsoredShortcutsToggle
-                ) { _ in
-                    store.dispatch(
-                        TopSitesAction(
-                            windowUUID: self.windowUUID,
-                            actionType: TopSitesActionType.toggleShowSponsoredSettings
-                        )
-                    )
+                )
+            }
 
-                    // If sponsored shortcuts are turned off, request to delete the user data
-                    let isSponsoredShortcutsEnabled = profile.prefs.boolForKey(
-                        PrefsKeys.FeatureFlags.SponsoredShortcuts
-                    ) ?? true
-                    if !isSponsoredShortcutsEnabled,
-                       let contextId = TelemetryContextualIdentifier.contextId {
-                        self.deleteUserRequest(contextId: contextId)
-                    }
+            #if ECOSIA
+            // MOB-4331: No sponsored shortcuts in Ecosia; omit toggle and copy.
+            let toggleSettings = [shortcutsToggle]
+            #else
+            let sponsoredToggle = BoolSetting(
+                prefs: profile.prefs,
+                theme: themeManager.getCurrentTheme(for: windowUUID),
+                prefKey: PrefsKeys.FeatureFlags.SponsoredShortcuts,
+                defaultValue: featureFlags.isFeatureEnabled(.hntSponsoredShortcuts, checking: .userOnly),
+                titleText: .Settings.Homepage.Shortcuts.SponsoredShortcutsToggle
+            ) { _ in
+                store.dispatch(
+                    TopSitesAction(
+                        windowUUID: self.windowUUID,
+                        actionType: TopSitesActionType.toggleShowSponsoredSettings
+                    )
+                )
+
+                // If sponsored shortcuts are turned off, request to delete the user data
+                let isSponsoredShortcutsEnabled = profile.prefs.boolForKey(
+                    PrefsKeys.FeatureFlags.SponsoredShortcuts
+                ) ?? true
+                if !isSponsoredShortcutsEnabled,
+                   let contextId = TelemetryContextualIdentifier.contextId {
+                    self.deleteUserRequest(contextId: contextId)
                 }
-            ]
+            }
+            let toggleSettings = [shortcutsToggle, sponsoredToggle]
+            #endif
             let toggleSection = SettingSection(title: nil, children: toggleSettings)
             sections.append(toggleSection)
         }

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
@@ -31,7 +31,6 @@ final class TopSitesSettingsViewController: SettingsTableViewController, Feature
         var sections: [SettingSection] = []
 
         if let profile {
-            /* Ecosia: No sponsored shortcuts in Ecosia; omit the sponsored toggle (MOB-4331).
             let toggleSettings = [
                 BoolSetting(
                     prefs: profile.prefs,
@@ -48,6 +47,7 @@ final class TopSitesSettingsViewController: SettingsTableViewController, Feature
                         )
                     )
                 },
+                /* Ecosia: No sponsored shortcuts in Ecosia; omit the sponsored toggle (MOB-4331).
                 BoolSetting(
                     prefs: profile.prefs,
                     theme: themeManager.getCurrentTheme(for: windowUUID),
@@ -71,50 +71,29 @@ final class TopSitesSettingsViewController: SettingsTableViewController, Feature
                         self.deleteUserRequest(contextId: contextId)
                     }
                 }
-            ]
-            */
-            let toggleSettings = [
-                BoolSetting(
-                    prefs: profile.prefs,
-                    theme: themeManager.getCurrentTheme(for: windowUUID),
-                    prefKey: PrefsKeys.UserFeatureFlagPrefs.TopSiteSection,
-                    defaultValue: true,
-                    titleText: .Settings.Homepage.Shortcuts.ShortcutsToggle
-                ) { isOn in
-                    store.dispatch(
-                        TopSitesAction(
-                            isEnabled: isOn,
-                            windowUUID: self.windowUUID,
-                            actionType: TopSitesActionType.toggleShowSectionSetting
-                        )
-                    )
-                }
+                 */
             ]
             let toggleSection = SettingSection(title: nil, children: toggleSettings)
             sections.append(toggleSection)
         }
-
-        /* Ecosia: Shortcuts are always displayed in a single row; remove the row-count picker (MOB-4331).
+        /* Ecosia: No sponsored row selection in Ecosia; omit the rows number selector (MOB-4331).
         let rowSetting = RowSettings(settings: self)
         let rowSection = SettingSection(title: nil, children: [rowSetting])
         sections.append(rowSection)
-        */
+         */
 
         return sections
     }
 
-    /* Ecosia: Only called by the sponsored toggle which is removed (MOB-4331).
     private func deleteUserRequest(contextId: String) {
         Task {
             let remover = UnifiedAdsUserDataRemover()
             try await remover.deleteUserData(contextID: contextId)
         }
     }
-    */
 }
 
 // MARK: - TopSitesSettings
-/* Ecosia: RowSettings is only used by the row-count picker which is removed (MOB-4331).
 extension TopSitesSettingsViewController {
     class RowSettings: Setting {
         let profile: Profile?
@@ -161,4 +140,3 @@ extension TopSitesSettingsViewController {
         }
     }
 }
-*/

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
@@ -78,9 +78,11 @@ final class TopSitesSettingsViewController: SettingsTableViewController, Feature
             sections.append(toggleSection)
         }
 
+        /* Ecosia: Shortcuts are always displayed in a single row; remove the row-count picker (MOB-4331).
         let rowSetting = RowSettings(settings: self)
         let rowSection = SettingSection(title: nil, children: [rowSetting])
         sections.append(rowSection)
+        */
 
         return sections
     }

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
@@ -47,10 +47,7 @@ final class TopSitesSettingsViewController: SettingsTableViewController, Feature
                 )
             }
 
-            #if ECOSIA
-            // Ecosia: No sponsored shortcuts in Ecosia; omit the sponsored toggle (MOB-4331).
-            let toggleSettings = [shortcutsToggle]
-            #else
+            /* Ecosia: No sponsored shortcuts in Ecosia; omit the sponsored toggle (MOB-4331).
             let sponsoredToggle = BoolSetting(
                 prefs: profile.prefs,
                 theme: themeManager.getCurrentTheme(for: windowUUID),
@@ -75,7 +72,8 @@ final class TopSitesSettingsViewController: SettingsTableViewController, Feature
                 }
             }
             let toggleSettings = [shortcutsToggle, sponsoredToggle]
-            #endif
+            */
+            let toggleSettings = [shortcutsToggle]
             let toggleSection = SettingSection(title: nil, children: toggleSettings)
             sections.append(toggleSection)
         }

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
@@ -48,7 +48,7 @@ final class TopSitesSettingsViewController: SettingsTableViewController, Feature
             }
 
             #if ECOSIA
-            // MOB-4331: No sponsored shortcuts in Ecosia; omit toggle and copy.
+            // Ecosia: No sponsored shortcuts in Ecosia; omit toggle and copy (MOB-4331).
             let toggleSettings = [shortcutsToggle]
             #else
             let sponsoredToggle = BoolSetting(

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
@@ -48,7 +48,7 @@ final class TopSitesSettingsViewController: SettingsTableViewController, Feature
             }
 
             #if ECOSIA
-            // Ecosia: No sponsored shortcuts in Ecosia; omit toggle and copy (MOB-4331).
+            // Ecosia: No sponsored shortcuts in Ecosia; omit the sponsored toggle (MOB-4331).
             let toggleSettings = [shortcutsToggle]
             #else
             let sponsoredToggle = BoolSetting(

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/TopSitesSettings/TopSitesSettingsViewController.swift
@@ -31,49 +31,65 @@ final class TopSitesSettingsViewController: SettingsTableViewController, Feature
         var sections: [SettingSection] = []
 
         if let profile {
-            let shortcutsToggle = BoolSetting(
-                prefs: profile.prefs,
-                theme: themeManager.getCurrentTheme(for: windowUUID),
-                prefKey: PrefsKeys.UserFeatureFlagPrefs.TopSiteSection,
-                defaultValue: true,
-                titleText: .Settings.Homepage.Shortcuts.ShortcutsToggle
-            ) { isOn in
-                store.dispatch(
-                    TopSitesAction(
-                        isEnabled: isOn,
-                        windowUUID: self.windowUUID,
-                        actionType: TopSitesActionType.toggleShowSectionSetting
-                    )
-                )
-            }
-
             /* Ecosia: No sponsored shortcuts in Ecosia; omit the sponsored toggle (MOB-4331).
-            let sponsoredToggle = BoolSetting(
-                prefs: profile.prefs,
-                theme: themeManager.getCurrentTheme(for: windowUUID),
-                prefKey: PrefsKeys.FeatureFlags.SponsoredShortcuts,
-                defaultValue: featureFlags.isFeatureEnabled(.hntSponsoredShortcuts, checking: .userOnly),
-                titleText: .Settings.Homepage.Shortcuts.SponsoredShortcutsToggle
-            ) { _ in
-                store.dispatch(
-                    TopSitesAction(
-                        windowUUID: self.windowUUID,
-                        actionType: TopSitesActionType.toggleShowSponsoredSettings
+            let toggleSettings = [
+                BoolSetting(
+                    prefs: profile.prefs,
+                    theme: themeManager.getCurrentTheme(for: windowUUID),
+                    prefKey: PrefsKeys.UserFeatureFlagPrefs.TopSiteSection,
+                    defaultValue: true,
+                    titleText: .Settings.Homepage.Shortcuts.ShortcutsToggle
+                ) { isOn in
+                    store.dispatch(
+                        TopSitesAction(
+                            isEnabled: isOn,
+                            windowUUID: self.windowUUID,
+                            actionType: TopSitesActionType.toggleShowSectionSetting
+                        )
                     )
-                )
+                },
+                BoolSetting(
+                    prefs: profile.prefs,
+                    theme: themeManager.getCurrentTheme(for: windowUUID),
+                    prefKey: PrefsKeys.FeatureFlags.SponsoredShortcuts,
+                    defaultValue: featureFlags.isFeatureEnabled(.hntSponsoredShortcuts, checking: .userOnly),
+                    titleText: .Settings.Homepage.Shortcuts.SponsoredShortcutsToggle
+                ) { _ in
+                    store.dispatch(
+                        TopSitesAction(
+                            windowUUID: self.windowUUID,
+                            actionType: TopSitesActionType.toggleShowSponsoredSettings
+                        )
+                    )
 
-                // If sponsored shortcuts are turned off, request to delete the user data
-                let isSponsoredShortcutsEnabled = profile.prefs.boolForKey(
-                    PrefsKeys.FeatureFlags.SponsoredShortcuts
-                ) ?? true
-                if !isSponsoredShortcutsEnabled,
-                   let contextId = TelemetryContextualIdentifier.contextId {
-                    self.deleteUserRequest(contextId: contextId)
+                    // If sponsored shortcuts are turned off, request to delete the user data
+                    let isSponsoredShortcutsEnabled = profile.prefs.boolForKey(
+                        PrefsKeys.FeatureFlags.SponsoredShortcuts
+                    ) ?? true
+                    if !isSponsoredShortcutsEnabled,
+                       let contextId = TelemetryContextualIdentifier.contextId {
+                        self.deleteUserRequest(contextId: contextId)
+                    }
                 }
-            }
-            let toggleSettings = [shortcutsToggle, sponsoredToggle]
+            ]
             */
-            let toggleSettings = [shortcutsToggle]
+            let toggleSettings = [
+                BoolSetting(
+                    prefs: profile.prefs,
+                    theme: themeManager.getCurrentTheme(for: windowUUID),
+                    prefKey: PrefsKeys.UserFeatureFlagPrefs.TopSiteSection,
+                    defaultValue: true,
+                    titleText: .Settings.Homepage.Shortcuts.ShortcutsToggle
+                ) { isOn in
+                    store.dispatch(
+                        TopSitesAction(
+                            isEnabled: isOn,
+                            windowUUID: self.windowUUID,
+                            actionType: TopSitesActionType.toggleShowSectionSetting
+                        )
+                    )
+                }
+            ]
             let toggleSection = SettingSection(title: nil, children: toggleSettings)
             sections.append(toggleSection)
         }


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-4331]

## Context

When performing the upgrade, we realised the customised homepage brought back the Firefox selection.
We need to remove them and revisit in favour of the new NTP 

## Approach

- Remove and update the code as usual for Ecosia's changes
- Realised that given the new NTP will only contain 1 row and 4 items,  we also had to remove the number of rows per section.

## Other

I understand there's no reason now to keep the shortcut's toggle in a dedicated view for only that option, but in favour of keeping our changes as lean as possible, I decided to keep it as is.

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ x I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4331]: https://ecosia.atlassian.net/browse/MOB-4331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ