### PR TITLE
Make sure hosted summarizer is always off

### DIFF
--- a/firefox-ios/Client/Frontend/Summarizer/SummarizerNimbusUtils.swift
+++ b/firefox-ios/Client/Frontend/Summarizer/SummarizerNimbusUtils.swift
@@ -73,18 +73,10 @@ struct DefaultSummarizerNimbusUtils: FeatureFlaggable, SummarizerNimbusUtils {
     }
 
     func isHostedSummarizerEnabled() -> Bool {
-        /* Ecosia: MOZ_CHANNEL_FENNEC is the Ecosia debug build channel, which maps to
-           AppBuildChannel.other — a value not recognised by the Nimbus YAML schema
-           (only developer/beta/release are valid). Enable the feature unconditionally
-           for those builds so it can be tested without a Nimbus override.
-
+        /* Ecosia: Ecosia uses only Apple Intelligence for summarization, no hosted LLM backend.
         return featureFlags.isFeatureEnabled(.hostedSummarizer, checking: .buildOnly)
         */
-        #if MOZ_CHANNEL_FENNEC
-        return true
-        #else
-        return featureFlags.isFeatureEnabled(.hostedSummarizer, checking: .buildOnly)
-        #endif
+        return false
     }
 
     private func isAppleSummarizerToolbarEndpointEnabled() -> Bool {


### PR DESCRIPTION
No ticket

## Context

Summarizer was appearing for me even on devices with no Apple Inteligence.

## Approach

Made sure hosted summarizer is off on all cases.

(It was only on for debug/staging anyway, but we won't use it even in those cases anyway)

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [x] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed