### PR TITLE
[MOB-4404] Add modifier to display the header in iOS<16

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -435,9 +435,15 @@ class BrowserCoordinator: BaseCoordinator,
         case .topSites:
             browserViewController.openURLInNewTab(HomePanelType.topSites.internalUrl)
         case .newPrivateTab:
+            /* Ecosia: Do not auto-focus the address bar when opening a new tab from the toolbar.
             browserViewController.openBlankNewTab(focusLocationField: true, isPrivate: true)
+            */
+            browserViewController.openBlankNewTab(focusLocationField: false, isPrivate: true)
         case .newTab:
+            /* Ecosia: Do not auto-focus the address bar when opening a new tab from the toolbar.
             browserViewController.openBlankNewTab(focusLocationField: true)
+            */
+            browserViewController.openBlankNewTab(focusLocationField: false)
         }
     }
 

--- a/firefox-ios/Client/Ecosia/Extensions/HomepageSectionLayoutProvider+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/HomepageSectionLayoutProvider+Ecosia.swift
@@ -94,11 +94,19 @@ extension HomepageSectionLayoutProvider {
 
         /* Size the impact section to fill the remaining card height so TopSites is
            always pinned at the bottom. Subtract the fixed-height surrounding sections:
-             • ecosiaHeader:  estimated 64 pt (matches createEcosiaHeaderLayout)
-             • topSites cell: estimated 100 pt + 8 pt top inset + 26 pt bottom inset = 134 pt
+             • ecosiaHeader:  NTPHeaderView ZStack height + vertical padding (_m × 2)
+                 iOS 16+: EcosiaAccountNavButton (40 pt + 4+4 pt padding) = 48 pt → 48 + 32 = 80 pt
+                 iOS 15:  EcosiaCustomizeButton 40 pt → 40 + 32 = 72 pt
+             • topSites cell: 100 pt + _1s (8 pt) top inset + _1l (24 pt) bottom inset = 132 pt
          */
-        let topSitesSectionHeight: CGFloat = 100 + CGFloat.ecosia.space._1s + 26
-        let headerSectionHeight: CGFloat = 64
+        let topSitesSectionHeight: CGFloat = 100 + CGFloat.ecosia.space._1s + CGFloat.ecosia.space._1l
+        // Ecosia: Use accurate header height per OS so the impact section isn't over-allocated.
+        let headerSectionHeight: CGFloat
+        if #available(iOS 16, *) {
+            headerSectionHeight = 80
+        } else {
+            headerSectionHeight = 72
+        }
         let fillHeight = environment.container.contentSize.height - headerSectionHeight - topSitesSectionHeight
         // Fall back to content-size estimate so the cell is never shorter than its content.
         let impactHeight = max(304, fillHeight)

--- a/firefox-ios/Client/Ecosia/Extensions/HomepageViewController+EcosiaCells.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/HomepageViewController+EcosiaCells.swift
@@ -25,20 +25,17 @@ extension HomepageViewController {
 
     func configureEcosiaHeaderCell(at indexPath: IndexPath) -> UICollectionViewCell {
         guard let cv = homepageCollectionView else { return UICollectionViewCell() }
-        if #available(iOS 16.0, *) {
-            guard let headerCell = cv.dequeueReusableCell(
-                cellType: NTPHeader.self,
-                for: indexPath
-            ) else {
-                return UICollectionViewCell()
-            }
-
-            if let viewModel = ecosiaAdapter?.headerViewModel {
-                headerCell.configure(with: viewModel, windowUUID: windowUUID)
-            }
-            return headerCell
+        guard let headerCell = cv.dequeueReusableCell(
+            cellType: NTPHeader.self,
+            for: indexPath
+        ) else {
+            return UICollectionViewCell()
         }
-        return UICollectionViewCell()
+
+        if let viewModel = ecosiaAdapter?.headerViewModel {
+            headerCell.configure(with: viewModel, windowUUID: windowUUID)
+        }
+        return headerCell
     }
 
     func configureEcosiaLogoCell(at indexPath: IndexPath) -> UICollectionViewCell {

--- a/firefox-ios/Client/Ecosia/Extensions/HomepageViewController+EcosiaSetup.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/HomepageViewController+EcosiaSetup.swift
@@ -17,15 +17,14 @@ extension HomepageViewController: @MainActor HomepageDataModelDelegate {
     func registerEcosiaCells(on collectionView: UICollectionView) {
         // NTPLogoCell removed — logo is now part of NTPHeader.
         var types: [ReusableCell.Type] = [
+            NTPHeader.self,
             NTPLibraryCell.self,
             TopSiteCell.self,
             EmptyTopSiteCell.self,
             NTPImpactCell.self,
             NTPCustomizationCell.self
         ]
-        if #available(iOS 16.0, *) {
-            types.insert(NTPHeader.self, at: 0)
-        }
+
         types.forEach {
             collectionView.register($0, forCellWithReuseIdentifier: $0.cellIdentifier)
         }

--- a/firefox-ios/Client/Ecosia/Extensions/HomepageViewController+EcosiaSetup.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/HomepageViewController+EcosiaSetup.swift
@@ -60,15 +60,13 @@ extension HomepageViewController: @MainActor HomepageDataModelDelegate {
 
         // Register Ecosia cell types; NTPLogoCell removed — logo now lives in NTPHeader.
         var ecosiaCellTypes: [ReusableCell.Type] = [
+            NTPHeader.self,
             NTPLibraryCell.self,
             TopSiteCell.self,
             EmptyTopSiteCell.self,
             NTPImpactCell.self,
             NTPCustomizationCell.self
         ]
-        if #available(iOS 16.0, *) {
-            ecosiaCellTypes.insert(NTPHeader.self, at: 0)
-        }
         homepageCellTypesToRegister = ecosiaCellTypes
         onDataSourceConfigured = { [weak self] dataSource in
             dataSource.ecosiaAdapter = self?.ecosiaAdapter

--- a/firefox-ios/Client/Ecosia/Frontend/Home/EcosiaHomepageAdapter.swift
+++ b/firefox-ios/Client/Ecosia/Frontend/Home/EcosiaHomepageAdapter.swift
@@ -52,16 +52,14 @@ final class EcosiaHomepageAdapter {
     }
 
     private func setupViewModels() {
-        // Header (iOS 16+ only)
-        if #available(iOS 16.0, *) {
-            headerViewModel = NTPHeaderViewModel(
-                profile: profile,
-                theme: theme,
-                windowUUID: windowUUID,
-                auth: auth,
-                delegate: headerDelegate
-            )
-        }
+        // Header
+        headerViewModel = NTPHeaderViewModel(
+            profile: profile,
+            theme: theme,
+            windowUUID: windowUUID,
+            auth: auth,
+            delegate: headerDelegate
+        )
 
         // Library shortcuts
         libraryViewModel = NTPLibraryCellViewModel(
@@ -162,10 +160,7 @@ final class EcosiaHomepageAdapter {
     // MARK: - Section Visibility
 
     private func shouldShowHeader() -> Bool {
-        if #available(iOS 16.0, *) {
-            return true
-        }
-        return false
+        return true
     }
 
     // MARK: - Lifecycle

--- a/firefox-ios/Client/Ecosia/Frontend/Home/EcosiaHomepageSectionType.swift
+++ b/firefox-ios/Client/Ecosia/Frontend/Home/EcosiaHomepageSectionType.swift
@@ -22,11 +22,7 @@ enum HomepageSectionType: Int, CaseIterable {
     var cellIdentifier: String {
         switch self {
         case .header:
-            if #available(iOS 16.0, *) {
-                return NTPHeader.cellIdentifier
-            } else {
-                return "" // Fallback for iOS < 16.0
-            }
+            return NTPHeader.cellIdentifier
         case .homepageHeader: return NTPLogoCell.cellIdentifier
         case .libraryShortcuts: return NTPLibraryCell.cellIdentifier
         case .topSites: return "" // Top sites has more than 1 cell type, dequeuing is done through FxHomeSectionHandler protocol
@@ -40,10 +36,7 @@ enum HomepageSectionType: Int, CaseIterable {
     static var cellTypes: [ReusableCell.Type] {
         var types: [ReusableCell.Type] = []
 
-        if #available(iOS 16.0, *) {
-            types.append(NTPHeader.self)
-        }
-
+        types.append(NTPHeader.self)
         types.append(contentsOf: [
             NTPLogoCell.self,
             TopSiteItemCell.self,

--- a/firefox-ios/Client/Ecosia/UI/NTP/Header/NTPHeader.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/Header/NTPHeader.swift
@@ -79,6 +79,9 @@ private struct NTPCircleGlassButtonStyle: ButtonStyle {
                     Color.clear.background(.ultraThinMaterial)
                     Self.glassTint.opacity(tintOpacity)
                 }
+                // Ecosia: Force the dark-mode variant of ultraThinMaterial so the glass always
+                // reads against the NTP wallpaper regardless of the system colour scheme.
+                .environment(\.colorScheme, .dark)
                 .clipShape(Circle())
             )
             .clipShape(Circle())

--- a/firefox-ios/Client/Ecosia/UI/NTP/Header/NTPHeader.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/Header/NTPHeader.swift
@@ -14,7 +14,6 @@ protocol NTPHeaderDelegate: AnyObject {
 }
 
 /// NTP header cell containing the Ecosia logo and navigation actions
-@available(iOS 16.0, *)
 final class NTPHeader: UICollectionViewCell, ReusableCell {
 
     // MARK: - Properties
@@ -65,10 +64,42 @@ final class NTPHeader: UICollectionViewCell, ReusableCell {
     }
 }
 
+// MARK: - Fallback glass button style (iOS 15)
+
+/// Circle-specific glass button style for iOS 15 that avoids `AnyShape` (iOS 16+).
+private struct NTPCircleGlassButtonStyle: ButtonStyle {
+    private static let glassTint = Color(red: 26 / 255, green: 26 / 255, blue: 26 / 255)
+    private static let glassBorder = Color.white.opacity(0x3D / 255.0)
+
+    func makeBody(configuration: Configuration) -> some View {
+        let tintOpacity: Double = configuration.isPressed ? 0.64 : 0.32
+        configuration.label
+            .background(
+                ZStack {
+                    Color.clear.background(.ultraThinMaterial)
+                    Self.glassTint.opacity(tintOpacity)
+                }
+                .clipShape(Circle())
+            )
+            .clipShape(Circle())
+            .overlay(Circle().stroke(Self.glassBorder, lineWidth: 1))
+    }
+}
+
+/// Applies the glass circle button style, selecting the appropriate variant by OS version.
+private struct GlassCircleModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(iOS 16, *) {
+            content.buttonStyle(NTPGlassButtonStyle(Circle()))
+        } else {
+            content.buttonStyle(NTPCircleGlassButtonStyle())
+        }
+    }
+}
+
 // MARK: - Customize (Pencil) Button
 
 /// Glass-style circular button with a pencil icon for opening NTP customization.
-@available(iOS 16.0, *)
 private struct EcosiaCustomizeButton: View {
     let onTap: () -> Void
 
@@ -84,7 +115,7 @@ private struct EcosiaCustomizeButton: View {
                 .frame(width: iconSize, height: iconSize)
                 .frame(width: buttonSize, height: buttonSize)
         }
-        .buttonStyle(NTPGlassButtonStyle(Circle()))
+        .modifier(GlassCircleModifier())
         .accessibilityLabel(String.localized(.customizeHomepage))
         .accessibilityIdentifier(EcosiaAccessibilityIdentifiers.NTP.customizeButton)
     }
@@ -92,7 +123,6 @@ private struct EcosiaCustomizeButton: View {
 
 // MARK: - Ecosia Logo (centered in header)
 
-@available(iOS 16.0, *)
 private struct NTPHeaderLogoView: View {
     private let logoHeight: CGFloat = 20
 
@@ -109,7 +139,6 @@ private struct NTPHeaderLogoView: View {
 }
 
 // MARK: - SwiftUI Multi-Purpose Header View
-@available(iOS 16.0, *)
 struct NTPHeaderView: View {
     @ObservedObject var viewModel: NTPHeaderViewModel
     let windowUUID: WindowUUID
@@ -127,36 +156,38 @@ struct NTPHeaderView: View {
                     onTap: handleCustomizeTap
                 )
                 Spacer()
-                ZStack(alignment: .topLeading) {
-                    EcosiaAccountNavButton(
-                        seedCount: viewModel.seedCount,
-                        avatarURL: viewModel.userAvatarURL,
-                        enableAnimation: !reduceMotion && viewModel.shouldAnimateSeed,
-                        showSeedSparkles: viewModel.showSeedSparkles,
-                        windowUUID: windowUUID,
-                        onTap: handleTap
-                    )
-                    .sheet(isPresented: $showAccountImpactView) {
-                        EcosiaAccountImpactView(
-                            viewModel: EcosiaAccountImpactViewModel(
-                                onLogin: {
-                                    viewModel.performLogin()
-                                },
-                                onDismiss: {
-                                    showAccountImpactView = false
-                                }
-                            ),
-                            windowUUID: windowUUID
+                if #available(iOS 16, *) {
+                    ZStack(alignment: .topLeading) {
+                        EcosiaAccountNavButton(
+                            seedCount: viewModel.seedCount,
+                            avatarURL: viewModel.userAvatarURL,
+                            enableAnimation: !reduceMotion && viewModel.shouldAnimateSeed,
+                            showSeedSparkles: viewModel.showSeedSparkles,
+                            windowUUID: windowUUID,
+                            onTap: handleTap
                         )
-                        .padding(.horizontal, .ecosia.space._m)
-                        .dynamicHeightPresentationDetent()
-                    }
-                    if let increment = viewModel.balanceIncrement {
-                        BalanceIncrementAnimationView(
-                            increment: increment,
-                            windowUUID: windowUUID
-                        )
-                        .offset(x: 18, y: -8)
+                        .sheet(isPresented: $showAccountImpactView) {
+                            EcosiaAccountImpactView(
+                                viewModel: EcosiaAccountImpactViewModel(
+                                    onLogin: {
+                                        viewModel.performLogin()
+                                    },
+                                    onDismiss: {
+                                        showAccountImpactView = false
+                                    }
+                                ),
+                                windowUUID: windowUUID
+                            )
+                            .padding(.horizontal, .ecosia.space._m)
+                            .dynamicHeightPresentationDetent()
+                        }
+                        if let increment = viewModel.balanceIncrement {
+                            BalanceIncrementAnimationView(
+                                increment: increment,
+                                windowUUID: windowUUID
+                            )
+                            .offset(x: 18, y: -8)
+                        }
                     }
                 }
             }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+ToolBarActionMenuDelegate.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+ToolBarActionMenuDelegate.swift
@@ -357,9 +357,13 @@ extension BrowserViewController: PhotonActionSheetProtocol {
         return SingleActionViewModel(title: .KeyboardShortcuts.NewTab,
                                      iconString: StandardImageIdentifiers.Large.plus,
                                      iconType: .Image) { _ in
+            /* Ecosia: Do not auto-focus the address bar when opening a new tab from the toolbar.
             let shouldFocusLocationField = self.newTabSettings == .blankPage
             self.overlayManager.openNewTab(url: nil, newTabSettings: self.newTabSettings)
             self.openBlankNewTab(focusLocationField: shouldFocusLocationField, isPrivate: false)
+            */
+            self.overlayManager.openNewTab(url: nil, newTabSettings: self.newTabSettings)
+            self.openBlankNewTab(focusLocationField: false, isPrivate: false)
         }.items
     }
 
@@ -369,9 +373,13 @@ extension BrowserViewController: PhotonActionSheetProtocol {
         return SingleActionViewModel(title: .KeyboardShortcuts.NewPrivateTab,
                                      iconString: iconString,
                                      iconType: .Image) { _ in
+            /* Ecosia: Do not auto-focus the address bar when opening a new private tab from the toolbar.
             let shouldFocusLocationField = self.newTabSettings == .blankPage
             self.overlayManager.openNewTab(url: nil, newTabSettings: self.newTabSettings)
             self.openBlankNewTab(focusLocationField: shouldFocusLocationField, isPrivate: true)
+            */
+            self.overlayManager.openNewTab(url: nil, newTabSettings: self.newTabSettings)
+            self.openBlankNewTab(focusLocationField: false, isPrivate: true)
             TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .newPrivateTab, value: .tabTray)
         }.items
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -3416,7 +3416,10 @@ class BrowserViewController: UIViewController,
         if let url {
             switchToTabForURLOrOpen(url, uuid: tabId, isPrivate: isPrivate)
         } else {
+            /* Ecosia: Do not auto-focus the address bar when a deeplink opens a new tab with no URL.
             openBlankNewTab(focusLocationField: true, isPrivate: isPrivate)
+            */
+            openBlankNewTab(focusLocationField: false, isPrivate: isPrivate)
         }
     }
 
@@ -5152,7 +5155,10 @@ extension BrowserViewController: TopTabsDelegate {
             openBlankNewTab(focusLocationField: false, isPrivate: isPrivate)
             tabManager.selectedTab?.loadRequest(PrivilegedRequest(url: url) as URLRequest)
         } else {
+            /* Ecosia: Do not auto-focus the address bar when opening a new tab from the top tab bar.
             openBlankNewTab(focusLocationField: true, isPrivate: isPrivate)
+            */
+            openBlankNewTab(focusLocationField: false, isPrivate: isPrivate)
             overlayManager.openNewTab(url: nil, newTabSettings: newTabSettings)
         }
     }


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

⚠️ This one https://github.com/ecosia/ios-browser/pull/1131 takes priority regarding merging, as well as needing to adapt the glass color. 

[MOB-4404]

## Context

Our Tester Engineer found out that our NTP looked different on devices below iOS16, stretching other components like the impact row.

## Approach

Created a set of wrappers and view modifiers to make sure they work in all scenarios. 

## Other

## Before merging

### Checklist

- [ ] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [x] I added the `// Ecosia:` helper comments where needed
- [x] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4404]: https://ecosia.atlassian.net/browse/MOB-4404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ