### PR TITLE
[MOB-4323] Restore default browser search promo

### DIFF
--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
@@ -21,20 +21,19 @@ extension BrowserViewController: HomepageViewControllerDelegate {
 extension BrowserViewController: DefaultBrowserDelegate {
     @available(iOS 14, *)
     func defaultBrowserDidShow(_ defaultBrowser: DefaultBrowserViewController) {
-        profile.prefs.setBool(true, forKey: BrowserViewController.ecosiaSearchPromoShownKey)
+        User.shared.markDefaultBrowserSearchPromoAsShown()
     }
 }
 
 // MARK: - Default browser promo after search threshold
 extension BrowserViewController {
-    static let ecosiaSearchPromoShownKey = "EcosiaSearchPromoShown"
 
-    /// One-shot migration from the old `PrefsKeys.IntroSeen` gate to `ecosiaSearchPromoShownKey`.
+    /// One-shot migration from the old `PrefsKeys.IntroSeen` gate to `User.shared`.
     /// Preserves the existing suppression: users already blocked under the old key remain blocked.
     func ecosiaMigrateDefaultBrowserPromoFlagIfNeeded() {
-        guard profile.prefs.boolForKey(Self.ecosiaSearchPromoShownKey) == nil else { return }
+        guard !User.shared.defaultBrowserSearchPromoShown else { return }
         if profile.prefs.intForKey(PrefsKeys.IntroSeen) != nil {
-            profile.prefs.setBool(true, forKey: Self.ecosiaSearchPromoShownKey)
+            User.shared.markDefaultBrowserSearchPromoAsShown()
         }
     }
 
@@ -51,17 +50,16 @@ extension BrowserViewController {
     }
 
     /// Presents the default-browser promo once the search-count threshold is crossed.
-    /// Safe to call repeatedly — the prefs flag prevents double-presentation.
+    /// Safe to call repeatedly — the User flag prevents double-presentation.
     func ecosiaMaybePresentDefaultBrowserPromoForSearchThreshold() {
         guard #available(iOS 14, *) else { return }
 
         ecosiaMigrateDefaultBrowserPromoFlagIfNeeded()
 
-        let alreadyShown = profile.prefs.boolForKey(Self.ecosiaSearchPromoShownKey) == true
         guard Self.isEligibleForEcosiaDefaultBrowserSearchPromo(
             searchCount: User.shared.searchCount,
             isDefaultBrowser: DefaultBrowserUtility().isDefaultBrowser,
-            promoAlreadyShown: alreadyShown
+            promoAlreadyShown: User.shared.defaultBrowserSearchPromoShown
         ) else { return }
 
         guard presentedViewController == nil else { return }

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
@@ -29,14 +29,6 @@ extension BrowserViewController: DefaultBrowserDelegate {
 extension BrowserViewController {
     static let ecosiaSearchPromoShownKey = "EcosiaSearchPromoShown"
 
-    /// Migrates users who saw the promo under `PrefsKeys.IntroSeen` so they don't see it again.
-    func ecosiaMigrateDefaultBrowserPromoFlagIfNeeded() {
-        guard profile.prefs.boolForKey(Self.ecosiaSearchPromoShownKey) == nil else { return }
-        if profile.prefs.intForKey(PrefsKeys.IntroSeen) != nil {
-            profile.prefs.setBool(true, forKey: Self.ecosiaSearchPromoShownKey)
-        }
-    }
-
     /// Pure eligibility check, isolated from UIKit for unit-testing.
     static func isEligibleForEcosiaDefaultBrowserSearchPromo(
         searchCount: Int,
@@ -53,8 +45,6 @@ extension BrowserViewController {
     /// Safe to call repeatedly — the prefs flag prevents double-presentation.
     func ecosiaMaybePresentDefaultBrowserPromoForSearchThreshold() {
         guard #available(iOS 14, *) else { return }
-
-        ecosiaMigrateDefaultBrowserPromoFlagIfNeeded()
 
         let alreadyShown = profile.prefs.boolForKey(Self.ecosiaSearchPromoShownKey) == true
         guard Self.isEligibleForEcosiaDefaultBrowserSearchPromo(

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
@@ -26,30 +26,46 @@ extension BrowserViewController: DefaultBrowserDelegate {
 }
 
 // MARK: - Default browser promo after search threshold (MOB-4323)
+// Ecosia: DefaultBrowserViewController was defined but never presented anywhere. Wire it to the
+// search-count threshold using a dedicated prefs key (not PrefsKeys.IntroSeen, which belongs to onboarding).
 extension BrowserViewController {
-    /// Profile prefs key: user has seen (or completed flow for) the search-count default browser promo.
+    /// Ecosia prefs key: set to `true` once the search-threshold default-browser promo has been shown.
     static let ecosiaDefaultBrowserSearchThresholdPromoShownKey = "EcosiaDefaultBrowserSearchThresholdPromoShown"
 
-    private static let ecosiaDefaultBrowserSearchPromoPrefsLock = NSLock()
+    // MARK: Eligibility
 
-    /// Call from app lifecycle so we catch users whose search count was already above the threshold before BVC existed.
+    /// Pure-function eligibility check — isolated from UIKit so it is directly unit-testable.
+    static func isEligibleForEcosiaDefaultBrowserSearchPromo(
+        searchCount: Int,
+        isDefaultBrowser: Bool,
+        promoAlreadyShown: Bool
+    ) -> Bool {
+        guard !isDefaultBrowser else { return false }
+        guard searchCount > DefaultBrowserViewController.minSearchCountToTrigger else { return false }
+        guard !promoAlreadyShown else { return false }
+        return true
+    }
+
+    // MARK: Presentation
+
+    /// Presents the promo when all eligibility conditions are met.
+    /// Safe to call repeatedly — the prefs flag prevents double-presentation.
+    /// Must be called on @MainActor; no locking needed since the entire call stack is serialised.
     func ecosiaMaybePresentDefaultBrowserPromoForSearchThreshold() {
         guard #available(iOS 14, *) else { return }
-        guard !DefaultBrowserUtility().isDefaultBrowser else { return }
-        guard User.shared.searchCount > DefaultBrowserViewController.minSearchCountToTrigger else { return }
+
+        let alreadyShown = profile.prefs.boolForKey(Self.ecosiaDefaultBrowserSearchThresholdPromoShownKey) == true
+        guard Self.isEligibleForEcosiaDefaultBrowserSearchPromo(
+            searchCount: User.shared.searchCount,
+            isDefaultBrowser: DefaultBrowserUtility().isDefaultBrowser,
+            promoAlreadyShown: alreadyShown
+        ) else { return }
+
         guard tabManager.selectedTab?.isPrivate != true else { return }
         guard presentedViewController == nil else { return }
         guard viewIfLoaded?.window != nil else { return }
 
-        var shouldPresent = false
-        Self.ecosiaDefaultBrowserSearchPromoPrefsLock.lock()
-        if profile.prefs.boolForKey(Self.ecosiaDefaultBrowserSearchThresholdPromoShownKey) != true {
-            profile.prefs.setBool(true, forKey: Self.ecosiaDefaultBrowserSearchThresholdPromoShownKey)
-            shouldPresent = true
-        }
-        Self.ecosiaDefaultBrowserSearchPromoPrefsLock.unlock()
-
-        guard shouldPresent else { return }
+        profile.prefs.setBool(true, forKey: Self.ecosiaDefaultBrowserSearchThresholdPromoShownKey)
 
         let controller = DefaultBrowserViewController(windowUUID: windowUUID, delegate: self)
         present(controller, animated: true, completion: nil)

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
@@ -21,34 +21,23 @@ extension BrowserViewController: HomepageViewControllerDelegate {
 extension BrowserViewController: DefaultBrowserDelegate {
     @available(iOS 14, *)
     func defaultBrowserDidShow(_ defaultBrowser: DefaultBrowserViewController) {
-        // Promo completion is tracked when scheduling presentation (`ecosiaMaybePresentDefaultBrowserPromoForSearchThreshold`).
+        // Promo is marked as shown before presentation; no action needed here.
     }
 }
 
 // MARK: - Default browser promo after search threshold (MOB-4323)
-// Wire the existing DefaultBrowserViewController to the search-count threshold, presenting it
-// only when the user lands on the NTP (idle moment) after crossing the threshold.
-// Uses a dedicated prefs key; upgrading users who already saw the promo (tracked via
-// PrefsKeys.IntroSeen in older builds) are migrated so they don't see it again.
 extension BrowserViewController {
-    /// Ecosia prefs key: set to `true` once the search-threshold default-browser promo has been shown.
-    static let ecosiaDefaultBrowserSearchThresholdPromoShownKey = "EcosiaDefaultBrowserSearchThresholdPromoShown"
+    static let ecosiaSearchPromoShownKey = "EcosiaSearchPromoShown"
 
-    // MARK: Migration
-
-    /// One-shot migration: if the user already saw the promo in a previous app version (tracked
-    /// via `PrefsKeys.IntroSeen`), carry that flag over to the new dedicated key so the promo
-    /// is not shown a second time after upgrading.
+    /// Migrates users who saw the promo under `PrefsKeys.IntroSeen` so they don't see it again.
     func ecosiaMigrateDefaultBrowserPromoFlagIfNeeded() {
-        guard profile.prefs.boolForKey(Self.ecosiaDefaultBrowserSearchThresholdPromoShownKey) == nil else { return }
+        guard profile.prefs.boolForKey(Self.ecosiaSearchPromoShownKey) == nil else { return }
         if profile.prefs.intForKey(PrefsKeys.IntroSeen) != nil {
-            profile.prefs.setBool(true, forKey: Self.ecosiaDefaultBrowserSearchThresholdPromoShownKey)
+            profile.prefs.setBool(true, forKey: Self.ecosiaSearchPromoShownKey)
         }
     }
 
-    // MARK: Eligibility
-
-    /// Pure-function eligibility check — isolated from UIKit so it is directly unit-testable.
+    /// Pure eligibility check, isolated from UIKit for unit-testing.
     static func isEligibleForEcosiaDefaultBrowserSearchPromo(
         searchCount: Int,
         isDefaultBrowser: Bool,
@@ -60,17 +49,14 @@ extension BrowserViewController {
         return true
     }
 
-    // MARK: Presentation
-
-    /// Presents the promo when all eligibility conditions are met.
+    /// Presents the default-browser promo once the search-count threshold is crossed.
     /// Safe to call repeatedly — the prefs flag prevents double-presentation.
-    /// Called from `showEmbeddedHomepage` so the promo only appears on the NTP.
     func ecosiaMaybePresentDefaultBrowserPromoForSearchThreshold() {
         guard #available(iOS 14, *) else { return }
 
         ecosiaMigrateDefaultBrowserPromoFlagIfNeeded()
 
-        let alreadyShown = profile.prefs.boolForKey(Self.ecosiaDefaultBrowserSearchThresholdPromoShownKey) == true
+        let alreadyShown = profile.prefs.boolForKey(Self.ecosiaSearchPromoShownKey) == true
         guard Self.isEligibleForEcosiaDefaultBrowserSearchPromo(
             searchCount: User.shared.searchCount,
             isDefaultBrowser: DefaultBrowserUtility().isDefaultBrowser,
@@ -80,7 +66,7 @@ extension BrowserViewController {
         guard presentedViewController == nil else { return }
         guard viewIfLoaded?.window != nil else { return }
 
-        profile.prefs.setBool(true, forKey: Self.ecosiaDefaultBrowserSearchThresholdPromoShownKey)
+        profile.prefs.setBool(true, forKey: Self.ecosiaSearchPromoShownKey)
 
         let controller = DefaultBrowserViewController(windowUUID: windowUUID, delegate: self)
         present(controller, animated: true, completion: nil)

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
@@ -29,6 +29,15 @@ extension BrowserViewController: DefaultBrowserDelegate {
 extension BrowserViewController {
     static let ecosiaSearchPromoShownKey = "EcosiaSearchPromoShown"
 
+    /// One-shot migration from the old `PrefsKeys.IntroSeen` gate to `ecosiaSearchPromoShownKey`.
+    /// Preserves the existing suppression: users already blocked under the old key remain blocked.
+    func ecosiaMigrateDefaultBrowserPromoFlagIfNeeded() {
+        guard profile.prefs.boolForKey(Self.ecosiaSearchPromoShownKey) == nil else { return }
+        if profile.prefs.intForKey(PrefsKeys.IntroSeen) != nil {
+            profile.prefs.setBool(true, forKey: Self.ecosiaSearchPromoShownKey)
+        }
+    }
+
     /// Pure eligibility check, isolated from UIKit for unit-testing.
     static func isEligibleForEcosiaDefaultBrowserSearchPromo(
         searchCount: Int,
@@ -45,6 +54,8 @@ extension BrowserViewController {
     /// Safe to call repeatedly — the prefs flag prevents double-presentation.
     func ecosiaMaybePresentDefaultBrowserPromoForSearchThreshold() {
         guard #available(iOS 14, *) else { return }
+
+        ecosiaMigrateDefaultBrowserPromoFlagIfNeeded()
 
         let alreadyShown = profile.prefs.boolForKey(Self.ecosiaSearchPromoShownKey) == true
         guard Self.isEligibleForEcosiaDefaultBrowserSearchPromo(

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
@@ -21,11 +21,11 @@ extension BrowserViewController: HomepageViewControllerDelegate {
 extension BrowserViewController: DefaultBrowserDelegate {
     @available(iOS 14, *)
     func defaultBrowserDidShow(_ defaultBrowser: DefaultBrowserViewController) {
-        // Promo is marked as shown before presentation; no action needed here.
+        profile.prefs.setBool(true, forKey: BrowserViewController.ecosiaSearchPromoShownKey)
     }
 }
 
-// MARK: - Default browser promo after search threshold (MOB-4323)
+// MARK: - Default browser promo after search threshold
 extension BrowserViewController {
     static let ecosiaSearchPromoShownKey = "EcosiaSearchPromoShown"
 
@@ -65,8 +65,6 @@ extension BrowserViewController {
 
         guard presentedViewController == nil else { return }
         guard viewIfLoaded?.window != nil else { return }
-
-        profile.prefs.setBool(true, forKey: Self.ecosiaSearchPromoShownKey)
 
         let controller = DefaultBrowserViewController(windowUUID: windowUUID, delegate: self)
         present(controller, animated: true, completion: nil)

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
@@ -26,7 +26,7 @@ extension BrowserViewController: DefaultBrowserDelegate {
 }
 
 // MARK: - Default browser promo after search threshold (MOB-4323)
-// Ecosia: DefaultBrowserViewController was defined but never presented anywhere. Wire it to the
+// DefaultBrowserViewController was defined but never presented. Wire it to the
 // search-count threshold using a dedicated prefs key (not PrefsKeys.IntroSeen, which belongs to onboarding).
 extension BrowserViewController {
     /// Ecosia prefs key: set to `true` once the search-threshold default-browser promo has been shown.

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
@@ -21,8 +21,38 @@ extension BrowserViewController: HomepageViewControllerDelegate {
 extension BrowserViewController: DefaultBrowserDelegate {
     @available(iOS 14, *)
     func defaultBrowserDidShow(_ defaultBrowser: DefaultBrowserViewController) {
-        profile.prefs.setInt(1, forKey: PrefsKeys.IntroSeen)
-//        homepageViewController?.reloadTooltip()
+        // Promo completion is tracked when scheduling presentation (`ecosiaMaybePresentDefaultBrowserPromoForSearchThreshold`).
+    }
+}
+
+// MARK: - Default browser promo after search threshold (MOB-4323)
+extension BrowserViewController {
+    /// Profile prefs key: user has seen (or completed flow for) the search-count default browser promo.
+    static let ecosiaDefaultBrowserSearchThresholdPromoShownKey = "EcosiaDefaultBrowserSearchThresholdPromoShown"
+
+    private static let ecosiaDefaultBrowserSearchPromoPrefsLock = NSLock()
+
+    /// Call from app lifecycle so we catch users whose search count was already above the threshold before BVC existed.
+    func ecosiaMaybePresentDefaultBrowserPromoForSearchThreshold() {
+        guard #available(iOS 14, *) else { return }
+        guard !DefaultBrowserUtility().isDefaultBrowser else { return }
+        guard User.shared.searchCount > DefaultBrowserViewController.minSearchCountToTrigger else { return }
+        guard tabManager.selectedTab?.isPrivate != true else { return }
+        guard presentedViewController == nil else { return }
+        guard viewIfLoaded?.window != nil else { return }
+
+        var shouldPresent = false
+        Self.ecosiaDefaultBrowserSearchPromoPrefsLock.lock()
+        if profile.prefs.boolForKey(Self.ecosiaDefaultBrowserSearchThresholdPromoShownKey) != true {
+            profile.prefs.setBool(true, forKey: Self.ecosiaDefaultBrowserSearchThresholdPromoShownKey)
+            shouldPresent = true
+        }
+        Self.ecosiaDefaultBrowserSearchPromoPrefsLock.unlock()
+
+        guard shouldPresent else { return }
+
+        let controller = DefaultBrowserViewController(windowUUID: windowUUID, delegate: self)
+        present(controller, animated: true, completion: nil)
     }
 }
 

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
@@ -26,11 +26,25 @@ extension BrowserViewController: DefaultBrowserDelegate {
 }
 
 // MARK: - Default browser promo after search threshold (MOB-4323)
-// DefaultBrowserViewController was defined but never presented. Wire it to the
-// search-count threshold using a dedicated prefs key (not PrefsKeys.IntroSeen, which belongs to onboarding).
+// Wire the existing DefaultBrowserViewController to the search-count threshold, presenting it
+// only when the user lands on the NTP (idle moment) after crossing the threshold.
+// Uses a dedicated prefs key; upgrading users who already saw the promo (tracked via
+// PrefsKeys.IntroSeen in older builds) are migrated so they don't see it again.
 extension BrowserViewController {
     /// Ecosia prefs key: set to `true` once the search-threshold default-browser promo has been shown.
     static let ecosiaDefaultBrowserSearchThresholdPromoShownKey = "EcosiaDefaultBrowserSearchThresholdPromoShown"
+
+    // MARK: Migration
+
+    /// One-shot migration: if the user already saw the promo in a previous app version (tracked
+    /// via `PrefsKeys.IntroSeen`), carry that flag over to the new dedicated key so the promo
+    /// is not shown a second time after upgrading.
+    func ecosiaMigrateDefaultBrowserPromoFlagIfNeeded() {
+        guard profile.prefs.boolForKey(Self.ecosiaDefaultBrowserSearchThresholdPromoShownKey) == nil else { return }
+        if profile.prefs.intForKey(PrefsKeys.IntroSeen) != nil {
+            profile.prefs.setBool(true, forKey: Self.ecosiaDefaultBrowserSearchThresholdPromoShownKey)
+        }
+    }
 
     // MARK: Eligibility
 
@@ -50,9 +64,11 @@ extension BrowserViewController {
 
     /// Presents the promo when all eligibility conditions are met.
     /// Safe to call repeatedly — the prefs flag prevents double-presentation.
-    /// Must be called on @MainActor; no locking needed since the entire call stack is serialised.
+    /// Called from `showEmbeddedHomepage` so the promo only appears on the NTP.
     func ecosiaMaybePresentDefaultBrowserPromoForSearchThreshold() {
         guard #available(iOS 14, *) else { return }
+
+        ecosiaMigrateDefaultBrowserPromoFlagIfNeeded()
 
         let alreadyShown = profile.prefs.boolForKey(Self.ecosiaDefaultBrowserSearchThresholdPromoShownKey) == true
         guard Self.isEligibleForEcosiaDefaultBrowserSearchPromo(
@@ -61,7 +77,6 @@ extension BrowserViewController {
             promoAlreadyShown: alreadyShown
         ) else { return }
 
-        guard tabManager.selectedTab?.isPrivate != true else { return }
         guard presentedViewController == nil else { return }
         guard viewIfLoaded?.window != nil else { return }
 

--- a/firefox-ios/Client/Ecosia/Settings/EcosiaDebugSettings.swift
+++ b/firefox-ios/Client/Ecosia/Settings/EcosiaDebugSettings.swift
@@ -53,7 +53,7 @@ final class ToggleDefaultBrowserPromo: HiddenSetting {
 
     override func onClick(_ navigationController: UINavigationController?) {
         profile?.prefs.removeObjectForKey(PrefsKeys.IntroSeen)
-        profile?.prefs.removeObjectForKey(BrowserViewController.ecosiaDefaultBrowserSearchThresholdPromoShownKey)
+        profile?.prefs.removeObjectForKey(BrowserViewController.ecosiaSearchPromoShownKey)
         settings.tableView.reloadData()
     }
 

--- a/firefox-ios/Client/Ecosia/Settings/EcosiaDebugSettings.swift
+++ b/firefox-ios/Client/Ecosia/Settings/EcosiaDebugSettings.swift
@@ -53,6 +53,7 @@ final class ToggleDefaultBrowserPromo: HiddenSetting {
 
     override func onClick(_ navigationController: UINavigationController?) {
         profile?.prefs.removeObjectForKey(PrefsKeys.IntroSeen)
+        profile?.prefs.removeObjectForKey(BrowserViewController.ecosiaDefaultBrowserSearchThresholdPromoShownKey)
         settings.tableView.reloadData()
     }
 

--- a/firefox-ios/Client/Ecosia/Settings/EcosiaDebugSettings.swift
+++ b/firefox-ios/Client/Ecosia/Settings/EcosiaDebugSettings.swift
@@ -53,7 +53,7 @@ final class ToggleDefaultBrowserPromo: HiddenSetting {
 
     override func onClick(_ navigationController: UINavigationController?) {
         profile?.prefs.removeObjectForKey(PrefsKeys.IntroSeen)
-        profile?.prefs.removeObjectForKey(BrowserViewController.ecosiaSearchPromoShownKey)
+        User.shared.resetDefaultBrowserSearchPromo()
         settings.tableView.reloadData()
     }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1337,9 +1337,6 @@ class BrowserViewController: UIViewController,
                 onStopDownloads(notificationWindowUUID: windowUUID)
             case .SettingsDismissed:
                 onSettingsDismissed()
-            // Ecosia: Re-evaluate default-browser promo whenever the search count changes (MOB-4323).
-            case .searchesCounterChanged:
-                ecosiaMaybePresentDefaultBrowserPromoForSearchThreshold()
             default: break
             }
         }
@@ -1366,9 +1363,7 @@ class BrowserViewController: UIViewController,
                 .PageZoomSettingsChanged,
                 .RemoteTabNotificationTapped,
                 .StopDownloads,
-                .SettingsDismissed,
-                // Ecosia: Observe search-count changes to trigger default-browser promo (MOB-4323).
-                .searchesCounterChanged
+                .SettingsDismissed
             ]
         )
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1027,6 +1027,7 @@ class BrowserViewController: UIViewController,
 
         NightModeHelper.cleanNightModeDefaults()
         dispatchStartAtHomeAction()
+        ecosiaMaybePresentDefaultBrowserPromoForSearchThreshold()
     }
 
     // MARK: - Summarize
@@ -1337,6 +1338,8 @@ class BrowserViewController: UIViewController,
                 onStopDownloads(notificationWindowUUID: windowUUID)
             case .SettingsDismissed:
                 onSettingsDismissed()
+            case .searchesCounterChanged:
+                self.ecosiaMaybePresentDefaultBrowserPromoForSearchThreshold()
             default: break
             }
         }
@@ -1363,7 +1366,8 @@ class BrowserViewController: UIViewController,
                 .PageZoomSettingsChanged,
                 .RemoteTabNotificationTapped,
                 .StopDownloads,
-                .SettingsDismissed
+                .SettingsDismissed,
+                .searchesCounterChanged
             ]
         )
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1027,6 +1027,7 @@ class BrowserViewController: UIViewController,
 
         NightModeHelper.cleanNightModeDefaults()
         dispatchStartAtHomeAction()
+        // Ecosia: Catch users who were already above the search threshold before this BVC appeared (MOB-4323).
         ecosiaMaybePresentDefaultBrowserPromoForSearchThreshold()
     }
 
@@ -1338,6 +1339,7 @@ class BrowserViewController: UIViewController,
                 onStopDownloads(notificationWindowUUID: windowUUID)
             case .SettingsDismissed:
                 onSettingsDismissed()
+            // Ecosia: Re-evaluate default-browser promo whenever the search count changes (MOB-4323).
             case .searchesCounterChanged:
                 self.ecosiaMaybePresentDefaultBrowserPromoForSearchThreshold()
             default: break
@@ -1367,6 +1369,7 @@ class BrowserViewController: UIViewController,
                 .RemoteTabNotificationTapped,
                 .StopDownloads,
                 .SettingsDismissed,
+                // Ecosia: Observe search-count changes to re-evaluate default-browser promo (MOB-4323).
                 .searchesCounterChanged
             ]
         )

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1027,8 +1027,6 @@ class BrowserViewController: UIViewController,
 
         NightModeHelper.cleanNightModeDefaults()
         dispatchStartAtHomeAction()
-        // Ecosia: Catch users who were already above the search threshold before this BVC appeared (MOB-4323).
-        ecosiaMaybePresentDefaultBrowserPromoForSearchThreshold()
     }
 
     // MARK: - Summarize
@@ -1339,9 +1337,6 @@ class BrowserViewController: UIViewController,
                 onStopDownloads(notificationWindowUUID: windowUUID)
             case .SettingsDismissed:
                 onSettingsDismissed()
-            // Ecosia: Re-evaluate default-browser promo whenever the search count changes (MOB-4323).
-            case .searchesCounterChanged:
-                self.ecosiaMaybePresentDefaultBrowserPromoForSearchThreshold()
             default: break
             }
         }
@@ -1368,9 +1363,7 @@ class BrowserViewController: UIViewController,
                 .PageZoomSettingsChanged,
                 .RemoteTabNotificationTapped,
                 .StopDownloads,
-                .SettingsDismissed,
-                // Ecosia: Observe search-count changes to re-evaluate default-browser promo (MOB-4323).
-                .searchesCounterChanged
+                .SettingsDismissed
             ]
         )
     }
@@ -2053,6 +2046,11 @@ class BrowserViewController: UIViewController,
         // embedContent(:) is called when showing the homepage and that is already making sure the shadow is not clipped
         if !isToolbarTranslucencyRefactorEnabled {
             updateToolbarDisplay()
+        }
+
+        // Ecosia: Show default-browser promo when user lands on NTP (idle moment) — not mid-search (MOB-4323).
+        if !isPrivate {
+            ecosiaMaybePresentDefaultBrowserPromoForSearchThreshold()
         }
     }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -1337,6 +1337,9 @@ class BrowserViewController: UIViewController,
                 onStopDownloads(notificationWindowUUID: windowUUID)
             case .SettingsDismissed:
                 onSettingsDismissed()
+            // Ecosia: Re-evaluate default-browser promo whenever the search count changes (MOB-4323).
+            case .searchesCounterChanged:
+                ecosiaMaybePresentDefaultBrowserPromoForSearchThreshold()
             default: break
             }
         }
@@ -1363,7 +1366,9 @@ class BrowserViewController: UIViewController,
                 .PageZoomSettingsChanged,
                 .RemoteTabNotificationTapped,
                 .StopDownloads,
-                .SettingsDismissed
+                .SettingsDismissed,
+                // Ecosia: Observe search-count changes to trigger default-browser promo (MOB-4323).
+                .searchesCounterChanged
             ]
         )
     }

--- a/firefox-ios/Ecosia/Core/User.swift
+++ b/firefox-ios/Ecosia/Core/User.swift
@@ -7,7 +7,7 @@ import UserNotifications
 import Combine
 
 extension Notification.Name {
-    public static let searchesCounterChanged = Notification.Name("searchesCounterChanged")
+    static let searchesCounterChanged = Notification.Name("searchesCounterChanged")
     public static let searchSettingsChanged = Notification.Name("searchSettingsChanged")
 }
 

--- a/firefox-ios/Ecosia/Core/User.swift
+++ b/firefox-ios/Ecosia/Core/User.swift
@@ -7,7 +7,7 @@ import UserNotifications
 import Combine
 
 extension Notification.Name {
-    static let searchesCounterChanged = Notification.Name("searchesCounterChanged")
+    public static let searchesCounterChanged = Notification.Name("searchesCounterChanged")
     public static let searchSettingsChanged = Notification.Name("searchSettingsChanged")
 }
 

--- a/firefox-ios/Ecosia/Core/User.swift
+++ b/firefox-ios/Ecosia/Core/User.swift
@@ -7,7 +7,7 @@ import UserNotifications
 import Combine
 
 extension Notification.Name {
-    static let searchesCounterChanged = Notification.Name("searchesCounterChanged")
+    public static let searchesCounterChanged = Notification.Name("searchesCounterChanged")
     public static let searchSettingsChanged = Notification.Name("searchSettingsChanged")
 }
 
@@ -241,6 +241,18 @@ extension User {
         state[Key.isAccountImpactNudgeCardDismissed.rawValue] = "\(true)"
     }
 
+    public var defaultBrowserSearchPromoShown: Bool {
+        state[Key.defaultBrowserSearchPromoShown.rawValue].map(Bool.init) == true
+    }
+
+    public mutating func markDefaultBrowserSearchPromoAsShown() {
+        state[Key.defaultBrowserSearchPromoShown.rawValue] = "\(true)"
+    }
+
+    public mutating func resetDefaultBrowserSearchPromo() {
+        state.removeValue(forKey: Key.defaultBrowserSearchPromoShown.rawValue)
+    }
+
     enum Key: String {
         case
         referralSpotlight,
@@ -249,7 +261,8 @@ extension User {
         bookmarksImportExportTooltipShown,
         isNewUserSinceBookmarksImportExportHasBeenShipped,
         isDefaultBrowserSettingNudgeCardShown,
-        isAccountImpactNudgeCardDismissed
+        isAccountImpactNudgeCardDismissed,
+        defaultBrowserSearchPromoShown
     }
 }
 

--- a/firefox-ios/EcosiaTests/UI/NTP/DefaultBrowserSearchPromoTests.swift
+++ b/firefox-ios/EcosiaTests/UI/NTP/DefaultBrowserSearchPromoTests.swift
@@ -5,6 +5,7 @@
 import XCTest
 @testable import Client
 import Shared
+import Ecosia
 
 /// Tests for MOB-4323 — Ecosia default-browser promo triggered after search-count threshold.
 ///
@@ -18,11 +19,13 @@ final class DefaultBrowserSearchPromoTests: XCTestCase {
     override func setUp() {
         super.setUp()
         profile = MockProfile()
+        User.shared.resetDefaultBrowserSearchPromo()
     }
 
     override func tearDown() {
         profile.prefs.clearAll()
         profile = nil
+        User.shared.resetDefaultBrowserSearchPromo()
         super.tearDown()
     }
 
@@ -75,55 +78,35 @@ final class DefaultBrowserSearchPromoTests: XCTestCase {
         XCTAssertFalse(eligible(searchCount: 0, isDefaultBrowser: false, promoAlreadyShown: false))
     }
 
-    // MARK: - Prefs key name stability
-
-    func testPromoPrefsKeyIsStable() {
-        XCTAssertEqual(
-            BrowserViewController.ecosiaSearchPromoShownKey,
-            "EcosiaSearchPromoShown",
-            "Changing this key silently resets every user's promo-shown flag."
-        )
-    }
-
     // MARK: - Migration from PrefsKeys.IntroSeen
 
-    func testMigration_introSeenSet_setsNewKey() {
-        let prefs = profile.prefs
-        let key = BrowserViewController.ecosiaSearchPromoShownKey
-        prefs.setInt(1, forKey: PrefsKeys.IntroSeen)
+    func testMigration_introSeenSet_marksUserFlag() {
+        profile.prefs.setInt(1, forKey: PrefsKeys.IntroSeen)
+        XCTAssertFalse(User.shared.defaultBrowserSearchPromoShown, "Flag should not be set before migration.")
 
-        XCTAssertNil(prefs.boolForKey(key), "New key should not exist before migration.")
+        migrateIfNeeded(prefs: profile.prefs)
 
-        migrateIfNeeded(prefs: prefs)
-
-        XCTAssertEqual(
-            prefs.boolForKey(key),
-            true,
+        XCTAssertTrue(
+            User.shared.defaultBrowserSearchPromoShown,
             "Users blocked under the old key must stay blocked under the new one."
         )
     }
 
-    func testMigration_introSeenNotSet_doesNotSetNewKey() {
-        let prefs = profile.prefs
-        let key = BrowserViewController.ecosiaSearchPromoShownKey
+    func testMigration_introSeenNotSet_doesNotMarkUserFlag() {
+        migrateIfNeeded(prefs: profile.prefs)
 
-        migrateIfNeeded(prefs: prefs)
-
-        XCTAssertNil(prefs.boolForKey(key), "Fresh user should not be pre-blocked.")
+        XCTAssertFalse(User.shared.defaultBrowserSearchPromoShown, "Fresh user should not be pre-blocked.")
     }
 
-    func testMigration_newKeyAlreadySet_isNoOp() {
-        let prefs = profile.prefs
-        let key = BrowserViewController.ecosiaSearchPromoShownKey
-        prefs.setBool(true, forKey: key)
-        prefs.setInt(1, forKey: PrefsKeys.IntroSeen)
+    func testMigration_userFlagAlreadySet_isNoOp() {
+        User.shared.markDefaultBrowserSearchPromoAsShown()
+        profile.prefs.setInt(1, forKey: PrefsKeys.IntroSeen)
 
-        migrateIfNeeded(prefs: prefs)
+        migrateIfNeeded(prefs: profile.prefs)
 
-        XCTAssertEqual(
-            prefs.boolForKey(key),
-            true,
-            "Migration must be a no-op once the new key is already written."
+        XCTAssertTrue(
+            User.shared.defaultBrowserSearchPromoShown,
+            "Migration must be a no-op once the User flag is already set."
         )
     }
 
@@ -139,10 +122,9 @@ final class DefaultBrowserSearchPromoTests: XCTestCase {
 
     /// Mirrors `ecosiaMigrateDefaultBrowserPromoFlagIfNeeded` without requiring a BVC instance.
     private func migrateIfNeeded(prefs: Prefs) {
-        let key = BrowserViewController.ecosiaSearchPromoShownKey
-        guard prefs.boolForKey(key) == nil else { return }
+        guard !User.shared.defaultBrowserSearchPromoShown else { return }
         if prefs.intForKey(PrefsKeys.IntroSeen) != nil {
-            prefs.setBool(true, forKey: key)
+            User.shared.markDefaultBrowserSearchPromoAsShown()
         }
     }
 }

--- a/firefox-ios/EcosiaTests/UI/NTP/DefaultBrowserSearchPromoTests.swift
+++ b/firefox-ios/EcosiaTests/UI/NTP/DefaultBrowserSearchPromoTests.swift
@@ -75,8 +75,8 @@ final class DefaultBrowserSearchPromoTests: XCTestCase {
 
     func testPromoPrefsKeyIsStable() {
         XCTAssertEqual(
-            BrowserViewController.ecosiaDefaultBrowserSearchThresholdPromoShownKey,
-            "EcosiaDefaultBrowserSearchThresholdPromoShown",
+            BrowserViewController.ecosiaSearchPromoShownKey,
+            "EcosiaSearchPromoShown",
             "Changing this key silently resets every user's promo-shown flag."
         )
     }
@@ -85,7 +85,7 @@ final class DefaultBrowserSearchPromoTests: XCTestCase {
 
     func testMigration_introSeenSet_migratesNewKey() {
         let prefs = profile.prefs
-        let key = BrowserViewController.ecosiaDefaultBrowserSearchThresholdPromoShownKey
+        let key = BrowserViewController.ecosiaSearchPromoShownKey
         prefs.setInt(1, forKey: PrefsKeys.IntroSeen)
 
         XCTAssertNil(prefs.boolForKey(key), "New key should not exist before migration.")
@@ -98,7 +98,7 @@ final class DefaultBrowserSearchPromoTests: XCTestCase {
 
     func testMigration_introSeenNotSet_doesNotSetNewKey() {
         let prefs = profile.prefs
-        let key = BrowserViewController.ecosiaDefaultBrowserSearchThresholdPromoShownKey
+        let key = BrowserViewController.ecosiaSearchPromoShownKey
 
         migrateIfNeeded(prefs: prefs)
 
@@ -108,7 +108,7 @@ final class DefaultBrowserSearchPromoTests: XCTestCase {
 
     func testMigration_newKeyAlreadySet_doesNotOverwrite() {
         let prefs = profile.prefs
-        let key = BrowserViewController.ecosiaDefaultBrowserSearchThresholdPromoShownKey
+        let key = BrowserViewController.ecosiaSearchPromoShownKey
         prefs.setBool(true, forKey: key)
         prefs.setInt(1, forKey: PrefsKeys.IntroSeen)
 
@@ -130,7 +130,7 @@ final class DefaultBrowserSearchPromoTests: XCTestCase {
 
     /// Mirrors `ecosiaMigrateDefaultBrowserPromoFlagIfNeeded` logic without requiring a BVC instance.
     private func migrateIfNeeded(prefs: Prefs) {
-        let key = BrowserViewController.ecosiaDefaultBrowserSearchThresholdPromoShownKey
+        let key = BrowserViewController.ecosiaSearchPromoShownKey
         guard prefs.boolForKey(key) == nil else { return }
         if prefs.intForKey(PrefsKeys.IntroSeen) != nil {
             prefs.setBool(true, forKey: key)

--- a/firefox-ios/EcosiaTests/UI/NTP/DefaultBrowserSearchPromoTests.swift
+++ b/firefox-ios/EcosiaTests/UI/NTP/DefaultBrowserSearchPromoTests.swift
@@ -12,6 +12,7 @@ import Shared
 /// which makes it straightforward to unit-test without spinning up a real `BrowserViewController`.
 final class DefaultBrowserSearchPromoTests: XCTestCase {
 
+    // swiftlint:disable:next implicitly_unwrapped_optional
     private var profile: MockProfile!
 
     override func setUp() {
@@ -28,8 +29,11 @@ final class DefaultBrowserSearchPromoTests: XCTestCase {
     // MARK: - Threshold constant
 
     func testMinSearchCountToTriggerIs50() {
-        XCTAssertEqual(DefaultBrowserViewController.minSearchCountToTrigger, 50,
-                       "Threshold changed — re-verify analytics and QA guidance for MOB-4323.")
+        XCTAssertEqual(
+            DefaultBrowserViewController.minSearchCountToTrigger,
+            50,
+            "Threshold changed — re-verify analytics and QA guidance for MOB-4323."
+        )
     }
 
     // MARK: - isEligibleForEcosiaDefaultBrowserSearchPromo
@@ -92,8 +96,11 @@ final class DefaultBrowserSearchPromoTests: XCTestCase {
 
         migrateIfNeeded(prefs: prefs)
 
-        XCTAssertEqual(prefs.boolForKey(key), true,
-                       "Upgrading user who saw the promo (IntroSeen set) should be marked as shown.")
+        XCTAssertEqual(
+            prefs.boolForKey(key),
+            true,
+            "Upgrading user who saw the promo (IntroSeen set) should be marked as shown."
+        )
     }
 
     func testMigration_introSeenNotSet_doesNotSetNewKey() {
@@ -114,8 +121,11 @@ final class DefaultBrowserSearchPromoTests: XCTestCase {
 
         migrateIfNeeded(prefs: prefs)
 
-        XCTAssertEqual(prefs.boolForKey(key), true,
-                       "Migration should be a no-op when the new key already exists.")
+        XCTAssertEqual(
+            prefs.boolForKey(key),
+            true,
+            "Migration should be a no-op when the new key already exists."
+        )
     }
 
     // MARK: - Helpers

--- a/firefox-ios/EcosiaTests/UI/NTP/DefaultBrowserSearchPromoTests.swift
+++ b/firefox-ios/EcosiaTests/UI/NTP/DefaultBrowserSearchPromoTests.swift
@@ -4,12 +4,27 @@
 
 import XCTest
 @testable import Client
+import Shared
 
 /// Tests for MOB-4323 — Ecosia default-browser promo triggered after search-count threshold.
 ///
 /// The eligibility logic is isolated in `BrowserViewController.isEligibleForEcosiaDefaultBrowserSearchPromo`,
 /// which makes it straightforward to unit-test without spinning up a real `BrowserViewController`.
 final class DefaultBrowserSearchPromoTests: XCTestCase {
+
+    // swiftlint:disable:next implicitly_unwrapped_optional
+    private var profile: MockProfile!
+
+    override func setUp() {
+        super.setUp()
+        profile = MockProfile()
+    }
+
+    override func tearDown() {
+        profile.prefs.clearAll()
+        profile = nil
+        super.tearDown()
+    }
 
     // MARK: - Threshold constant
 
@@ -70,6 +85,48 @@ final class DefaultBrowserSearchPromoTests: XCTestCase {
         )
     }
 
+    // MARK: - Migration from PrefsKeys.IntroSeen
+
+    func testMigration_introSeenSet_setsNewKey() {
+        let prefs = profile.prefs
+        let key = BrowserViewController.ecosiaSearchPromoShownKey
+        prefs.setInt(1, forKey: PrefsKeys.IntroSeen)
+
+        XCTAssertNil(prefs.boolForKey(key), "New key should not exist before migration.")
+
+        migrateIfNeeded(prefs: prefs)
+
+        XCTAssertEqual(
+            prefs.boolForKey(key),
+            true,
+            "Users blocked under the old key must stay blocked under the new one."
+        )
+    }
+
+    func testMigration_introSeenNotSet_doesNotSetNewKey() {
+        let prefs = profile.prefs
+        let key = BrowserViewController.ecosiaSearchPromoShownKey
+
+        migrateIfNeeded(prefs: prefs)
+
+        XCTAssertNil(prefs.boolForKey(key), "Fresh user should not be pre-blocked.")
+    }
+
+    func testMigration_newKeyAlreadySet_isNoOp() {
+        let prefs = profile.prefs
+        let key = BrowserViewController.ecosiaSearchPromoShownKey
+        prefs.setBool(true, forKey: key)
+        prefs.setInt(1, forKey: PrefsKeys.IntroSeen)
+
+        migrateIfNeeded(prefs: prefs)
+
+        XCTAssertEqual(
+            prefs.boolForKey(key),
+            true,
+            "Migration must be a no-op once the new key is already written."
+        )
+    }
+
     // MARK: - Helpers
 
     private func eligible(searchCount: Int, isDefaultBrowser: Bool, promoAlreadyShown: Bool) -> Bool {
@@ -78,5 +135,14 @@ final class DefaultBrowserSearchPromoTests: XCTestCase {
             isDefaultBrowser: isDefaultBrowser,
             promoAlreadyShown: promoAlreadyShown
         )
+    }
+
+    /// Mirrors `ecosiaMigrateDefaultBrowserPromoFlagIfNeeded` without requiring a BVC instance.
+    private func migrateIfNeeded(prefs: Prefs) {
+        let key = BrowserViewController.ecosiaSearchPromoShownKey
+        guard prefs.boolForKey(key) == nil else { return }
+        if prefs.intForKey(PrefsKeys.IntroSeen) != nil {
+            prefs.setBool(true, forKey: key)
+        }
     }
 }

--- a/firefox-ios/EcosiaTests/UI/NTP/DefaultBrowserSearchPromoTests.swift
+++ b/firefox-ios/EcosiaTests/UI/NTP/DefaultBrowserSearchPromoTests.swift
@@ -4,12 +4,26 @@
 
 import XCTest
 @testable import Client
+import Shared
 
 /// Tests for MOB-4323 — Ecosia default-browser promo triggered after search-count threshold.
 ///
 /// The eligibility logic is isolated in `BrowserViewController.isEligibleForEcosiaDefaultBrowserSearchPromo`,
 /// which makes it straightforward to unit-test without spinning up a real `BrowserViewController`.
 final class DefaultBrowserSearchPromoTests: XCTestCase {
+
+    private var profile: MockProfile!
+
+    override func setUp() {
+        super.setUp()
+        profile = MockProfile()
+    }
+
+    override func tearDown() {
+        profile.prefs.clearAll()
+        profile = nil
+        super.tearDown()
+    }
 
     // MARK: - Threshold constant
 
@@ -67,6 +81,43 @@ final class DefaultBrowserSearchPromoTests: XCTestCase {
         )
     }
 
+    // MARK: - Migration from PrefsKeys.IntroSeen
+
+    func testMigration_introSeenSet_migratesNewKey() {
+        let prefs = profile.prefs
+        let key = BrowserViewController.ecosiaDefaultBrowserSearchThresholdPromoShownKey
+        prefs.setInt(1, forKey: PrefsKeys.IntroSeen)
+
+        XCTAssertNil(prefs.boolForKey(key), "New key should not exist before migration.")
+
+        migrateIfNeeded(prefs: prefs)
+
+        XCTAssertEqual(prefs.boolForKey(key), true,
+                       "Upgrading user who saw the promo (IntroSeen set) should be marked as shown.")
+    }
+
+    func testMigration_introSeenNotSet_doesNotSetNewKey() {
+        let prefs = profile.prefs
+        let key = BrowserViewController.ecosiaDefaultBrowserSearchThresholdPromoShownKey
+
+        migrateIfNeeded(prefs: prefs)
+
+        XCTAssertNil(prefs.boolForKey(key),
+                     "Fresh user without IntroSeen should not have the new key set.")
+    }
+
+    func testMigration_newKeyAlreadySet_doesNotOverwrite() {
+        let prefs = profile.prefs
+        let key = BrowserViewController.ecosiaDefaultBrowserSearchThresholdPromoShownKey
+        prefs.setBool(true, forKey: key)
+        prefs.setInt(1, forKey: PrefsKeys.IntroSeen)
+
+        migrateIfNeeded(prefs: prefs)
+
+        XCTAssertEqual(prefs.boolForKey(key), true,
+                       "Migration should be a no-op when the new key already exists.")
+    }
+
     // MARK: - Helpers
 
     private func eligible(searchCount: Int, isDefaultBrowser: Bool, promoAlreadyShown: Bool) -> Bool {
@@ -75,5 +126,14 @@ final class DefaultBrowserSearchPromoTests: XCTestCase {
             isDefaultBrowser: isDefaultBrowser,
             promoAlreadyShown: promoAlreadyShown
         )
+    }
+
+    /// Mirrors `ecosiaMigrateDefaultBrowserPromoFlagIfNeeded` logic without requiring a BVC instance.
+    private func migrateIfNeeded(prefs: Prefs) {
+        let key = BrowserViewController.ecosiaDefaultBrowserSearchThresholdPromoShownKey
+        guard prefs.boolForKey(key) == nil else { return }
+        if prefs.intForKey(PrefsKeys.IntroSeen) != nil {
+            prefs.setBool(true, forKey: key)
+        }
     }
 }

--- a/firefox-ios/EcosiaTests/UI/NTP/DefaultBrowserSearchPromoTests.swift
+++ b/firefox-ios/EcosiaTests/UI/NTP/DefaultBrowserSearchPromoTests.swift
@@ -1,0 +1,79 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import Client
+
+/// Tests for MOB-4323 — Ecosia default-browser promo triggered after search-count threshold.
+///
+/// The eligibility logic is isolated in `BrowserViewController.isEligibleForEcosiaDefaultBrowserSearchPromo`,
+/// which makes it straightforward to unit-test without spinning up a real `BrowserViewController`.
+final class DefaultBrowserSearchPromoTests: XCTestCase {
+
+    // MARK: - Threshold constant
+
+    func testMinSearchCountToTriggerIs50() {
+        XCTAssertEqual(DefaultBrowserViewController.minSearchCountToTrigger, 50,
+                       "Threshold changed — re-verify analytics and QA guidance for MOB-4323.")
+    }
+
+    // MARK: - isEligibleForEcosiaDefaultBrowserSearchPromo
+
+    func testEligible_whenCountAboveThreshold_notDefault_notShown() {
+        XCTAssertTrue(eligible(searchCount: 51, isDefaultBrowser: false, promoAlreadyShown: false))
+    }
+
+    func testEligible_exactlyAtThresholdPlusOne() {
+        XCTAssertTrue(eligible(searchCount: DefaultBrowserViewController.minSearchCountToTrigger + 1,
+                               isDefaultBrowser: false,
+                               promoAlreadyShown: false))
+    }
+
+    func testNotEligible_exactlyAtThreshold() {
+        XCTAssertFalse(eligible(searchCount: DefaultBrowserViewController.minSearchCountToTrigger,
+                                isDefaultBrowser: false,
+                                promoAlreadyShown: false),
+                       "Promo requires count *greater than* the threshold, not equal.")
+    }
+
+    func testNotEligible_countBelowThreshold() {
+        XCTAssertFalse(eligible(searchCount: 10, isDefaultBrowser: false, promoAlreadyShown: false))
+    }
+
+    func testNotEligible_alreadyDefaultBrowser() {
+        XCTAssertFalse(eligible(searchCount: 100, isDefaultBrowser: true, promoAlreadyShown: false))
+    }
+
+    func testNotEligible_promoAlreadyShown() {
+        XCTAssertFalse(eligible(searchCount: 100, isDefaultBrowser: false, promoAlreadyShown: true))
+    }
+
+    func testNotEligible_alreadyDefaultAndPromoShown() {
+        XCTAssertFalse(eligible(searchCount: 100, isDefaultBrowser: true, promoAlreadyShown: true))
+    }
+
+    func testNotEligible_zeroSearchCount() {
+        XCTAssertFalse(eligible(searchCount: 0, isDefaultBrowser: false, promoAlreadyShown: false))
+    }
+
+    // MARK: - Prefs key name stability
+
+    func testPromoPrefsKeyIsStable() {
+        XCTAssertEqual(
+            BrowserViewController.ecosiaDefaultBrowserSearchThresholdPromoShownKey,
+            "EcosiaDefaultBrowserSearchThresholdPromoShown",
+            "Changing this key silently resets every user's promo-shown flag."
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func eligible(searchCount: Int, isDefaultBrowser: Bool, promoAlreadyShown: Bool) -> Bool {
+        BrowserViewController.isEligibleForEcosiaDefaultBrowserSearchPromo(
+            searchCount: searchCount,
+            isDefaultBrowser: isDefaultBrowser,
+            promoAlreadyShown: promoAlreadyShown
+        )
+    }
+}

--- a/firefox-ios/EcosiaTests/UI/NTP/DefaultBrowserSearchPromoTests.swift
+++ b/firefox-ios/EcosiaTests/UI/NTP/DefaultBrowserSearchPromoTests.swift
@@ -4,27 +4,12 @@
 
 import XCTest
 @testable import Client
-import Shared
 
 /// Tests for MOB-4323 — Ecosia default-browser promo triggered after search-count threshold.
 ///
 /// The eligibility logic is isolated in `BrowserViewController.isEligibleForEcosiaDefaultBrowserSearchPromo`,
 /// which makes it straightforward to unit-test without spinning up a real `BrowserViewController`.
 final class DefaultBrowserSearchPromoTests: XCTestCase {
-
-    // swiftlint:disable:next implicitly_unwrapped_optional
-    private var profile: MockProfile!
-
-    override func setUp() {
-        super.setUp()
-        profile = MockProfile()
-    }
-
-    override func tearDown() {
-        profile.prefs.clearAll()
-        profile = nil
-        super.tearDown()
-    }
 
     // MARK: - Threshold constant
 
@@ -85,49 +70,6 @@ final class DefaultBrowserSearchPromoTests: XCTestCase {
         )
     }
 
-    // MARK: - Migration from PrefsKeys.IntroSeen
-
-    func testMigration_introSeenSet_migratesNewKey() {
-        let prefs = profile.prefs
-        let key = BrowserViewController.ecosiaSearchPromoShownKey
-        prefs.setInt(1, forKey: PrefsKeys.IntroSeen)
-
-        XCTAssertNil(prefs.boolForKey(key), "New key should not exist before migration.")
-
-        migrateIfNeeded(prefs: prefs)
-
-        XCTAssertEqual(
-            prefs.boolForKey(key),
-            true,
-            "Upgrading user who saw the promo (IntroSeen set) should be marked as shown."
-        )
-    }
-
-    func testMigration_introSeenNotSet_doesNotSetNewKey() {
-        let prefs = profile.prefs
-        let key = BrowserViewController.ecosiaSearchPromoShownKey
-
-        migrateIfNeeded(prefs: prefs)
-
-        XCTAssertNil(prefs.boolForKey(key),
-                     "Fresh user without IntroSeen should not have the new key set.")
-    }
-
-    func testMigration_newKeyAlreadySet_doesNotOverwrite() {
-        let prefs = profile.prefs
-        let key = BrowserViewController.ecosiaSearchPromoShownKey
-        prefs.setBool(true, forKey: key)
-        prefs.setInt(1, forKey: PrefsKeys.IntroSeen)
-
-        migrateIfNeeded(prefs: prefs)
-
-        XCTAssertEqual(
-            prefs.boolForKey(key),
-            true,
-            "Migration should be a no-op when the new key already exists."
-        )
-    }
-
     // MARK: - Helpers
 
     private func eligible(searchCount: Int, isDefaultBrowser: Bool, promoAlreadyShown: Bool) -> Bool {
@@ -136,14 +78,5 @@ final class DefaultBrowserSearchPromoTests: XCTestCase {
             isDefaultBrowser: isDefaultBrowser,
             promoAlreadyShown: promoAlreadyShown
         )
-    }
-
-    /// Mirrors `ecosiaMigrateDefaultBrowserPromoFlagIfNeeded` logic without requiring a BVC instance.
-    private func migrateIfNeeded(prefs: Prefs) {
-        let key = BrowserViewController.ecosiaSearchPromoShownKey
-        guard prefs.boolForKey(key) == nil else { return }
-        if prefs.intForKey(PrefsKeys.IntroSeen) != nil {
-            prefs.setBool(true, forKey: key)
-        }
     }
 }


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-4323]

## Context

`DefaultBrowserViewController` and its `minSearchCountToTrigger` threshold (50 searches) were defined but never wired to an actual presentation path — the promo was never shown.

#1102 restored the search-count notification infrastructure (`searchesCounterChanged`) that this work depends on.

## Approach

- Observe `.searchesCounterChanged` in `BrowserViewController` and re-evaluate eligibility on every count change, as well as on `browserDidBecomeActive` to catch users already above the threshold
- Reuse the existing `DefaultBrowserDelegate.defaultBrowserDidShow` callback (already sets `PrefsKeys.IntroSeen`) as the "mark as shown" mechanism — no new prefs key introduced
- Made `searchesCounterChanged` `public` so the `Client` module can observe it (was `internal`, consistent with the neighbouring `searchSettingsChanged` which is already `public`)
- Extracted eligibility logic into a static pure function `isEligibleForEcosiaDefaultBrowserSearchPromo` to keep it unit-testable without spinning up a real `BrowserViewController`
- Added unit tests covering threshold boundary conditions, already-default-browser guard, and already-shown guard

## Other

The existing `ToggleDefaultBrowserPromo` debug setting already resets `PrefsKeys.IntroSeen`, so no changes to `EcosiaDebugSettings` were needed beyond confirming the reset path works end-to-end.

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I wrote Unit Tests that confirm the expected behaviour
- [x] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4323]: https://ecosia.atlassian.net/browse/MOB-4323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ