### PR TITLE
MOB-4300: QA fixes

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationContainer.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationContainer.swift
@@ -14,6 +14,12 @@ final class LocationContainer: UIView, ThemeApplicable {
         static let borderWidthEditing: CGFloat = 2
     }
 
+    // Ecosia: cached so the border can be refreshed when only the scroll
+    // alpha changes (e.g. address bar shrinking into its compact pill).
+    private var isEditing = false
+    private var scrollAlpha: CGFloat = 1
+    private var borderTheme: Theme?
+
     init() {
         super.init(frame: .zero)
         setupShadow()
@@ -36,14 +42,28 @@ final class LocationContainer: UIView, ThemeApplicable {
     }
 
     func updateShadowOpacityBasedOn(scrollAlpha: CGFloat) {
+        self.scrollAlpha = scrollAlpha
         let targetOpacity = scrollAlpha.isZero ? 0 : UX.shadowOpacity
-        guard layer.shadowOpacity != targetOpacity else { return }
-        layer.shadowOpacity = targetOpacity
+        if layer.shadowOpacity != targetOpacity {
+            layer.shadowOpacity = targetOpacity
+        }
+        // Ecosia: re-evaluate the editing border too. While shrinking into
+        // the compact pill the toolbar's editing state can still be true,
+        // but the border should disappear alongside the shadow so the pill
+        // doesn't carry a leftover outline.
+        refreshEditingBorder()
     }
 
     // Ecosia: Update border based on editing state (legacy URLBarView overlay border styling)
     func updateBorder(isEditing: Bool, theme: Theme) {
-        if isEditing {
+        self.isEditing = isEditing
+        self.borderTheme = theme
+        refreshEditingBorder()
+    }
+
+    private func refreshEditingBorder() {
+        let shouldShowBorder = isEditing && !scrollAlpha.isZero
+        if shouldShowBorder, let theme = borderTheme {
             layer.borderWidth = UX.borderWidthEditing
             layer.borderColor = theme.colors.ecosia.buttonBackgroundPrimary.cgColor
         } else {

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -501,15 +501,6 @@ final class LocationView: UIView,
             hasHomeIndicator ? UX.bottomAddressBarYoffset : UX.bottomAddressBarYoffsetForHomeButton
         }
         let yOffset: CGFloat = (barPosition == .bottom && !isiPad) ? bottomAddressBarYoffset : UX.topAddressBarYoffset
-        // Ecosia: Keep `urlTextField` interactive even while the location
-        // view is in its compact pill form. With interaction disabled the
-        // tap that visually hits the pill is dropped on the floor — no
-        // gesture in the toolbar fires, so the toolbar never re-expands
-        // (and the container-level tap can't compensate when the pill is
-        // the only thing covering the tap point). Letting the text field
-        // receive the tap routes it through the normal
-        // `textFieldDidBeginEditing` → `addressToolbarDidBeginEditing`
-        // pipeline, which both expands the bar and enters overlay mode.
         UIView.animate(
             withDuration: UX.identityResetAnimationDuration,
             delay: 0,
@@ -518,6 +509,14 @@ final class LocationView: UIView,
                 let scaledTransformation = CGAffineTransform(scaleX: UX.smallScale, y: UX.smallScale)
                     .translatedBy(x: 0, y: yOffset)
                 self.transform = scaledTransformation
+                /* Ecosia: Keep `urlTextField` interactive even while the location view is in its compact pill form.
+                   With interaction disabled the tap that visually hits the pill is dropped on the floor — no
+                   gesture in the toolbar fires, so the toolbar never re-expands (and the container-level tap
+                   can't compensate when the pill is the only thing covering the tap point). Letting the text
+                   field receive the tap routes it through the normal `textFieldDidBeginEditing` →
+                   `addressToolbarDidBeginEditing` pipeline, which both expands the bar and enters overlay mode.
+                self.urlTextField.isUserInteractionEnabled = false
+                 */
             })
     }
 

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -501,6 +501,15 @@ final class LocationView: UIView,
             hasHomeIndicator ? UX.bottomAddressBarYoffset : UX.bottomAddressBarYoffsetForHomeButton
         }
         let yOffset: CGFloat = (barPosition == .bottom && !isiPad) ? bottomAddressBarYoffset : UX.topAddressBarYoffset
+        // Ecosia: Keep `urlTextField` interactive even while the location
+        // view is in its compact pill form. With interaction disabled the
+        // tap that visually hits the pill is dropped on the floor — no
+        // gesture in the toolbar fires, so the toolbar never re-expands
+        // (and the container-level tap can't compensate when the pill is
+        // the only thing covering the tap point). Letting the text field
+        // receive the tap routes it through the normal
+        // `textFieldDidBeginEditing` → `addressToolbarDidBeginEditing`
+        // pipeline, which both expands the bar and enters overlay mode.
         UIView.animate(
             withDuration: UX.identityResetAnimationDuration,
             delay: 0,
@@ -509,7 +518,6 @@ final class LocationView: UIView,
                 let scaledTransformation = CGAffineTransform(scaleX: UX.smallScale, y: UX.smallScale)
                     .translatedBy(x: 0, y: yOffset)
                 self.transform = scaledTransformation
-                self.urlTextField.isUserInteractionEnabled = false
             })
     }
 

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Omnibox.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Omnibox.swift
@@ -57,9 +57,6 @@ extension BrowserViewController: NTPSearchBarDelegate {
             hideOmniboxSuggestions()
             return
         }
-        // Always show suggestions while there's content — no length-based
-        // suppression. Inferring "AI chat intent" from input length is
-        // server-side concern; the client just feeds the query.
         showOmniboxSuggestions(searchTerm: searchTerm, anchorView: anchor)
     }
 

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Omnibox.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Omnibox.swift
@@ -12,7 +12,7 @@ import Ecosia
 // standard toolbar; live keystrokes feed the shared suggestions overlay.
 @MainActor
 extension BrowserViewController: NTPSearchBarDelegate {
-    func ntpSearchBarDidSubmit(_ searchTerm: String, mode: NTPSearchBarSubmitMode) {
+    func ntpSearchBarDidSubmit(_ searchTerm: String) {
         // Mark the session engaged before tearing down the suggestions so the
         // existing `searchViewControllerWillHide` → `recordURLBarSearchEngagementTelemetryEvent`
         // pipeline records the omnibox submit the same way the URL bar would.
@@ -25,36 +25,20 @@ extension BrowserViewController: NTPSearchBarDelegate {
             bar.text = ""
             _ = bar.resignFirstResponder()
         }
-        switch mode {
-        case .search:
-            submitOmniboxSearch(query: searchTerm)
-        case .aiChat:
-            submitOmniboxAIChat(query: searchTerm)
-        }
+        submitOmniboxSearch(query: searchTerm)
         // Force the swap to the webview. Without URL bar overlay mode, the
         // standard `addressToolbar(_:didLeaveOverlayModeForReason:)` chain
         // — which is what normally calls `showEmbeddedWebview()` — never fires.
         showEmbeddedWebview()
     }
 
-    /// Routes a long-prompt submit (above the omnibox AI threshold) into the
-    /// AI search backend. Mirrors `handleAIChatSelection` in
-    /// `SearchViewController+Ecosia` but loads through the active tab since
-    /// the omnibox keyboard-Done path doesn't go through the search delegate.
-    private func submitOmniboxAIChat(query: String) {
-        guard let tab = tabManager.selectedTab else { return }
-        let url = Environment.current.urlProvider.aiChat(origin: .omnibox, query: query)
-        searchTelemetry.shouldSetUrlTypeSearch = true
-        finishEditingAndSubmit(url, visitType: .typed, forTab: tab)
-    }
-
-    /// Builds the search URL for a `.search`-mode omnibox submission (direct
-    /// typed submit or autocomplete row tap) and loads it. Pasted URLs
-    /// navigate directly; everything else goes through Ecosia's `urlProvider`
-    /// via `URL.ecosiaSearchWithQuery` with `autoRedirect: true`, which
-    /// appends the `ar=1` parameter so the backend can decide whether the
-    /// query lands on AI search or the standard SERP.
-    /// `.aiChat` mode is handled separately by `submitOmniboxAIChat`.
+    /// Builds the search URL for an omnibox submission (direct typed submit
+    /// or autocomplete row tap) and loads it. Pasted URLs navigate directly;
+    /// everything else goes through Ecosia's `urlProvider` via
+    /// `URL.ecosiaSearchWithQuery` with `autoRedirect: true`, which appends
+    /// the `ar=1` parameter so the backend can decide whether the query
+    /// lands on AI search or the standard SERP — the client never makes that
+    /// call itself.
     private func submitOmniboxSearch(query: String) {
         guard let tab = tabManager.selectedTab else { return }
 
@@ -73,28 +57,10 @@ extension BrowserViewController: NTPSearchBarDelegate {
             hideOmniboxSuggestions()
             return
         }
-        if anchor.isMultiline {
-            // Past two lines the suggestions rows aren't useful anymore, but
-            // we keep the overlay attached so its colored background stays
-            // visible behind the pill (only the table content is hidden).
-            ensureOmniboxSuggestionsAttached(anchorView: anchor)
-            searchController?.tableView.isHidden = true
-            return
-        }
-        searchController?.tableView.isHidden = false
+        // Always show suggestions while there's content — no length-based
+        // suppression. Inferring "AI chat intent" from input length is
+        // server-side concern; the client just feeds the query.
         showOmniboxSuggestions(searchTerm: searchTerm, anchorView: anchor)
-    }
-
-    /// Attaches the suggestions overlay (creating the search controller if
-    /// needed) without populating its query — used for the multi-line state
-    /// where we want the background visible but no rows.
-    private func ensureOmniboxSuggestionsAttached(anchorView: UIView & Autocompletable) {
-        createSearchControllerIfNeeded()
-        guard let searchController else { return }
-        searchLoader?.autocompleteView = anchorView
-        if searchController.parent == nil {
-            attachOmniboxSuggestions(anchorView: anchorView)
-        }
     }
 
     func ntpSearchBarDidBeginEditing() {

--- a/firefox-ios/Client/Ecosia/Extensions/HomepageSectionLayoutProvider+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/HomepageSectionLayoutProvider+Ecosia.swift
@@ -164,11 +164,12 @@ extension HomepageSectionLayoutProvider {
             numberOfTilesPerRow: numberOfTilesPerRow
         )
         let edgeInset: CGFloat = traitCollection.horizontalSizeClass == .regular ? 100 : .ecosia.space._s
-        /* TopSites row uses 8 pt (EcosiaSpacing._1s) top and 26 pt bottom padding
-           so the row height equals TopSiteCell height + those insets.
+        /* TopSites row uses 16 pt (EcosiaSpacing._m) top so the row sits
+           noticeably below the impact tiles above it, and 24 pt bottom
+           (EcosiaSpacing._1l) so the gap to the omnibox stays balanced.
          */
         let insets = NSDirectionalEdgeInsets(
-            top: .ecosia.space._1s,
+            top: .ecosia.space._m,
             leading: edgeInset,
             bottom: .ecosia.space._1l,
             trailing: edgeInset

--- a/firefox-ios/Client/Ecosia/Extensions/HomepageViewController+EcosiaSetup.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/HomepageViewController+EcosiaSetup.swift
@@ -69,7 +69,7 @@ extension HomepageViewController: @MainActor HomepageDataModelDelegate {
 
         let bottomConstraint = searchBar.bottomAnchor.constraint(
             equalTo: view.safeAreaLayoutGuide.bottomAnchor,
-            constant: -.ecosia.space._s
+            constant: -.ecosia.space._l
         )
         let horizontalInset = Self.ntpSearchBarHorizontalInset(for: traitCollection)
         let leadingConstraint = searchBar.leadingAnchor.constraint(
@@ -387,7 +387,7 @@ extension HomepageViewController: @MainActor HomepageDataModelDelegate {
 // MARK: - KeyboardHelperDelegate
 // Ecosia: Keeps the omnibox glued just above the keyboard while editing.
 extension HomepageViewController: KeyboardHelperDelegate {
-    private static let restingBottomOffset: CGFloat = .ecosia.space._s
+    private static let restingBottomOffset: CGFloat = .ecosia.space._l
 
     public func keyboardHelper(
         _ keyboardHelper: KeyboardHelper,

--- a/firefox-ios/Client/Ecosia/UI/NTP/Impact/NTPImpactRowView.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/Impact/NTPImpactRowView.swift
@@ -152,6 +152,10 @@ final class NTPImpactRowView: UIView, ThemeApplicable {
         // honour the corner radius via `layer.cornerRadius`, so the rounded
         // card outline stays intact.
         clipsToBounds = false
+        // Mirror the row's rounding on the glass background so its sharp
+        // rectangle corners don't peek past the rounded border outline.
+        // Without this, the trailing top/bottom corners look ragged.
+        glassBackground.layer.cornerRadius = .ecosia.borderRadius._l
         addSubview(glassBackground)
 
         labelsStack.addArrangedSubview(titleLabel)

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPSearchBarView.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPSearchBarView.swift
@@ -8,20 +8,13 @@ import Ecosia
 
 // MARK: - Delegate
 
-/// Whether a submission should route to the standard search pipeline or the
-/// long-form AI chat. The omnibox flips into `.aiChat` once the input crosses
-/// the configured threshold (see `NTPSearchBarView.UX.aiChatThreshold`).
-enum NTPSearchBarSubmitMode {
-    case search
-    case aiChat
-}
-
 @MainActor
 protocol NTPSearchBarDelegate: AnyObject {
     /// Called when the user commits a query (Return key or submit button).
-    /// `mode` indicates whether the input should be treated as a search query
-    /// or a long-form AI chat prompt.
-    func ntpSearchBarDidSubmit(_ searchTerm: String, mode: NTPSearchBarSubmitMode)
+    /// Submissions always go through the standard search pipeline — the
+    /// client doesn't attempt to infer "AI chat intent" from the input
+    /// length or content.
+    func ntpSearchBarDidSubmit(_ searchTerm: String)
     /// Called on every keystroke so the browser can feed suggestions.
     func ntpSearchBarTextDidChange(_ searchTerm: String)
     /// Called when the text field becomes first responder.
@@ -67,9 +60,6 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable {
         static let shadowOpacity: Float = 0.10
         static let shadowRadius: CGFloat = 12
         static let shadowOffset = CGSize(width: 0, height: 4)
-        /// At/above this character count, submit routes to AI chat instead of
-        /// the standard search pipeline.
-        static let aiChatThreshold = 60
         /// Character count at which the remaining-character counter becomes
         /// visible.
         static let counterVisibleThreshold = 100
@@ -78,9 +68,6 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable {
         static let counterWarningThreshold = 960
         /// Hard cap on input length. Further input is rejected.
         static let maxLength = 1060
-        /// Once the input wraps past this many lines, the suggestions overlay
-        /// is suppressed and the pill grows upward to fit the content.
-        static let multilineThreshold = 2
         /// Padding between the textView and the pill's top edge.
         static let textPadding: CGFloat = .ecosia.space._m
         /// Vertical footprint of the bottom-controls row (submit button + its
@@ -176,15 +163,8 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable {
     var onFocusChange: ((Bool) -> Void)?
 
     private var currentTheme: Theme?
-    private var currentSubmitMode: NTPSearchBarSubmitMode = .search
     private lazy var textViewHeightConstraint: NSLayoutConstraint =
         textView.heightAnchor.constraint(equalToConstant: UX.minTextHeight)
-
-    /// True once the text wraps past `UX.multilineThreshold` lines. The host
-    /// reads this in `ntpSearchBarTextDidChange` to suppress the suggestions
-    /// overlay — once the user is composing a long-form prompt, the short-form
-    /// suggestions are no longer useful.
-    private(set) var isMultiline = false
 
     /// Current text content. Mirrors `textView.text` but lets callers drive
     /// programmatic changes (e.g. accepting a tapped suggestion).
@@ -331,7 +311,7 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable {
         let text = (textView.text ?? "").trimmingCharacters(in: .whitespaces)
         guard !text.isEmpty else { return }
         textView.resignFirstResponder()
-        delegate?.ntpSearchBarDidSubmit(text, mode: currentSubmitMode)
+        delegate?.ntpSearchBarDidSubmit(text)
     }
 
     @objc private func clearTapped() {
@@ -347,21 +327,12 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable {
         onContentChange?("")
     }
 
-    /// Recomputes the textView height (and therefore the pill height) and the
-    /// `isMultiline` flag from the current content. The pill grows from
-    /// `minHeight` up to `maxHeight`; past the cap the textView starts
-    /// scrolling internally instead of pushing further upward.
+    /// Recomputes the textView height (and therefore the pill height) from
+    /// the current content. The pill grows from `minHeight` up to `maxHeight`;
+    /// past the cap the textView starts scrolling internally instead of
+    /// pushing further upward.
     private func updateLayoutForContent() {
-        let lineHeight = textView.font?.lineHeight ?? 22
-        // contentSize includes textContainerInset on top + bottom — strip
-        // those out before counting lines so the threshold matches the
-        // visible text rather than the reserved bottom-row spacer.
-        let inset = textView.textContainerInset
         let contentHeight = textView.contentSize.height
-        let textOnlyHeight = max(0, contentHeight - inset.top - inset.bottom)
-        let lineCount = max(1, Int((textOnlyHeight / lineHeight).rounded()))
-        isMultiline = lineCount > UX.multilineThreshold
-
         let clamped = min(UX.maxTextHeight, max(UX.minTextHeight, contentHeight))
         if textViewHeightConstraint.constant != clamped {
             textViewHeightConstraint.constant = clamped
@@ -374,12 +345,7 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable {
     private func updateSubmitState(for text: String) {
         let hasContent = !text.trimmingCharacters(in: .whitespaces).isEmpty
         submitButton.isEnabled = hasContent
-        currentSubmitMode = Self.submitMode(for: text)
         applySubmitButtonColors()
-    }
-
-    private static func submitMode(for text: String) -> NTPSearchBarSubmitMode {
-        text.count >= UX.aiChatThreshold ? .aiChat : .search
     }
 
     private func updateCounter(for text: String) {
@@ -525,9 +491,6 @@ extension NTPSearchBarView: @MainActor @preconcurrency UITextViewDelegate {
         updateSubmitState(for: text)
         updateCounter(for: text)
         updateClearButtonVisibility(for: text)
-        // Update layout BEFORE notifying the host so it can read
-        // `isMultiline` from `ntpSearchBarTextDidChange` and decide whether
-        // to suppress the suggestions overlay.
         updateLayoutForContent()
         delegate?.ntpSearchBarTextDidChange(text)
         onContentChange?(text)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -4700,7 +4700,7 @@ extension BrowserViewController: SearchViewControllerDelegate {
         let isOmniboxOverlay = self.searchController?.parent is HomepageViewController
         if isOmniboxOverlay {
             if let searchTerm, !searchTerm.isEmpty {
-                ntpSearchBarDidSubmit(searchTerm, mode: .search)
+                ntpSearchBarDidSubmit(searchTerm)
                 return
             }
             hideOmniboxSuggestions()

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -4218,6 +4218,13 @@ class BrowserViewController: UIViewController,
     func addressToolbarDidEnterOverlayMode(_ view: UIView) {
         guard let profile = profile as? BrowserProfile else { return }
 
+        // Ecosia: If the user tapped the URL bar while it was scroll-collapsed
+        // into its minimal pill form, expand the toolbar back to its full
+        // size before entering overlay/edit mode — otherwise the pill just
+        // grows a caret and shows a tiny edit field instead of the proper
+        // full-width address bar.
+        scrollController.showToolbars(animated: true)
+
         if let isHomeTab = tabManager.selectedTab?.isFxHomeTab,
            featureFlags.isFeatureEnabled(.homepageScrim, checking: .buildOnly) && isHomeTab {
             configureHomepageZeroSearchView()

--- a/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -724,11 +724,20 @@ class SearchViewController: SiteTableViewController,
         reloadData()
     }
 
+    // Ecosia: Require the suggestion to truly start with the query and the
+    // extension to be more than a single character. The original
+    // `range(of:)` accepted any substring match, and any 1-character
+    // extension would render a single bold letter — which produced a
+    // distracting flicker as the user typed past it (e.g. typing the last
+    // letter of an autocomplete match briefly bolded that letter before
+    // the suggestion was removed/refreshed). A 2+ character minimum keeps
+    // the bold styling meaningful and stops the trailing-letter flicker.
     func getAttributedBoldSearchSuggestions(searchPhrase: String, query: String) -> NSAttributedString? {
-        // the search term (query) stays normal weight
-        // everything past the search term (query) will be bold
-        let range = searchPhrase.range(of: query)
-        guard searchPhrase != query, let upperBound = range?.upperBound else { return nil }
+        guard searchPhrase != query,
+              searchPhrase.hasPrefix(query) else { return nil }
+        let upperBound = searchPhrase.index(searchPhrase.startIndex, offsetBy: query.count)
+        let extensionLength = searchPhrase.distance(from: upperBound, to: searchPhrase.endIndex)
+        guard extensionLength > 1 else { return nil }
 
         let attributedString = searchPhrase.attributedText(
             boldIn: upperBound..<searchPhrase.endIndex,

--- a/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -724,15 +724,18 @@ class SearchViewController: SiteTableViewController,
         reloadData()
     }
 
-    // Ecosia: Require the suggestion to truly start with the query and the
-    // extension to be more than a single character. The original
-    // `range(of:)` accepted any substring match, and any 1-character
-    // extension would render a single bold letter — which produced a
-    // distracting flicker as the user typed past it (e.g. typing the last
-    // letter of an autocomplete match briefly bolded that letter before
-    // the suggestion was removed/refreshed). A 2+ character minimum keeps
-    // the bold styling meaningful and stops the trailing-letter flicker.
     func getAttributedBoldSearchSuggestions(searchPhrase: String, query: String) -> NSAttributedString? {
+        /* Ecosia: Require the suggestion to truly start with the query and the extension to be more than a
+           single character. The original `range(of:)` accepted any substring match, and any 1-character
+           extension would render a single bold letter — which produced a distracting flicker as the user typed
+           past it (e.g. typing the last letter of an autocomplete match briefly bolded that letter before the
+           suggestion was removed/refreshed). A 2+ character minimum keeps the bold styling meaningful and stops
+           the trailing-letter flicker.
+        // the search term (query) stays normal weight
+        // everything past the search term (query) will be bold
+        let range = searchPhrase.range(of: query)
+        guard searchPhrase != query, let upperBound = range?.upperBound else { return nil }
+         */
         guard searchPhrase != query,
               searchPhrase.hasPrefix(query) else { return nil }
         let upperBound = searchPhrase.index(searchPhrase.startIndex, offsetBy: query.count)

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
@@ -290,12 +290,12 @@ final class LegacyTabScrollController: NSObject,
 
     func createToolbarTapHandler() -> (() -> Void) {
         return { [unowned self] in
-            // Ecosia: Drop the `.collapsed` guard. When the toolbar is in
-            // its minimal pill form the state and visuals can drift apart
-            // (especially across animations / scroll transitions), so a
-            // tap that visually hits the pill but lands while `toolbarState`
-            // is still `.transitioning` would otherwise no-op. `showToolbars`
-            // already guards itself against re-entry from `.visible`.
+            /* Ecosia: Drop the `.collapsed` guard. When the toolbar is in its minimal pill form the state and
+               visuals can drift apart (especially across animations / scroll transitions), so a tap that
+               visually hits the pill but lands while `toolbarState` is still `.transitioning` would otherwise
+               no-op. `showToolbars` already guards itself against re-entry from `.visible`.
+            guard isMinimalAddressBarEnabled && toolbarState == .collapsed else { return }
+             */
             guard isMinimalAddressBarEnabled else { return }
             showToolbars(animated: true)
         }

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
@@ -290,7 +290,13 @@ final class LegacyTabScrollController: NSObject,
 
     func createToolbarTapHandler() -> (() -> Void) {
         return { [unowned self] in
-            guard isMinimalAddressBarEnabled && toolbarState == .collapsed else { return }
+            // Ecosia: Drop the `.collapsed` guard. When the toolbar is in
+            // its minimal pill form the state and visuals can drift apart
+            // (especially across animations / scroll transitions), so a
+            // tap that visually hits the pill but lands while `toolbarState`
+            // is still `.transitioning` would otherwise no-op. `showToolbars`
+            // already guards itself against re-entry from `.visible`.
+            guard isMinimalAddressBarEnabled else { return }
             showToolbars(animated: true)
         }
     }

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollHandler.swift
@@ -295,7 +295,13 @@ final class TabScrollHandler: NSObject,
 
     func createToolbarTapHandler() -> (() -> Void) {
         return { [unowned self] in
-            guard isMinimalAddressBarEnabled && toolbarDisplayState.isCollapsed  else { return }
+            // Ecosia: Drop the `isCollapsed` guard. When the toolbar is in
+            // its minimal pill form the state and visuals can drift apart
+            // (especially under iOS 26 translucency), so a tap that visually
+            // hits the pill but lands while `displayState` is still
+            // `.transitioning` would otherwise no-op. `showToolbars` is
+            // idempotent — calling it from `.expanded` is harmless.
+            guard isMinimalAddressBarEnabled else { return }
             showToolbars(animated: true)
         }
     }

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollHandler.swift
@@ -295,12 +295,12 @@ final class TabScrollHandler: NSObject,
 
     func createToolbarTapHandler() -> (() -> Void) {
         return { [unowned self] in
-            // Ecosia: Drop the `isCollapsed` guard. When the toolbar is in
-            // its minimal pill form the state and visuals can drift apart
-            // (especially under iOS 26 translucency), so a tap that visually
-            // hits the pill but lands while `displayState` is still
-            // `.transitioning` would otherwise no-op. `showToolbars` is
-            // idempotent — calling it from `.expanded` is harmless.
+            /* Ecosia: Drop the `isCollapsed` guard. When the toolbar is in its minimal pill form the state and
+               visuals can drift apart (especially under iOS 26 translucency), so a tap that visually hits the
+               pill but lands while `displayState` is still `.transitioning` would otherwise no-op.
+               `showToolbars` is idempotent — calling it from `.expanded` is harmless.
+            guard isMinimalAddressBarEnabled && toolbarDisplayState.isCollapsed  else { return }
+             */
             guard isMinimalAddressBarEnabled else { return }
             showToolbars(animated: true)
         }


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-4300]

## Context

Apart from **2. Token used for the shortcuts is different than the global counter** issues found by QA shall be fixed now.

## Approach

## Other

## Before merging

### Checklist

- [ ] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [ ] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4300]: https://ecosia.atlassian.net/browse/MOB-4300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ