### PR TITLE
[MOB-3998] Disable Firefox's default browser banner

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
@@ -55,12 +55,7 @@ class MainMenuViewController: UIViewController,
     }
 
     private var isMenuDefaultBrowserBanner: Bool {
-        // Ecosia (MOB-3998): We ship our own default-browser prompts; hide Firefox’s menu banner.
-        #if ECOSIA
-        return false
-        #else
         return featureFlags.isFeatureEnabled(.menuDefaultBrowserBanner, checking: .buildOnly)
-        #endif
     }
 
     private var bannerShown: Bool {

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/Views/MainMenuViewController.swift
@@ -55,7 +55,12 @@ class MainMenuViewController: UIViewController,
     }
 
     private var isMenuDefaultBrowserBanner: Bool {
+        // Ecosia (MOB-3998): We ship our own default-browser prompts; hide Firefox’s menu banner.
+        #if ECOSIA
+        return false
+        #else
         return featureFlags.isFeatureEnabled(.menuDefaultBrowserBanner, checking: .buildOnly)
+        #endif
     }
 
     private var bannerShown: Bool {

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -444,8 +444,15 @@ final class NimbusFeatureFlagLayer: Sendable {
     }
 
     private func checkMenuDefaultBrowserBanner(from nimbus: FxNimbus) -> Bool {
+        #if ECOSIA
+        // Ecosia: We ship our own default-browser prompts (MOB-3998); always suppress the Firefox menu banner.
+        /* let config = nimbus.features.menuRefactorFeature.value()
+        return config.menuDefaultBrowserBanner */
+        return false
+        #else
         let config = nimbus.features.menuRefactorFeature.value()
         return config.menuDefaultBrowserBanner
+        #endif
     }
 
     private func checkMenuRefactor(from nimbus: FxNimbus) -> Bool {

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -444,15 +444,10 @@ final class NimbusFeatureFlagLayer: Sendable {
     }
 
     private func checkMenuDefaultBrowserBanner(from nimbus: FxNimbus) -> Bool {
-        #if ECOSIA
-        // Ecosia: We ship our own default-browser prompts (MOB-3998); always suppress the Firefox menu banner.
-        /* let config = nimbus.features.menuRefactorFeature.value()
+        /* Ecosia: We ship our own default-browser prompts (MOB-3998); always suppress the Firefox menu banner.
+        let config = nimbus.features.menuRefactorFeature.value()
         return config.menuDefaultBrowserBanner */
         return false
-        #else
-        let config = nimbus.features.menuRefactorFeature.value()
-        return config.menuDefaultBrowserBanner
-        #endif
     }
 
     private func checkMenuRefactor(from nimbus: FxNimbus) -> Bool {

--- a/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
+++ b/firefox-ios/Client/Nimbus/NimbusFeatureFlagLayer.swift
@@ -446,7 +446,8 @@ final class NimbusFeatureFlagLayer: Sendable {
     private func checkMenuDefaultBrowserBanner(from nimbus: FxNimbus) -> Bool {
         /* Ecosia: We ship our own default-browser prompts (MOB-3998); always suppress the Firefox menu banner.
         let config = nimbus.features.menuRefactorFeature.value()
-        return config.menuDefaultBrowserBanner */
+        return config.menuDefaultBrowserBanner
+        */
         return false
     }
 


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-3998]

## Context

We noticed the default user banner (Firefox) was enabled, and we need to remove it. 

## Approach

- Find the least invasive place that removes
- Found its Nimbus feature and disabled.

## Other

## Before merging

### Checklist

- [x] I added the `// Ecosia:` helper comments where needed

[MOB-3998]: https://ecosia.atlassian.net/browse/MOB-3998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ