### PR TITLE
MOB-4300: QA Fixes Round #2

### DIFF
--- a/BrowserKit/Sources/Common/Theming/EcosiaThemeColourPalette.swift
+++ b/BrowserKit/Sources/Common/Theming/EcosiaThemeColourPalette.swift
@@ -27,6 +27,9 @@ public protocol EcosiaSemanticColors {
     var borderDecorative: UIColor { get }
     var borderNegative: UIColor { get }
 
+    // MARK: - Form
+    var formBorderPrimaryActive: UIColor { get }
+
     // MARK: - Brand
     var brandFeatured: UIColor { get }
     var brandPrimary: UIColor { get }
@@ -118,6 +121,7 @@ class FakeEcosiaSemanticColors: EcosiaSemanticColors {
     var buttonContentSecondary: UIColor = .systemGray
     var buttonContentSecondaryStatic: UIColor = .systemGray
     var borderNegative: UIColor = .systemGray
+    var formBorderPrimaryActive: UIColor = .systemGray
     var highlighter: UIColor = .systemGray
     var linkPrimary: UIColor = .systemGray
     var iconDecorative: UIColor = .systemGray

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Omnibox.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Omnibox.swift
@@ -200,8 +200,14 @@ extension BrowserViewController {
             searchController.view.bottomAnchor.constraint(equalTo: host.bottomAnchor)
         ])
 
-        // Keep the omnibox — and the floating top-right close button — above
-        // the suggestions overlay.
+        // z-order back→front: suggestions overlay, focused-state scrim,
+        // omnibox pill, floating close button. The scrim sits above the
+        // suggestions so the bottom of the list fades into the pill, but
+        // below the pill itself so the pill stays fully opaque.
+        if let homepage = hostVC as? HomepageViewController,
+           let backdrop = homepage.ntpSearchBarBackdrop {
+            host.bringSubviewToFront(backdrop)
+        }
         host.bringSubviewToFront(anchorView)
         if let homepage = hostVC as? HomepageViewController,
            let closeButton = homepage.ntpOmniboxCloseButton {

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Omnibox.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Omnibox.swift
@@ -107,24 +107,28 @@ extension BrowserViewController: NTPSearchBarDelegate {
     }
 
     func ntpSearchBarDidCancel() {
-        // Mark the session abandoned synchronously so the deferred
-        // `hideOmniboxSuggestions` below — which triggers
-        // `searchViewControllerWillHide` — sees the right state and routes
-        // to `recordURLBarSearchAbandonmentTelemetryEvent`. A submit that
-        // races in before the deferred hide runs flips the state back to
-        // `.engaged`, which is exactly what we want.
+        // Mark the session abandoned synchronously so the eventual overlay
+        // teardown — which triggers `searchViewControllerWillHide` — sees
+        // the right state and routes to
+        // `recordURLBarSearchAbandonmentTelemetryEvent`. A submit that races
+        // in flips the state back to `.engaged`, which is exactly what we
+        // want. Note: this callback intentionally does NOT hide the overlay
+        // any more. A keyboard drag-dismiss resigns the textView too, and
+        // tearing the suggestions down there would kill the whole point of
+        // letting the user swipe the keyboard away to read the full list.
+        // The explicit dismiss paths (`ntpSearchBarRequestsOverlayDismiss`,
+        // submit, suggestion-row selection, text-cleared) handle teardown.
         if searchSessionState == .active {
             searchSessionState = .abandoned
         }
-        // The bar resigns first responder for two distinct reasons: an explicit
-        // user dismissal, or the tap-outside gesture firing on a tap that's
-        // actually selecting a suggestion row. Tearing the suggestions overlay
-        // down synchronously kills the second case — the table view's row
-        // selection gesture fires *after* the parent tap recognizer's action,
-        // so by the time `didSelectRowAt` runs, the search controller has
-        // already been removed from the hierarchy. Defer to the next runloop
-        // so any pending row tap completes first; an explicit submit/cancel
-        // hides the overlay before the deferred call lands, making it a no-op.
+    }
+
+    func ntpSearchBarRequestsOverlayDismiss() {
+        // Defer to the next runloop so a tap-outside that's actually a
+        // suggestion-row tap can complete its `didSelectRowAt` before the
+        // table is removed from the hierarchy — an explicit submit/select
+        // hides the overlay before the deferred call lands, making it a
+        // no-op.
         DispatchQueue.main.async { [weak self] in
             self?.hideOmniboxSuggestions()
         }
@@ -216,9 +220,11 @@ extension BrowserViewController {
         // Re-enable interaction in case the previous attach left the table
         // disabled by the fast-tap path below.
         searchController.tableView.isUserInteractionEnabled = true
-        // Drag-down on the suggestions list dismisses the keyboard interactively,
-        // matching the homepage collection view's behavior.
-        searchController.tableView.keyboardDismissMode = .interactive
+        // Any drag on the suggestions list dismisses the keyboard so the user
+        // can scan the full list. Resigning the textView's first responder
+        // from this path fires `ntpSearchBarDidCancel`, which intentionally
+        // no longer tears down the overlay — so the suggestions stay visible.
+        searchController.tableView.keyboardDismissMode = .onDrag
         installOmniboxFastTap(on: searchController.tableView)
     }
 

--- a/firefox-ios/Client/Ecosia/Extensions/HomepageViewController+EcosiaCells.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/HomepageViewController+EcosiaCells.swift
@@ -146,6 +146,15 @@ extension HomepageViewController {
     func setNTPOmniboxCloseButton(_ button: UIButton) {
         objc_setAssociatedObject(self, &AssociatedKeys.ntpOmniboxCloseButton, button, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
     }
+
+    // Ecosia: Active-state gradient scrim behind the focused pill.
+    var ntpSearchBarBackdrop: NTPSearchBarBackdropView? {
+        return objc_getAssociatedObject(self, &AssociatedKeys.ntpSearchBarBackdrop) as? NTPSearchBarBackdropView
+    }
+
+    func setNTPSearchBarBackdrop(_ view: NTPSearchBarBackdropView) {
+        objc_setAssociatedObject(self, &AssociatedKeys.ntpSearchBarBackdrop, view, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+    }
 }
 
 // MARK: - Associated Keys
@@ -158,4 +167,5 @@ private struct AssociatedKeys {
     nonisolated(unsafe) static var ntpSearchBarLeadingConstraint: UInt8 = 0
     nonisolated(unsafe) static var ntpSearchBarTrailingConstraint: UInt8 = 0
     nonisolated(unsafe) static var ntpOmniboxCloseButton: UInt8 = 0
+    nonisolated(unsafe) static var ntpSearchBarBackdrop: UInt8 = 0
 }

--- a/firefox-ios/Client/Ecosia/Extensions/HomepageViewController+EcosiaSetup.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/HomepageViewController+EcosiaSetup.swift
@@ -139,11 +139,19 @@ extension HomepageViewController: @MainActor HomepageDataModelDelegate {
             button.heightAnchor.constraint(equalToConstant: 36)
         ])
 
-        let theme = themeManager.getCurrentTheme(for: windowUUID).colors
-        button.backgroundColor = theme.ecosia.backgroundElevation2
-        button.tintColor = theme.ecosia.textPrimary
-
         setNTPOmniboxCloseButton(button)
+        applyOmniboxCloseButtonTheme()
+    }
+
+    /// Paints the floating top-right close button using the same `layer5`
+    /// token as the autocomplete row backgrounds, so the button visually
+    /// belongs to the suggestions surface beneath it instead of reading as
+    /// a separate pill.
+    private func applyOmniboxCloseButtonTheme() {
+        guard let button = ntpOmniboxCloseButton else { return }
+        let colors = themeManager.getCurrentTheme(for: windowUUID).colors
+        button.backgroundColor = colors.layer5
+        button.tintColor = colors.ecosia.textPrimary
     }
 
     private func installOmniboxTapOutsideDismiss() {
@@ -351,6 +359,7 @@ extension HomepageViewController: @MainActor HomepageDataModelDelegate {
         ecosiaAdapter?.updateTheme(theme)
         ntpSearchBar?.applyTheme(theme: theme)
         ntpSearchBarBackdrop?.applyTheme(theme: theme)
+        applyOmniboxCloseButtonTheme()
     }
 
     /// Refreshes the Ecosia snapshot so the UI updates

--- a/firefox-ios/Client/Ecosia/Extensions/HomepageViewController+EcosiaSetup.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/HomepageViewController+EcosiaSetup.swift
@@ -140,15 +140,29 @@ extension HomepageViewController: @MainActor HomepageDataModelDelegate {
     @objc private func handleOmniboxCloseButtonTapped() {
         guard let bar = ntpSearchBar else { return }
         bar.text = ""
-        _ = bar.resignFirstResponder()
+        if bar.isFirstResponder {
+            _ = bar.resignFirstResponder()
+        }
+        // The bar's `didCancel` callback no longer hides the overlay (that
+        // would tear it down on every keyboard drag-dismiss too), so always
+        // request the explicit dismiss here. After a drag-dismiss the bar
+        // isn't first responder either, but the request still tears the
+        // suggestions overlay down.
+        bar.delegate?.ntpSearchBarRequestsOverlayDismiss()
     }
 
     @objc private func handleTapOutsideOmnibox(_ gesture: UITapGestureRecognizer) {
-        guard let bar = ntpSearchBar, bar.isFirstResponder else { return }
+        guard let bar = ntpSearchBar else { return }
         let location = gesture.location(in: view)
-        if !bar.frame.contains(location) {
+        guard !bar.frame.contains(location) else { return }
+        if bar.isFirstResponder {
             _ = bar.resignFirstResponder()
         }
+        // Always request the explicit overlay dismiss — `didCancel` no
+        // longer hides the overlay (so keyboard drag-dismiss leaves the
+        // list visible), and after a drag-dismiss the bar isn't first
+        // responder so `resignFirstResponder` above is a no-op.
+        bar.delegate?.ntpSearchBarRequestsOverlayDismiss()
     }
 
     /// Sets up the Ecosia homepage adapter and integrates it with the view controller
@@ -291,8 +305,12 @@ extension HomepageViewController: @MainActor HomepageDataModelDelegate {
     func ecosiaViewDidDisappear() {
         // Defensive: if the user navigated away while the omnibox was editing,
         // tear down the suggestions overlay so the SearchLoader doesn't keep a
-        // dangling reference to this view's autocomplete sink.
+        // dangling reference to this view's autocomplete sink. `didCancel`
+        // updates session state; `requestsOverlayDismiss` actually hides the
+        // overlay (the cancel callback no longer does that on its own so
+        // keyboard drag-dismiss can leave the list visible).
         ntpSearchBar?.delegate?.ntpSearchBarDidCancel()
+        ntpSearchBar?.delegate?.ntpSearchBarRequestsOverlayDismiss()
         _ = ntpSearchBar?.resignFirstResponder()
         ecosiaAdapter?.viewDidDisappear()
     }

--- a/firefox-ios/Client/Ecosia/Extensions/HomepageViewController+EcosiaSetup.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/HomepageViewController+EcosiaSetup.swift
@@ -35,14 +35,41 @@ extension HomepageViewController: @MainActor HomepageDataModelDelegate {
     // Replaces the standard URL bar while the homepage is visible. Submission and
     // suggestions are wired through the browser's existing navigation pipeline.
     func setupNTPSearchBar(delegate: NTPSearchBarDelegate) {
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
+
+        // Active-state scrim sits behind the pill. Added before the pill so
+        // the pill (and the floating close button installed below) naturally
+        // render on top of it. Hidden by default — appears only on focus.
+        let backdrop = NTPSearchBarBackdropView()
+        backdrop.translatesAutoresizingMaskIntoConstraints = false
+        backdrop.applyTheme(theme: theme)
+        view.addSubview(backdrop)
+
         let searchBar = NTPSearchBarView()
         searchBar.delegate = delegate
         searchBar.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(searchBar)
 
+        NSLayoutConstraint.activate([
+            backdrop.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            backdrop.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            // Anchor the scrim tightly to the pill: 12pt above so the fade
+            // region sits just above the omnibox, and 24pt below so the
+            // solid tail fills the 12pt gap between the pill and the
+            // keyboard's top edge AND extends another 12pt under the
+            // keyboard (the pill itself sits 12pt above the keyboard, so
+            // `pill.bottom + 24 == keyboard.top + 12`). The 12pt under-
+            // keyboard portion is occluded by iOS' keyboard window — paired
+            // with the dialled-back blur peak (α 0.5) in the backdrop view
+            // it stays out of the way of the keyboard's own translucency.
+            backdrop.bottomAnchor.constraint(equalTo: searchBar.bottomAnchor, constant: 24),
+            backdrop.topAnchor.constraint(equalTo: searchBar.topAnchor, constant: -12)
+        ])
+        setNTPSearchBarBackdrop(backdrop)
+
         let bottomConstraint = searchBar.bottomAnchor.constraint(
             equalTo: view.safeAreaLayoutGuide.bottomAnchor,
-            constant: -.ecosia.space._1l
+            constant: -.ecosia.space._s
         )
         let horizontalInset = Self.ntpSearchBarHorizontalInset(for: traitCollection)
         let leadingConstraint = searchBar.leadingAnchor.constraint(
@@ -69,7 +96,7 @@ extension HomepageViewController: @MainActor HomepageDataModelDelegate {
             maxHeightConstraint
         ])
 
-        searchBar.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
+        searchBar.applyTheme(theme: theme)
         setNTPSearchBar(searchBar)
         setNTPSearchBarBottomConstraint(bottomConstraint)
         setNTPSearchBarLeadingConstraint(leadingConstraint)
@@ -81,6 +108,9 @@ extension HomepageViewController: @MainActor HomepageDataModelDelegate {
 
         searchBar.onContentChange = { [weak self] text in
             self?.handleOmniboxContentChange(text)
+        }
+        searchBar.onFocusChange = { [weak self] focused in
+            self?.ntpSearchBarBackdrop?.setVisible(focused, animated: true)
         }
 
         installOmniboxCloseButton()
@@ -273,7 +303,7 @@ extension HomepageViewController: @MainActor HomepageDataModelDelegate {
 
     /// Re-applies the iPad horizontal inset to the omnibox after a rotation or
     /// size-class change (e.g. iPad split-screen resize). On iPhone-class
-    /// surfaces the value collapses back to the default `_m` margin.
+    /// surfaces the value collapses back to the default `_s` (12pt) margin.
     func updateNTPSearchBarHorizontalInset() {
         let inset = Self.ntpSearchBarHorizontalInset(for: traitCollection)
         ntpSearchBarLeadingConstraint?.constant = inset
@@ -282,11 +312,11 @@ extension HomepageViewController: @MainActor HomepageDataModelDelegate {
 
     /// 160pt of breathing room on iPad regular-width surfaces so the pill doesn't
     /// stretch the full width of a 1024pt display; everything else (iPhone, iPad
-    /// narrow split-screen) uses the standard `_m` margin.
+    /// narrow split-screen) uses the design-system `_s` (12pt) margin.
     fileprivate static func ntpSearchBarHorizontalInset(for traitCollection: UITraitCollection) -> CGFloat {
         let isWideIPad = traitCollection.userInterfaceIdiom == .pad
             && traitCollection.horizontalSizeClass == .regular
-        return isWideIPad ? 160 : .ecosia.space._m
+        return isWideIPad ? 160 : .ecosia.space._s
     }
 
     /// Called from `viewDidLayoutSubviews`. The omnibox cushion is now baked
@@ -320,6 +350,7 @@ extension HomepageViewController: @MainActor HomepageDataModelDelegate {
         let theme = themeManager.getCurrentTheme(for: windowUUID)
         ecosiaAdapter?.updateTheme(theme)
         ntpSearchBar?.applyTheme(theme: theme)
+        ntpSearchBarBackdrop?.applyTheme(theme: theme)
     }
 
     /// Refreshes the Ecosia snapshot so the UI updates
@@ -347,7 +378,7 @@ extension HomepageViewController: @MainActor HomepageDataModelDelegate {
 // MARK: - KeyboardHelperDelegate
 // Ecosia: Keeps the omnibox glued just above the keyboard while editing.
 extension HomepageViewController: KeyboardHelperDelegate {
-    private static let restingBottomOffset: CGFloat = .ecosia.space._1l
+    private static let restingBottomOffset: CGFloat = .ecosia.space._s
 
     public func keyboardHelper(
         _ keyboardHelper: KeyboardHelper,

--- a/firefox-ios/Client/Ecosia/Extensions/SearchViewController+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/SearchViewController+Ecosia.swift
@@ -59,6 +59,7 @@ extension SearchViewController {
         let theme = themeManager.getCurrentTheme(for: windowUUID)
 
         cell.titleLabel.text = viewModel.searchQuery
+        applyOneLineHeadTruncation(to: cell.titleLabel)
 
         let aiSearchImage = UIImage(named: "searchLarge")?.withRenderingMode(.alwaysTemplate)
         cell.leftImageView.contentMode = .center
@@ -142,5 +143,18 @@ extension SearchViewController {
     func isValidSuggestionIndex(_ index: Int) -> Bool {
         guard let suggestions = viewModel.suggestions else { return false }
         return index < min(suggestions.count, 4)
+    }
+
+    // MARK: - One-line Truncation
+
+    /// Constrains a suggestion title to a single line truncated at the head so
+    /// very long queries reveal the trailing portion (where the bold
+    /// autocomplete completion lives) instead of wrapping over several rows.
+    /// `OneLineTableViewCell.prepareForReuse` does not reset these label
+    /// properties, but every suggestion-section cell configuration sets them
+    /// explicitly, so reuse across sections stays consistent.
+    func applyOneLineHeadTruncation(to titleLabel: UILabel) {
+        titleLabel.numberOfLines = 1
+        titleLabel.lineBreakMode = .byTruncatingHead
     }
 }

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPSearchBarBackdropView.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPSearchBarBackdropView.swift
@@ -1,0 +1,144 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+import Common
+import Ecosia
+
+/// Vertical scrim that sits behind the focused NTP omnibox. Two effects fade
+/// in together from `top → bottom`:
+///
+/// 1. A `UIVisualEffectView` (system ultra-thin material) blurs whatever sits
+///    behind the scrim. A `CAGradientLayer` mask scales the visible effect
+///    from 0 at the top to full at the bottom — matching the "blur 0 → 16"
+///    fade in the design spec.
+/// 2. A `CAGradientLayer` filled with the design-system `backgroundGradient`
+///    colour (white in light, gray-90 in dark) sits on top of the blur and
+///    fades from α 0 at the top to α 1 at ~70% down, then stays solid the
+///    rest of the way. That solid tail keeps the colour fully opaque at the
+///    visible bottom (where the keyboard cuts the scrim off) so the scrim
+///    doesn't look like it dies on a half-opaque pixel.
+///
+/// The host shows the scrim on omnibox focus and hides it on blur via
+/// `setVisible(_:animated:)`, so the homepage's pre-focus state is preserved
+/// when the user isn't typing.
+final class NTPSearchBarBackdropView: UIView, ThemeApplicable {
+
+    private let blurView = UIVisualEffectView(effect: nil)
+    private let blurEffect = UIBlurEffect(style: .systemUltraThinMaterial)
+    private let blurMaskLayer = CAGradientLayer()
+    private let gradientLayer = CAGradientLayer()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setup() {
+        isUserInteractionEnabled = false
+        backgroundColor = .clear
+        // Start fully invisible AND hidden so neither the blur nor the
+        // gradient layer contribute anything to the unfocused homepage.
+        alpha = 0
+        isHidden = true
+
+        // Blur first so its layer sits BEHIND the colour gradient layer
+        // added afterwards (sublayers are rendered back-to-front in the
+        // order they're appended).
+        blurView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(blurView)
+        NSLayoutConstraint.activate([
+            blurView.topAnchor.constraint(equalTo: topAnchor),
+            blurView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            blurView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            blurView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+
+        // Mask the blur with the same fade curve as the colour layer (clear
+        // at top → ~half-opaque at 70% → ~half-opaque at bottom). The peak
+        // is capped at ~0.5 because the scrim sits behind iOS' own
+        // translucent keyboard surface — a full-intensity blur there
+        // compounds with the keyboard's own blur and reads as a strongly
+        // tinted wash. Half-strength keeps the soft frosted-glass feel
+        // above the pill without the bottom looking heavy-handed.
+        blurMaskLayer.colors = [
+            UIColor.clear.cgColor,
+            UIColor.white.withAlphaComponent(0.5).cgColor,
+            UIColor.white.withAlphaComponent(0.5).cgColor
+        ]
+        blurMaskLayer.locations = [0.0, 0.7, 1.0]
+        blurMaskLayer.startPoint = CGPoint(x: 0.5, y: 0.0)
+        blurMaskLayer.endPoint = CGPoint(x: 0.5, y: 1.0)
+        blurView.layer.mask = blurMaskLayer
+
+        // Colour gradient uses a plain linear fade across the full height
+        // (no solid plateau at the bottom). The visible bottom below the
+        // pill is then a soft tail rather than a flat wash — the blur
+        // (which keeps its `[0, 0.7, 1]` ramp) gives the bottom enough
+        // body without the colour also stamping a solid bar.
+        gradientLayer.locations = [0.0, 1.0]
+        gradientLayer.startPoint = CGPoint(x: 0.5, y: 0.0)
+        gradientLayer.endPoint = CGPoint(x: 0.5, y: 1.0)
+        layer.addSublayer(gradientLayer)
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        // CAGradientLayer doesn't auto-resize with its host view; keep the
+        // frames in sync without implicit animations so they don't lag
+        // behind constraint-driven layout passes.
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        gradientLayer.frame = bounds
+        blurMaskLayer.frame = bounds
+        CATransaction.commit()
+    }
+
+    func applyTheme(theme: any Theme) {
+        let color = theme.colors.ecosia.backgroundGradient
+        // Cap the colour tint at 50% even at the bottom of the scrim. Full
+        // opacity reads as a solid bar across the gap between the pill and
+        // the keyboard; capping it lets the wallpaper bleed through, which
+        // is closer to the subtle fade in the design reference.
+        gradientLayer.colors = [
+            color.withAlphaComponent(0).cgColor,
+            color.withAlphaComponent(0.5).cgColor
+        ]
+    }
+
+    func setVisible(_ visible: Bool, animated: Bool, duration: TimeInterval = 0.2) {
+        if visible {
+            // Make sure the view participates in rendering before alpha
+            // ramps up. Also install the blur effect — we keep it `nil`
+            // while hidden so the system material isn't visible at α 0.
+            isHidden = false
+            if blurView.effect == nil {
+                blurView.effect = blurEffect
+            }
+        }
+        let targetAlpha: CGFloat = visible ? 1 : 0
+        guard alpha != targetAlpha else { return }
+        let finalise: () -> Void = { [weak self] in
+            guard let self, !visible else { return }
+            // Drop the effect AND mark hidden so neither the blur nor the
+            // gradient can render — restoring the pre-focus state exactly.
+            self.blurView.effect = nil
+            self.isHidden = true
+        }
+        guard animated else {
+            alpha = targetAlpha
+            finalise()
+            return
+        }
+        UIView.animate(withDuration: duration, delay: 0, options: [.curveEaseInOut]) {
+            self.alpha = targetAlpha
+        } completion: { _ in
+            finalise()
+        }
+    }
+}

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPSearchBarView.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPSearchBarView.swift
@@ -434,16 +434,27 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable {
         let colors = theme.colors
 
         backgroundColor = colors.ecosia.backgroundElevation2
-        layer.borderColor = colors.ecosia.borderDecorative.cgColor
         textView.textColor = colors.ecosia.textPrimary
         textView.tintColor = colors.ecosia.textPrimary
         placeholderLabel.textColor = colors.ecosia.textSecondary
+        applyBorderColor()
         applySubmitButtonColors()
         applyCounterColor()
         // Clear button: dark filled pill with a light glyph, matching the
         // Figma design.
         clearButton.backgroundColor = colors.ecosia.textPrimary
         clearButton.tintColor = colors.ecosia.backgroundElevation2
+    }
+
+    /// Swaps the pill border between the resting `borderDecorative` token and
+    /// the focused `formBorderPrimaryActive` token. Called from the textView
+    /// focus delegate methods and on each theme change.
+    private func applyBorderColor() {
+        guard let colors = currentTheme?.colors else { return }
+        let token = textView.isFirstResponder
+            ? colors.ecosia.formBorderPrimaryActive
+            : colors.ecosia.borderDecorative
+        layer.borderColor = token.cgColor
     }
 
     // MARK: Autocompletable
@@ -458,10 +469,12 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable {
 extension NTPSearchBarView: @MainActor @preconcurrency UITextViewDelegate {
 
     func textViewDidBeginEditing(_ textView: UITextView) {
+        applyBorderColor()
         delegate?.ntpSearchBarDidBeginEditing()
     }
 
     func textViewDidEndEditing(_ textView: UITextView) {
+        applyBorderColor()
         delegate?.ntpSearchBarDidCancel()
     }
 

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPSearchBarView.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPSearchBarView.swift
@@ -408,8 +408,13 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable {
         submitButton.layer.cornerRadius = UX.submitButtonSize / 2
         submitButton.layer.masksToBounds = true
         if submitButton.isEnabled {
+            // The featured background is grellow in both themes, so the
+            // icon must stay dark in both. `buttonContentSecondary` resolves
+            // to white in dark mode (white-on-grellow is illegible); the
+            // `Static` variant keeps the dark glyph in both modes — matching
+            // the design-system primary CTA pattern used by Welcome / Sign-in.
             submitButton.backgroundColor = colors.ecosia.buttonBackgroundFeatured
-            submitButton.tintColor = colors.ecosia.buttonContentSecondary
+            submitButton.tintColor = colors.ecosia.buttonContentSecondaryStatic
         } else {
             submitButton.backgroundColor = .clear
             submitButton.tintColor = colors.ecosia.textSecondary

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPSearchBarView.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPSearchBarView.swift
@@ -413,11 +413,17 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable {
             // to white in dark mode (white-on-grellow is illegible); the
             // `Static` variant keeps the dark glyph in both modes — matching
             // the design-system primary CTA pattern used by Welcome / Sign-in.
+            // The 1pt border in the same featured color is part of the
+            // design-system button spec for consistency with other CTAs.
             submitButton.backgroundColor = colors.ecosia.buttonBackgroundFeatured
             submitButton.tintColor = colors.ecosia.buttonContentSecondaryStatic
+            submitButton.layer.borderWidth = 1
+            submitButton.layer.borderColor = colors.ecosia.buttonBackgroundFeatured.cgColor
         } else {
             submitButton.backgroundColor = .clear
             submitButton.tintColor = colors.ecosia.textSecondary
+            submitButton.layer.borderWidth = 0
+            submitButton.layer.borderColor = nil
         }
     }
 

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPSearchBarView.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPSearchBarView.swift
@@ -26,8 +26,17 @@ protocol NTPSearchBarDelegate: AnyObject {
     func ntpSearchBarTextDidChange(_ searchTerm: String)
     /// Called when the text field becomes first responder.
     func ntpSearchBarDidBeginEditing()
-    /// Called when editing ends without a submission (e.g. tap outside).
+    /// Called when the text field resigns first responder for any reason
+    /// (explicit cancel, tap-outside, keyboard drag-dismiss). The host may
+    /// use it to update session-state telemetry but MUST NOT tear down the
+    /// suggestions overlay here — a keyboard drag-dismiss should leave the
+    /// list visible so the user can read it without the keyboard. Use
+    /// `ntpSearchBarRequestsOverlayDismiss` for explicit overlay teardown.
     func ntpSearchBarDidCancel()
+    /// Called when the user explicitly asks the omnibox UI to dismiss
+    /// (tap-outside the pill, close-button tap, host view disappearing).
+    /// The host is expected to tear down the suggestions overlay here.
+    func ntpSearchBarRequestsOverlayDismiss()
 }
 
 /// Pill-shaped search input pinned to the bottom of the redesigned NTP. Replaces

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPSearchBarView.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPSearchBarView.swift
@@ -52,7 +52,18 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable {
 
     private enum UX {
         static let submitButtonSize: CGFloat = .ecosia.space._3l
-        static let clearButtonSize: CGFloat = 20
+        /// Tappable footprint of the in-pill clear button. Matches the
+        /// submit button so both controls present the same 40×40 hit
+        /// target; the visible artwork is the smaller `clearCircleSize`.
+        static let clearButtonSize: CGFloat = .ecosia.space._3l
+        /// Visible diameter of the dark circle behind the clear-button's
+        /// X glyph. The remaining 24pt of the button is a transparent
+        /// hit-padding ring that catches taps just outside the artwork.
+        static let clearCircleSize: CGFloat = 16
+        /// Gap between the textView's trailing edge and the leading edge
+        /// of the right-hand button column so typed text never collides
+        /// with either button.
+        static let textTrailingGap: CGFloat = .ecosia.space._1s
         static let shadowOpacity: Float = 0.10
         static let shadowRadius: CGFloat = 12
         static let shadowOffset = CGSize(width: 0, height: 4)
@@ -120,16 +131,38 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable {
         label.accessibilityIdentifier = "NTPSearchBarCounterLabel"
     }
 
-    /// In-pill clear button at the top-right of the omnibox. Visible only while
-    /// the field has content — taps wipe the text without dropping focus.
+    /// In-pill clear button at the top-right of the omnibox. Visible only
+    /// while the field has content — taps wipe the text without dropping
+    /// focus. The button itself is the 40×40 hit target with no rendered
+    /// content; `clearButtonCircle` and `clearButtonGlyph` are siblings
+    /// inside it that draw the visible disc and the X glyph respectively.
+    /// We don't use `setImage` because the resulting `imageView`'s z-order
+    /// relative to other subviews is unreliable across iOS versions/button
+    /// configuration modes — using an explicit `UIImageView` keeps the X
+    /// guaranteed to sit on top of the disc.
     private lazy var clearButton: UIButton = .build { button in
-        let symbolConfig = UIImage.SymbolConfiguration(pointSize: 11, weight: .semibold)
-        let image = UIImage(systemName: "xmark", withConfiguration: symbolConfig)
-        button.setImage(image, for: .normal)
-        button.layer.cornerRadius = UX.clearButtonSize / 2
         button.accessibilityLabel = String.localized(.cancel)
         button.accessibilityIdentifier = "NTPSearchBarClearButton"
         button.isHidden = true
+    }
+
+    /// Visible 16×16 disc inside the clear button. Rendered behind the X
+    /// glyph so it acts as the glyph's background pill, while the
+    /// surrounding 40×40 button frame stays transparent for hit testing.
+    private lazy var clearButtonCircle: UIView = .build { circle in
+        circle.layer.cornerRadius = UX.clearCircleSize / 2
+        circle.isUserInteractionEnabled = false
+    }
+
+    /// X glyph rendered on top of `clearButtonCircle`. Tinted via the
+    /// template-rendered image; we leave hit-testing disabled so taps fall
+    /// through to the enclosing `clearButton`.
+    private lazy var clearButtonGlyph: UIImageView = .build { glyph in
+        let symbolConfig = UIImage.SymbolConfiguration(pointSize: 9, weight: .semibold)
+        glyph.image = UIImage(systemName: "xmark", withConfiguration: symbolConfig)?
+            .withRenderingMode(.alwaysTemplate)
+        glyph.contentMode = .center
+        glyph.isUserInteractionEnabled = false
     }
 
     /// Fires whenever the text content changes (including programmatic clears).
@@ -193,25 +226,6 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable {
         textView.becomeFirstResponder()
     }
 
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        updateTextExclusionPath()
-    }
-
-    /// Carves out the area occupied by the clear button so wrapping text flows
-    /// around it instead of running underneath. Only takes effect while the
-    /// button is visible — empty pills keep the full text width.
-    private func updateTextExclusionPath() {
-        guard !clearButton.isHidden, clearButton.bounds != .zero else {
-            textView.textContainer.exclusionPaths = []
-            return
-        }
-        let buttonFrame = textView.convert(clearButton.frame, from: clearButton.superview)
-        // Pad the exclusion zone slightly so descenders don't kiss the glyph.
-        let excluded = buttonFrame.insetBy(dx: -.ecosia.space._1s, dy: -.ecosia.space._2s)
-        textView.textContainer.exclusionPaths = [UIBezierPath(rect: excluded)]
-    }
-
     // MARK: Setup
 
     private func setup() {
@@ -227,6 +241,11 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable {
         addSubview(submitButton)
         addSubview(counterLabel)
         addSubview(clearButton)
+        // Layered inside `clearButton`: the disc paints the dark
+        // background, the glyph draws the X on top. Both have user
+        // interaction disabled so taps fall through to the button.
+        clearButton.addSubview(clearButtonCircle)
+        clearButton.addSubview(clearButtonGlyph)
 
         textView.delegate = self
         submitButton.addTarget(self, action: #selector(submitTapped), for: .touchUpInside)
@@ -247,14 +266,15 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable {
         addGestureRecognizer(swipeDown)
 
         NSLayoutConstraint.activate([
-            // textView occupies the upper region of the pill. Its bottom is
-            // pinned to the submit button's top so wrapped text physically
-            // cannot enter the bottom-row area (where submit + counter live)
-            // — guaranteeing no overlap regardless of content length or
-            // Dynamic Type scaling.
+            // textView occupies the upper-left region of the pill. Its
+            // bottom is pinned to the submit button's top so wrapped text
+            // physically cannot enter the bottom-row area, and its trailing
+            // edge stops at the submit button's leading edge (with an 8pt
+            // gap) so neither typed text nor the placeholder collide with
+            // the right-hand button column.
             textView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: UX.textPadding),
             textView.topAnchor.constraint(equalTo: topAnchor, constant: UX.textPadding),
-            textView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -UX.textPadding),
+            textView.trailingAnchor.constraint(equalTo: submitButton.leadingAnchor, constant: -UX.textTrailingGap),
             textView.bottomAnchor.constraint(equalTo: submitButton.topAnchor),
             textViewHeightConstraint,
 
@@ -276,14 +296,22 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable {
             counterLabel.centerYAnchor.constraint(equalTo: submitButton.centerYAnchor),
             counterLabel.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor, constant: .ecosia.space._m),
 
-            // Clear-text button sits in the top-right of the pill, floating
-            // over the textView. Horizontally centered with the submit
-            // button so the two right-hand controls stack on the same axis.
-            // Hidden until the user has content.
-            clearButton.topAnchor.constraint(equalTo: topAnchor, constant: .ecosia.space._m),
+            // Clear-text button sits in the top-right of the pill — its
+            // 40×40 hit target is symmetric to the submit button's 8pt
+            // inset from the pill's bottom-right corner, with the 16×16
+            // visible disc centred inside. Hidden until the user has content.
+            clearButton.topAnchor.constraint(equalTo: topAnchor, constant: .ecosia.space._1s),
             clearButton.centerXAnchor.constraint(equalTo: submitButton.centerXAnchor),
             clearButton.widthAnchor.constraint(equalToConstant: UX.clearButtonSize),
-            clearButton.heightAnchor.constraint(equalToConstant: UX.clearButtonSize)
+            clearButton.heightAnchor.constraint(equalToConstant: UX.clearButtonSize),
+
+            clearButtonCircle.centerXAnchor.constraint(equalTo: clearButton.centerXAnchor),
+            clearButtonCircle.centerYAnchor.constraint(equalTo: clearButton.centerYAnchor),
+            clearButtonCircle.widthAnchor.constraint(equalToConstant: UX.clearCircleSize),
+            clearButtonCircle.heightAnchor.constraint(equalToConstant: UX.clearCircleSize),
+
+            clearButtonGlyph.centerXAnchor.constraint(equalTo: clearButton.centerXAnchor),
+            clearButtonGlyph.centerYAnchor.constraint(equalTo: clearButton.centerYAnchor)
         ])
     }
 
@@ -447,8 +475,14 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable {
         applyCounterColor()
         // Clear button: dark filled pill with a light glyph, matching the
         // Figma design.
-        clearButton.backgroundColor = colors.ecosia.textPrimary
-        clearButton.tintColor = colors.ecosia.backgroundElevation2
+        // Only the inner 16×16 disc carries the dark fill; the surrounding
+        // 40×40 button frame stays transparent so it doesn't read as a
+        // larger pill. The X glyph is its own `UIImageView` (template
+        // rendered), so the tint lives on the glyph directly rather than
+        // travelling through the button's internal imageView.
+        clearButton.backgroundColor = .clear
+        clearButtonCircle.backgroundColor = colors.ecosia.textPrimary
+        clearButtonGlyph.tintColor = colors.ecosia.backgroundElevation2
     }
 
     /// Swaps the pill border between the resting `borderDecorative` token and

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPSearchBarView.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPSearchBarView.swift
@@ -137,6 +137,11 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable {
     /// — for example, the top-right close button.
     var onContentChange: ((String) -> Void)?
 
+    /// Fires whenever the textView's first-responder state changes. Use from
+    /// the host to drive focus-only chrome — for example, the active-state
+    /// gradient backdrop behind the pill.
+    var onFocusChange: ((Bool) -> Void)?
+
     private var currentTheme: Theme?
     private var currentSubmitMode: NTPSearchBarSubmitMode = .search
     private lazy var textViewHeightConstraint: NSLayoutConstraint =
@@ -470,11 +475,13 @@ extension NTPSearchBarView: @MainActor @preconcurrency UITextViewDelegate {
 
     func textViewDidBeginEditing(_ textView: UITextView) {
         applyBorderColor()
+        onFocusChange?(true)
         delegate?.ntpSearchBarDidBeginEditing()
     }
 
     func textViewDidEndEditing(_ textView: UITextView) {
         applyBorderColor()
+        onFocusChange?(false)
         delegate?.ntpSearchBarDidCancel()
     }
 

--- a/firefox-ios/Client/Ecosia/UI/Theme/EcosiaDarkTheme.swift
+++ b/firefox-ios/Client/Ecosia/UI/Theme/EcosiaDarkTheme.swift
@@ -36,6 +36,7 @@ private struct EcosiaDarkSemanticColors: EcosiaSemanticColors {
     var backgroundElevation2: UIColor = EcosiaColor.Gray70
     var borderDecorative: UIColor = EcosiaColor.Gray60
     var borderNegative: UIColor = EcosiaColor.Claret600
+    var formBorderPrimaryActive: UIColor = EcosiaColor.White
     var brandFeatured: UIColor = EcosiaColor.Grellow100
     var brandImpact: UIColor = EcosiaColor.Yellow40
     var brandPrimary: UIColor = EcosiaColor.White

--- a/firefox-ios/Client/Ecosia/UI/Theme/EcosiaLightTheme.swift
+++ b/firefox-ios/Client/Ecosia/UI/Theme/EcosiaLightTheme.swift
@@ -130,6 +130,7 @@ private struct EcosiaLightSemanticColors: EcosiaSemanticColors {
     var backgroundElevation2: UIColor = EcosiaColor.White
     var borderDecorative: UIColor = EcosiaColor.Gray30
     var borderNegative: UIColor = EcosiaColor.Claret300
+    var formBorderPrimaryActive: UIColor = EcosiaColor.Gray70
     var brandFeatured: UIColor = EcosiaColor.Grellow100
     var brandImpact: UIColor = EcosiaColor.Yellow40
     var brandPrimary: UIColor = EcosiaColor.Gray70

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -5239,6 +5239,19 @@ extension BrowserViewController: KeyboardHelperDelegate {
             addressToolbarContainer.updateSkeletonAddressBarsVisibility(tabManager: tabManager)
         }
         guard shouldCancelEditing else { return }
+        // Ecosia: When the embedded NTP omnibox owns the suggestions overlay
+        // (the shared search controller is parented to the homepage VC), the
+        // URL-bar overlay-cancel pipeline must not run on keyboard-hide. The
+        // `.onDrag` keyboard dismiss from the suggestions table fires this
+        // callback every time, and the default path tears down the shared
+        // search controller through `destroySearchController()` — collapsing
+        // the omnibox overlay the moment the user swipes to hide the
+        // keyboard. The omnibox's own delegate callbacks
+        // (`ntpSearchBarDidSubmit`, `ntpSearchBarDidCancel`, suggestion-row
+        // selection) handle teardown explicitly when the user really leaves.
+        if searchController?.parent is HomepageViewController {
+            return
+        }
         overlayManager.cancelEditing(shouldCancelLoading: false)
     }
 

--- a/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -752,6 +752,8 @@ class SearchViewController: SiteTableViewController,
                 oneLineCell.configure(viewModel: oneLineCellViewModel)
                 // Ecosia: Replace the Firefox history icon with the Ecosia equivalent.
                 oneLineCell.leftImageView.image = UIImage.ecosia(named: "history")?.withRenderingMode(.alwaysTemplate)
+                // Ecosia: Keep long queries on a single row, truncated at the head so the trailing autocomplete remains visible.
+                applyOneLineHeadTruncation(to: oneLineCell.titleLabel)
                 cell = oneLineCell
             }
 
@@ -760,6 +762,8 @@ class SearchViewController: SiteTableViewController,
                 let arrowImageName = StandardImageIdentifiers.Large.arrowTrending
                 let oneLineCellViewModel = oneLineCellModelForSearch(with: trendingSearch, and: arrowImageName)
                 oneLineCell.configure(viewModel: oneLineCellViewModel)
+                // Ecosia: Keep long queries on a single row, truncated at the head so the trailing autocomplete remains visible.
+                applyOneLineHeadTruncation(to: oneLineCell.titleLabel)
                 cell = oneLineCell
             }
 
@@ -780,6 +784,8 @@ class SearchViewController: SiteTableViewController,
                    ) {
                     oneLineCell.titleLabel.attributedText = attributedString
                 }
+                // Ecosia: Keep long queries on a single row, truncated at the head so the trailing autocomplete remains visible.
+                applyOneLineHeadTruncation(to: oneLineCell.titleLabel)
                 cell = oneLineCell
             }
         case .openedTabs:


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-4300]

## Context

### Fixed

* Query should be truncated in the suggestions
* Swiping down when the user interacts with suggestions
* Send button has an incorrect semantic for the icon
* Border for the omnibox focused
* Close button color on light mode when omnibox is selected
* Gradient behind the active omnibox + margins
* Omnibox safe space is wrong
* Browsing suggestions close button appearance
* Omnibox cancel button appearance

## Approach

## Other

## Before merging

### Checklist

- [ ] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [ ] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4300]: https://ecosia.atlassian.net/browse/MOB-4300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ