### PR TITLE
Use glob to include all EcosiaTests subfolders and exclude Snapshot

### DIFF
--- a/firefox-ios/Tuist/ProjectDescriptionHelpers/Targets+Tests.swift
+++ b/firefox-ios/Tuist/ProjectDescriptionHelpers/Targets+Tests.swift
@@ -213,11 +213,7 @@ public enum TestTargets {
             bundleId: "com.ecosia.tests.Ecosia",
             infoPlist: .default,
             sources: [
-                "EcosiaTests/*.swift",
-                "EcosiaTests/Mocks/**/*.swift",
-                "EcosiaTests/UI/**/*.swift",
-                "EcosiaTests/Core/**/*.swift",
-                "EcosiaTests/IntegrationTests/**/*.swift",
+                .glob("EcosiaTests/**/*.swift", excluding: ["EcosiaTests/SnapshotTests/**/*.swift"]),
                 // Shared ClientTests helpers required by integration tests
                 "firefox-ios-tests/Tests/ClientTests/XCTestCaseExtensions.swift",
                 "firefox-ios-tests/Tests/ClientTests/ProfileTest.swift",


### PR DESCRIPTION
[MOB-4445]

## Context

See ticket follow-up `3`.

`EcosiaTests/Analytics/*` was not included on `EcosiaTests` target Tuist configuration.

## Approach

Use glob to include all subfolders, but ignore `SnapshotTests` as that is a separate target.

[MOB-4445]: https://ecosia.atlassian.net/browse/MOB-4445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ