### PR TITLE
[MOB-4377] Fix search event trigger on private tabs

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -608,6 +608,9 @@ extension BrowserViewController: WKNavigationDelegate {
                 return
             }
 
+            // Ecosia: Handle navigation tracking
+            ecosiaHandleNavigationAction(url: url, navigationAction: navigationAction)
+
             let isGoogleDomain = url.host?.contains("google") ?? false
             let isPrivate = tab.isPrivate
 
@@ -615,8 +618,6 @@ extension BrowserViewController: WKNavigationDelegate {
                 decisionHandler(allowPolicy)
                 return
             }
-            // Ecosia: Handle navigation tracking
-            ecosiaHandleNavigationAction(url: url, navigationAction: navigationAction)
 
             decisionHandler(.allow)
             return


### PR DESCRIPTION
[MOB-4377]

## Context

Anonymised incognito searches were not being tracked on the updated version.

## Approach

Found out the reason was a new early return for private tabs on the WK navigation delegate was resulting in `ecosiaHandleNavigationAction` not being called there (and therefore no `pendingInappSearchUrl` set to be checked).

Just moved this call and it works now 🎉 

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [x] I added the `// Ecosia:` helper comments where needed
- [x] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4377]: https://ecosia.atlassian.net/browse/MOB-4377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ