### PR TITLE
[MOB-4379] Password prompts fix

### DIFF
--- a/firefox-ios/Tuist/ProjectDescriptionHelpers/Targets+Client.swift
+++ b/firefox-ios/Tuist/ProjectDescriptionHelpers/Targets+Client.swift
@@ -86,6 +86,9 @@ public enum ClientTarget {
                 "Client/Assets/*.js",
                 "Client/Assets/RemoteSettingsData/**/*.json",
                 "Client/ContentBlocker/TrackingProtectionStats.js",
+                "Client/Experiments/initial_experiments.json",
+                "Client/Frontend/LottieFiles/**/*.json",
+                "Client/Frontend/Reader/Resources/*.{html,css}",
                 "Client/MailSchemes.plist",
                 .glob(pattern: "Client/Assets/**/*.xcassets", excluding: [
                     "Client/Assets/Images.xcassets/AppIcon.appiconset",

--- a/firefox-ios/Tuist/ProjectDescriptionHelpers/Targets+Client.swift
+++ b/firefox-ios/Tuist/ProjectDescriptionHelpers/Targets+Client.swift
@@ -81,9 +81,11 @@ public enum ClientTarget {
                 "Client/Assets/CC_Script/LabelUtils.sys.mjs",
                 "Client/Assets/CC_Script/LoginManager.shared.sys.mjs",
                 "Client/Assets/CC_Script/Overrides.ios.js",
+                "Client/Assets/CC_Script/bergamot-translator.js",
                 "Client/Assets/**/*.{css,html,png,jpg,jpeg,pdf,otf,ttf}",
+                "Client/Assets/*.js",
                 "Client/Assets/RemoteSettingsData/**/*.json",
-                "Client/Assets/SpotlightHelper.js",
+                "Client/ContentBlocker/TrackingProtectionStats.js",
                 "Client/MailSchemes.plist",
                 .glob(pattern: "Client/Assets/**/*.xcassets", excluding: [
                     "Client/Assets/Images.xcassets/AppIcon.appiconset",


### PR DESCRIPTION
[MOB-4379]

## Context

Password prompts were not getting triggered - see ticket.

## Approach

Turns out this is due to some missing javascript files on the target. Re-added files needed ✅ 

This is also linked to other features and somewhat covered by https://github.com/ecosia/ios-browser/pull/1115, but maybe it a bit more scalable here removing explicit listing to prevent silent breakage on future upstream changes.

## Other

Since this was the root-cause for some other issues, also did a bigger AI-assisted assessment of any other files that might still be missing and added them here

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [ ] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4379]: https://ecosia.atlassian.net/browse/MOB-4379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ