### PR TITLE
[MOB-4105] NTP Followup - Always hide predefined topsites

### DIFF
--- a/firefox-ios/Client/Ecosia/Frontend/Home/TopSites/EcosiaGoogleTopSiteManager.swift
+++ b/firefox-ios/Client/Ecosia/Frontend/Home/TopSites/EcosiaGoogleTopSiteManager.swift
@@ -1,0 +1,14 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Storage
+
+/// Ecosia: Replaces Firefox's GoogleTopSiteManager with a no-op so that
+/// Google is never injected as a pinned tile on the NTP. Gmail is already
+/// present as a regular (non-pinned) suggested site in DefaultSuggestedSites.
+struct EcosiaGoogleTopSiteManager: GoogleTopSiteManagerProvider {
+    var pinnedSiteData: Site? { nil }
+    func shouldAddGoogleTopSite(hasSpace: Bool) -> Bool { false }
+    func removeGoogleTopSite(site: Site) {}
+}

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
@@ -63,6 +63,8 @@ final class HomepageViewController: UIViewController,
     private var wallpaperBottomConstraint: NSLayoutConstraint?
     // Ecosia: Guards against re-applying the iPad cross-hierarchy constraint on each layout pass
     private var wallpaperExtendedToParent = false
+    // Ecosia: Holds the cross-hierarchy bottom constraint added while the keyboard is visible on iPhone
+    private var wallpaperKeyboardConstraint: NSLayoutConstraint?
 
     private let jumpBackInContextualHintViewController: ContextualHintViewController
     private let syncTabContextualHintViewController: ContextualHintViewController
@@ -184,6 +186,15 @@ final class HomepageViewController: UIViewController,
         termsOfUseDelegate?.showTermsOfUse(context: .homepageOpened)
         // Ecosia: Trigger Ecosia data loading
         ecosiaViewWillAppear()
+        // Ecosia: Keep the wallpaper card visually fixed while the keyboard is on screen
+        notificationCenter.addObserver(self,
+                                       selector: #selector(ecosiaKeyboardWillShow),
+                                       name: UIResponder.keyboardWillShowNotification,
+                                       object: nil)
+        notificationCenter.addObserver(self,
+                                       selector: #selector(ecosiaKeyboardWillHide),
+                                       name: UIResponder.keyboardWillHideNotification,
+                                       object: nil)
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -207,6 +218,9 @@ final class HomepageViewController: UIViewController,
         resetTrackedObjects()
         // Ecosia: Clean up Ecosia resources
         ecosiaViewDidDisappear()
+        // Ecosia: Remove keyboard observers added in viewWillAppear
+        notificationCenter.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
+        notificationCenter.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
     }
 
     override func viewDidLayoutSubviews() {
@@ -926,6 +940,40 @@ final class HomepageViewController: UIViewController,
         extended.isActive = true
         wallpaperBottomConstraint = extended
         wallpaperExtendedToParent = true
+    }
+
+    /* Ecosia: When the keyboard appears the overKeyboardContainer grows, shrinking
+     contentContainer and HomepageViewController.view along with it. The wallpaper card
+     is pinned to view.bottomAnchor, so it also shrinks and scaleAspectFill rescales the
+     image — producing a visible zoom/shift artifact. Fix: snapshot the wallpaper's current
+     visual bottom in the parent's coordinate space and lock it there with a cross-hierarchy
+     constraint for the duration of the keyboard session. iPhone only — iPad already uses
+     a cross-hierarchy constraint via extendEcosiaWallpaperToParentOnPad. */
+    @objc private func ecosiaKeyboardWillShow() {
+        guard traitCollection.userInterfaceIdiom == .phone,
+              wallpaperKeyboardConstraint == nil,
+              let parentView = parent?.view else { return }
+
+        let bottomInParent = wallpaperView.convert(
+            CGPoint(x: 0, y: wallpaperView.bounds.maxY),
+            to: parentView
+        ).y
+        let constant = bottomInParent - parentView.bounds.height
+
+        wallpaperBottomConstraint?.isActive = false
+        let constraint = wallpaperView.bottomAnchor.constraint(
+            equalTo: parentView.bottomAnchor,
+            constant: constant
+        )
+        constraint.isActive = true
+        wallpaperKeyboardConstraint = constraint
+    }
+
+    @objc private func ecosiaKeyboardWillHide() {
+        guard let keyboardConstraint = wallpaperKeyboardConstraint else { return }
+        keyboardConstraint.isActive = false
+        wallpaperKeyboardConstraint = nil
+        wallpaperBottomConstraint?.isActive = true
     }
 
     // MARK: Tap Gesture Recognizer

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
@@ -63,8 +63,6 @@ final class HomepageViewController: UIViewController,
     private var wallpaperBottomConstraint: NSLayoutConstraint?
     // Ecosia: Guards against re-applying the iPad cross-hierarchy constraint on each layout pass
     private var wallpaperExtendedToParent = false
-    // Ecosia: Holds the cross-hierarchy bottom constraint added while the keyboard is visible on iPhone
-    private var wallpaperKeyboardConstraint: NSLayoutConstraint?
 
     private let jumpBackInContextualHintViewController: ContextualHintViewController
     private let syncTabContextualHintViewController: ContextualHintViewController
@@ -186,15 +184,6 @@ final class HomepageViewController: UIViewController,
         termsOfUseDelegate?.showTermsOfUse(context: .homepageOpened)
         // Ecosia: Trigger Ecosia data loading
         ecosiaViewWillAppear()
-        // Ecosia: Keep the wallpaper card visually fixed while the keyboard is on screen
-        notificationCenter.addObserver(self,
-                                       selector: #selector(ecosiaKeyboardWillShow),
-                                       name: UIResponder.keyboardWillShowNotification,
-                                       object: nil)
-        notificationCenter.addObserver(self,
-                                       selector: #selector(ecosiaKeyboardWillHide),
-                                       name: UIResponder.keyboardWillHideNotification,
-                                       object: nil)
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -218,9 +207,6 @@ final class HomepageViewController: UIViewController,
         resetTrackedObjects()
         // Ecosia: Clean up Ecosia resources
         ecosiaViewDidDisappear()
-        // Ecosia: Remove keyboard observers added in viewWillAppear
-        notificationCenter.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
-        notificationCenter.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
     }
 
     override func viewDidLayoutSubviews() {
@@ -940,40 +926,6 @@ final class HomepageViewController: UIViewController,
         extended.isActive = true
         wallpaperBottomConstraint = extended
         wallpaperExtendedToParent = true
-    }
-
-    /* Ecosia: When the keyboard appears the overKeyboardContainer grows, shrinking
-     contentContainer and HomepageViewController.view along with it. The wallpaper card
-     is pinned to view.bottomAnchor, so it also shrinks and scaleAspectFill rescales the
-     image — producing a visible zoom/shift artifact. Fix: snapshot the wallpaper's current
-     visual bottom in the parent's coordinate space and lock it there with a cross-hierarchy
-     constraint for the duration of the keyboard session. iPhone only — iPad already uses
-     a cross-hierarchy constraint via extendEcosiaWallpaperToParentOnPad. */
-    @objc private func ecosiaKeyboardWillShow() {
-        guard traitCollection.userInterfaceIdiom == .phone,
-              wallpaperKeyboardConstraint == nil,
-              let parentView = parent?.view else { return }
-
-        let bottomInParent = wallpaperView.convert(
-            CGPoint(x: 0, y: wallpaperView.bounds.maxY),
-            to: parentView
-        ).y
-        let constant = bottomInParent - parentView.bounds.height
-
-        wallpaperBottomConstraint?.isActive = false
-        let constraint = wallpaperView.bottomAnchor.constraint(
-            equalTo: parentView.bottomAnchor,
-            constant: constant
-        )
-        constraint.isActive = true
-        wallpaperKeyboardConstraint = constraint
-    }
-
-    @objc private func ecosiaKeyboardWillHide() {
-        guard let keyboardConstraint = wallpaperKeyboardConstraint else { return }
-        keyboardConstraint.isActive = false
-        wallpaperKeyboardConstraint = nil
-        wallpaperBottomConstraint?.isActive = true
     }
 
     // MARK: Tap Gesture Recognizer

--- a/firefox-ios/Client/Frontend/Home/Homepage/TopSites/TopSitesMiddleware.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/TopSites/TopSitesMiddleware.swift
@@ -28,9 +28,14 @@ final class TopSitesMiddleware: FeatureFlaggable {
     ) {
         self.topSitesManager = topSitesManager ?? TopSitesManager(
             profile: profile,
+            /* Ecosia: Replace Firefox's GoogleTopSiteManager with a no-op so Google is not
+               injected as a pinned tile; Gmail is already in the Ecosia suggested sites list.
+
             googleTopSiteManager: GoogleTopSiteManager(
                 prefs: profile.prefs
             ),
+            */
+            googleTopSiteManager: EcosiaGoogleTopSiteManager(),
             topSiteHistoryManager: TopSiteHistoryManager(profile: profile),
             searchEnginesManager: searchEnginesManager
         )

--- a/firefox-ios/Storage/DefaultSuggestedSites.swift
+++ b/firefox-ios/Storage/DefaultSuggestedSites.swift
@@ -219,7 +219,9 @@ open class DefaultSuggestedSites {
     ]
 
     public static func defaultSites() -> [Site] {
-        /* Ecosia: Return Ecosia-curated default shortcuts; locale-based Firefox sites disabled
+        /* Ecosia: No suggested sites on first-time experience; locale-based Firefox sites disabled.
+           The ecosiaSites list is kept below for reference should the product decision change.
+
         let locale = Locale.current
         let defaultSites = sites[locale.identifier] ?? sites["default"]
         return defaultSites?.map { site in
@@ -230,6 +232,6 @@ open class DefaultSuggestedSites {
             return site
         } ?? []
         */
-        ecosiaSites
+        []
     }
 }

--- a/firefox-ios/nimbus-features/hntSponsoredShortcutsFeature.yaml
+++ b/firefox-ios/nimbus-features/hntSponsoredShortcutsFeature.yaml
@@ -11,7 +11,9 @@ features:
     defaults:
       - channel: beta
         value:
+          # Ecosia: Sponsored shortcuts are disabled by default; no sponsored tiles on FTE.
           enabled: false
       - channel: developer
         value:
+          # Ecosia: Sponsored shortcuts are disabled by default; no sponsored tiles on FTE.
           enabled: false

--- a/firefox-ios/nimbus-features/hntSponsoredShortcutsFeature.yaml
+++ b/firefox-ios/nimbus-features/hntSponsoredShortcutsFeature.yaml
@@ -6,11 +6,12 @@ features:
       enabled:
         description: Setting 'enabled' to false will hide sponsored shortcuts on the homepage and disable the respective toggle in the homepage settings
         type: Boolean
-        default: true
+        # Ecosia: Sponsored shortcuts are disabled by default; no sponsored tiles on FTE.
+        default: false
     defaults:
       - channel: beta
         value:
-          enabled: true
+          enabled: false
       - channel: developer
         value:
-          enabled: true
+          enabled: false


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-4105]

## Context

We agreed with the product to remove the suggested Top Sites in First Time Experience.

## Approach

This time the approach is littel bit different 🤏  due to the nature of how these sites are handled.

**No suggested shortcuts on first-time experience**
`DefaultSuggestedSites.defaultSites()` now returns an empty array as we usually do (without replacing with ours)

**No sponsored tiles**
`hntSponsoredShortcuts` is disabled by default across all channels via the Nimbus YAML. Sponsored tiles from the unified ads network are opt-in only.

**Google pinned tile removed**
Firefox injects Google as a pinned tile through a separate pipeline that is completely independent of `defaultSites()`. Without an explicit override, a new user would still see a pinned Google tile even with an otherwise empty row. `EcosiaGoogleTopSiteManager` — a no-op conformance to `GoogleTopSiteManagerProvider` — replaces Firefox's implementation at the injection point in `TopSitesMiddleware`, preventing Google from ever being added.

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad

[MOB-4105]: https://ecosia.atlassian.net/browse/MOB-4105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ