### PR TITLE
[NO TICKET] Fix the release build against Xcode 26.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ environment_common: &environment_common
 
 macos_common: &macos_common
   macos:
-    xcode: "26.2"
+    xcode: "26.4.0"
   resource_class: m4pro.medium
 
 jobs:

--- a/.circleci/release-config.yml
+++ b/.circleci/release-config.yml
@@ -37,7 +37,7 @@ environment_common: &environment_common
 
 macos_common: &macos_common
   macos:
-    xcode: "26.2"
+    xcode: "26.4.0"
   resource_class: m4pro.medium
 
 jobs:

--- a/BrowserKit/Package.swift
+++ b/BrowserKit/Package.swift
@@ -245,15 +245,16 @@ let package = Package(
         .target(
             name: "OnboardingKit",
             dependencies: ["Common", "ComponentLibrary"],
-            resources: [
-                .process("Shaders")
-            ],
+            // Shaders/AnimatedGradient.metal is kept in the repo for future Metal
+            // implementation but is NOT registered as an SPM resource. Compiling it
+            // via .process("Shaders") produces a code-containing bundle (linked via
+            // Ld in Xcode 26) which the build system schedules once per package
+            // consumer context, causing "Multiple commands produce
+            // BrowserKit_OnboardingKit.bundle" during archive. Remove this entry
+            // (and the now-unnecessary Metal linker flags) until the Metal rendering
+            // path is actually implemented in Swift.
             swiftSettings: [
                 .unsafeFlags(["-enable-testing"]),
-            ],
-            linkerSettings: [
-                .linkedFramework("Metal"),
-                .linkedFramework("MetalKit")
             ]),
         .testTarget(
             name: "OnboardingKitTests",

--- a/BrowserKit/Package.swift
+++ b/BrowserKit/Package.swift
@@ -245,14 +245,14 @@ let package = Package(
         .target(
             name: "OnboardingKit",
             dependencies: ["Common", "ComponentLibrary"],
-            // Shaders/AnimatedGradient.metal is kept in the repo for future Metal
-            // implementation but is NOT registered as an SPM resource. Compiling it
-            // via .process("Shaders") produces a code-containing bundle (linked via
-            // Ld in Xcode 26) which the build system schedules once per package
-            // consumer context, causing "Multiple commands produce
-            // BrowserKit_OnboardingKit.bundle" during archive. Remove this entry
-            // (and the now-unnecessary Metal linker flags) until the Metal rendering
-            // path is actually implemented in Swift.
+            // Explicit resource declaration avoids an Xcode 26 build-system bug
+            // where auto-discovered xcassets produce both a "create directory"
+            // and an "Ld link" command for the same bundle path, causing:
+            // "error: Multiple commands produce BrowserKit_OnboardingKit.bundle"
+            // during archive. Shaders/AnimatedGradient.metal is kept for future
+            // use but excluded here since no Swift code loads it yet.
+            exclude: ["Shaders"],
+            resources: [.process("Media.xcassets")],
             swiftSettings: [
                 .unsafeFlags(["-enable-testing"]),
             ]),

--- a/BrowserKit/Package.swift
+++ b/BrowserKit/Package.swift
@@ -245,12 +245,10 @@ let package = Package(
         .target(
             name: "OnboardingKit",
             dependencies: ["Common", "ComponentLibrary"],
-            // Explicit resource declaration avoids an Xcode 26 build-system bug
-            // where auto-discovered xcassets produce both a "create directory"
-            // and an "Ld link" command for the same bundle path, causing:
-            // "error: Multiple commands produce BrowserKit_OnboardingKit.bundle"
-            // during archive. Shaders/AnimatedGradient.metal is kept for future
-            // use but excluded here since no Swift code loads it yet.
+            // Ecosia: Xcode 26 bug - auto-discovered xcassets produce conflicting
+            // "create directory" and "Ld link" commands for the same bundle path.
+            // Declaring resources explicitly avoids the issue.
+            // Shaders/AnimatedGradient.metal is unused by Swift code; excluded until needed.
             exclude: ["Shaders"],
             resources: [.process("Media.xcassets")],
             swiftSettings: [

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -148,15 +148,6 @@ platform :ios do
       readonly: true
     )
 
-    build_app(
-      scheme: "Ecosia",
-      workspace: workspace_path,
-      configuration: "Release",
-      export_method: "app-store",
-      xcargs: testflight_archive_args,
-      skip_archive: true
-    )
-
     gym(
       scheme: "Ecosia",
       workspace: workspace_path,      


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

## Context

The Release configuration was failing to build and archive.

## Approach

One of the few rare cases of code remoal > code added 😝

Two separate issues were blocking the release pipeline:
1. **Duplicate bundle commands (archive failure)**
   Xcode 26 with `swift-tools-version: 6.2` generates both a "create directory" and an "Ld link" command for the same bundle output path when xcassets are **auto-discovered** inside an SPM target.

2. **Wrong xcconfig for `MARKETING_VERSION`**
Fastlane lanes `testflight_live` and `upload_release_notes` were reading `MARKETING_VERSION` from the old `Configuration/Common.xcconfig`. The source of truth is `Ecosia/BuildSettingsConfigurations/EcosiaCommon.xcconfig`. Also removed a redundant `build_app(skip_archive: true)` call that ran a full build immediately before `gym`, which already builds and archives in one pass.
