### PR TITLE
[MOB-4405] Design debt follow-up and additions #2

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -803,9 +803,6 @@ final class LocationView: UIView,
         let colors = theme.colors
         /* Ecosia: Use backgroundElevation1 to match the locationContainer background so the
            gradient fade blends seamlessly into the URL bar pill on long URLs.
-           backgroundTertiary was previously used here but differs from backgroundElevation1
-           (Gray20 vs White in light mode; Gray70 vs Gray80 in dark mode), causing a visible
-           colour seam between the fade and the container.
         let mainBackgroundColor = hasAlternativeLocationColor ? colors.layerSurfaceMediumAlt : colors.layerSurfaceMedium
          */
         let mainBackgroundColor = colors.ecosia.backgroundElevation1

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -801,10 +801,14 @@ final class LocationView: UIView,
     func applyTheme(theme: Theme) {
         self.theme = theme
         let colors = theme.colors
-        /* Ecosia: Use Ecosia semantic colors for location view (legacy URLBarView applyTheme)
+        /* Ecosia: Use backgroundElevation1 to match the locationContainer background so the
+           gradient fade blends seamlessly into the URL bar pill on long URLs.
+           backgroundTertiary was previously used here but differs from backgroundElevation1
+           (Gray20 vs White in light mode; Gray70 vs Gray80 in dark mode), causing a visible
+           colour seam between the fade and the container.
         let mainBackgroundColor = hasAlternativeLocationColor ? colors.layerSurfaceMediumAlt : colors.layerSurfaceMedium
          */
-        let mainBackgroundColor = colors.ecosia.backgroundTertiary
+        let mainBackgroundColor = colors.ecosia.backgroundElevation1
         if #available(iOS 26.0, *), scrollAlpha.isZero {
             // We want to use system colors when the location view is fully transparent
             // To make sure it blends well with the background when using glass effect.

--- a/firefox-ios/Client/Coordinators/Scene/SceneSetupHelper.swift
+++ b/firefox-ios/Client/Coordinators/Scene/SceneSetupHelper.swift
@@ -49,10 +49,10 @@ struct SceneSetupHelper {
         let currentTheme = themeManager.getCurrentTheme(for: windowUUID)
         window.overrideUserInterfaceStyle = currentTheme.type.getInterfaceStyle()
 
-        // Ecosia: Set the window background to the NTP/homepage background colour so the window
-        // is already the correct colour before the BVC's backgroundView is painted by applyTheme.
-        // Without this, UIWindow's default nil/black background shows through briefly on cold
-        // start (dark → light flash in light mode).
+        /* Ecosia: Set the window background to the NTP/homepage background colour so the window
+           is already the correct colour before the BVC's backgroundView is painted by applyTheme.
+           Without this, UIWindow's default nil/black background shows through briefly on cold
+           start (dark → light flash in light mode). */
         window.backgroundColor = (currentTheme.colors as? EcosiaThemeColourPalette)?.ecosia.backgroundPrimaryDecorative
 
         return window

--- a/firefox-ios/Client/Coordinators/Scene/SceneSetupHelper.swift
+++ b/firefox-ios/Client/Coordinators/Scene/SceneSetupHelper.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
+import Ecosia
 import UIKit
 
 class BrowserWindow: UIWindow {
@@ -41,7 +42,14 @@ struct SceneSetupHelper {
         // Setting the initial theme correctly as we don't have a window attached yet to let ThemeManager set it
         let themeManager: ThemeManager = AppContainer.shared.resolve()
         themeManager.setWindow(window, for: windowUUID)
-        window.overrideUserInterfaceStyle = themeManager.getCurrentTheme(for: windowUUID).type.getInterfaceStyle()
+        let currentTheme = themeManager.getCurrentTheme(for: windowUUID)
+        window.overrideUserInterfaceStyle = currentTheme.type.getInterfaceStyle()
+
+        // Ecosia: Set the window background to the NTP/homepage background colour so the window
+        // is already the correct colour before the BVC's backgroundView is painted by applyTheme.
+        // Without this, UIWindow's default nil/black background shows through briefly on cold
+        // start (dark → light flash in light mode).
+        window.backgroundColor = (currentTheme.colors as? EcosiaThemeColourPalette)?.ecosia.backgroundPrimaryDecorative
 
         return window
     }

--- a/firefox-ios/Client/Coordinators/Scene/SceneSetupHelper.swift
+++ b/firefox-ios/Client/Coordinators/Scene/SceneSetupHelper.swift
@@ -42,6 +42,10 @@ struct SceneSetupHelper {
         // Setting the initial theme correctly as we don't have a window attached yet to let ThemeManager set it
         let themeManager: ThemeManager = AppContainer.shared.resolve()
         themeManager.setWindow(window, for: windowUUID)
+        /* Ecosia: Extract currentTheme to a constant so it can be reused for the window
+           background colour set below without calling getCurrentTheme twice.
+        window.overrideUserInterfaceStyle = themeManager.getCurrentTheme(for: windowUUID).type.getInterfaceStyle()
+        */
         let currentTheme = themeManager.getCurrentTheme(for: windowUUID)
         window.overrideUserInterfaceStyle = currentTheme.type.getInterfaceStyle()
 

--- a/firefox-ios/Client/Ecosia/UI/NTP/Header/NTPHeader.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/Header/NTPHeader.swift
@@ -110,7 +110,10 @@ private struct EcosiaCustomizeButton: View {
     private let iconSize: CGFloat = 16
 
     var body: some View {
-        Button(action: onTap) {
+        Button(action: {
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            onTap()
+        }) {
             Image.ecosia("ntp-pencil-edit")
                 .resizable()
                 .renderingMode(.template)

--- a/firefox-ios/Client/Ecosia/UI/NTP/Header/NTPHeader.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/Header/NTPHeader.swift
@@ -110,10 +110,7 @@ private struct EcosiaCustomizeButton: View {
     private let iconSize: CGFloat = 16
 
     var body: some View {
-        Button(action: {
-            UIImpactFeedbackGenerator(style: .light).impactOccurred()
-            onTap()
-        }) {
+        Button(action: { onTap() }) {
             Image.ecosia("ntp-pencil-edit")
                 .resizable()
                 .renderingMode(.template)
@@ -122,6 +119,7 @@ private struct EcosiaCustomizeButton: View {
                 .frame(width: buttonSize, height: buttonSize)
         }
         .modifier(GlassCircleModifier())
+        .hapticFeedback()
         .accessibilityLabel(String.localized(.customizeHomepage))
         .accessibilityIdentifier(EcosiaAccessibilityIdentifiers.NTP.customizeButton)
     }

--- a/firefox-ios/Client/Ecosia/UI/NTP/Impact/NTPImpactGlassBackgroundView.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/Impact/NTPImpactGlassBackgroundView.swift
@@ -122,9 +122,19 @@ final class NTPImpactGlassBackgroundView: UIView {
     }
     // MARK: - ThemeApplicable
 
+    private var currentTheme: Theme?
+
     func applyTheme(theme: Theme) {
+        currentTheme = theme
         guard let ecosia = (theme.colors as? EcosiaThemeColourPalette)?.ecosia else { return }
         tintView.backgroundColor = ecosia.buttonBgGlassStatic
+    }
+
+    // Ecosia: Mirror the pressed state of NTPGlassButtonStyle — tint steps from
+    // buttonBgGlassStatic (32 %) at rest to buttonBgGlassStaticActive (64 %) when highlighted.
+    func setHighlighted(_ highlighted: Bool) {
+        guard let ecosia = (currentTheme?.colors as? EcosiaThemeColourPalette)?.ecosia else { return }
+        tintView.backgroundColor = highlighted ? ecosia.buttonBgGlassStaticActive : ecosia.buttonBgGlassStatic
     }
 
     // MARK: - Public API

--- a/firefox-ios/Client/Ecosia/UI/NTP/Impact/NTPImpactRowView.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/Impact/NTPImpactRowView.swift
@@ -244,10 +244,12 @@ final class NTPImpactRowView: UIView, ThemeApplicable {
     // MARK: - Actions
 
     @objc private func handleTileTap() {
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
         delegate?.impactCellButtonClickedWithInfo(info)
     }
 
     @objc private func buttonAction() {
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
         delegate?.impactCellButtonClickedWithInfo(info)
     }
 }

--- a/firefox-ios/Client/Ecosia/UI/NTP/Impact/NTPImpactRowView.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/Impact/NTPImpactRowView.swift
@@ -244,12 +244,12 @@ final class NTPImpactRowView: UIView, ThemeApplicable {
     // MARK: - Actions
 
     @objc private func handleTileTap() {
-        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+        HapticFeedback.impact()
         delegate?.impactCellButtonClickedWithInfo(info)
     }
 
     @objc private func buttonAction() {
-        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+        HapticFeedback.impact()
         delegate?.impactCellButtonClickedWithInfo(info)
     }
 }

--- a/firefox-ios/Client/Ecosia/UI/NTP/Impact/NTPImpactRowView.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/Impact/NTPImpactRowView.swift
@@ -220,6 +220,27 @@ final class NTPImpactRowView: UIView, ThemeApplicable {
         addGestureRecognizer(tap)
     }
 
+    // MARK: - Touch Highlight (mirrors NTPGlassButtonStyle pressed state)
+
+    // Ecosia: Provide the same glass-active pressed feedback as EcosiaCustomizeButton.
+    // The tintView steps from buttonBgGlassStatic (32 %) to buttonBgGlassStaticActive (64 %)
+    // while the finger is down, exactly matching NTPGlassButtonStyle's behaviour.
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesBegan(touches, with: event)
+        glassBackground.setHighlighted(true)
+    }
+
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesEnded(touches, with: event)
+        glassBackground.setHighlighted(false)
+    }
+
+    override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesCancelled(touches, with: event)
+        glassBackground.setHighlighted(false)
+    }
+
     // MARK: - Actions
 
     @objc private func handleTileTap() {

--- a/firefox-ios/Client/Ecosia/UI/Theme/EcosiaLightTheme.swift
+++ b/firefox-ios/Client/Ecosia/UI/Theme/EcosiaLightTheme.swift
@@ -31,11 +31,11 @@ class EcosiaLightColourPalette: EcosiaThemeColourPalette {
     var layerGradient: Gradient { fallbackTheme.colors.layerGradient }
     var layerGradientOverlay: Gradient { fallbackTheme.colors.layerGradientOverlay }
     var layerAccentNonOpaque: UIColor { ecosia.buttonBackgroundPrimary }
-    /* Ecosia: Replace Firefox's purple (Purple60) private-mode selection circle with a
-       neutral solid Ecosia highlight that matches the design language.
+    /* Ecosia: Replace Firefox's purple (Purple60) private-mode selection circle with the
+       primary icon colour so the selected state inverts icon and background.
     var layerAccentPrivate: UIColor { fallbackTheme.colors.layerAccentPrivate }
      */
-    var layerAccentPrivate: UIColor { ecosia.buttonBackgroundSecondaryActive }
+    var layerAccentPrivate: UIColor { ecosia.buttonContentSecondary }
     var layerAccentPrivateNonOpaque: UIColor { ecosia.textPrimary }
     var layerSepia: UIColor { fallbackTheme.colors.layerSepia }
     var layerHomepage: Gradient { fallbackTheme.colors.layerHomepage }

--- a/firefox-ios/Client/Ecosia/UI/Theme/EcosiaLightTheme.swift
+++ b/firefox-ios/Client/Ecosia/UI/Theme/EcosiaLightTheme.swift
@@ -31,7 +31,11 @@ class EcosiaLightColourPalette: EcosiaThemeColourPalette {
     var layerGradient: Gradient { fallbackTheme.colors.layerGradient }
     var layerGradientOverlay: Gradient { fallbackTheme.colors.layerGradientOverlay }
     var layerAccentNonOpaque: UIColor { ecosia.buttonBackgroundPrimary }
+    /* Ecosia: Replace Firefox's purple (Purple60) private-mode selection circle with a
+       neutral solid Ecosia highlight that matches the design language.
     var layerAccentPrivate: UIColor { fallbackTheme.colors.layerAccentPrivate }
+     */
+    var layerAccentPrivate: UIColor { ecosia.buttonBackgroundSecondaryActive }
     var layerAccentPrivateNonOpaque: UIColor { ecosia.textPrimary }
     var layerSepia: UIColor { fallbackTheme.colors.layerSepia }
     var layerHomepage: Gradient { fallbackTheme.colors.layerHomepage }

--- a/firefox-ios/Client/Ecosia/UI/Theme/EcosiaLightTheme.swift
+++ b/firefox-ios/Client/Ecosia/UI/Theme/EcosiaLightTheme.swift
@@ -31,10 +31,6 @@ class EcosiaLightColourPalette: EcosiaThemeColourPalette {
     var layerGradient: Gradient { fallbackTheme.colors.layerGradient }
     var layerGradientOverlay: Gradient { fallbackTheme.colors.layerGradientOverlay }
     var layerAccentNonOpaque: UIColor { ecosia.buttonBackgroundPrimary }
-    /* Ecosia: Replace Firefox's purple (Purple60) private-mode selection circle with the
-       primary icon colour so the selected state inverts icon and background.
-    var layerAccentPrivate: UIColor { fallbackTheme.colors.layerAccentPrivate }
-     */
     var layerAccentPrivate: UIColor { ecosia.buttonContentSecondary }
     var layerAccentPrivateNonOpaque: UIColor { ecosia.textPrimary }
     var layerSepia: UIColor { fallbackTheme.colors.layerSepia }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -1176,7 +1176,12 @@ struct AddressBarState: StateType, Sendable, Equatable {
         let isShowMenuWarningAction = action.actionType as? ToolbarActionType == .showMenuWarningBadge
         let showActionWarningBadge = action.showMenuWarningBadge ?? toolbarState.showMenuWarningBadge
         let showWarningBadge = isShowMenuWarningAction ? showActionWarningBadge : toolbarState.showMenuWarningBadge
+        /* Ecosia: moreHorizontalRoundLarge does not exist in any Ecosia asset catalog,
+           causing the menu button to render with no image on iPad. Use the same custom
+           ellipsis icon as the iPhone navigation bar.
         let menuIcon = StandardImageIdentifiers.Large.moreHorizontalRound
+         */
+        let menuIcon = "elipsis"
 
         switch layout {
         case .version1, .none:

--- a/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
@@ -289,6 +289,13 @@ class TopTabsViewController: UIViewController, Themeable, Notifiable, FeatureFla
         view.addSubview(newTab)
         view.addSubview(privateModeButton)
 
+        // Ecosia: Constrain the incognito icon to 24×24 pt so the PDF vector doesn't fill the
+        // full 44 pt touch target and appear disproportionately large in the tab strip.
+        let iconInset: CGFloat = (UX.topTabsViewHeight - 24) / 2
+        privateModeButton.imageEdgeInsets = UIEdgeInsets(
+            top: iconInset, left: iconInset, bottom: iconInset, right: iconInset
+        )
+
         NSLayoutConstraint.activate([
             view.heightAnchor.constraint(equalToConstant: UX.topTabsViewHeight),
 
@@ -297,7 +304,11 @@ class TopTabsViewController: UIViewController, Themeable, Notifiable, FeatureFla
             newTab.heightAnchor.constraint(equalTo: view.heightAnchor),
 
             privateModeButton.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            /* Ecosia: Use safeAreaLayoutGuide so the button stays clear of screen-edge safe areas
+               (e.g. iPad landscape on Face ID models).
             privateModeButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 10),
+             */
+            privateModeButton.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 10),
             privateModeButton.widthAnchor.constraint(equalTo: view.heightAnchor),
             privateModeButton.heightAnchor.constraint(equalTo: view.heightAnchor),
 
@@ -312,7 +323,13 @@ class TopTabsViewController: UIViewController, Themeable, Notifiable, FeatureFla
             collectionView.trailingAnchor.constraint(equalTo: topTabFader.trailingAnchor),
         ])
 
+        /* Ecosia: Use safeAreaLayoutGuide so the new-tab button stays clear of screen-edge safe areas.
         newTab.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -UX.trailingEdgeSpace).isActive = true
+         */
+        newTab.trailingAnchor.constraint(
+            equalTo: view.safeAreaLayoutGuide.trailingAnchor,
+            constant: -UX.trailingEdgeSpace
+        ).isActive = true
     }
 
     private func handleFadeOutAfterTabSelection() {

--- a/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TopTabsViewController.swift
@@ -289,9 +289,9 @@ class TopTabsViewController: UIViewController, Themeable, Notifiable, FeatureFla
         view.addSubview(newTab)
         view.addSubview(privateModeButton)
 
-        // Ecosia: Constrain the incognito icon to 24×24 pt so the PDF vector doesn't fill the
-        // full 44 pt touch target and appear disproportionately large in the tab strip.
-        let iconInset: CGFloat = (UX.topTabsViewHeight - 24) / 2
+        /* Ecosia: Constrain the incognito icon to 20×20 pt so the PDF vector doesn't fill the
+           full 44 pt touch target and appear disproportionately large in the tab strip. */
+        let iconInset: CGFloat = (UX.topTabsViewHeight - 20) / 2
         privateModeButton.imageEdgeInsets = UIEdgeInsets(
             top: iconInset, left: iconInset, bottom: iconInset, right: iconInset
         )

--- a/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/HomepageSettings/HomePageSettingViewController.swift
@@ -134,6 +134,10 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
         // Ecosia: Climate Impact toggle to show/hide impact rows on the NTP
         sectionItems.append(ClimateImpactSettings(settings: self))
 
+        /* Ecosia: Ecosia's NTP never shows Jump Back In or Bookmarks sections, so their
+           settings toggles must never appear regardless of feature-flag state. The original
+           Firefox guard (shouldHideSections) only suppresses them when .homepageStoriesRedesign
+           is enabled at build time, which is not the case on release builds.
         let shouldHideSections = featureFlags.isFeatureEnabled(.homepageStoriesRedesign, checking: .buildOnly)
         let isStoriesRedesignV2Enabled = featureFlags.isFeatureEnabled(.homepageStoriesRedesignV2, checking: .buildOnly)
 
@@ -178,6 +182,7 @@ class HomePageSettingViewController: SettingsTableViewController, FeatureFlaggab
             }
             sectionItems.append(bookmarksSetting)
         }
+        */
 
         // TODO: FXIOS-12980: Replace "Stories" title with "Top Stories" string once it is translated in v143
         if isPocketSectionEnabled, let profile {

--- a/firefox-ios/Client/Frontend/Widgets/PrivateModeButton.swift
+++ b/firefox-ios/Client/Frontend/Widgets/PrivateModeButton.swift
@@ -30,7 +30,13 @@ final class PrivateModeButton: ToggleButton, PrivateModeUI {
         let colors = theme.colors
         isSelected = isPrivate
 
+        /* Ecosia: Use iconPrimary (Ecosia's own token) for both states. Firefox's iconOnColor
+           falls back to LightGrey05 (#fbfbfe), which is near-white and invisible against
+           the light-mode toolbar background when private mode is active.
         tintColor = isPrivate ? colors.iconOnColor : colors.iconPrimary
+        imageView?.tintColor = tintColor
+         */
+        tintColor = colors.iconPrimary
         imageView?.tintColor = tintColor
 
         if isSelected {
@@ -42,8 +48,11 @@ final class PrivateModeButton: ToggleButton, PrivateModeUI {
 
     override func applyTheme(theme: Theme) {
         super.applyTheme(theme: theme)
-        let colors = theme.colors
+        /* Ecosia: Use iconPrimary (Ecosia's own token) rather than iconOnColor — see applyUIMode.
         tintColor = isSelected ? colors.iconOnColor : colors.iconPrimary
+        imageView?.tintColor = tintColor
+         */
+        tintColor = theme.colors.iconPrimary
         imageView?.tintColor = tintColor
     }
 }

--- a/firefox-ios/Client/Frontend/Widgets/PrivateModeButton.swift
+++ b/firefox-ios/Client/Frontend/Widgets/PrivateModeButton.swift
@@ -36,7 +36,6 @@ final class PrivateModeButton: ToggleButton, PrivateModeUI {
            - selected: buttonContentPrimary (White) as icon, buttonContentSecondary circle
                        (circle colour is driven by layerAccentPrivate in EcosiaLightTheme).
         tintColor = isPrivate ? colors.iconOnColor : colors.iconPrimary
-        imageView?.tintColor = tintColor
          */
         tintColor = isPrivate ? theme.colors.ecosia.buttonContentPrimary : colors.iconPrimary
         imageView?.tintColor = tintColor
@@ -52,7 +51,6 @@ final class PrivateModeButton: ToggleButton, PrivateModeUI {
         super.applyTheme(theme: theme)
         /* Ecosia: Same inversion logic as applyUIMode — see comment there.
         tintColor = isSelected ? colors.iconOnColor : colors.iconPrimary
-        imageView?.tintColor = tintColor
          */
         tintColor = isSelected ? theme.colors.ecosia.buttonContentPrimary : theme.colors.iconPrimary
         imageView?.tintColor = tintColor

--- a/firefox-ios/Client/Frontend/Widgets/PrivateModeButton.swift
+++ b/firefox-ios/Client/Frontend/Widgets/PrivateModeButton.swift
@@ -30,13 +30,16 @@ final class PrivateModeButton: ToggleButton, PrivateModeUI {
         let colors = theme.colors
         isSelected = isPrivate
 
-        /* Ecosia: Use iconPrimary (Ecosia's own token) for both states. Firefox's iconOnColor
-           falls back to LightGrey05 (#fbfbfe), which is near-white and invisible against
-           the light-mode toolbar background when private mode is active.
+        /* Ecosia: Invert icon and background when selected. Firefox used iconOnColor (near-white
+           LightGrey05) for both states, which is invisible on a light toolbar. Instead:
+           - normal:   iconPrimary  (buttonContentSecondary) as icon, no circle
+           - selected: buttonContentPrimary (White) as icon, buttonContentSecondary circle
+                       (circle colour is driven by layerAccentPrivate in EcosiaLightTheme).
         tintColor = isPrivate ? colors.iconOnColor : colors.iconPrimary
         imageView?.tintColor = tintColor
          */
-        tintColor = colors.iconPrimary
+        let selectedColor = (colors as? EcosiaThemeColourPalette)?.ecosia.buttonContentPrimary
+        tintColor = isPrivate ? (selectedColor ?? colors.iconPrimary) : colors.iconPrimary
         imageView?.tintColor = tintColor
 
         if isSelected {
@@ -48,11 +51,12 @@ final class PrivateModeButton: ToggleButton, PrivateModeUI {
 
     override func applyTheme(theme: Theme) {
         super.applyTheme(theme: theme)
-        /* Ecosia: Use iconPrimary (Ecosia's own token) rather than iconOnColor — see applyUIMode.
+        /* Ecosia: Same inversion logic as applyUIMode — see comment there.
         tintColor = isSelected ? colors.iconOnColor : colors.iconPrimary
         imageView?.tintColor = tintColor
          */
-        tintColor = theme.colors.iconPrimary
+        let selectedColor = (theme.colors as? EcosiaThemeColourPalette)?.ecosia.buttonContentPrimary
+        tintColor = isSelected ? (selectedColor ?? theme.colors.iconPrimary) : theme.colors.iconPrimary
         imageView?.tintColor = tintColor
     }
 }

--- a/firefox-ios/Client/Frontend/Widgets/PrivateModeButton.swift
+++ b/firefox-ios/Client/Frontend/Widgets/PrivateModeButton.swift
@@ -38,8 +38,7 @@ final class PrivateModeButton: ToggleButton, PrivateModeUI {
         tintColor = isPrivate ? colors.iconOnColor : colors.iconPrimary
         imageView?.tintColor = tintColor
          */
-        let selectedColor = (colors as? EcosiaThemeColourPalette)?.ecosia.buttonContentPrimary
-        tintColor = isPrivate ? (selectedColor ?? colors.iconPrimary) : colors.iconPrimary
+        tintColor = isPrivate ? theme.colors.ecosia.buttonContentPrimary : colors.iconPrimary
         imageView?.tintColor = tintColor
 
         if isSelected {
@@ -55,8 +54,7 @@ final class PrivateModeButton: ToggleButton, PrivateModeUI {
         tintColor = isSelected ? colors.iconOnColor : colors.iconPrimary
         imageView?.tintColor = tintColor
          */
-        let selectedColor = (theme.colors as? EcosiaThemeColourPalette)?.ecosia.buttonContentPrimary
-        tintColor = isSelected ? (selectedColor ?? theme.colors.iconPrimary) : theme.colors.iconPrimary
+        tintColor = isSelected ? theme.colors.ecosia.buttonContentPrimary : theme.colors.iconPrimary
         imageView?.tintColor = tintColor
     }
 }

--- a/firefox-ios/Ecosia/UI/Components/HapticFeedback.swift
+++ b/firefox-ios/Ecosia/UI/Components/HapticFeedback.swift
@@ -1,0 +1,32 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import SwiftUI
+import UIKit
+
+/// Ecosia-owned wrapper for triggering impact haptic feedback.
+public struct HapticFeedback {
+    public static func impact(_ style: UIImpactFeedbackGenerator.FeedbackStyle = .light) {
+        UIImpactFeedbackGenerator(style: style).impactOccurred()
+    }
+}
+
+// MARK: - SwiftUI ViewModifier
+
+private struct HapticFeedbackModifier: ViewModifier {
+    let style: UIImpactFeedbackGenerator.FeedbackStyle
+
+    func body(content: Content) -> some View {
+        content.simultaneousGesture(
+            TapGesture().onEnded { HapticFeedback.impact(style) }
+        )
+    }
+}
+
+public extension View {
+    /// Adds an impact haptic feedback on tap without interfering with existing button actions.
+    func hapticFeedback(_ style: UIImpactFeedbackGenerator.FeedbackStyle = .light) -> some View {
+        modifier(HapticFeedbackModifier(style: style))
+    }
+}

--- a/firefox-ios/Ecosia/UI/NTP/Header/EcosiaAccountNavButton.swift
+++ b/firefox-ios/Ecosia/UI/NTP/Header/EcosiaAccountNavButton.swift
@@ -43,7 +43,10 @@ public struct EcosiaAccountNavButton: View {
     }
 
     public var body: some View {
-        Button(action: onTap) {
+        Button(action: {
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            onTap()
+        }) {
             HStack(spacing: .ecosia.space._1s) {
                 if !authStateProvider.hasRegisterVisitError {
                     EcosiaSeedView(

--- a/firefox-ios/Ecosia/UI/NTP/Header/EcosiaAccountNavButton.swift
+++ b/firefox-ios/Ecosia/UI/NTP/Header/EcosiaAccountNavButton.swift
@@ -43,10 +43,7 @@ public struct EcosiaAccountNavButton: View {
     }
 
     public var body: some View {
-        Button(action: {
-            UIImpactFeedbackGenerator(style: .light).impactOccurred()
-            onTap()
-        }) {
+        Button(action: { onTap() }) {
             HStack(spacing: .ecosia.space._1s) {
                 if !authStateProvider.hasRegisterVisitError {
                     EcosiaSeedView(
@@ -82,6 +79,7 @@ public struct EcosiaAccountNavButton: View {
         .accessibilityIdentifier(EcosiaAccessibilityIdentifiers.Account.navButton)
         .accessibilityAddTraits(.isButton)
         .ecosiaThemed(windowUUID, $theme)
+        .hapticFeedback()
     }
 }
 


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-4405]

## Context

A second batch of design and UX debt items was identified after the first follow-up shipped. They span the NTP interactive elements, the iPad toolbar, the address bar, and the app cold-start experience.

## Approach

- **URL bar gradient** — the fade-out layer on long URLs was using `backgroundTertiary` while the location container uses `backgroundElevation1`; now both share the same colour so the truncation blends seamlessly.
- **Impact rows press state** — impact rows now respond visually to touch by toggling between `buttonBgGlassStatic` and `buttonBgGlassStaticActive` on the glass background, matching the `EcosiaCustomizeButton` behaviour.
- **Cold-start background flash** — `SceneSetupHelper` now sets `window.backgroundColor` to `backgroundPrimaryDecorative` before the BVC is painted, eliminating the dark→light flicker on cold start in light mode.
- **Homepage settings toggles** — "Jump Back In" and "Bookmarks" toggles are unconditionally hidden in `HomePageSettingViewController`; the previous Firefox feature-flag guard only suppressed them when `.homepageStoriesRedesign` was enabled at build time, which is never the case on release builds.
- **iPad incognito icon** — the icon is constrained to 20×20 pt via `imageEdgeInsets`, so the PDF vector no longer fills the full 44 pt touch target. Leading and trailing anchors now use `safeAreaLayoutGuide` so the buttons clear the screen-edge safe areas in landscape. We also fixed the selection circle, replacing Firefox's Purple60 with `buttonContentSecondary` (the current icon colour), and the icon itself switches to `buttonContentPrimary` (White) when selected — matching the tint used by `PrivateMessageCardCell` — so the selected state is a clean colour inversion.
- **Three-dots menu on iPad** — the address bar was referencing `moreHorizontalRoundLarge`, an asset that doesn't exist in the Ecosia catalogue, causing the button to render with no image. Now uses the same `elipsis` icon as the iPhone navigation bar.

## Other

- **Haptic feedback** — Created a `HapticFeedback` reusable component we apply to any view or a Button view modifier

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [x] I added the // Ecosia helper comments where needed
- [x] I made sure that any change to the Analytics events included in PR won't alter current analytics
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4405]: https://ecosia.atlassian.net/browse/MOB-4405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ