### PR TITLE
[MOB-4407] `AI Search` becomes `AI Chat`

### DIFF
--- a/Ecosia/Analytics/Analytics.Values.swift
+++ b/Ecosia/Analytics/Analytics.Values.swift
@@ -130,9 +130,9 @@ extension Analytics {
             toolbar
         }
 
-        public enum AISearch: String {
+        public enum AIChat: String {
             case
-            cta = "ai_search_cta"
+            cta = "ai_chat_cta"
         }
     }
 

--- a/Ecosia/Analytics/Analytics.swift
+++ b/Ecosia/Analytics/Analytics.swift
@@ -314,7 +314,7 @@ open actor Analytics {
             .property(position))
     }
 
-    public func toggleAISearchOverviewsSetting(enabled: Bool) {
+    public func toggleAIChatOverviewsSetting(enabled: Bool) {
         track(Structured(category: Category.settings.rawValue,
                          action: Action.change.rawValue)
             .label(Label.Settings.aiOverviews.rawValue)
@@ -357,19 +357,19 @@ open actor Analytics {
                              payload: payload))
     }
 
-    // MARK: AI Search MVP
+    // MARK: AI Chat MVP
 
-    public func aiSearchNTPButtonTapped() {
+    public func aiChatNTPButtonTapped() {
         track(Structured(category: Category.ntp.rawValue,
                          action: Action.click.rawValue)
-            .label(Analytics.Label.AISearch.cta.rawValue)
+            .label(Analytics.Label.AIChat.cta.rawValue)
             .property(Analytics.Property.header.rawValue))
     }
 
-    public func aiSearchAutocompleteForQuery(_ text: String) {
+    public func aiChatAutocompleteForQuery(_ text: String) {
         track(Structured(category: Category.autocomplete.rawValue,
                          action: Action.click.rawValue)
-            .label(Analytics.Label.AISearch.cta.rawValue)
+            .label(Analytics.Label.AIChat.cta.rawValue)
             .property(text))
 	}
 

--- a/Ecosia/Core/Environment/URLProvider.swift
+++ b/Ecosia/Core/Environment/URLProvider.swift
@@ -167,12 +167,12 @@ public enum URLProvider {
         ])
     }
 
-    public enum AISearchOrigin: String {
+    public enum AIChatOrigin: String {
         case ntp = "newtabbutton"
         case autocomplete = "autocomplete_app"
     }
-    public func aiSearch(origin: AISearchOrigin?) -> URL {
-        let baseURL = root.appendingPathComponent("ai-search")
+    public func aiChat(origin: AIChatOrigin?) -> URL {
+        let baseURL = root.appendingPathComponent("ai-chat")
         guard let origin = origin else {
             return baseURL
         }

--- a/Ecosia/Core/FeatureManagement/Unleash/Unleash.Model.swift
+++ b/Ecosia/Core/FeatureManagement/Unleash/Unleash.Model.swift
@@ -25,7 +25,7 @@ extension Unleash {
             case seedCounterNTP = "mob_ios_seed_counter_ntp"
             case nativeSRPVAnalytics = "mob_ios_native_srpv_analytics"
             case newsletterCard = "mob_ios_newsletter_card"
-            case aiSearchMVP = "ai2-67-ai-search-mvp"
+            case aiChatMVP = "ai2-67-ai-search-mvp"
         }
 
         public let name: String

--- a/Ecosia/Experiments/Unleash/AIChatMVPExperiment.swift
+++ b/Ecosia/Experiments/Unleash/AIChatMVPExperiment.swift
@@ -4,16 +4,16 @@
 
 import Foundation
 
-public struct AISearchMVPExperiment {
+public struct AIChatMVPExperiment {
 
     private init() {}
 
     public static var isEnabled: Bool {
-        Unleash.isEnabled(.aiSearchMVP) && !isControl
+        Unleash.isEnabled(.aiChatMVP) && !isControl
     }
 
     private static var variant: Unleash.Variant {
-        Unleash.getVariant(.aiSearchMVP)
+        Unleash.getVariant(.aiChatMVP)
     }
 
     // More variants might be introduced, but control should remain the same

--- a/Ecosia/L10N/String.swift
+++ b/Ecosia/L10N/String.swift
@@ -19,7 +19,8 @@ extension String {
 
     public enum Key: String, CaseIterable {
         case addMoreDetailAboutYourFeedback = "Add more detail about your feedback..."
-        case aiSearch = "AI Search"
+        case aiChat = "AI Chat"
+        case aiChatAccessibilityHint = "Opens AI Chat"
         case aiOverviewsTitle = "Overviews"
         case aiOverviewsDescription = "Show AI-generated overviews at the top of search results"
         case allRegions = "All regions"

--- a/Ecosia/L10N/en.lproj/Ecosia.strings
+++ b/Ecosia/L10N/en.lproj/Ecosia.strings
@@ -1,5 +1,6 @@
 "%@ days ago" = "%@ days ago";
-"AI Search" = "AI Search";
+"AI Chat" = "AI Chat";
+"Opens AI Chat" = "Opens AI Chat";
 "Autocomplete" = "Autocomplete";
 "Blog" = "Blog";
 "Close all" = "Close all";

--- a/Ecosia/UI/NTP/Header/EcosiaAIChatButton.swift
+++ b/Ecosia/UI/NTP/Header/EcosiaAIChatButton.swift
@@ -6,11 +6,11 @@ import SwiftUI
 import Common
 
 @available(iOS 16.0, *)
-public struct EcosiaAISearchButton: View {
+public struct EcosiaAIChatButton: View {
     private let windowUUID: WindowUUID
     private let onTap: () -> Void
 
-    @State private var theme = EcosiaAISearchButtonTheme()
+    @State private var theme = EcosiaAIChatButtonTheme()
 
     public init(
         windowUUID: WindowUUID,
@@ -34,8 +34,8 @@ public struct EcosiaAISearchButton: View {
                 .cornerRadius(.ecosia.borderRadius._1l)
         }
         .buttonStyle(PlainButtonStyle())
-        .accessibilityLabel("AI Search")
-        .accessibilityHint("Opens AI search functionality")
+        .accessibilityLabel(String.localized(.aiChat))
+        .accessibilityHint(String.localized(.aiChatAccessibilityHint))
         .ecosiaThemed(windowUUID, $theme)
     }
 }
@@ -43,11 +43,11 @@ public struct EcosiaAISearchButton: View {
 #if DEBUG
 // MARK: - Preview
 @available(iOS 16.0, *)
-struct EcosiaAISearchButton_Previews: PreviewProvider {
+struct EcosiaAIChatButton_Previews: PreviewProvider {
     static var previews: some View {
         VStack(spacing: .ecosia.space._l) {
 
-            EcosiaAISearchButton(
+            EcosiaAIChatButton(
                 windowUUID: .XCTestDefaultUUID,
                 onTap: {}
             )

--- a/Ecosia/UI/NTP/Header/EcosiaAIChatButtonTheme.swift
+++ b/Ecosia/UI/NTP/Header/EcosiaAIChatButtonTheme.swift
@@ -5,12 +5,14 @@
 import SwiftUI
 import Common
 
-public struct EcosiaAISearchButtonTheme: EcosiaThemeable {
+public struct EcosiaAIChatButtonTheme: EcosiaThemeable {
+    public var backgroundColor = Color.gray.opacity(0.2)
     public var iconColor = Color.primary
 
     public init() {}
 
     public mutating func applyTheme(theme: Theme) {
+        backgroundColor = Color(theme.colors.ecosia.backgroundElevation1)
         iconColor = Color(theme.colors.ecosia.textPrimary)
     }
 }

--- a/firefox-ios/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
@@ -93,7 +93,7 @@ extension AppSettingsTableViewController {
         let unleashSettings: [Setting] = [
             UnleashBrazeIntegrationSetting(settings: self),
             UnleashNativeSRPVAnalyticsSetting(settings: self),
-            UnleashAISearchMVPSetting(settings: self),
+            UnleashAIChatMVPSetting(settings: self),
             UnleashIdentifierSetting(settings: self)
         ]
 

--- a/firefox-ios/Client/Ecosia/Extensions/SearchViewController+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/SearchViewController+Ecosia.swift
@@ -15,7 +15,7 @@ extension SearchViewController {
     override var tableViewStyle: UITableView.Style { .insetGrouped }
 }
 
-// MARK: - AI Search Autocomplete Extensions
+// MARK: - AI Chat Autocomplete Extensions
 extension SearchViewController {
 
     // MARK: - Helper Methods
@@ -28,36 +28,36 @@ extension SearchViewController {
         return min(count, max)
     }
 
-    /// Check if current row is the AI Search item
-    func isAISearchRow(_ indexPath: IndexPath) -> Bool {
+    /// Check if current row is the AI Chat item
+    func isAIChatRow(_ indexPath: IndexPath) -> Bool {
         guard SearchListSection(rawValue: indexPath.section) == .searchSuggestions else { return false }
-        let shouldShowAISearch = AISearchMVPExperiment.isEnabled && !viewModel.searchQuery.isEmpty
-        guard shouldShowAISearch, let lastIndex = suggestionsCount() else { return false }
+        let shouldShowAIChat = AIChatMVPExperiment.isEnabled && !viewModel.searchQuery.isEmpty
+        guard shouldShowAIChat, let lastIndex = suggestionsCount() else { return false }
         return indexPath.row == lastIndex // Item after last suggestion (0-based index)
     }
 
-    /// Calculate number of rows including AI Search item if enabled
+    /// Calculate number of rows including AI Chat item if enabled
     func numberOfRowsForSearchSuggestions() -> Int {
         guard let count = suggestionsCount() else { return 0 }
-        let shouldShowAISearch = AISearchMVPExperiment.isEnabled && !viewModel.searchQuery.isEmpty
-        return shouldShowAISearch ? count + 1 : count
+        let shouldShowAIChat = AIChatMVPExperiment.isEnabled && !viewModel.searchQuery.isEmpty
+        return shouldShowAIChat ? count + 1 : count
     }
 
-    // MARK: - AI Search Navigation
+    // MARK: - AI Chat Navigation
 
-    /// Handle AI Search navigation when item is selected
-    func handleAISearchSelection(_ indexPath: IndexPath) {
-        let url = Environment.current.urlProvider.aiSearch(origin: .autocomplete)
+    /// Handle AI Chat navigation when item is selected
+    func handleAIChatSelection(_ indexPath: IndexPath) {
+        let url = Environment.current.urlProvider.aiChat(origin: .autocomplete)
         let finalURL = url.appendingQueryItems([URLQueryItem(name: "q", value: viewModel.searchQuery)])
 
         searchDelegate?.searchViewController(self, didSelectURL: finalURL, searchTerm: viewModel.searchQuery)
         Analytics.shared.aiSearchAutocompleteForQuery(viewModel.searchQuery)
     }
 
-    // MARK: - AI Search Cell Configuration
+    // MARK: - AI Chat Cell Configuration
 
-    /// Configure AI Search cell appearance
-    func configureAISearchCell(_ cell: OneLineTableViewCell) -> OneLineTableViewCell {
+    /// Configure AI Chat cell appearance
+    func configureAIChatCell(_ cell: OneLineTableViewCell) -> OneLineTableViewCell {
         let theme = themeManager.getCurrentTheme(for: windowUUID)
 
         cell.titleLabel.text = viewModel.searchQuery
@@ -80,7 +80,7 @@ extension SearchViewController {
         twinkleImageView.contentMode = .scaleAspectFit
 
         let aiSearchLabel = UILabel()
-        aiSearchLabel.text = String.localized(.aiSearch)
+        aiSearchLabel.text = String.localized(.aiChat)
         aiSearchLabel.textColor = theme.colors.ecosia.textInversePrimary
         aiSearchLabel.font = .preferredFont(forTextStyle: .caption1)
         aiSearchLabel.sizeToFit()
@@ -124,10 +124,10 @@ extension SearchViewController {
         return cell
     }
 
-    // MARK: - AI Search Highlighting
+    // MARK: - AI Chat Highlighting
 
-    /// Handle AI Search highlighting
-    func handleAISearchHighlight(_ indexPath: IndexPath) {
+    /// Handle AI Chat highlighting
+    func handleAIChatHighlight(_ indexPath: IndexPath) {
         searchDelegate?.searchViewController(self, didHighlightText: viewModel.searchQuery, search: false)
     }
 

--- a/firefox-ios/Client/Ecosia/Extensions/SearchViewController+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/SearchViewController+Ecosia.swift
@@ -51,7 +51,7 @@ extension SearchViewController {
         let finalURL = url.appendingQueryItems([URLQueryItem(name: "q", value: viewModel.searchQuery)])
 
         searchDelegate?.searchViewController(self, didSelectURL: finalURL, searchTerm: viewModel.searchQuery)
-        Analytics.shared.aiSearchAutocompleteForQuery(viewModel.searchQuery)
+        Analytics.shared.aiChatAutocompleteForQuery(viewModel.searchQuery)
     }
 
     // MARK: - AI Chat Cell Configuration

--- a/firefox-ios/Client/Ecosia/Settings/EcosiaDebugSettings.swift
+++ b/firefox-ios/Client/Ecosia/Settings/EcosiaDebugSettings.swift
@@ -288,17 +288,17 @@ final class UnleashNativeSRPVAnalyticsSetting: UnleashVariantResetSetting {
     }
 }
 
-final class UnleashAISearchMVPSetting: UnleashVariantResetSetting {
+final class UnleashAIChatMVPSetting: UnleashVariantResetSetting {
     override var titleName: String? {
-        "AI Search MVP"
+        "AI Chat MVP"
     }
 
     override var variant: Unleash.Variant? {
-        Unleash.getVariant(.aiSearchMVP)
+        Unleash.getVariant(.aiChatMVP)
     }
 
     override var unleashEnabled: Bool? {
-        Unleash.isEnabled(.aiSearchMVP)
+        Unleash.isEnabled(.aiChatMVP)
     }
 }
 

--- a/firefox-ios/Client/Ecosia/Settings/EcosiaSettings.swift
+++ b/firefox-ios/Client/Ecosia/Settings/EcosiaSettings.swift
@@ -152,7 +152,7 @@ final class AIOverviewsSearchSettings: BoolSetting {
                   statusText: .localized(.aiOverviewsDescription),
                   settingDidChange: { value in
             User.shared.aiOverviews = value
-            Analytics.shared.toggleAISearchOverviewsSetting(enabled: value)
+            Analytics.shared.toggleAIChatOverviewsSetting(enabled: value)
         })
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -452,9 +452,9 @@ class SearchViewController: SiteTableViewController,
             searchTelemetry?.trendingSearchesTapped(at: indexPath.row)
 
         case .searchSuggestions:
-            // Ecosia: Check if this is the AI Search item
-            if isAISearchRow(indexPath) {
-                handleAISearchSelection(indexPath)
+            // Ecosia: Check if this is the AI Chat item
+            if isAIChatRow(indexPath) {
+                handleAIChatSelection(indexPath)
                 return
             }
 
@@ -609,8 +609,8 @@ class SearchViewController: SiteTableViewController,
             case .trendingSearches:
                 viewModel.recordTrendingSearchesDisplayedEvent()
             case .searchSuggestions:
-                // Ecosia: Skip telemetry for AI Search item
-                if !isAISearchRow(indexPath),
+                // Ecosia: Skip telemetry for AI Chat item
+                if !isAIChatRow(indexPath),
                    let site = safeSuggestion(at: indexPath.row) {
                     if searchTelemetry?.visibleSuggestions.contains(site) == false {
                         searchTelemetry?.visibleSuggestions.append(site)
@@ -663,7 +663,7 @@ class SearchViewController: SiteTableViewController,
         case .trendingSearches:
             return viewModel.shouldShowTrendingSearches ? viewModel.trendingSearches.count : 0
         case .searchSuggestions:
-            // Ecosia: Use custom method that includes AI Search item
+            // Ecosia: Use custom method that includes AI Chat item
             return numberOfRowsForSearchSuggestions()
         case .openedTabs:
             return !viewModel.isZeroSearchState ? viewModel.filteredOpenedTabs.count : 0
@@ -694,9 +694,9 @@ class SearchViewController: SiteTableViewController,
             let suggestion = viewModel.historySites[indexPath.item]
             searchDelegate?.searchViewController(self, didHighlightText: suggestion.url, search: false)
         case .searchSuggestions:
-            // Ecosia: Check if this is the AI Search item
-            if isAISearchRow(indexPath) {
-                handleAISearchHighlight(indexPath)
+            // Ecosia: Check if this is the AI Chat item
+            if isAIChatRow(indexPath) {
+                handleAIChatHighlight(indexPath)
                 return
             }
             guard let suggestion = safeSuggestion(at: indexPath.item) else { return }
@@ -764,9 +764,9 @@ class SearchViewController: SiteTableViewController,
             }
 
         case .searchSuggestions:
-            // Ecosia: Check if this is the AI Search item
-            if isAISearchRow(indexPath) {
-                cell = configureAISearchCell(oneLineCell)
+            // Ecosia: Check if this is the AI Chat item
+            if isAIChatRow(indexPath) {
+                cell = configureAIChatCell(oneLineCell)
             } else if let site = safeSuggestion(at: indexPath.row) {
                 let oneLineCellViewModel = oneLineCellModelForSearch(
                     with: site,

--- a/firefox-ios/Ecosia/Analytics/Analytics.Values.swift
+++ b/firefox-ios/Ecosia/Analytics/Analytics.Values.swift
@@ -133,9 +133,9 @@ extension Analytics {
             toolbar
         }
 
-        public enum AISearch: String {
+        public enum AIChat: String {
             case
-            cta = "ai_search_cta"
+            cta = "ai_chat_cta"
         }
     }
 

--- a/firefox-ios/Ecosia/Analytics/Analytics.Values.swift
+++ b/firefox-ios/Ecosia/Analytics/Analytics.Values.swift
@@ -135,7 +135,7 @@ extension Analytics {
 
         public enum AIChat: String {
             case
-            cta = "ai_chat_cta"
+            cta = "ai_search_cta"
         }
     }
 

--- a/firefox-ios/Ecosia/Analytics/Analytics.swift
+++ b/firefox-ios/Ecosia/Analytics/Analytics.swift
@@ -319,7 +319,7 @@ open class Analytics {
             .property(position))
     }
 
-    public func toggleAISearchOverviewsSetting(enabled: Bool) {
+    public func toggleAIChatOverviewsSetting(enabled: Bool) {
         track(Structured(category: Category.settings.rawValue,
                          action: Action.change.rawValue)
             .label(Label.Settings.aiOverviews.rawValue)
@@ -370,19 +370,19 @@ open class Analytics {
             .label(Label.NTP.history.rawValue))
     }
 
-    // MARK: AI Search MVP
+    // MARK: AI Chat MVP
 
-    public func aiSearchNTPButtonTapped() {
+    public func aiChatNTPButtonTapped() {
         track(Structured(category: Category.ntp.rawValue,
                          action: Action.click.rawValue)
-            .label(Analytics.Label.AISearch.cta.rawValue)
+            .label(Analytics.Label.AIChat.cta.rawValue)
             .property(Analytics.Property.header.rawValue))
     }
 
-    public func aiSearchAutocompleteForQuery(_ text: String) {
+    public func aiChatAutocompleteForQuery(_ text: String) {
         track(Structured(category: Category.autocomplete.rawValue,
                          action: Action.click.rawValue)
-            .label(Analytics.Label.AISearch.cta.rawValue)
+            .label(Analytics.Label.AIChat.cta.rawValue)
             .property(text))
 	}
 

--- a/firefox-ios/Ecosia/Core/Environment/URLProvider.swift
+++ b/firefox-ios/Ecosia/Core/Environment/URLProvider.swift
@@ -200,12 +200,12 @@ public enum URLProvider {
         ])
     }
 
-    public enum AISearchOrigin: String {
+    public enum AIChatOrigin: String {
         case ntp = "newtabbutton"
         case autocomplete = "autocomplete_app"
     }
-    public func aiSearch(origin: AISearchOrigin?) -> URL {
-        let baseURL = root.appendingPathComponent("ai-search")
+    public func aiChat(origin: AIChatOrigin?) -> URL {
+        let baseURL = root.appendingPathComponent("ai-chat")
         guard let origin = origin else {
             return baseURL
         }

--- a/firefox-ios/Ecosia/Core/FeatureManagement/Unleash/Unleash.Model.swift
+++ b/firefox-ios/Ecosia/Core/FeatureManagement/Unleash/Unleash.Model.swift
@@ -20,7 +20,7 @@ extension Unleash {
 
     public struct Toggle: Codable, Hashable {
         public enum Name: String {
-            case aiSearchMVP = "ai2-67-ai-search-mvp"
+            case aiChatMVP = "ai2-67-ai-search-mvp"
             case brazeIntegration = "mob_ios_braze_integration"
             case configTest = "mob_ios_staging_config"
             case seedCounterNTP = "mob_ios_seed_counter_ntp"

--- a/firefox-ios/Ecosia/Experiments/Unleash/AIChatMVPExperiment.swift
+++ b/firefox-ios/Ecosia/Experiments/Unleash/AIChatMVPExperiment.swift
@@ -4,16 +4,16 @@
 
 import Foundation
 
-public struct AISearchMVPExperiment {
+public struct AIChatMVPExperiment {
 
     private init() {}
 
     public static var isEnabled: Bool {
-        Unleash.isEnabled(.aiSearchMVP) && !isControl
+        Unleash.isEnabled(.aiChatMVP) && !isControl
     }
 
     private static var variant: Unleash.Variant {
-        Unleash.getVariant(.aiSearchMVP)
+        Unleash.getVariant(.aiChatMVP)
     }
 
     // More variants might be introduced, but control should remain the same

--- a/firefox-ios/Ecosia/L10N/String.swift
+++ b/firefox-ios/Ecosia/L10N/String.swift
@@ -19,7 +19,8 @@ extension String {
 
     public enum Key: String, CaseIterable {
         case addMoreDetailAboutYourFeedback = "Add more detail about your feedback..."
-        case aiSearch = "AI Search"
+        case aiChat = "AI Chat"
+        case aiChatAccessibilityHint = "Opens AI Chat"
         case aiOverviewsTitle = "Overviews"
         case aiOverviewsDescription = "Show AI-generated overviews at the top of search results"
         case allRegions = "All regions"

--- a/firefox-ios/Ecosia/L10N/en.lproj/Ecosia.strings
+++ b/firefox-ios/Ecosia/L10N/en.lproj/Ecosia.strings
@@ -1,5 +1,6 @@
 "%@ days ago" = "%@ days ago";
-"AI Search" = "AI Search";
+"AI Chat" = "AI Chat";
+"Opens AI Chat" = "Opens AI Chat";
 "Search. Find. Save the planet." = "Search. Find. Save the planet.";
 "Autocomplete" = "Autocomplete";
 "Blog" = "Blog";

--- a/firefox-ios/Ecosia/UI/Components/NTPGlassButtonStyle.swift
+++ b/firefox-ios/Ecosia/UI/Components/NTPGlassButtonStyle.swift
@@ -4,7 +4,7 @@
 
 import SwiftUI
 
-/// Frosted-glass button style shared across all NTP elements (customize, account, AI search).
+/// Frosted-glass button style shared across all NTP elements (customize, account, AI Chat).
 ///
 /// Applies `ultraThinMaterial` blur + a Gray90 dark tint that steps from 32 % at rest
 /// to 64 % when pressed, with a translucent white border — matching the Ecosia NTP glass spec.

--- a/firefox-ios/Ecosia/UI/NTP/Header/EcosiaAIChatButton.swift
+++ b/firefox-ios/Ecosia/UI/NTP/Header/EcosiaAIChatButton.swift
@@ -6,11 +6,11 @@ import SwiftUI
 import Common
 
 @available(iOS 16.0, *)
-public struct EcosiaAISearchButton: View {
+public struct EcosiaAIChatButton: View {
     private let windowUUID: WindowUUID
     private let onTap: () -> Void
 
-    @State private var theme = EcosiaAISearchButtonTheme()
+    @State private var theme = EcosiaAIChatButtonTheme()
 
     public init(
         windowUUID: WindowUUID,
@@ -31,8 +31,8 @@ public struct EcosiaAISearchButton: View {
                 .frame(width: .ecosia.space._3l, height: .ecosia.space._3l)
         }
         .buttonStyle(NTPGlassButtonStyle(RoundedRectangle(cornerRadius: .ecosia.borderRadius._1l)))
-        .accessibilityLabel("AI Search")
-        .accessibilityHint("Opens AI search functionality")
+        .accessibilityLabel(String.localized(.aiChat))
+        .accessibilityHint(String.localized(.aiChatAccessibilityHint))
         .ecosiaThemed(windowUUID, $theme)
     }
 }
@@ -40,11 +40,11 @@ public struct EcosiaAISearchButton: View {
 #if DEBUG
 // MARK: - Preview
 @available(iOS 16.0, *)
-struct EcosiaAISearchButton_Previews: PreviewProvider {
+struct EcosiaAIChatButton_Previews: PreviewProvider {
     static var previews: some View {
         VStack(spacing: .ecosia.space._l) {
 
-            EcosiaAISearchButton(
+            EcosiaAIChatButton(
                 windowUUID: .XCTestDefaultUUID,
                 onTap: {}
             )

--- a/firefox-ios/Ecosia/UI/NTP/Header/EcosiaAIChatButtonTheme.swift
+++ b/firefox-ios/Ecosia/UI/NTP/Header/EcosiaAIChatButtonTheme.swift
@@ -5,14 +5,12 @@
 import SwiftUI
 import Common
 
-public struct EcosiaAISearchButtonTheme: EcosiaThemeable {
-    public var backgroundColor = Color.gray.opacity(0.2)
+public struct EcosiaAIChatButtonTheme: EcosiaThemeable {
     public var iconColor = Color.primary
 
     public init() {}
 
     public mutating func applyTheme(theme: Theme) {
-        backgroundColor = Color(theme.colors.ecosia.backgroundElevation1)
         iconColor = Color(theme.colors.ecosia.textPrimary)
     }
 }

--- a/firefox-ios/EcosiaTests/Core/URLProviderDependantTests/URLProviderTests.swift
+++ b/firefox-ios/EcosiaTests/Core/URLProviderDependantTests/URLProviderTests.swift
@@ -171,21 +171,21 @@ final class URLProviderTests: XCTestCase {
         Language.current = def
     }
 
-    // MARK: - AI Search Tests
+    // MARK: - AI Chat Tests
 
-    func testAISearchWithoutOrigin() {
-        let url = urlProvider.aiSearch(origin: nil)
-        XCTAssertTrue(url.absoluteString.hasSuffix("/ai-search"))
+    func testAIChatWithoutOrigin() {
+        let url = urlProvider.aiChat(origin: nil)
+        XCTAssertTrue(url.absoluteString.hasSuffix("/ai-chat"))
         XCTAssertNil(URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems)
     }
 
-    func testAISearchWithNTPOrigin() {
-        let url = urlProvider.aiSearch(origin: .ntp)
-        XCTAssertTrue(url.absoluteString.contains("/ai-search?origin=newtabbutton"))
+    func testAIChatWithNTPOrigin() {
+        let url = urlProvider.aiChat(origin: .ntp)
+        XCTAssertTrue(url.absoluteString.contains("/ai-chat?origin=newtabbutton"))
     }
 
-    func testAISearchWithAutocompleteOrigin() {
-        let url = urlProvider.aiSearch(origin: .autocomplete)
-        XCTAssertTrue(url.absoluteString.contains("/ai-search?origin=autocomplete_app"))
+    func testAIChatWithAutocompleteOrigin() {
+        let url = urlProvider.aiChat(origin: .autocomplete)
+        XCTAssertTrue(url.absoluteString.contains("/ai-chat?origin=autocomplete_app"))
     }
 }

--- a/firefox-ios/EcosiaTests/UI/NTPHeader/EcosiaAIChatButtonThemeTests.swift
+++ b/firefox-ios/EcosiaTests/UI/NTPHeader/EcosiaAIChatButtonThemeTests.swift
@@ -8,7 +8,7 @@ import Common
 @testable import Client
 @testable import Ecosia
 
-final class EcosiaAISearchButtonThemeTests: XCTestCase {
+final class EcosiaAIChatButtonThemeTests: XCTestCase {
 
     // MARK: - Integration Tests
 
@@ -16,7 +16,7 @@ final class EcosiaAISearchButtonThemeTests: XCTestCase {
     func testIntegrationWithButton() {
         // Given
         let windowUUID: WindowUUID = .XCTestDefaultUUID
-        let button = EcosiaAISearchButton(windowUUID: windowUUID, onTap: {})
+        let button = EcosiaAIChatButton(windowUUID: windowUUID, onTap: {})
 
         // When/Then
         let buttonMirror = Mirror(reflecting: button)

--- a/firefox-ios/Tuist/upgrade/ecosia-customizations-sample.json
+++ b/firefox-ios/Tuist/upgrade/ecosia-customizations-sample.json
@@ -3688,8 +3688,8 @@
       "comment": "Check if this is the AI Search item",
       "firefox_code": [],
       "ecosia_code": [
-        "            if isAISearchRow(indexPath) {",
-        "                handleAISearchSelection(indexPath)",
+        "            if isAIChatRow(indexPath) {",
+        "                handleAIChatSelection(indexPath)",
         "                return"
       ],
       "context_before": [
@@ -3720,7 +3720,7 @@
       ],
       "context_after": [
         "                // Ecosia: Skip telemetry for AI Search item",
-        "                if !isAISearchRow(indexPath),"
+        "                if !isAIChatRow(indexPath),"
       ]
     },
     {
@@ -3801,8 +3801,8 @@
       "comment": "Check if this is the AI Search item",
       "firefox_code": [],
       "ecosia_code": [
-        "            if isAISearchRow(indexPath) {",
-        "                handleAISearchHighlight(indexPath)",
+        "            if isAIChatRow(indexPath) {",
+        "                handleAIChatHighlight(indexPath)",
         "                return"
       ],
       "context_before": [
@@ -3883,8 +3883,8 @@
         "        case .searchSuggestions:"
       ],
       "context_after": [
-        "            if isAISearchRow(indexPath) {",
-        "                cell = configureAISearchCell(oneLineCell)"
+        "            if isAIChatRow(indexPath) {",
+        "                cell = configureAIChatCell(oneLineCell)"
       ]
     },
     {


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-4407]

## Context

The product area previously named “AI Search” is now “AI Chat”. The iOS app still showed the old wording in places and routed the experience using the `/ai-search` path. This PR aligns user-facing copy, URLs, and filenames.
## Approach

- **Localization** — `String.Key` / `en.lproj/Ecosia.strings` expose `AI Chat` plus an accessibility hint; NTP sparkle and autocomplete pill use `String.localized` for label/hint instead of literal English.

- **Web routing** — `URLProvider` uses the `ai-chat` path segment. `AISearchOrigin` / `aiSearch(origin:)` are renamed to `AIChatOrigin` / `aiChat(origin:)`. Tests assert `/ai-chat` and existing `origin` query parameters.

- **Types and files** — Renamed NTP components (`EcosiaAIChatButton`, `EcosiaAIChatButtonTheme`), MVP experiment wrapper (`AIChatMVPExperiment`), debug Unleash setting type, and autocomplete helpers (`isAIChatRow`, selection/cell / highlight). Unleash case is `aiChatMVP` but the remote toggle id stays `ai2-67-ai-search-mvp`.

- **Analytics** — Label `AIChat` with CTA `ai_chat_cta`; tap methods `aiChatNTPButtonTapped` / `aiChatAutocompleteForQuery`; `toggleAIChatOverviewsSetting` for settings. Call sites updated. Split so analytics can be reverted independently.

## Other

Deliberately left the Experiment and MVP wording on as off-scope.

- **Upgrade sample** — `firefox-ios/Tuist/upgrade/ecosia-customizations-sample.json` updated for new helper names.

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad  
- [ ] I wrote Unit Tests that confirm the expected behaviour  
- [x] I updated only the english localization source files if needed  
- [x] I added the // Ecosia helper comments where needed  
- [x] I made sure that any change to the Analytics events included in PR won't alter current analytics  
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed  

[DC-4407]: https://ecosia.atlassian.net/browse/DC-4407

[MOB-4407]: https://ecosia.atlassian.net/browse/MOB-4407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ