### PR TITLE
[MOB-4293] Make url bar reveal queries instead of URL

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -185,6 +185,9 @@ final class LocationView: UIView,
         configureLockIconButton(config)
         configureURLTextField(config)
         configureA11y(config)
+        // Ecosia: Set searchTerm before formatAndTruncateURLTextField so the guard in that
+        // method sees the latest value and skips URL truncation when a search query is present.
+        searchTerm = config.searchTerm
         formatAndTruncateURLTextField()
         updateIconContainer(iconContainerCornerRadius: uxConfig.toolbarCornerRadius,
                             isURLTextFieldCentered: isURLTextFieldCentered,
@@ -197,7 +200,10 @@ final class LocationView: UIView,
         )
         self.delegate = delegate
         self.isUnifiedSearchEnabled = isUnifiedSearchEnabled
+        /* Ecosia: Moved above formatAndTruncateURLTextField so that method's guard can
+           read the updated searchTerm and skip URL truncation on search result pages.
         searchTerm = config.searchTerm
+        */
         onLongPress = config.onLongPress
 
         layoutContainerView(isEditing: config.isEditing, isURLTextFieldCentered: isURLTextFieldCentered)
@@ -593,7 +599,12 @@ final class LocationView: UIView,
         // Once the user started typing we should not update the text anymore as that interferes with
         // setting the autocomplete suggestions which is done using a delegate method.
         guard !config.didStartTyping else { return }
+        /* Ecosia: Show the search query in the collapsed address bar when on a SERP.
+           Firefox only showed the search term while editing; Ecosia shows it in both
+           editing and collapsed states so users always see what they searched for.
         let shouldShowSearchTerm = (config.searchTerm != nil) && configurationIsEditing
+        */
+        let shouldShowSearchTerm = config.searchTerm != nil
         let text = shouldShowSearchTerm ? config.searchTerm : config.url?.absoluteString
         urlTextField.text = text
 
@@ -607,6 +618,9 @@ final class LocationView: UIView,
 
     private func formatAndTruncateURLTextField() {
         guard !isEditing else { return }
+        // Ecosia: When a search query is available the text field already shows it as plain text;
+        // applying URL-style host truncation here would overwrite the query with a hostname.
+        guard searchTerm == nil else { return }
 
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.lineBreakMode = .byTruncatingHead

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -185,10 +185,10 @@ final class LocationView: UIView,
         configureLockIconButton(config)
         configureURLTextField(config)
         configureA11y(config)
-        // Ecosia: Set searchTerm before formatAndTruncateURLTextField so the guard in that
-        // method sees the latest value and skips URL truncation when a search query is present.
-        searchTerm = config.searchTerm
+        /* Ecosia: Pass whether a search query is displayed so URL truncation is skipped on SERPs.
         formatAndTruncateURLTextField()
+        */
+        formatAndTruncateURLTextField(hasSearchTerm: config.searchTerm != nil)
         updateIconContainer(iconContainerCornerRadius: uxConfig.toolbarCornerRadius,
                             isURLTextFieldCentered: isURLTextFieldCentered,
                             locationTextFieldTrailingPadding: uxConfig.locationTextFieldTrailingPadding)
@@ -200,10 +200,7 @@ final class LocationView: UIView,
         )
         self.delegate = delegate
         self.isUnifiedSearchEnabled = isUnifiedSearchEnabled
-        /* Ecosia: Moved above formatAndTruncateURLTextField so that method's guard can
-           read the updated searchTerm and skip URL truncation on search result pages.
         searchTerm = config.searchTerm
-        */
         onLongPress = config.onLongPress
 
         layoutContainerView(isEditing: config.isEditing, isURLTextFieldCentered: isURLTextFieldCentered)
@@ -253,7 +250,10 @@ final class LocationView: UIView,
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         DispatchQueue.main.async { [self] in
+            /* Ecosia: Pass whether a search query is displayed so URL truncation is skipped on SERPs.
             formatAndTruncateURLTextField()
+            */
+            formatAndTruncateURLTextField(hasSearchTerm: searchTerm != nil)
         }
     }
 
@@ -616,11 +616,14 @@ final class LocationView: UIView,
         }
     }
 
-    private func formatAndTruncateURLTextField() {
+    /* Ecosia: Accept whether a search query is displayed so URL truncation can be skipped on SERPs.
+    private func formatAndTruncateURLTextField()
+    */
+    private func formatAndTruncateURLTextField(hasSearchTerm: Bool) {
         guard !isEditing else { return }
         // Ecosia: When a search query is available the text field already shows it as plain text;
         // applying URL-style host truncation here would overwrite the query with a hostname.
-        guard searchTerm == nil else { return }
+        guard !hasSearchTerm else { return }
 
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.lineBreakMode = .byTruncatingHead
@@ -781,7 +784,10 @@ final class LocationView: UIView,
     }
 
     func locationTextFieldDidEndEditing(_ textField: UITextField) {
+        /* Ecosia: Pass whether a search query is displayed so URL truncation is skipped on SERPs.
         formatAndTruncateURLTextField()
+        */
+        formatAndTruncateURLTextField(hasSearchTerm: searchTerm != nil)
         if isURLTextFieldEmpty {
             updateGradient()
         } else {
@@ -860,7 +866,10 @@ final class LocationView: UIView,
         setLockIconImage()
         // Applying the theme to urlTextField can cause the url formatting to get removed
         // so we apply it again
+        /* Ecosia: Pass whether a search query is displayed so URL truncation is skipped on SERPs.
         formatAndTruncateURLTextField()
+        */
+        formatAndTruncateURLTextField(hasSearchTerm: searchTerm != nil)
     }
 
     // MARK: - UIGestureRecognizerDelegate

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
@@ -318,7 +318,14 @@ final class AddressToolbarContainerModel: Equatable {
             searchURL = url
         }
 
+        /* Ecosia: The search engine XML template is hardcoded to ecosia.org, so
+           queryForSearchURL fails for staging (ecosia-staging.xyz) whose shortDisplayString
+           doesn't match. Fall back to the URL-provider-aware Ecosia framework method so
+           all environments and search verticals (images, videos, news) show the query.
         return searchEnginesManager.queryForSearchURL(searchURL)
+        */
+        if let term = searchEnginesManager.queryForSearchURL(searchURL) { return term }
+        return searchURL?.isEcosiaSearchVertical() == true ? searchURL?.getEcosiaSearchQuery() : nil
     }
 
     @MainActor

--- a/firefox-ios/EcosiaTests/Core/URLProviderDependantTests/StagingURLProviderTests.swift
+++ b/firefox-ios/EcosiaTests/Core/URLProviderDependantTests/StagingURLProviderTests.swift
@@ -23,4 +23,46 @@ final class StagingURLProviderTests: XCTestCase {
         XCTAssertNotNil(urlProvider.snowplow)
         XCTAssertNotNil(urlProvider.notifications)
     }
+
+    // MARK: - Search term extraction (address bar query display)
+    //
+    // The Ecosia search engine XML template is hardcoded to ecosia.org, so the standard
+    // OpenSearchEngine matching fails for staging URLs. The AddressToolbarContainerModel
+    // fallback uses isEcosiaSearchVertical + getEcosiaSearchQuery, tested here.
+
+    func testStagingTextSearchIsSearchVertical() {
+        let url = URL(string: "https://www.ecosia-staging.xyz/search?q=trees")!
+        XCTAssertTrue(url.isEcosiaSearchVertical(urlProvider))
+    }
+
+    func testStagingImageSearchIsSearchVertical() {
+        let url = URL(string: "https://www.ecosia-staging.xyz/images?q=ocean")!
+        XCTAssertTrue(url.isEcosiaSearchVertical(urlProvider))
+    }
+
+    func testStagingVideoSearchIsSearchVertical() {
+        let url = URL(string: "https://www.ecosia-staging.xyz/videos?q=reforestation")!
+        XCTAssertTrue(url.isEcosiaSearchVertical(urlProvider))
+    }
+
+    func testStagingNewsSearchIsSearchVertical() {
+        let url = URL(string: "https://www.ecosia-staging.xyz/news?q=solar+energy")!
+        XCTAssertTrue(url.isEcosiaSearchVertical(urlProvider))
+    }
+
+    func testStagingSearchReturnsQuery() {
+        let url = URL(string: "https://www.ecosia-staging.xyz/search?q=trees")!
+        XCTAssertEqual(url.getEcosiaSearchQuery(urlProvider), "trees")
+    }
+
+    func testStagingImageSearchReturnsQuery() {
+        let url = URL(string: "https://www.ecosia-staging.xyz/images?q=ocean")!
+        XCTAssertEqual(url.getEcosiaSearchQuery(urlProvider), "ocean")
+    }
+
+    func testNonSearchStagingPageIsNotSearchVertical() {
+        let url = URL(string: "https://www.ecosia-staging.xyz/settings")!
+        XCTAssertFalse(url.isEcosiaSearchVertical(urlProvider))
+        XCTAssertNil(url.getEcosiaSearchQuery(urlProvider))
+    }
 }

--- a/firefox-ios/EcosiaTests/Core/URLProviderDependantTests/StagingURLProviderTests.swift
+++ b/firefox-ios/EcosiaTests/Core/URLProviderDependantTests/StagingURLProviderTests.swift
@@ -30,34 +30,12 @@ final class StagingURLProviderTests: XCTestCase {
     // OpenSearchEngine matching fails for staging URLs. The AddressToolbarContainerModel
     // fallback uses isEcosiaSearchVertical + getEcosiaSearchQuery, tested here.
 
-    func testStagingTextSearchIsSearchVertical() {
-        let url = URL(string: "https://www.ecosia-staging.xyz/search?q=trees")!
-        XCTAssertTrue(url.isEcosiaSearchVertical(urlProvider))
-    }
-
-    func testStagingImageSearchIsSearchVertical() {
-        let url = URL(string: "https://www.ecosia-staging.xyz/images?q=ocean")!
-        XCTAssertTrue(url.isEcosiaSearchVertical(urlProvider))
-    }
-
-    func testStagingVideoSearchIsSearchVertical() {
-        let url = URL(string: "https://www.ecosia-staging.xyz/videos?q=reforestation")!
-        XCTAssertTrue(url.isEcosiaSearchVertical(urlProvider))
-    }
-
-    func testStagingNewsSearchIsSearchVertical() {
-        let url = URL(string: "https://www.ecosia-staging.xyz/news?q=solar+energy")!
-        XCTAssertTrue(url.isEcosiaSearchVertical(urlProvider))
-    }
-
-    func testStagingSearchReturnsQuery() {
-        let url = URL(string: "https://www.ecosia-staging.xyz/search?q=trees")!
-        XCTAssertEqual(url.getEcosiaSearchQuery(urlProvider), "trees")
-    }
-
-    func testStagingImageSearchReturnsQuery() {
-        let url = URL(string: "https://www.ecosia-staging.xyz/images?q=ocean")!
-        XCTAssertEqual(url.getEcosiaSearchQuery(urlProvider), "ocean")
+    func testStagingSearchVerticalsAreRecognized() {
+        for vertical in URL.EcosiaSearchVertical.allCases {
+            let url = URL(string: "https://www.ecosia-staging.xyz/\(vertical.rawValue)?q=test-query")!
+            XCTAssertTrue(url.isEcosiaSearchVertical(urlProvider))
+            XCTAssertEqual(url.getEcosiaSearchQuery(urlProvider), "test-query")
+        }
     }
 
     func testNonSearchStagingPageIsNotSearchVertical() {

--- a/firefox-ios/EcosiaTests/UI/Toolbar/LocationViewTests.swift
+++ b/firefox-ios/EcosiaTests/UI/Toolbar/LocationViewTests.swift
@@ -11,22 +11,23 @@ import XCTest
 /// whenever a `searchTerm` is available — both when editing and when collapsed.
 @MainActor
 final class LocationViewTests: XCTestCase {
-
+    // swiftlint:disable:next implicitly_unwrapped_optional
     private var sut: LocationView!
+    // swiftlint:disable:next implicitly_unwrapped_optional
     private var mockDelegate: MockLocationViewDelegate!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         sut = LocationView(frame: .zero)
         mockDelegate = MockLocationViewDelegate()
         trackForMemoryLeaks(sut)
         trackForMemoryLeaks(mockDelegate)
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         sut = nil
         mockDelegate = nil
-        super.tearDown()
+        try await super.tearDown()
     }
 
     // MARK: - Collapsed bar (isEditing = false)

--- a/firefox-ios/EcosiaTests/UI/Toolbar/LocationViewTests.swift
+++ b/firefox-ios/EcosiaTests/UI/Toolbar/LocationViewTests.swift
@@ -1,0 +1,174 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import ToolbarKit
+
+/// Tests for the address bar search query display in collapsed state.
+///
+/// The address bar must show the user's typed search query rather than the raw URL
+/// whenever a `searchTerm` is available — both when editing and when collapsed.
+@MainActor
+final class LocationViewTests: XCTestCase {
+
+    private var sut: LocationView!
+    private var mockDelegate: MockLocationViewDelegate!
+
+    override func setUp() {
+        super.setUp()
+        sut = LocationView(frame: .zero)
+        mockDelegate = MockLocationViewDelegate()
+        trackForMemoryLeaks(sut)
+        trackForMemoryLeaks(mockDelegate)
+    }
+
+    override func tearDown() {
+        sut = nil
+        mockDelegate = nil
+        super.tearDown()
+    }
+
+    // MARK: - Collapsed bar (isEditing = false)
+
+    func testCollapsedBar_withTextSearchTerm_showsSearchTermNotURL() {
+        let searchTerm = "climate change"
+        let url = URL(string: "https://www.ecosia.org/search?q=climate+change")!
+        configure(url: url, searchTerm: searchTerm, isEditing: false)
+
+        XCTAssertEqual(textFieldText(), searchTerm)
+    }
+
+    func testCollapsedBar_withImageVerticalSearchTerm_showsSearchTermNotURL() {
+        let searchTerm = "ocean"
+        let url = URL(string: "https://www.ecosia.org/images?q=ocean")!
+        configure(url: url, searchTerm: searchTerm, isEditing: false)
+
+        XCTAssertEqual(textFieldText(), searchTerm)
+    }
+
+    func testCollapsedBar_withVideoVerticalSearchTerm_showsSearchTermNotURL() {
+        let searchTerm = "reforestation"
+        let url = URL(string: "https://www.ecosia.org/videos?q=reforestation")!
+        configure(url: url, searchTerm: searchTerm, isEditing: false)
+
+        XCTAssertEqual(textFieldText(), searchTerm)
+    }
+
+    func testCollapsedBar_withNewsVerticalSearchTerm_showsSearchTermNotURL() {
+        let searchTerm = "solar energy"
+        let url = URL(string: "https://www.ecosia.org/news?q=solar+energy")!
+        configure(url: url, searchTerm: searchTerm, isEditing: false)
+
+        XCTAssertEqual(textFieldText(), searchTerm)
+    }
+
+    func testCollapsedBar_withStagingSearchTerm_showsSearchTermNotURL() {
+        let searchTerm = "mangroves"
+        let url = URL(string: "https://www.ecosia-staging.xyz/search?q=mangroves")!
+        configure(url: url, searchTerm: searchTerm, isEditing: false)
+
+        XCTAssertEqual(textFieldText(), searchTerm)
+    }
+
+    func testCollapsedBar_withNoSearchTerm_showsURLHostname() {
+        let url = URL(string: "https://www.example.com/page")!
+        configure(url: url, searchTerm: nil, isEditing: false)
+
+        // formatAndTruncateURLTextField reduces the URL to its normalised host.
+        XCTAssertEqual(textFieldText(), "example.com")
+    }
+
+    func testCollapsedBar_withNonEcosiaSearchURL_showsURLHostname() {
+        // When searching on a non-Ecosia engine the model passes searchTerm = nil;
+        // the bar must show the URL, not the raw query string.
+        let url = URL(string: "https://www.google.com/search?q=trees")!
+        configure(url: url, searchTerm: nil, isEditing: false)
+
+        XCTAssertEqual(textFieldText(), "google.com")
+    }
+
+    func testCollapsedBar_withRegularWebsite_showsURLHostname() {
+        let url = URL(string: "https://www.wikipedia.org/wiki/Reforestation")!
+        configure(url: url, searchTerm: nil, isEditing: false)
+
+        XCTAssertEqual(textFieldText(), "wikipedia.org")
+    }
+
+    func testCollapsedBar_withNoURLAndNoSearchTerm_isNilOrEmpty() {
+        configure(url: nil, searchTerm: nil, isEditing: false)
+
+        let text = textFieldText() ?? ""
+        XCTAssertTrue(text.isEmpty, "URL bar should be empty when neither a URL nor a search term is provided")
+    }
+
+    // MARK: - Editing bar (isEditing = true)
+
+    func testEditingBar_withSearchTerm_showsSearchTerm() {
+        let searchTerm = "rainforest"
+        let url = URL(string: "https://www.ecosia.org/search?q=rainforest")!
+        configure(url: url, searchTerm: searchTerm, isEditing: true)
+
+        XCTAssertEqual(textFieldText(), searchTerm)
+    }
+
+    func testEditingBar_withNoSearchTerm_showsURL() {
+        let url = URL(string: "https://www.ecosia.org/search?q=rainforest")!
+        configure(url: url, searchTerm: nil, isEditing: true)
+
+        XCTAssertEqual(textFieldText(), url.absoluteString)
+    }
+
+    // MARK: - Helpers
+
+    private func configure(url: URL?, searchTerm: String?, isEditing: Bool) {
+        let config = LocationViewConfiguration(
+            searchEngineImageViewA11yId: "searchEngine",
+            searchEngineImageViewA11yLabel: "Search Engine",
+            lockIconButtonA11yId: "lockIcon",
+            lockIconButtonA11yLabel: "Lock",
+            urlTextFieldPlaceholder: "Search or enter address",
+            urlTextFieldA11yId: "urlTextField",
+            searchEngineImage: nil,
+            lockIconImageName: nil,
+            lockIconNeedsTheming: false,
+            safeListedURLImageName: nil,
+            url: url,
+            droppableUrl: nil,
+            searchTerm: searchTerm,
+            isEditing: isEditing,
+            didStartTyping: false,
+            shouldShowKeyboard: false,
+            shouldSelectSearchTerm: false
+        )
+        sut.configure(config,
+                      delegate: mockDelegate,
+                      isUnifiedSearchEnabled: false,
+                      uxConfig: .experiment(),
+                      addressBarPosition: .top)
+    }
+
+    private func textFieldText() -> String? {
+        findTextField(in: sut)?.text
+    }
+
+    private func findTextField(in view: UIView) -> UITextField? {
+        for subview in view.subviews {
+            if let tf = subview as? UITextField { return tf }
+            if let found = findTextField(in: subview) { return found }
+        }
+        return nil
+    }
+}
+
+// MARK: - Mock
+
+private final class MockLocationViewDelegate: LocationViewDelegate {
+    func locationViewDidEnterText(_ text: String) {}
+    func locationViewDidClearText() {}
+    func locationViewDidBeginEditing(_ text: String, shouldShowSuggestions: Bool) {}
+    func locationViewDidSubmitText(_ text: String) {}
+    func locationViewDidTapSearchEngine<T: SearchEngineView>(_ searchEngine: T) {}
+    func locationViewAccessibilityActions() -> [UIAccessibilityCustomAction]? { nil }
+    func locationTextFieldNeedsSearchReset() {}
+}

--- a/firefox-ios/Tuist/ProjectDescriptionHelpers/Targets+Tests.swift
+++ b/firefox-ios/Tuist/ProjectDescriptionHelpers/Targets+Tests.swift
@@ -235,7 +235,6 @@ public enum TestTargets {
                 .package(product: "SiteImageView"),
                 .package(product: "SnowplowTracker"),
                 .package(product: "TabDataStore"),
-                // Ecosia: needed for @testable import ToolbarKit in LocationView tests
                 .package(product: "ToolbarKit"),
                 .package(product: "ViewInspector"),
             ],

--- a/firefox-ios/Tuist/ProjectDescriptionHelpers/Targets+Tests.swift
+++ b/firefox-ios/Tuist/ProjectDescriptionHelpers/Targets+Tests.swift
@@ -235,6 +235,8 @@ public enum TestTargets {
                 .package(product: "SiteImageView"),
                 .package(product: "SnowplowTracker"),
                 .package(product: "TabDataStore"),
+                // Ecosia: needed for @testable import ToolbarKit in LocationView tests
+                .package(product: "ToolbarKit"),
                 .package(product: "ViewInspector"),
             ],
             settings: .settings(base: BuildConfigurations.testBaseSettings)


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-4293]

## Context

On Ecosia SERPs the native address bar showed the full URL (e.g. `ecosia.org/search?q=…`) instead of the typed query. Firefox only shows the search term while editing; we want it in the collapsed bar too, for all Ecosia verticals and environments (production and staging).

Staging was also affected: the search engine XML template is hardcoded to `ecosia.org`, so `queryForSearchURL` did not match `ecosia-staging.xyz` URLs.

## Approach

- **`LocationView`**: set `searchTerm` before `formatAndTruncateURLTextField`; show the query when collapsed (not only while editing); skip URL host truncation when a search term is present.
- **`AddressToolbarContainerModel.searchTermFromURL`**: fall back to `isEcosiaSearchVertical` / `getEcosiaSearchQuery` when `queryForSearchURL` returns nil.
- Add `ToolbarKit` as a direct dependency of `EcosiaTests` so `LocationView` can be tested with `@testable import ToolbarKit`.
- Tests: `LocationViewTests` (Ecosia/staging verticals, non-Ecosia search, regular sites) and `StagingURLProviderTests` for the staging fallback.

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [x] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4293]: https://ecosia.atlassian.net/browse/MOB-4293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ