### PR TITLE
[NO TICKET] Fix Release pipeline ecosia common xcconfig

### DIFF
--- a/.circleci/release-config.yml
+++ b/.circleci/release-config.yml
@@ -37,7 +37,7 @@ environment_common: &environment_common
 
 macos_common: &macos_common
   macos:
-    xcode: "16.4"
+    xcode: "26.2"
   resource_class: m4pro.medium
 
 jobs:

--- a/check_marketing_version.sh
+++ b/check_marketing_version.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-# Check if MARKETING_VERSION has changed
+# Check if MARKETING_VERSION has changed in EcosiaCommon.xcconfig.
 # The cut -d ' ' -f3 takes the output from grep command as input.
-# For example, let's assume that the Common.xcconfig file contains the following line:
+# For example, let's assume that EcosiaCommon.xcconfig contains the following line:
 # MARKETING_VERSION = 100.2.44
 # grep will return -> MARKETING_VERSION = 100.2.44
 # The cut command will then extract the third field from the input, using a space (' ') as the delimiter.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -131,7 +131,7 @@ platform :ios do
   lane :testflight_live do
 
     version_number = get_xcconfig_value(
-      path: "#{target_folder_path}/Configuration/Common.xcconfig",
+      path: "#{target_folder_path}/Ecosia/BuildSettingsConfigurations/EcosiaCommon.xcconfig",
       name: 'MARKETING_VERSION'
     )
 
@@ -189,7 +189,7 @@ platform :ios do
     inject_appstore_connect_api
 
     version_number = get_xcconfig_value(
-      path: "#{target_folder_path}/Configuration/Common.xcconfig",
+      path: "#{target_folder_path}/Ecosia/BuildSettingsConfigurations/EcosiaCommon.xcconfig",
       name: 'MARKETING_VERSION'
     )
 


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

## Context & Approach

- Fixes `testflight_live` and `upload_release_notes` Fastlane lanes to read `MARKETING_VERSION` from `EcosiaCommon.xcconfig` instead of Mozilla's `Common.xcconfig` (which does not contain that key). This was causing the git tag and App Store version reference to be `nil` on every `manual-release-deploy` run.
- Updates the stale comment in `check_marketing_version.sh` to reference `EcosiaCommon.xcconfig` (the code was already correct, only the comment was outdated).
- Aligns the Xcode version in `release-config.yml` to `26.2`, matching what `config.yml` already uses, so the setup and release continuation pipelines run on the same toolchain.

## Notes
- `manual-release-deploy` already bypasses `check-version-bump` — it triggers `manual-build-testflight-deploy` directly with no version gate. No changes needed to the workflow structure.
- `EcosiaCommon.xcconfig` is and remains the single source of truth for `MARKETING_VERSION`.