### PR TITLE
[MOB-4387] Passwords encryption migration

### DIFF
--- a/firefox-ios/Ecosia/Ecosia.docc/Ecosia.md
+++ b/firefox-ios/Ecosia/Ecosia.docc/Ecosia.md
@@ -240,7 +240,7 @@ To run the app on a new device, register it on the Apple Developer Portal and re
 
 1. Plug in your device and register it via the [`register_devices`](https://docs.fastlane.tools/actions/register_devices/) action. You will be prompted for the device name and UDID:
     ```shell
-    bundle exec fastlane run register_devices
+    bundle exec fastlane run register_device
     ```
 2. Re-generate the provisioning profiles to include the new device by running `match` with `--force_for_new_devices` for both **development** (for local development) and **ad hoc** (for Firebase releases):
     ```shell

--- a/firefox-ios/Storage/MockRustKeychain.swift
+++ b/firefox-ios/Storage/MockRustKeychain.swift
@@ -72,6 +72,7 @@ class MockRustKeychain: @unchecked Sendable, KeychainProtocol {
         return .success(storage[key])
     }
 
+    // Ecosia: mock conformance for the legacyDataForKey requirement added for the v133→v147 migration
     func legacyDataForKey(_ key: String) -> Data? {
         return storage[key]?.data(using: .utf8)
     }

--- a/firefox-ios/Storage/MockRustKeychain.swift
+++ b/firefox-ios/Storage/MockRustKeychain.swift
@@ -72,6 +72,10 @@ class MockRustKeychain: @unchecked Sendable, KeychainProtocol {
         return .success(storage[key])
     }
 
+    func legacyDataForKey(_ key: String) -> Data? {
+        return storage[key]?.data(using: .utf8)
+    }
+
     func createAndStoreKey(canaryPhrase: String, canaryIdentifier: String, keyIdentifier: String) throws -> String {
         let keyValue = try createKey()
         let canaryValue = try createCanary(text: canaryPhrase, encryptionKey: keyValue)

--- a/firefox-ios/Storage/Rust/RustLogins+EcosiaMigration.swift
+++ b/firefox-ios/Storage/Rust/RustLogins+EcosiaMigration.swift
@@ -38,23 +38,68 @@ extension RustLogins {
     // Ecosia: UserDefaults key that gates the migration to run exactly once
     static let v133MigrationKey = "ecosia_v133_login_migration_complete"
 
+    // Ecosia: backup path used during migration to avoid permanent data loss.
+    // The backup is created before LoginsStorage opens and deleted after re-add completes.
+    // If the app is killed mid-migration, the backup survives and allows retry on next launch.
+    var v133BackupDatabasePath: String { perFieldDatabasePath + ".v133backup" }
+
+    // Ecosia: moves the v133 database to the backup path so LoginsStorage can create a fresh DB.
+    // If a backup already exists (interrupted migration), deletes any partial new DB and returns
+    // true so the migration re-runs cleanly from the existing backup.
+    // Returns false and leaves everything untouched if the move fails.
+    func backupV133Database() -> Bool {
+        let backup = v133BackupDatabasePath
+        if FileManager.default.fileExists(atPath: backup) {
+            // Previous migration was interrupted — wipe the partial new DB and retry
+            try? FileManager.default.removeItem(atPath: perFieldDatabasePath)
+            return true
+        }
+        do {
+            try FileManager.default.moveItem(atPath: perFieldDatabasePath, toPath: backup)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    // Ecosia: restores the backup to the original path so the migration can retry next launch
+    func restoreV133Backup() {
+        try? FileManager.default.moveItem(atPath: v133BackupDatabasePath, toPath: perFieldDatabasePath)
+        UserDefaults.standard.removeObject(forKey: Self.v133MigrationKey)
+    }
+
     // Ecosia: extracts and decrypts all pre-v147 login records from the SQLite database before
     // LoginsStorage opens it. The schema version check is skipped intentionally — previous runs
     // of LoginsStorage may have already migrated user_version from 2 to 5 while leaving the
-    // encrypted secFields blobs intact.
+    // encrypted secFields blobs intact. Checks the backup path first to handle retries after
+    // an interrupted migration.
     func extractV133Logins() -> [LoginEntry] {
         guard !UserDefaults.standard.bool(forKey: Self.v133MigrationKey) else { return [] }
 
+        // Prefer the backup path — it means a previous migration was interrupted after the DB
+        // was moved but before re-add completed. The new (partial) DB at perFieldDatabasePath
+        // will be discarded by backupV133Database() when open() calls it.
+        let dbPath = FileManager.default.fileExists(atPath: v133BackupDatabasePath)
+            ? v133BackupDatabasePath
+            : perFieldDatabasePath
+
         var db: OpaquePointer?
-        guard sqlite3_open_v2(perFieldDatabasePath, &db, SQLITE_OPEN_READONLY, nil) == SQLITE_OK else {
-            UserDefaults.standard.set(true, forKey: Self.v133MigrationKey)
+        let openStatus = sqlite3_open_v2(dbPath, &db, SQLITE_OPEN_READONLY, nil)
+        guard openStatus == SQLITE_OK else {
+            // Only mark complete when the file definitively doesn't exist — any other open
+            // failure (busy, locked, permissions) could be transient and should retry next launch.
+            if !FileManager.default.fileExists(atPath: dbPath) {
+                UserDefaults.standard.set(true, forKey: Self.v133MigrationKey)
+            }
             return []
         }
         defer { sqlite3_close(db) }
 
+        // No completion here — a nil result could mean the keychain is temporarily unavailable
+        // (e.g., post-restore before first unlock). Retry next launch until the key is readable
+        // or until we can definitively confirm there is no legacy data.
         guard let keyData = rustKeychain.legacyDataForKey(rustKeychain.loginsKeyIdentifier),
               let keyString = String(data: keyData, encoding: .utf8) else {
-            UserDefaults.standard.set(true, forKey: Self.v133MigrationKey)
             return []
         }
 
@@ -93,17 +138,27 @@ extension RustLogins {
                 username: username
             ))
         }
-        UserDefaults.standard.set(true, forKey: Self.v133MigrationKey)
+
+        if entries.isEmpty {
+            // Nothing to re-add — mark complete immediately.
+            UserDefaults.standard.set(true, forKey: Self.v133MigrationKey)
+        }
+        // If entries is non-empty, the flag is set by readdMigratedLogins after all adds complete.
         return entries
     }
 
-    // Ecosia: re-adds logins extracted from the v133 database using the new v147 API
+    // Ecosia: re-adds logins extracted from the v133 database using the new v147 API.
+    // All adds are dispatched as a single block on queue so storage access is serialised.
+    // The backup is deleted and the migration flag set only after all adds complete, so a
+    // failure or app kill before this point leaves the backup intact for retry next launch.
     func readdMigratedLogins(_ logins: [LoginEntry]) {
-        for login in logins {
-            getStoredKey { [weak self] result in
-                guard case .success = result, let self = self else { return }
+        queue.async { [weak self] in
+            guard let self, self.isOpen else { return }
+            for login in logins {
                 _ = try? self.storage?.add(login: login)
             }
+            try? FileManager.default.removeItem(atPath: self.v133BackupDatabasePath)
+            UserDefaults.standard.set(true, forKey: Self.v133MigrationKey)
         }
     }
 

--- a/firefox-ios/Storage/Rust/RustLogins+EcosiaMigration.swift
+++ b/firefox-ios/Storage/Rust/RustLogins+EcosiaMigration.swift
@@ -1,0 +1,135 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+// Ecosia: one-time migration of login records from application-services v133 to v147.
+//
+// We jumped directly from v133 to v147, skipping the gradual useRustKeychain Nimbus rollout
+// (FXIOS-11415) that Firefox upstream used to migrate users between encryption architectures.
+// In v133, login credentials were stored in a `secFields` column as JWE compact tokens
+// (alg:dir, enc:A256GCM) with a JWK oct key held by MZKeychainWrapper. In v147, the Rust
+// component manages encryption directly via the KeyManager protocol and no longer understands
+// the old secFields format.
+//
+// This file provides the migration that should have happened upstream:
+// - reads and decrypts secFields directly from SQLite using the legacy MZKeychainWrapper key
+// - re-adds the extracted logins via the new v147 API after opening a fresh database
+//
+// Reference: application-services schema.rs v133 (user_version=2), encryption.rs v147 (KeyManager).
+
+import CryptoKit
+import Foundation
+import struct MozillaAppServices.LoginEntry
+
+// Ecosia: base64url → base64 conversion helper required by the JWE decryption below
+private extension Data {
+    init?(base64URLEncoded string: String) {
+        var base64 = string
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        let remainder = base64.count % 4
+        if remainder > 0 { base64 += String(repeating: "=", count: 4 - remainder) }
+        self.init(base64Encoded: base64)
+    }
+}
+
+extension RustLogins {
+
+    // Ecosia: UserDefaults key that gates the migration to run exactly once
+    static let v133MigrationKey = "ecosia_v133_login_migration_complete"
+
+    // Ecosia: extracts and decrypts all pre-v147 login records from the SQLite database before
+    // LoginsStorage opens it. The schema version check is skipped intentionally — previous runs
+    // of LoginsStorage may have already migrated user_version from 2 to 5 while leaving the
+    // encrypted secFields blobs intact.
+    func extractV133Logins() -> [LoginEntry] {
+        guard !UserDefaults.standard.bool(forKey: Self.v133MigrationKey) else { return [] }
+
+        var db: OpaquePointer?
+        guard sqlite3_open_v2(perFieldDatabasePath, &db, SQLITE_OPEN_READONLY, nil) == SQLITE_OK else {
+            UserDefaults.standard.set(true, forKey: Self.v133MigrationKey)
+            return []
+        }
+        defer { sqlite3_close(db) }
+
+        guard let keyData = rustKeychain.legacyDataForKey(rustKeychain.loginsKeyIdentifier),
+              let keyString = String(data: keyData, encoding: .utf8) else {
+            UserDefaults.standard.set(true, forKey: Self.v133MigrationKey)
+            return []
+        }
+
+        let query = """
+            SELECT origin, httpRealm, formActionOrigin, usernameField, passwordField, secFields
+            FROM loginsL WHERE secFields != '' AND is_deleted = 0
+            """
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, query, -1, &stmt, nil) == SQLITE_OK else {
+            UserDefaults.standard.set(true, forKey: Self.v133MigrationKey)
+            return []
+        }
+        defer { sqlite3_finalize(stmt) }
+
+        var entries: [LoginEntry] = []
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            func col(_ i: Int32) -> String? {
+                guard let ptr = sqlite3_column_text(stmt, i) else { return nil }
+                return String(cString: ptr)
+            }
+            guard let secFields = col(5),
+                  let decrypted = decryptJWEDirect(jwe: secFields, jwkString: keyString),
+                  let data = decrypted.data(using: .utf8),
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: String],
+                  let username = json["u"],
+                  let password = json["p"],
+                  !password.isEmpty else { continue }
+
+            entries.append(LoginEntry(
+                origin: col(0) ?? "",
+                httpRealm: col(1),
+                formActionOrigin: col(2),
+                usernameField: col(3) ?? "",
+                passwordField: col(4) ?? "",
+                password: password,
+                username: username
+            ))
+        }
+        UserDefaults.standard.set(true, forKey: Self.v133MigrationKey)
+        return entries
+    }
+
+    // Ecosia: re-adds logins extracted from the v133 database using the new v147 API
+    func readdMigratedLogins(_ logins: [LoginEntry]) {
+        for login in logins {
+            getStoredKey { [weak self] result in
+                guard case .success = result, let self = self else { return }
+                _ = try? self.storage?.add(login: login)
+            }
+        }
+    }
+
+    // Ecosia: decrypts a v133 secFields JWE compact token (alg:dir, enc:A256GCM) using CryptoKit.
+    // jwkString is the JWK oct key stored by MZKeychainWrapper: {"kty":"oct","k":"<base64url>"}.
+    // AAD is the ASCII-encoded JWE Protected Header per RFC 7516.
+    private func decryptJWEDirect(jwe: String, jwkString: String) -> String? {
+        let parts = jwe.split(separator: ".", omittingEmptySubsequences: false).map(String.init)
+        guard parts.count == 5,
+              let jwkData = jwkString.data(using: .utf8),
+              let jwk = try? JSONDecoder().decode([String: String].self, from: jwkData),
+              let kBase64 = jwk["k"],
+              let keyBytes = Data(base64URLEncoded: kBase64),
+              keyBytes.count == 32,
+              let iv = Data(base64URLEncoded: parts[2]),
+              let ciphertext = Data(base64URLEncoded: parts[3]),
+              let tag = Data(base64URLEncoded: parts[4]) else { return nil }
+
+        do {
+            let symmetricKey = SymmetricKey(data: keyBytes)
+            let nonce = try AES.GCM.Nonce(data: iv)
+            let sealedBox = try AES.GCM.SealedBox(nonce: nonce, ciphertext: ciphertext, tag: tag)
+            let plaintext = try AES.GCM.open(sealedBox, using: symmetricKey, authenticating: Data(parts[0].utf8))
+            return String(data: plaintext, encoding: .utf8)
+        } catch {
+            return nil
+        }
+    }
+}

--- a/firefox-ios/Storage/Rust/RustLogins.swift
+++ b/firefox-ios/Storage/Rust/RustLogins.swift
@@ -251,22 +251,25 @@ public final class RustLogins: LoginsProtocol, KeyManager, @unchecked Sendable {
 
     // Open the db.
     private func open() -> NSError? {
-        // Ecosia: run v133→v147 migration before LoginsStorage opens the database
+        // Ecosia: run v133→v147 migration before LoginsStorage opens the database.
+        // backupV133Database() moves the legacy DB away from perFieldDatabasePath so LoginsStorage
+        // finds no file there and creates a fresh one — same effect as deleting, but the data is
+        // preserved at v133BackupDatabasePath and only removed after re-add completes.
         let migratedLogins = extractV133Logins()
-        if !migratedLogins.isEmpty {
-            // Delete the v133 database so LoginsStorage creates a fresh one with the new schema.
-            // Migrated logins are re-added after open via readdMigratedLogins.
-            try? FileManager.default.removeItem(atPath: perFieldDatabasePath)
-        }
+        let migrationActive = !migratedLogins.isEmpty && backupV133Database()
         do {
             storage = try LoginsStorage(databasePath: self.perFieldDatabasePath, keyManager: self)
             isOpen = true
-            // Ecosia: readd entries from v133→v147 migration
-            if !migratedLogins.isEmpty {
+            if migrationActive {
                 readdMigratedLogins(migratedLogins)
             }
             return nil
         } catch let err as NSError {
+            // Ecosia: restore the v133 backup so the migration can retry next launch
+            if migrationActive {
+                restoreV133Backup()
+            }
+
             if let loginsStoreError = err as? LoginsStoreError {
                 // This is an unrecoverable
                 // state unless we can move the existing file to a backup

--- a/firefox-ios/Storage/Rust/RustLogins.swift
+++ b/firefox-ios/Storage/Rust/RustLogins.swift
@@ -782,12 +782,6 @@ public final class RustLogins: LoginsProtocol, KeyManager, @unchecked Sendable {
     * ```
     */
     public func getKey() throws -> Data {
-        // Ecosia: prefer the legacy MZKeychainWrapper key (no kSecAttrGeneric) so that records
-        // encrypted by the pre-v147 app can be decrypted consistently after migration.
-        if let legacyData = rustKeychain.legacyDataForKey(rustKeychain.loginsKeyIdentifier) {
-            return legacyData
-        }
-
         switch rustKeychain.queryKeychainForKey(key: rustKeychain.loginsKeyIdentifier) {
         case .success(let result):
             guard let data = result, let key = data.data(using: String.Encoding.utf8) else {

--- a/firefox-ios/Storage/Rust/RustLogins.swift
+++ b/firefox-ios/Storage/Rust/RustLogins.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import CryptoKit // Ecosia: required for AES-256-GCM decryption of v133 login secFields during migration
 import Glean
 import Shared
 import Common
@@ -13,6 +14,18 @@ import func MozillaAppServices.checkCanary
 import struct MozillaAppServices.Login
 import struct MozillaAppServices.LoginEntry
 import protocol MozillaAppServices.KeyManager
+
+// Ecosia: base64url decoding helper used by the v133→v147 login migration
+private extension Data {
+    init?(base64URLEncoded string: String) {
+        var base64 = string
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        let remainder = base64.count % 4
+        if remainder > 0 { base64 += String(repeating: "=", count: 4 - remainder) }
+        self.init(base64Encoded: base64)
+    }
+}
 
 typealias LoginsStoreError = LoginsApiError
 public typealias LoginRecord = Login
@@ -249,11 +262,132 @@ public final class RustLogins: LoginsProtocol, KeyManager, @unchecked Sendable {
         queue = DispatchQueue(label: "RustLogins queue: \(databasePath)", attributes: [])
     }
 
+    // Ecosia: one-time migration flag for the v133→v147 login secFields migration
+    private static let v133MigrationKey = "ecosia_v133_login_migration_complete"
+
+    // Ecosia: reads and decrypts all pre-v147 login records directly from SQLite before opening
+    // LoginsStorage. Needed because we jumped from application-services v133 to v149, skipping
+    // the gradual useRustKeychain Nimbus rollout (FXIOS-11415) that upstream used to migrate users.
+    // secFields are JWE compact tokens (alg:dir, enc:A256GCM); the key is a JWK oct stored by the
+    // legacy MZKeychainWrapper. Gated by a UserDefaults flag so it runs exactly once.
+    private func extractV133Logins() -> [LoginEntry] {
+        guard !UserDefaults.standard.bool(forKey: Self.v133MigrationKey) else {
+            return []
+        }
+
+        var db: OpaquePointer?
+        guard sqlite3_open_v2(perFieldDatabasePath, &db, SQLITE_OPEN_READONLY, nil) == SQLITE_OK else {
+            UserDefaults.standard.set(true, forKey: Self.v133MigrationKey)
+            return []
+        }
+        defer { sqlite3_close(db) }
+
+        guard let keyData = rustKeychain.legacyDataForKey(rustKeychain.loginsKeyIdentifier),
+              let keyString = String(data: keyData, encoding: .utf8) else {
+            UserDefaults.standard.set(true, forKey: Self.v133MigrationKey)
+            return []
+        }
+
+        let query = """
+            SELECT origin, httpRealm, formActionOrigin, usernameField, passwordField, secFields
+            FROM loginsL WHERE secFields != '' AND is_deleted = 0
+            """
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, query, -1, &stmt, nil) == SQLITE_OK else {
+            UserDefaults.standard.set(true, forKey: Self.v133MigrationKey)
+            return []
+        }
+        defer { sqlite3_finalize(stmt) }
+
+        var entries: [LoginEntry] = []
+        var skipped = 0
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            func col(_ i: Int32) -> String? {
+                guard let ptr = sqlite3_column_text(stmt, i) else { return nil }
+                return String(cString: ptr)
+            }
+            guard let secFields = col(5) else { skipped += 1; continue }
+            guard let decrypted = decryptJWEDirect(jwe: secFields, jwkString: keyString),
+                  let data = decrypted.data(using: .utf8),
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: String],
+                  let username = json["u"],
+                  let password = json["p"],
+                  !password.isEmpty else {
+                skipped += 1
+                continue
+            }
+
+            entries.append(LoginEntry(
+                origin: col(0) ?? "",
+                httpRealm: col(1),
+                formActionOrigin: col(2),
+                usernameField: col(3) ?? "",
+                passwordField: col(4) ?? "",
+                password: password,
+                username: username
+            ))
+        }
+        UserDefaults.standard.set(true, forKey: Self.v133MigrationKey)
+        return entries
+    }
+
+    // Ecosia: decrypts a v133 secFields JWE compact token (alg:dir, enc:A256GCM) using CryptoKit.
+    // jwkString is the JWK oct key stored by MZKeychainWrapper: {"kty":"oct","k":"<base64url>"}.
+    // AAD is the ASCII-encoded JWE Protected Header per RFC 7516.
+    private func decryptJWEDirect(jwe: String, jwkString: String) -> String? {
+        let parts = jwe.split(separator: ".", omittingEmptySubsequences: false).map(String.init)
+        guard parts.count == 5 else { return nil }
+
+        // Parse JWK to get raw key bytes
+        guard let jwkData = jwkString.data(using: .utf8),
+              let jwk = try? JSONDecoder().decode([String: String].self, from: jwkData),
+              let kBase64 = jwk["k"],
+              let keyBytes = Data(base64URLEncoded: kBase64),
+              keyBytes.count == 32 else { return nil }
+
+        // Decode JWE parts (parts[1] is empty for "dir")
+        guard let iv = Data(base64URLEncoded: parts[2]),
+              let ciphertext = Data(base64URLEncoded: parts[3]),
+              let tag = Data(base64URLEncoded: parts[4]) else { return nil }
+
+        do {
+            let symmetricKey = SymmetricKey(data: keyBytes)
+            let nonce = try AES.GCM.Nonce(data: iv)
+            let sealedBox = try AES.GCM.SealedBox(nonce: nonce, ciphertext: ciphertext, tag: tag)
+            let aad = Data(parts[0].utf8)
+            let plaintext = try AES.GCM.open(sealedBox, using: symmetricKey, authenticating: aad)
+            return String(data: plaintext, encoding: .utf8)
+        } catch {
+            return nil
+        }
+    }
+
+    // Ecosia: re-adds logins extracted from the v133 database using the new v147 API
+    private func readdMigratedLogins(_ logins: [LoginEntry]) {
+        for login in logins {
+            getStoredKey { [weak self] result in
+                guard case .success = result, let self = self else { return }
+                _ = try? self.storage?.add(login: login)
+            }
+        }
+    }
+
     // Open the db.
     private func open() -> NSError? {
+        // Ecosia: run v133→v147 migration before LoginsStorage opens the database
+        let migratedLogins = extractV133Logins()
+        if !migratedLogins.isEmpty {
+            // Delete the v133 database so LoginsStorage creates a fresh one with the new schema.
+            // Migrated logins are re-added after open via readdMigratedLogins.
+            try? FileManager.default.removeItem(atPath: perFieldDatabasePath)
+        }
         do {
             storage = try LoginsStorage(databasePath: self.perFieldDatabasePath, keyManager: self)
             isOpen = true
+            // Ecosia: readd entries from v133→v147 migration
+            if !migratedLogins.isEmpty {
+                readdMigratedLogins(migratedLogins)
+            }
             return nil
         } catch let err as NSError {
             if let loginsStoreError = err as? LoginsStoreError {
@@ -771,13 +905,9 @@ public final class RustLogins: LoginsProtocol, KeyManager, @unchecked Sendable {
     * ```
     */
     public func getKey() throws -> Data {
-        // Try the legacy MZKeychainWrapper path first (no kSecAttrGeneric). Users upgrading from
-        // pre-v147 had their key stored by MZKeychainWrapper, and the old Rust encryption received
-        // the raw keychain bytes directly. Returning those same bytes allows decryption of existing
-        // records. If not found (fresh install or already migrated), fall back to RustKeychain.
+        // Ecosia: prefer the legacy MZKeychainWrapper key (no kSecAttrGeneric) so that records
+        // encrypted by the pre-v147 app can be decrypted consistently after migration.
         if let legacyData = rustKeychain.legacyDataForKey(rustKeychain.loginsKeyIdentifier) {
-            // Ecosia [MOB-passwords-debug]: temporary diagnostic logging — remove once password persistence is understood
-            print("[MOB-passwords-debug] getKey: legacy key retrieved (length=\(legacyData.count))")
             return legacyData
         }
 

--- a/firefox-ios/Storage/Rust/RustLogins.swift
+++ b/firefox-ios/Storage/Rust/RustLogins.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
-import CryptoKit // Ecosia: required for AES-256-GCM decryption of v133 login secFields during migration
 import Glean
 import Shared
 import Common
@@ -14,18 +13,6 @@ import func MozillaAppServices.checkCanary
 import struct MozillaAppServices.Login
 import struct MozillaAppServices.LoginEntry
 import protocol MozillaAppServices.KeyManager
-
-// Ecosia: base64url decoding helper used by the v133→v147 login migration
-private extension Data {
-    init?(base64URLEncoded string: String) {
-        var base64 = string
-            .replacingOccurrences(of: "-", with: "+")
-            .replacingOccurrences(of: "_", with: "/")
-        let remainder = base64.count % 4
-        if remainder > 0 { base64 += String(repeating: "=", count: 4 - remainder) }
-        self.init(base64Encoded: base64)
-    }
-}
 
 typealias LoginsStoreError = LoginsApiError
 public typealias LoginRecord = Login
@@ -260,116 +247,6 @@ public final class RustLogins: LoginsProtocol, KeyManager, @unchecked Sendable {
         self.logger = logger
 
         queue = DispatchQueue(label: "RustLogins queue: \(databasePath)", attributes: [])
-    }
-
-    // Ecosia: one-time migration flag for the v133→v147 login secFields migration
-    private static let v133MigrationKey = "ecosia_v133_login_migration_complete"
-
-    // Ecosia: reads and decrypts all pre-v147 login records directly from SQLite before opening
-    // LoginsStorage. Needed because we jumped from application-services v133 to v149, skipping
-    // the gradual useRustKeychain Nimbus rollout (FXIOS-11415) that upstream used to migrate users.
-    // secFields are JWE compact tokens (alg:dir, enc:A256GCM); the key is a JWK oct stored by the
-    // legacy MZKeychainWrapper. Gated by a UserDefaults flag so it runs exactly once.
-    private func extractV133Logins() -> [LoginEntry] {
-        guard !UserDefaults.standard.bool(forKey: Self.v133MigrationKey) else {
-            return []
-        }
-
-        var db: OpaquePointer?
-        guard sqlite3_open_v2(perFieldDatabasePath, &db, SQLITE_OPEN_READONLY, nil) == SQLITE_OK else {
-            UserDefaults.standard.set(true, forKey: Self.v133MigrationKey)
-            return []
-        }
-        defer { sqlite3_close(db) }
-
-        guard let keyData = rustKeychain.legacyDataForKey(rustKeychain.loginsKeyIdentifier),
-              let keyString = String(data: keyData, encoding: .utf8) else {
-            UserDefaults.standard.set(true, forKey: Self.v133MigrationKey)
-            return []
-        }
-
-        let query = """
-            SELECT origin, httpRealm, formActionOrigin, usernameField, passwordField, secFields
-            FROM loginsL WHERE secFields != '' AND is_deleted = 0
-            """
-        var stmt: OpaquePointer?
-        guard sqlite3_prepare_v2(db, query, -1, &stmt, nil) == SQLITE_OK else {
-            UserDefaults.standard.set(true, forKey: Self.v133MigrationKey)
-            return []
-        }
-        defer { sqlite3_finalize(stmt) }
-
-        var entries: [LoginEntry] = []
-        var skipped = 0
-        while sqlite3_step(stmt) == SQLITE_ROW {
-            func col(_ i: Int32) -> String? {
-                guard let ptr = sqlite3_column_text(stmt, i) else { return nil }
-                return String(cString: ptr)
-            }
-            guard let secFields = col(5) else { skipped += 1; continue }
-            guard let decrypted = decryptJWEDirect(jwe: secFields, jwkString: keyString),
-                  let data = decrypted.data(using: .utf8),
-                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: String],
-                  let username = json["u"],
-                  let password = json["p"],
-                  !password.isEmpty else {
-                skipped += 1
-                continue
-            }
-
-            entries.append(LoginEntry(
-                origin: col(0) ?? "",
-                httpRealm: col(1),
-                formActionOrigin: col(2),
-                usernameField: col(3) ?? "",
-                passwordField: col(4) ?? "",
-                password: password,
-                username: username
-            ))
-        }
-        UserDefaults.standard.set(true, forKey: Self.v133MigrationKey)
-        return entries
-    }
-
-    // Ecosia: decrypts a v133 secFields JWE compact token (alg:dir, enc:A256GCM) using CryptoKit.
-    // jwkString is the JWK oct key stored by MZKeychainWrapper: {"kty":"oct","k":"<base64url>"}.
-    // AAD is the ASCII-encoded JWE Protected Header per RFC 7516.
-    private func decryptJWEDirect(jwe: String, jwkString: String) -> String? {
-        let parts = jwe.split(separator: ".", omittingEmptySubsequences: false).map(String.init)
-        guard parts.count == 5 else { return nil }
-
-        // Parse JWK to get raw key bytes
-        guard let jwkData = jwkString.data(using: .utf8),
-              let jwk = try? JSONDecoder().decode([String: String].self, from: jwkData),
-              let kBase64 = jwk["k"],
-              let keyBytes = Data(base64URLEncoded: kBase64),
-              keyBytes.count == 32 else { return nil }
-
-        // Decode JWE parts (parts[1] is empty for "dir")
-        guard let iv = Data(base64URLEncoded: parts[2]),
-              let ciphertext = Data(base64URLEncoded: parts[3]),
-              let tag = Data(base64URLEncoded: parts[4]) else { return nil }
-
-        do {
-            let symmetricKey = SymmetricKey(data: keyBytes)
-            let nonce = try AES.GCM.Nonce(data: iv)
-            let sealedBox = try AES.GCM.SealedBox(nonce: nonce, ciphertext: ciphertext, tag: tag)
-            let aad = Data(parts[0].utf8)
-            let plaintext = try AES.GCM.open(sealedBox, using: symmetricKey, authenticating: aad)
-            return String(data: plaintext, encoding: .utf8)
-        } catch {
-            return nil
-        }
-    }
-
-    // Ecosia: re-adds logins extracted from the v133 database using the new v147 API
-    private func readdMigratedLogins(_ logins: [LoginEntry]) {
-        for login in logins {
-            getStoredKey { [weak self] result in
-                guard case .success = result, let self = self else { return }
-                _ = try? self.storage?.add(login: login)
-            }
-        }
     }
 
     // Open the db.

--- a/firefox-ios/Storage/Rust/RustLogins.swift
+++ b/firefox-ios/Storage/Rust/RustLogins.swift
@@ -771,6 +771,16 @@ public final class RustLogins: LoginsProtocol, KeyManager, @unchecked Sendable {
     * ```
     */
     public func getKey() throws -> Data {
+        // Try the legacy MZKeychainWrapper path first (no kSecAttrGeneric). Users upgrading from
+        // pre-v147 had their key stored by MZKeychainWrapper, and the old Rust encryption received
+        // the raw keychain bytes directly. Returning those same bytes allows decryption of existing
+        // records. If not found (fresh install or already migrated), fall back to RustKeychain.
+        if let legacyData = rustKeychain.legacyDataForKey(rustKeychain.loginsKeyIdentifier) {
+            // Ecosia [MOB-passwords-debug]: temporary diagnostic logging — remove once password persistence is understood
+            print("[MOB-passwords-debug] getKey: legacy key retrieved (length=\(legacyData.count))")
+            return legacyData
+        }
+
         switch rustKeychain.queryKeychainForKey(key: rustKeychain.loginsKeyIdentifier) {
         case .success(let result):
             guard let data = result, let key = data.data(using: String.Encoding.utf8) else {

--- a/firefox-ios/Storage/RustKeychain+Ecosia.swift
+++ b/firefox-ios/Storage/RustKeychain+Ecosia.swift
@@ -1,0 +1,31 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+// Ecosia: keychain helpers needed for the v133→v149 login migration.
+// See RustLogins+EcosiaMigration.swift for context.
+
+import Foundation
+
+extension RustKeychain {
+    // Ecosia: queries keychain items written by the legacy MZKeychainWrapper (pre-v147).
+    // Uses kSecAttrAccount as a plain String (matching MZKeychainWrapper's storage format) and
+    // omits kSecAttrGeneric so it finds the original item rather than any newer RustKeychain item.
+    public func legacyDataForKey(_ key: String) -> Data? {
+        var query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: self.serviceName,
+            kSecAttrAccount as String: key,
+            kSecAttrSynchronizable as String: false,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        if let accessGroup = self.accessGroup {
+            query[kSecAttrAccessGroup as String] = accessGroup
+        }
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess, let data = result as? Data else { return nil }
+        return data
+    }
+}

--- a/firefox-ios/Storage/RustKeychain+Ecosia.swift
+++ b/firefox-ios/Storage/RustKeychain+Ecosia.swift
@@ -2,10 +2,15 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-// Ecosia: keychain helpers needed for the v133→v149 login migration.
+// Ecosia: keychain helpers needed for the v133→v147 login migration.
 // See RustLogins+EcosiaMigration.swift for context.
 
 import Foundation
+
+// Ecosia: default implementation so existing KeychainProtocol conformers are not source-broken
+public extension KeychainProtocol {
+    func legacyDataForKey(_ key: String) -> Data? { return nil }
+}
 
 extension RustKeychain {
     // Ecosia: queries keychain items written by the legacy MZKeychainWrapper (pre-v147).

--- a/firefox-ios/Storage/RustKeychain.swift
+++ b/firefox-ios/Storage/RustKeychain.swift
@@ -55,7 +55,7 @@ public protocol KeychainProtocol: Sendable {
     static func wipeKeychain()
     func createLoginsKeyData() throws -> String
     func queryKeychainForKey(key: String) -> Result<String?, Error>
-    func legacyDataForKey(_ key: String) -> Data?
+    func legacyDataForKey(_ key: String) -> Data? // Ecosia: finds pre-v147 MZKeychainWrapper keys for migration
     func createAndStoreKey(canaryPhrase: String, canaryIdentifier: String, keyIdentifier: String) throws -> String
     func decryptCreditCardNum(encryptedCCNum: String) -> String?
     func checkCanary(canary: String,
@@ -345,11 +345,9 @@ public final class RustKeychain: KeychainProtocol {
         return keychainQueryDictionary
     }
 
-    // Queries for keychain items stored by the legacy MZKeychainWrapper (pre-v147).
-    // MZKeychainWrapper stored kSecAttrAccount as a plain CFString (not Data), so we query
-    // with a String to match what it wrote. Does not filter on kSecAttrGeneric (which
-    // MZKeychainWrapper did not set) so it finds the original item rather than any newer
-    // RustKeychain item. Returns raw kSecValueData bytes.
+    // Ecosia: queries keychain items written by the legacy MZKeychainWrapper (pre-v147).
+    // Uses kSecAttrAccount as a plain String (matching MZKeychainWrapper's storage format) and
+    // omits kSecAttrGeneric so it finds the original item rather than any RustKeychain item.
     public func legacyDataForKey(_ key: String) -> Data? {
         var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,

--- a/firefox-ios/Storage/RustKeychain.swift
+++ b/firefox-ios/Storage/RustKeychain.swift
@@ -345,27 +345,6 @@ public final class RustKeychain: KeychainProtocol {
         return keychainQueryDictionary
     }
 
-    // Ecosia: queries keychain items written by the legacy MZKeychainWrapper (pre-v147).
-    // Uses kSecAttrAccount as a plain String (matching MZKeychainWrapper's storage format) and
-    // omits kSecAttrGeneric so it finds the original item rather than any RustKeychain item.
-    public func legacyDataForKey(_ key: String) -> Data? {
-        var query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: self.serviceName,
-            kSecAttrAccount as String: key,         // String, not Data — matches MZKeychainWrapper
-            kSecAttrSynchronizable as String: false,
-            kSecReturnData as String: true,
-            kSecMatchLimit as String: kSecMatchLimitOne
-        ]
-        if let accessGroup = self.accessGroup {
-            query[kSecAttrAccessGroup as String] = accessGroup
-        }
-        var result: AnyObject?
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
-        guard status == errSecSuccess, let data = result as? Data else { return nil }
-        return data
-    }
-
     private func logErrorFromStatus(_ status: OSStatus, errMsg: String) {
         guard status != errSecSuccess else {
             return

--- a/firefox-ios/Storage/RustKeychain.swift
+++ b/firefox-ios/Storage/RustKeychain.swift
@@ -55,6 +55,7 @@ public protocol KeychainProtocol: Sendable {
     static func wipeKeychain()
     func createLoginsKeyData() throws -> String
     func queryKeychainForKey(key: String) -> Result<String?, Error>
+    func legacyDataForKey(_ key: String) -> Data?
     func createAndStoreKey(canaryPhrase: String, canaryIdentifier: String, keyIdentifier: String) throws -> String
     func decryptCreditCardNum(encryptedCCNum: String) -> String?
     func checkCanary(canary: String,
@@ -342,6 +343,29 @@ public final class RustKeychain: KeychainProtocol {
             keychainQueryDictionary[kSecAttrAccessGroup as String] = accessGroup
         }
         return keychainQueryDictionary
+    }
+
+    // Queries for keychain items stored by the legacy MZKeychainWrapper (pre-v147).
+    // MZKeychainWrapper stored kSecAttrAccount as a plain CFString (not Data), so we query
+    // with a String to match what it wrote. Does not filter on kSecAttrGeneric (which
+    // MZKeychainWrapper did not set) so it finds the original item rather than any newer
+    // RustKeychain item. Returns raw kSecValueData bytes.
+    public func legacyDataForKey(_ key: String) -> Data? {
+        var query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: self.serviceName,
+            kSecAttrAccount as String: key,         // String, not Data — matches MZKeychainWrapper
+            kSecAttrSynchronizable as String: false,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        if let accessGroup = self.accessGroup {
+            query[kSecAttrAccessGroup as String] = accessGroup
+        }
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess, let data = result as? Data else { return nil }
+        return data
     }
 
     private func logErrorFromStatus(_ status: OSStatus, errMsg: String) {

--- a/firefox-ios/Tuist/ProjectDescriptionHelpers/Targets+Frameworks.swift
+++ b/firefox-ios/Tuist/ProjectDescriptionHelpers/Targets+Frameworks.swift
@@ -18,7 +18,7 @@ public enum FrameworkTargets {
         .target(
             name: "Account",
             destinations: .iOS,
-            product: .staticLibrary,
+            product: .framework,
             bundleId: "org.mozilla.ios.Account",
             infoPlist: .file(path: "Account/Info.plist"),
             sources: [
@@ -63,7 +63,7 @@ public enum FrameworkTargets {
         .target(
             name: "Storage",
             destinations: .iOS,
-            product: .staticLibrary,
+            product: .framework,
             bundleId: "org.mozilla.ios.Storage",
             infoPlist: .file(path: "Storage/Info.plist"),
             sources: [


### PR DESCRIPTION
[MOB-4387]

## Context

After the v133 → v147 Firefox upstream upgrade, passwords were not visible and newly saved passwords disappeared for users upgrading from a production app with previous passwords. Fresh installs and upgrades for users with no passwords worked fine.

## Investigation

Investigation revealed two root causes:                   

1. Duplicate RustLogins class 

Storage and Account were configured as .staticLibrary in Tuist. Since both Sync.framework (dynamic) and the main Client target statically linked them, RustLogins was compiled into both binaries. Sync.framework's copy won the Objective-C runtime race, causing all password operations to silently execute against an instance with diverged state — specifically isOpen = false for saves, and an incorrect encryption key for reads.

2. Missing v133 → v147 encryption migration                                                                    

Firefox upstream migrated users between encryption architectures gradually over v134–v146 via the useRustKeychain Nimbus feature flag (FXIOS-11415). In v133, login credentials were stored as JWE compact tokens (alg:dir, enc:A256GCM) in a secFields SQLite column, encrypted with a key held by MZKeychainWrapper. In v147, the Rust component manages encryption directly via the KeyManager protocol and no longer understands the old format. By jumping directly from v133 to v147, we skipped this migration window entirely. The old decrypt_fields / decryptLogin FFI functions were also completely removed from the v147 application-services binary (confirmed via nm), so the only viable path was implementing decryption directly.

References: application-services
* https://github.com/mozilla/application-services/blob/v133.0/components/logins/src/schema.rs (confirms user_version=2 and loginsL column names)
* https://github.com/mozilla/application-services/blob/v149.0/components/logins/src/encryption.rs (confirms
  JWK/JWE format).

## Approach

Fix 1 — Duplicate class (Targets+Frameworks.swift)

Changed Storage and Account from .staticLibrary to .framework. Both are now loaded once as dynamic frameworks, eliminating the duplicate class and all associated runtime issues.                                             

Fix 2 — v133 → v147 login migration (RustLogins+EcosiaMigration.swift, RustKeychain+Ecosia.swift)

A one-time migration runs in open() before LoginsStorage is opened:
- extractV133Logins() opens the existing SQLite database read-only and queries all non-deleted records with non-empty secFields. It retrieves the original MZKeychainWrapper key via legacyDataForKey — which queries without kSecAttrGeneric to match how MZKeychainWrapper stored items (plain CFString account, no generic attribute). Each secFields blob is decrypted using CryptoKit's AES.GCM, with the 32-byte key extracted from the JWK k field and the encoded JWE header as the GCM additional authenticated data (per RFC 7516).
- If records were extracted, the old database is moved to a backup file so LoginsStorage opens a fresh one, then readdMigratedLogins() re-adds the credentials via the new v147 addLogin API and, if successful, deletes the backup and marks as complete.
- The migration is gated by a UserDefaults flag (ecosia_v133_login_migration_complete) so it runs exactly once. For new users or users with no prior passwords, the migration exits early (no legacy key or no records) and sets the flag on first launch.

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [x] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4387]: https://ecosia.atlassian.net/browse/MOB-4387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ