### PR TITLE
[MOB-4390] Fix Import bookmarks 

### DIFF
--- a/BrowserKit/Sources/MenuKit/MenuCell.swift
+++ b/BrowserKit/Sources/MenuKit/MenuCell.swift
@@ -138,7 +138,10 @@ final class MenuCell: UITableViewCell, ReusableCell, ThemeApplicable {
         if model.isActive {
             titleLabel.textColor = theme.colors.textAccent
             descriptionLabel.textColor = theme.colors.textSecondary
+            /* Ecosia: Use textAccent so the icon tint matches the title and aligns with the toggle's active colour
             iconImageView.tintColor = theme.colors.iconAccentBlue
+            */
+            iconImageView.tintColor = theme.colors.textAccent
         } else if !model.isEnabled {
             titleLabel.textColor = theme.colors.textDisabled
             descriptionLabel.textColor = theme.colors.textDisabled

--- a/BrowserKit/Sources/MenuKit/MenuInfoCell.swift
+++ b/BrowserKit/Sources/MenuKit/MenuInfoCell.swift
@@ -117,8 +117,12 @@ final class MenuInfoCell: UITableViewCell, ReusableCell, ThemeApplicable {
         backgroundColor = theme.colors.layerSurfaceMedium.withAlphaComponent(mainMenuHelper?.backgroundAlpha() ?? 1.0)
         if model.isActive {
             titleLabel.textColor = theme.colors.textAccent
+            /* Ecosia: Tint the badge with the accent colour (white text on green) to match the toggle's active state
             infoLabelView.textColor = theme.colors.textPrimary
             infoLabelView.backgroundColor = theme.colors.layerInformation
+            */
+            infoLabelView.textColor = theme.colors.textInverted
+            infoLabelView.backgroundColor = theme.colors.textAccent
         } else if !model.isEnabled {
             titleLabel.textColor = theme.colors.textDisabled
             infoLabelView.textColor = theme.colors.textDisabled

--- a/firefox-ios/Client/Ecosia/Bookmarks/BookmarksExchange.swift
+++ b/firefox-ios/Client/Ecosia/Bookmarks/BookmarksExchange.swift
@@ -95,8 +95,10 @@ final class BookmarksExchange: BookmarksExchangable {
         )
 
         do {
-            let (data, _) = try await URLSession.shared.data(from: fileURL)
-            guard let html = String(data: data, encoding: .utf8) else { throw Error.couldNotReadData }
+            let didStartAccessing = fileURL.startAccessingSecurityScopedResource()
+            defer { if didStartAccessing { fileURL.stopAccessingSecurityScopedResource() } }
+            guard let data = try? Data(contentsOf: fileURL),
+                  let html = String(data: data, encoding: .utf8) else { throw Error.couldNotReadData }
             let parser = try BookmarkParser(html: html)
             let bookmarks = try await parser.parseBookmarks()
             try await importBookmarks(bookmarks, viewController: viewController, toast: toast)


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-4390]

## Context

Our UI Automation tests reported that bookmark import fails after export/re-import with "Importing failed — The requested URL was not found on this server."
I could repro so we needed to find the root cause.

## Approach

Bookmark import

- Switch picker from `forOpeningContentTypes` to `forImportingItemsConforming` — copies the file into the app sandbox, returns a plain file:// URL; so we are good "security-wise".
- BookmarksExchange.import: replace `URLSession.shared.data(from:)` with `Data(contentsOf:)` wrapped in `startAccessingSecurityScopedResource() / stopAccessingSecurityScopedResource()` as defence-in-depth

## Other

Took the opportunity to also revisit the colours of the menu (realised they were still matching old FF styles when active/mutated states).
Revisited: active-state menu items (bookmark star, zoom %, dark mode/desktop site "On" badge).

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [x] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)

[MOB-4390]: https://ecosia.atlassian.net/browse/MOB-4390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ