### PR TITLE
[DC-4291] Searches retain vertical upon subsequent searches

### DIFF
--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+EcosiaNavigationHandling.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+EcosiaNavigationHandling.swift
@@ -39,4 +39,25 @@ extension BrowserViewController {
         pendingInappSearchUrl = nil
         Analytics.shared.inappSearch(url: url, isPrivate: isPrivate)
     }
+
+    /// Rewrites in-page SERP navigations that target the default text vertical (`/search`) so they
+    /// stay on the user's active vertical (e.g. Images). Returns `nil` when navigation should proceed unchanged.
+    func ecosiaSearchURLPreservingVertical(
+        navigationURL: URL,
+        currentPageURL: URL?,
+        navigationType: WKNavigationType
+    ) -> URL? {
+        guard let rewritten = navigationURL.ecosiaSearchURLPreservingVertical(from: currentPageURL) else {
+            return nil
+        }
+        // Same-query link to `/search` is a vertical-tab switch (e.g. Web from Images), not a new search.
+        if navigationType == .linkActivated,
+           let currentPageURL,
+           let currentQuery = currentPageURL.getEcosiaSearchQuery(),
+           let newQuery = navigationURL.getEcosiaSearchQuery(),
+           currentQuery == newQuery {
+            return nil
+        }
+        return rewritten
+    }
 }

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+EcosiaNavigationHandling.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+EcosiaNavigationHandling.swift
@@ -60,4 +60,43 @@ extension BrowserViewController {
         }
         return rewritten
     }
+
+    /// Returns `true` when navigation was rewritten to preserve the active SERP vertical.
+    @discardableResult
+    func ecosiaApplyVerticalPreservingSearchNavigationIfNeeded(
+        navigationURL: URL,
+        currentPageURL: URL?,
+        navigationType: WKNavigationType,
+        tab: Tab
+    ) -> Bool {
+        guard let rewritten = ecosiaSearchURLPreservingVertical(
+            navigationURL: navigationURL,
+            currentPageURL: currentPageURL,
+            navigationType: navigationType
+        ) else {
+            return false
+        }
+        tab.loadRequest(URLRequest(url: rewritten))
+        return true
+    }
+
+    /// Cancels navigation when it was rewritten to preserve the active SERP vertical.
+    func ecosiaCancelNavigationPreservingVerticalIfNeeded(
+        url: URL,
+        webView: WKWebView,
+        tab: Tab,
+        navigationAction: WKNavigationAction,
+        decisionHandler: @escaping @MainActor (WKNavigationActionPolicy) -> Void
+    ) -> Bool {
+        guard ecosiaApplyVerticalPreservingSearchNavigationIfNeeded(
+            navigationURL: url,
+            currentPageURL: webView.url ?? tab.url,
+            navigationType: navigationAction.navigationType,
+            tab: tab
+        ) else {
+            return false
+        }
+        decisionHandler(.cancel)
+        return true
+    }
 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -609,15 +609,13 @@ extension BrowserViewController: WKNavigationDelegate {
             }
 
             // Ecosia: Keep the active vertical for in-page `/search` navigations; run before tracking so analytics see the rewritten URL.
-            if let rewritten = ecosiaSearchURLPreservingVertical(
-                navigationURL: url,
-                currentPageURL: webView.url ?? tab.url,
-                navigationType: navigationAction.navigationType
-            ) {
-                tab.loadRequest(URLRequest(url: rewritten))
-                decisionHandler(.cancel)
-                return
-            }
+            if ecosiaCancelNavigationPreservingVerticalIfNeeded(
+                url: url,
+                webView: webView,
+                tab: tab,
+                navigationAction: navigationAction,
+                decisionHandler: decisionHandler
+            ) { return }
 
             // Ecosia: Handle navigation tracking
             ecosiaHandleNavigationAction(url: url, navigationAction: navigationAction)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -608,10 +608,7 @@ extension BrowserViewController: WKNavigationDelegate {
                 return
             }
 
-            // Ecosia: Handle navigation tracking
-            ecosiaHandleNavigationAction(url: url, navigationAction: navigationAction)
-
-            // Ecosia: In-page SERP searches navigate to `/search`; keep the active vertical.
+            // Ecosia: Keep the active vertical for in-page `/search` navigations; run before tracking so analytics see the rewritten URL.
             if let rewritten = ecosiaSearchURLPreservingVertical(
                 navigationURL: url,
                 currentPageURL: webView.url ?? tab.url,
@@ -621,6 +618,9 @@ extension BrowserViewController: WKNavigationDelegate {
                 decisionHandler(.cancel)
                 return
             }
+
+            // Ecosia: Handle navigation tracking
+            ecosiaHandleNavigationAction(url: url, navigationAction: navigationAction)
 
             let isGoogleDomain = url.host?.contains("google") ?? false
             let isPrivate = tab.isPrivate

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -611,6 +611,17 @@ extension BrowserViewController: WKNavigationDelegate {
             // Ecosia: Handle navigation tracking
             ecosiaHandleNavigationAction(url: url, navigationAction: navigationAction)
 
+            // Ecosia: In-page SERP searches navigate to `/search`; keep the active vertical.
+            if let rewritten = ecosiaSearchURLPreservingVertical(
+                navigationURL: url,
+                currentPageURL: webView.url ?? tab.url,
+                navigationType: navigationAction.navigationType
+            ) {
+                tab.loadRequest(URLRequest(url: rewritten))
+                decisionHandler(.cancel)
+                return
+            }
+
             let isGoogleDomain = url.host?.contains("google") ?? false
             let isPrivate = tab.isPrivate
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -3392,9 +3392,16 @@ class BrowserViewController: UIViewController,
             .add()
         searchTelemetry.shouldSetUrlTypeSearch = true
 
+        /* Ecosia: Preserve the user's current search vertical for follow-up queries so that,
+           e.g., typing a new query from the Images SERP opens Images results, not the default
+           text SERP. We derive the vertical from the tab's current URL; non-search pages and
+           nil URLs fall back to .search.
         finishEditingAndSubmit(searchURL, visitType: VisitType.typed, forTab: tab)
-
         dispatchSubmitSearchTermAction(with: searchURL, searchTerm: text)
+        */
+        let targetURL = URL.ecosiaSearchWithQuery(text, preservingVerticalFrom: tab.url)
+        finishEditingAndSubmit(targetURL, visitType: VisitType.typed, forTab: tab)
+        dispatchSubmitSearchTermAction(with: targetURL, searchTerm: text)
     }
 
     private func dispatchSubmitSearchTermAction(with searchURL: URL, searchTerm: String) {
@@ -4716,7 +4723,12 @@ extension BrowserViewController: SearchViewControllerDelegate {
         }
 
         searchTelemetry.shouldSetUrlTypeSearch = true
+        /* Ecosia: Suggestion rows use `searchURLForQuery`, which always targets `/search`.
+           Preserve the tab's active vertical when the user is on Images/Videos/News.
         finishEditingAndSubmit(url, visitType: VisitType.typed, forTab: tab)
+        */
+        let urlToLoad = url.ecosiaSearchURLPreservingVertical(from: tab.url) ?? url
+        finishEditingAndSubmit(urlToLoad, visitType: VisitType.typed, forTab: tab)
     }
 
     // In searchViewController when user selects an open tabs and switch to it

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -3395,7 +3395,8 @@ class BrowserViewController: UIViewController,
         /* Ecosia: Preserve the user's current search vertical for follow-up queries so that,
            e.g., typing a new query from the Images SERP opens Images results, not the default
            text SERP. We derive the vertical from the tab's current URL; non-search pages and
-           nil URLs fall back to .search.
+           nil URLs fall back to .search. Building the final URL here avoids an extra redirect
+           through the web view delegate, which only rewrites in-page `/search` navigations.
         finishEditingAndSubmit(searchURL, visitType: VisitType.typed, forTab: tab)
         dispatchSubmitSearchTermAction(with: searchURL, searchTerm: text)
         */

--- a/firefox-ios/Ecosia/Core/URL+Extensions.swift
+++ b/firefox-ios/Ecosia/Core/URL+Extensions.swift
@@ -30,23 +30,69 @@ extension URL {
     /// Builds the Ecosia SERP URL for a typed query.
     /// - Parameters:
     ///   - query: The user's search term.
+    ///   - vertical: The search vertical to target. Defaults to `.search` (text results).
     ///   - urlProvider: Provider supplying the search root URL. Defaults to the current environment.
     ///   - autoRedirect: When `true`, appends the `ar=1` query parameter so the backend can decide
     ///     whether the request lands on AI search or the standard SERP. Use this for entry points
     ///     where the routing decision belongs to the backend (e.g. the NTP omnibox).
     public static func ecosiaSearchWithQuery(
         _ query: String,
+        vertical: EcosiaSearchVertical = .search,
         urlProvider: URLProvider = EcosiaEnvironment.current.urlProvider,
         autoRedirect: Bool = false
     ) -> URL {
         var components = URLComponents(url: urlProvider.root, resolvingAgainstBaseURL: false)!
-        components.path = "/search"
+        components.path = "/\(vertical.rawValue)"
         var queryItems = [item(name: .query, value: query), item(name: .typeTag, value: "iosapp")]
         if autoRedirect {
             queryItems.append(item(name: .autoRedirect, value: "1"))
         }
         components.queryItems = queryItems
         return components.url!
+    }
+
+    /// Builds a SERP URL for `query`, keeping the search vertical of `currentPageURL` when the user
+    /// is already on Images, Videos, or News. Falls back to the text SERP for other pages.
+    public static func ecosiaSearchWithQuery(
+        _ query: String,
+        preservingVerticalFrom currentPageURL: URL?,
+        urlProvider: URLProvider = EcosiaEnvironment.current.urlProvider,
+        autoRedirect: Bool = false
+    ) -> URL {
+        let vertical = currentPageURL?.ecosiaSearchVerticalForPreservation(urlProvider: urlProvider) ?? .search
+        return ecosiaSearchWithQuery(
+            query,
+            vertical: vertical,
+            urlProvider: urlProvider,
+            autoRedirect: autoRedirect
+        )
+    }
+
+    /// Non-default vertical on `currentPageURL`, or `.search` when not on a SERP vertical.
+    func ecosiaSearchVerticalForPreservation(
+        urlProvider: URLProvider = EcosiaEnvironment.current.urlProvider
+    ) -> EcosiaSearchVertical {
+        guard let verticalPath = getEcosiaSearchVerticalPath(urlProvider),
+              verticalPath != EcosiaSearchVertical.search.rawValue,
+              let vertical = EcosiaSearchVertical(rawValue: verticalPath) else {
+            return .search
+        }
+        return vertical
+    }
+
+    /// Rewrites a default text SERP (`/search?q=…`) to the vertical of `currentPageURL`.
+    /// Returns `nil` when no rewrite is needed (already on the right vertical, or not a text SERP URL).
+    public func ecosiaSearchURLPreservingVertical(
+        from currentPageURL: URL?,
+        urlProvider: URLProvider = EcosiaEnvironment.current.urlProvider
+    ) -> URL? {
+        guard isEcosiaSearchQuery(urlProvider), let query = getEcosiaSearchQuery(urlProvider) else {
+            return nil
+        }
+        let vertical = currentPageURL?.ecosiaSearchVerticalForPreservation(urlProvider: urlProvider) ?? .search
+        guard vertical != .search else { return nil }
+        let rewritten = URL.ecosiaSearchWithQuery(query, vertical: vertical, urlProvider: urlProvider)
+        return rewritten.absoluteString == absoluteString ? nil : rewritten
     }
 
     /// Check whether the URL being browsed will present the SERP out of a search or a search suggestion

--- a/firefox-ios/Ecosia/Core/URL+Extensions.swift
+++ b/firefox-ios/Ecosia/Core/URL+Extensions.swift
@@ -25,6 +25,14 @@ extension URL {
             let pathWithNoLeadingSlash = String(path.dropFirst())
             self.init(rawValue: pathWithNoLeadingSlash)
         }
+
+        init?(url: URL, urlProvider: URLProvider = EcosiaEnvironment.current.urlProvider) {
+            guard url.isEcosia(urlProvider),
+                  let path = URLComponents(url: url, resolvingAgainstBaseURL: false)?.path else {
+                return nil
+            }
+            self.init(path: path)
+        }
     }
 
     /// Builds the Ecosia SERP URL for a typed query.
@@ -68,16 +76,11 @@ extension URL {
         )
     }
 
-    /// Non-default vertical on `currentPageURL`, or `.search` when not on a SERP vertical.
+    /// Search vertical on `currentPageURL`, or `.search` when not on a SERP vertical.
     func ecosiaSearchVerticalForPreservation(
         urlProvider: URLProvider = EcosiaEnvironment.current.urlProvider
     ) -> EcosiaSearchVertical {
-        guard let verticalPath = getEcosiaSearchVerticalPath(urlProvider),
-              verticalPath != EcosiaSearchVertical.search.rawValue,
-              let vertical = EcosiaSearchVertical(rawValue: verticalPath) else {
-            return .search
-        }
-        return vertical
+        EcosiaSearchVertical(url: self, urlProvider: urlProvider) ?? .search
     }
 
     /// Rewrites a default text SERP (`/search?q=…`) to the vertical of `currentPageURL`.
@@ -109,11 +112,7 @@ extension URL {
     }
 
     public func getEcosiaSearchVerticalPath(_ urlProvider: URLProvider = EcosiaEnvironment.current.urlProvider) -> String? {
-        guard isEcosia(urlProvider),
-              let components = components else {
-            return nil
-        }
-        return EcosiaSearchVertical(path: components.path)?.rawValue
+        EcosiaSearchVertical(url: self, urlProvider: urlProvider)?.rawValue
     }
 
     public func getEcosiaSearchQuery(_ urlProvider: URLProvider = EcosiaEnvironment.current.urlProvider) -> String? {

--- a/firefox-ios/EcosiaTests/Core/URLTests.swift
+++ b/firefox-ios/EcosiaTests/Core/URLTests.swift
@@ -45,6 +45,139 @@ final class URLTests: XCTestCase, @unchecked Sendable {
         waitForExpectations(timeout: 1)
     }
 
+    func testSearchUrl_defaultVertical_producesSearchPath() {
+        let expect = expectation(description: "")
+        User.queue.async {
+            XCTAssertEqual(
+                self.root + "/search?q=trees&tt=iosapp",
+                URL.ecosiaSearchWithQuery("trees", urlProvider: self.urlProvider).absoluteString
+            )
+            expect.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    func testSearchUrl_imagesVertical_producesImagesPath() {
+        let expect = expectation(description: "")
+        User.queue.async {
+            XCTAssertEqual(
+                self.root + "/images?q=trees&tt=iosapp",
+                URL.ecosiaSearchWithQuery("trees", vertical: .images, urlProvider: self.urlProvider).absoluteString
+            )
+            expect.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    func testSearchUrl_videosVertical_producesVideosPath() {
+        let expect = expectation(description: "")
+        User.queue.async {
+            XCTAssertEqual(
+                self.root + "/videos?q=trees&tt=iosapp",
+                URL.ecosiaSearchWithQuery("trees", vertical: .videos, urlProvider: self.urlProvider).absoluteString
+            )
+            expect.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    func testSearchUrl_newsVertical_producesNewsPath() {
+        let expect = expectation(description: "")
+        User.queue.async {
+            XCTAssertEqual(
+                self.root + "/news?q=trees&tt=iosapp",
+                URL.ecosiaSearchWithQuery("trees", vertical: .news, urlProvider: self.urlProvider).absoluteString
+            )
+            expect.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    // MARK: - `EcosiaSearchVertical(path:)` — used by vertical retention logic
+
+    func testEcosiaSearchVerticalInit_searchPath_returnsSearch() {
+        XCTAssertEqual(URL.EcosiaSearchVertical(path: "/search"), .search)
+    }
+
+    func testEcosiaSearchVerticalInit_imagesPath_returnsImages() {
+        XCTAssertEqual(URL.EcosiaSearchVertical(path: "/images"), .images)
+    }
+
+    func testEcosiaSearchVerticalInit_videosPath_returnsVideos() {
+        XCTAssertEqual(URL.EcosiaSearchVertical(path: "/videos"), .videos)
+    }
+
+    func testEcosiaSearchVerticalInit_newsPath_returnsNews() {
+        XCTAssertEqual(URL.EcosiaSearchVertical(path: "/news"), .news)
+    }
+
+    func testEcosiaSearchVerticalInit_nonSearchPath_returnsNil() {
+        XCTAssertNil(URL.EcosiaSearchVertical(path: "/wiki/Forest"))
+        XCTAssertNil(URL.EcosiaSearchVertical(path: "/settings"))
+        XCTAssertNil(URL.EcosiaSearchVertical(path: "/"))
+    }
+
+    // MARK: - Vertical preservation
+
+    func testPreservingVerticalFrom_imagesPage_producesImagesPath() {
+        let expect = expectation(description: "")
+        let imagesPage = URL(string: "https://www.ecosia.org/images?q=trees")!
+        User.queue.async {
+            XCTAssertEqual(
+                self.root + "/images?q=flowers&tt=iosapp",
+                URL.ecosiaSearchWithQuery("flowers", preservingVerticalFrom: imagesPage, urlProvider: self.urlProvider).absoluteString
+            )
+            expect.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    func testPreservingVerticalFrom_searchPage_producesSearchPath() {
+        let expect = expectation(description: "")
+        let searchPage = URL(string: "https://www.ecosia.org/search?q=trees")!
+        User.queue.async {
+            XCTAssertEqual(
+                self.root + "/search?q=flowers&tt=iosapp",
+                URL.ecosiaSearchWithQuery("flowers", preservingVerticalFrom: searchPage, urlProvider: self.urlProvider).absoluteString
+            )
+            expect.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    func testPreservingVerticalFrom_nonSearchPage_producesSearchPath() {
+        let expect = expectation(description: "")
+        let wikiPage = URL(string: "https://www.ecosia.org/wiki/Forest")!
+        User.queue.async {
+            XCTAssertEqual(
+                self.root + "/search?q=flowers&tt=iosapp",
+                URL.ecosiaSearchWithQuery("flowers", preservingVerticalFrom: wikiPage, urlProvider: self.urlProvider).absoluteString
+            )
+            expect.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    func testRewriteTextSerp_preservesImagesVertical() {
+        let imagesPage = URL(string: "https://www.ecosia.org/images?q=trees")!
+        let textSerp = URL(string: "https://www.ecosia.org/search?q=flowers")!
+        let rewritten = textSerp.ecosiaSearchURLPreservingVertical(from: imagesPage, urlProvider: urlProvider)
+        XCTAssertEqual(rewritten?.path, "/images")
+        XCTAssertEqual(rewritten?.getEcosiaSearchQuery(urlProvider), "flowers")
+    }
+
+    func testRewriteTextSerp_sameQueryOnSearchPage_doesNotRewrite() {
+        let searchPage = URL(string: "https://www.ecosia.org/search?q=trees")!
+        let textSerp = URL(string: "https://www.ecosia.org/search?q=flowers")!
+        XCTAssertNil(textSerp.ecosiaSearchURLPreservingVertical(from: searchPage, urlProvider: urlProvider))
+    }
+
+    func testRewriteTextSerp_alreadyOnImages_doesNotRewrite() {
+        let imagesPage = URL(string: "https://www.ecosia.org/images?q=flowers")!
+        let imagesSerp = URL(string: "https://www.ecosia.org/images?q=flowers")!
+        XCTAssertNil(imagesSerp.ecosiaSearchURLPreservingVertical(from: imagesPage, urlProvider: urlProvider))
+    }
+
     // MARK: - `isEcosiaSearchQuery`
 
     func testAssertIsNotEcosiaSearchURLOnNonEcosiaURL() {

--- a/firefox-ios/EcosiaTests/Core/URLTests.swift
+++ b/firefox-ios/EcosiaTests/Core/URLTests.swift
@@ -117,6 +117,17 @@ final class URLTests: XCTestCase, @unchecked Sendable {
         XCTAssertNil(URL.EcosiaSearchVertical(path: "/"))
     }
 
+    func testEcosiaSearchVerticalInit_url_returnsMatchingVertical() {
+        let imagesURL = URL(string: "https://www.ecosia.org/images?q=trees")!
+        XCTAssertEqual(URL.EcosiaSearchVertical(url: imagesURL, urlProvider: urlProvider), .images)
+
+        let searchURL = URL(string: "https://www.ecosia.org/search?q=trees")!
+        XCTAssertEqual(URL.EcosiaSearchVertical(url: searchURL, urlProvider: urlProvider), .search)
+
+        let settingsURL = URL(string: "https://www.ecosia.org/settings")!
+        XCTAssertNil(URL.EcosiaSearchVertical(url: settingsURL, urlProvider: urlProvider))
+    }
+
     // MARK: - Vertical preservation
 
     func testPreservingVerticalFrom_imagesPage_producesImagesPath() {


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[DC-4291]

## Context

On an Ecosia SERP, switching verticals (e.g. Images) updates the page in the WebView. A follow-up search often navigates to the default text SERP (`/search?q=…`) instead of staying on the active vertical.

That happens across several native paths: address-bar submit, suggestion selection, and in-page SERP search (WebView navigation). `URL.ecosiaSearchWithQuery` always built `/search` URLs.

## Approach

- Add a `vertical` parameter to `URL.ecosiaSearchWithQuery`, plus helpers to build or rewrite URLs while preserving the vertical from the current page (`preservingVerticalFrom`, `ecosiaSearchURLPreservingVertical`).
- **Address bar submit** (`submitSearchText`): build the target URL from `tab.url` so Images/Videos/News are kept.
- **Suggestion overlay** (`searchViewController(didSelectURL:)`): rewrite `/search` URLs from `searchURLForQuery` before loading.
- **In-page SERP search** (`decidePolicyFor`): intercept navigations to `/search` and rewrite to the active vertical; skip rewrite when the user switches to the Web tab (same query, `linkActivated`).
- Unit tests in `URLTests` for vertical URL building and rewrite logic.

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I wrote Unit Tests that confirm the expected behaviour
- [] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [x] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed