### PR TITLE
[MOB-4434] Setup Aikido code scanning configuration

### DIFF
--- a/.aikido
+++ b/.aikido
@@ -2,12 +2,8 @@ exclude:
   paths:
     # Root-level folders not related to Ecosia's product
     - focus-ios/
-    - BrowserKit/
     - SampleBrowser/
     - SampleComponentLibraryApp/
-    - MozillaRustComponents/
-    - ContentBlockingLists/
-    - shavar-prod-lists/
     - taskcluster/
     - monorepo-migration/
     - test-fixtures/

--- a/.aikido
+++ b/.aikido
@@ -1,0 +1,17 @@
+exclude:
+  paths:
+    # Root-level folders not related to Ecosia's product
+    - focus-ios/
+    - BrowserKit/
+    - SampleBrowser/
+    - SampleComponentLibraryApp/
+    - MozillaRustComponents/
+    - ContentBlockingLists/
+    - shavar-prod-lists/
+    - taskcluster/
+    - monorepo-migration/
+    - test-fixtures/
+    - firefox-ios/ThirdParty/
+    # Disabled third-party services within firefox-ios
+    - firefox-ios/Client/AdjustHelper.swift
+    - firefox-ios/Client/AdjustTelemetryHelper.swift


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-4434]

## Context

Aikido ignore rules were previously managed via the dashboard, making them invisible to code review and hard to audit over time. Managing them in code ensures they are reviewable, versioned, and self-documenting.

## Approach

- Introduces a `.aikido` file at the repository root to manage Aikido scanning exclusions from code rather than the dashboard
- Excludes root-level Mozilla/Firefox directories not owned or maintained by Ecosia
- Excludes `firefox-ios/ThirdParty/` (vendored binaries, including `sentry-cli`) and Adjust SDK files that are fully commented out

## Other


### Out of scope

CVE-specific suppressions (`ignore.cves`) are intentionally left for a follow-up once specific CVE IDs are identified from the Aikido dashboard.

## Before merging

### Checklist

- [ ] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [ ] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4434]: https://ecosia.atlassian.net/browse/MOB-4434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ