### PR TITLE
[MOB-4445] Fix dropped install tracking

### DIFF
--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -230,6 +230,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, FeatureFlaggable {
 
         addObservers()
 
+        // Ecosia: Send the install event. It happens only once per App install.
+        Analytics.shared.install()
+
         /// Prewarm translation resources off the main thread
         /// This will fetch the translator WASM and model attachments for the device language.
         /// Running this on a utility QoS to avoid impacting app launch time.


### PR DESCRIPTION
[MOB-4445]

## Context

See ticket.

## Approach

Re-add dropped line from previous version: https://github.com/ecosia/ios-browser/blob/2644f2aa06422e35f90b6fd98531d6feeaffbced/firefox-ios/Client/Application/AppDelegate.swift#L180-L181

## Other

There's a strange `application_install` unstruct event being tracked together which I don't recognise (and was apparently still happening with the bug) - having a look but don't want to block the fix.

<img width="1447" height="75" alt="Screenshot 2026-05-13 at 14 16 46" src="https://github.com/user-attachments/assets/2c5ebe1b-1ccc-442f-a575-6561e840b32c" />

[MOB-4445]: https://ecosia.atlassian.net/browse/MOB-4445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ