### PR TITLE
[MOB-4464] Align user agent

### DIFF
--- a/BrowserKit/Sources/Shared/UserAgent.swift
+++ b/BrowserKit/Sources/Shared/UserAgent.swift
@@ -10,11 +10,24 @@ open class UserAgent {
     public static let uaBitSafari = "Safari/604.1"
     public static let uaBitMobile = "Mobile/15E148"
     public static let uaBitFx = "FxiOS/\(AppInfo.appVersion)"
+    // Ecosia: Add Ecosia user agent info.
+    public static let uaBitVersion = "Version/\(UIDeviceDetails.systemVersion)"
+    public static var uaBitEcosia: String {
+        return "(Ecosia ios@\(AppInfo.appVersion).\(AppInfo.buildNumber))"
+    }
+    public static var ecosiaDesktopUA: String {
+        return "\(UserAgent.desktopUserAgent()) \(UserAgent.uaBitEcosia)"
+    }
     public static let product = "Mozilla/5.0"
     public static let platform = "AppleWebKit/605.1.15"
     public static let platformDetails = "(KHTML, like Gecko)"
 
     private static let defaults = UserDefaults(suiteName: AppInfo.sharedContainerIdentifier)!
+    // Ecosia: Configure Ecosia domains from the app layer's URLProvider.
+    private static let configuration = UserAgentConfiguration()
+    public static func configureEcosiaDesktopUserAgentDomains(_ domains: [String]) {
+        configuration.configureEcosiaDesktopUserAgentDomains(domains)
+    }
 
     private static func clientUserAgent(prefix: String) -> String {
         let versionStr: String
@@ -27,19 +40,31 @@ open class UserAgent {
     }
 
     public static var syncUserAgent: String {
+        /* Ecosia: Use Ecosia UA prefix for sync requests.
         return clientUserAgent(prefix: "Firefox-iOS-Sync")
+         */
+        return clientUserAgent(prefix: "Ecosia-iOS-Sync")
     }
 
     public static var tokenServerClientUserAgent: String {
+        /* Ecosia: Use Ecosia UA prefix for token server requests.
         return clientUserAgent(prefix: "Firefox-iOS-Token")
+         */
+        return clientUserAgent(prefix: "Ecosia-iOS-Token")
     }
 
     public static var fxaUserAgent: String {
+        /* Ecosia: Use Ecosia UA prefix for account webviews.
         return clientUserAgent(prefix: "Firefox-iOS-FxA")
+         */
+        return clientUserAgent(prefix: "Ecosia-iOS-EcosiaA")
     }
 
     public static var defaultClientUserAgent: String {
+        /* Ecosia: Use Ecosia UA prefix for generic client requests.
         return clientUserAgent(prefix: "Firefox-iOS")
+         */
+        return clientUserAgent(prefix: "Ecosia-iOS")
     }
 
     public static func isDesktop(ua: String) -> Bool {
@@ -66,6 +91,10 @@ open class UserAgent {
     public static func getUserAgent(domain: String, platform: UserAgentPlatform) -> String {
         switch platform {
         case .Desktop:
+            if configuration.containsEcosiaDesktopUserAgentDomain(domain) {
+                return ecosiaDesktopUA
+            }
+
             guard let customUA = CustomUserAgentConstant.customDesktopUAForDomain[domain] else {
                 return desktopUserAgent()
             }
@@ -94,11 +123,40 @@ public enum UserAgentPlatform {
     case Mobile
 }
 
+// Ecosia: Keeps URLProvider-derived domains out of BrowserKit's static upstream domain list.
+private final class UserAgentConfiguration: @unchecked Sendable {
+    private let lock = NSLock()
+    private var ecosiaDesktopUserAgentDomains = Set<String>()
+
+    func configureEcosiaDesktopUserAgentDomains(_ domains: [String]) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        ecosiaDesktopUserAgentDomains = Set(domains.map { $0.lowercased() })
+    }
+
+    func containsEcosiaDesktopUserAgentDomain(_ domain: String) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+
+        return ecosiaDesktopUserAgentDomains.contains(domain.lowercased())
+    }
+}
+
 struct CustomUserAgentConstant {
     private static let defaultMobileUA = UserAgentBuilder.defaultMobileUserAgent().userAgent()
+    // Ecosia: Keep a Firefox mobile UA for domains that reject Ecosia's default UA.
+    private static let defaultFirefoxMobileUA = UserAgentBuilder.defaultFirefoxMobileUserAgent().userAgent()
+    /* Ecosia: Build Safari-only overrides from the Firefox mobile UA.
     private static let safariMobileUA = UserAgentBuilder.defaultMobileUserAgent().clone(extensions: "Version/18.6 \(UserAgent.uaBitMobile) \(UserAgent.uaBitSafari)")
+     */
+    private static let safariMobileUA = UserAgentBuilder.defaultFirefoxMobileUserAgent().clone(
+        extensions: "Version/18.6 \(UserAgent.uaBitMobile) \(UserAgent.uaBitSafari)"
+    )
 
     static let customMobileUAForDomain = [
+        // Ecosia: PayPal expects the Firefox mobile UA.
+        "paypal.com": defaultFirefoxMobileUA,
         // TODO: FXIOS-14371 [webcompat] rokuchannel blocking FXIOS "this browser isn't supported" (webcompat #126427)
         "roku.com": safariMobileUA,
         // TODO: FXIOS-13391 [webcompat] "connection error" only on FxiOS/* UA (bug 1983983)
@@ -113,7 +171,10 @@ struct CustomUserAgentConstant {
 
     static let customDesktopUAForDomain = [
         // TODO: FXIOS-8027, FXIOS-11230, FXIOS-13891 PayPal buttons open blank tabs
+        /* Ecosia: PayPal expects the Firefox mobile UA.
         "paypal.com": defaultMobileUA,
+         */
+        "paypal.com": defaultFirefoxMobileUA,
         // FXIOS-10251: Do not appear as desktop/Safari for firefox.com/pair
         "firefox.com": defaultMobileUA
     ]
@@ -170,6 +231,18 @@ public struct UserAgentBuilder {
     }
 
     public static func defaultMobileUserAgent() -> UserAgentBuilder {
+        /* Ecosia: Always return Ecosia's UA as the default mobile UA.
+        return UserAgentBuilder(
+            product: UserAgent.product,
+            systemInfo: "(\(UIDeviceDetails.model); CPU iPhone OS 18_7 like Mac OS X)",
+            platform: UserAgent.platform,
+            platformDetails: UserAgent.platformDetails,
+            extensions: "FxiOS/\(AppInfo.appVersion) \(UserAgent.uaBitMobile) \(UserAgent.uaBitSafari)")
+         */
+        return UserAgentBuilder.ecosiaMobileUserAgent()
+    }
+
+    public static func defaultFirefoxMobileUserAgent() -> UserAgentBuilder {
         return UserAgentBuilder(
             product: UserAgent.product,
             systemInfo: "(\(UIDeviceDetails.model); CPU iPhone OS 18_7 like Mac OS X)",
@@ -185,5 +258,19 @@ public struct UserAgentBuilder {
             platform: UserAgent.platform,
             platformDetails: UserAgent.platformDetails,
             extensions: "Version/18.6 Safari/605.1.15")
+    }
+}
+
+// Ecosia: Ecosia mobile UA.
+extension UserAgentBuilder {
+    public static func ecosiaMobileUserAgent() -> UserAgentBuilder {
+        let formattedSystemVersion = UIDeviceDetails.systemVersion.replacingOccurrences(of: ".", with: "_")
+
+        return UserAgentBuilder(
+            product: UserAgent.product,
+            systemInfo: "(\(UIDeviceDetails.model); CPU iPhone OS \(formattedSystemVersion) like Mac OS X)",
+            platform: UserAgent.platform,
+            platformDetails: UserAgent.platformDetails,
+            extensions: "\(UserAgent.uaBitVersion) \(UserAgent.uaBitMobile) \(UserAgent.uaBitSafari) \(UserAgent.uaBitEcosia)")
     }
 }

--- a/BrowserKit/Sources/Shared/UserAgent.swift
+++ b/BrowserKit/Sources/Shared/UserAgent.swift
@@ -91,6 +91,7 @@ open class UserAgent {
     public static func getUserAgent(domain: String, platform: UserAgentPlatform) -> String {
         switch platform {
         case .Desktop:
+            // Ecosia: Use Ecosia's desktop UA for URLProvider-backed Ecosia domains.
             if configuration.containsEcosiaDesktopUserAgentDomain(domain) {
                 return ecosiaDesktopUA
             }

--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -69,6 +69,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, FeatureFlaggable {
         BrowserKitInformation.shared.configure(buildChannel: AppConstants.buildChannel,
                                                nightlyAppVersion: AppConstants.nightlyAppVersion,
                                                sharedContainerIdentifier: AppInfo.sharedContainerIdentifier)
+        // Ecosia: Register URLProvider domains that need Ecosia's desktop UA.
+        UserAgent.configureEcosiaDesktopUserAgentDomains([
+            URLProvider.production.domain,
+            URLProvider.staging.domain
+        ])
 
         // Set-up Rust network stack. Note that this has to be called
         // before any Application Services component gets used.

--- a/firefox-ios/Client/Application/UnitTestAppDelegate.swift
+++ b/firefox-ios/Client/Application/UnitTestAppDelegate.swift
@@ -4,6 +4,9 @@
 
 import UIKit
 import MozillaAppServices
+// Ecosia: Configure URLProvider-backed user agent domains.
+import Shared
+import Ecosia
 
 @objc(UnitTestAppDelegate)
 final class UnitTestAppDelegate: UIResponder, UIApplicationDelegate {
@@ -12,6 +15,11 @@ final class UnitTestAppDelegate: UIResponder, UIApplicationDelegate {
         /// Initialize app services ( including NSS ). Must be called before any other calls to rust components.
         /// This needs to be called early on, otherwise stuff like enc/dec fails.
         MozillaAppServices.initialize()
+        // Ecosia: Register URLProvider domains that need Ecosia's desktop UA in unit tests.
+        UserAgent.configureEcosiaDesktopUserAgentDomains([
+            URLProvider.production.domain,
+            URLProvider.staging.domain
+        ])
         return true
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/ClientTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/ClientTests.swift
@@ -17,7 +17,12 @@ class ClientTests: XCTestCase {
         let systemVersion = UIDevice.current.systemVersion
 
         if AppInfo.buildNumber != "1" {
-            let expectedRegex = "^Firefox-iOS-Sync/[0-9\\.]+b[0-9]* \\(\(device); iPhone OS \(systemVersion)\\) \\([-_A-Za-z0-9= \\(\\)]+\\)$"
+            /* Ecosia: Sync UA uses the Ecosia prefix.
+            let expectedRegex = "^Firefox-iOS-Sync/[0-9\\.]+b[0-9]* " +
+            "\\(\(device); iPhone OS \(systemVersion)\\) \\([-_A-Za-z0-9= \\(\\)]+\\)$"
+             */
+            let expectedRegex = "^Ecosia-iOS-Sync/[0-9\\.]+b[0-9]* " +
+            "\\(\(device); iPhone OS \(systemVersion)\\) \\([-_A-Za-z0-9= \\(\\)]+\\)$"
             let loc = ua.range(of: expectedRegex, options: .regularExpression)
             XCTAssertTrue(loc != nil, "Sync UA is as expected. Was \(ua)")
         } else {

--- a/firefox-ios/firefox-ios-tests/Tests/SharedTests/UserAgentTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/SharedTests/UserAgentTests.swift
@@ -7,6 +7,33 @@ import XCTest
 import Common
 
 final class UserAgentTests: XCTestCase {
+    // Ecosia: Verify the default mobile UA uses Ecosia's UA marker.
+    func testDefaultMobileUserAgent_returnsEcosiaUserAgent() {
+        let userAgent = UserAgent.mobileUserAgent()
+
+        XCTAssertTrue(userAgent.contains(UserAgent.uaBitVersion))
+        XCTAssertTrue(userAgent.contains(UserAgent.uaBitEcosia))
+        XCTAssertFalse(userAgent.contains(UserAgent.uaBitFx))
+    }
+
+    // Ecosia: Verify client UA prefixes use Ecosia branding.
+    func testClientUserAgents_useEcosiaPrefixes() {
+        XCTAssertTrue(UserAgent.syncUserAgent.hasPrefix("Ecosia-iOS-Sync/"))
+        XCTAssertTrue(UserAgent.tokenServerClientUserAgent.hasPrefix("Ecosia-iOS-Token/"))
+        XCTAssertTrue(UserAgent.fxaUserAgent.hasPrefix("Ecosia-iOS-EcosiaA/"))
+        XCTAssertTrue(UserAgent.defaultClientUserAgent.hasPrefix("Ecosia-iOS/"))
+    }
+
+    // Ecosia: Verify Ecosia domains receive Ecosia's desktop UA override.
+    func testGetUserAgentDesktop_withEcosiaDomains_returnEcosiaDesktopUserAgent() {
+        let domains = ["ecosia.org", "ecosia-staging.xyz"]
+        UserAgent.configureEcosiaDesktopUserAgentDomains(domains)
+
+        domains.forEach { domain in
+            XCTAssertEqual(UserAgent.ecosiaDesktopUA, UserAgent.getUserAgent(domain: domain, platform: .Desktop))
+        }
+    }
+
     func testGetUserAgentDesktop_withListedDomain_returnProperUserAgent() {
         let domains = CustomUserAgentConstant.customDesktopUAForDomain
         domains.forEach { domain, agent in
@@ -25,19 +52,21 @@ final class UserAgentTests: XCTestCase {
 
     func testGetUserAgentDesktop_withPaypalDomain_returnMobileUserAgent() {
         let paypalDomain = "paypal.com"
-        /* Ecosia: Use default Firefox UA instead
-        XCTAssertEqual(UserAgent.mobileUserAgent(),
-         */
+        /* Ecosia: Use default Firefox UA instead.
         XCTAssertEqual(UserAgentBuilder.defaultMobileUserAgent().userAgent(),
+                       UserAgent.getUserAgent(domain: paypalDomain, platform: .Desktop))
+         */
+        XCTAssertEqual(UserAgentBuilder.defaultFirefoxMobileUserAgent().userAgent(),
                        UserAgent.getUserAgent(domain: paypalDomain, platform: .Desktop))
     }
 
     func testGetUserAgentMobile_withPaypalDomain_returnProperUserAgent() {
         let paypalDomain = "paypal.com"
-        /* Ecosia: Use default Firefox UA instead
-        XCTAssertEqual(UserAgent.mobileUserAgent(),
-         */
+        /* Ecosia: Use default Firefox UA instead.
         XCTAssertEqual(UserAgentBuilder.defaultMobileUserAgent().userAgent(),
+                       UserAgent.getUserAgent(domain: paypalDomain, platform: .Mobile))
+         */
+        XCTAssertEqual(UserAgentBuilder.defaultFirefoxMobileUserAgent().userAgent(),
                        UserAgent.getUserAgent(domain: paypalDomain, platform: .Mobile))
     }
 }


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-4464]

## Context

After the latest upstream alignment, `BrowserKit/Sources/Shared/UserAgent.swift` was using Firefox’s default UA again. This meant the app no longer sent Ecosia’s mobile UA marker (`Ecosia ios@…`) that we had in `main-133`.

The file now lives in `BrowserKit`, so it cannot import the `Ecosia` module directly. For Ecosia-specific domains, the app layer needs to provide the values from `URLProvider` instead of hardcoding them in `Shared`.

## Approach

- **`UserAgent`**: restore Ecosia’s default mobile UA, including `Version/<systemVersion>`, `Mobile/15E148`, Safari, and the `(Ecosia ios@<version>.<build>)` marker.
- **Client UAs**: restore the Ecosia prefixes for sync/token/FxA/default client requests.
- **Domain configuration**: add `UserAgent.configureEcosiaDesktopUserAgentDomains(_:)` so `BrowserKit` stays independent while the app registers `URLProvider.production.domain` and `URLProvider.staging.domain`.
- **App startup**: configure the Ecosia desktop UA domains from `AppDelegate` and `UnitTestAppDelegate`.
- **Compatibility overrides**: keep PayPal on the Firefox mobile UA and preserve the latest upstream webcompat UA overrides.
- Tests: update `UserAgentTests` and `ClientTests` to cover the Ecosia UA marker, Ecosia client prefixes, PayPal override, and configured Ecosia desktop domains.

## Other

Testing performed, now printing:
`Mozilla/5.0 (iPhone; CPU iPhone OS 26_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Mobile/15E148 Safari/604.1 (Ecosia ios@12.0.2.1)`

Targeted `EcosiaBeta` tests could not run because the scheme currently references the missing file `firefox-ios/EcosiaTests/UI/Toolbar/LocationViewTests.swift`.

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [x] I added the `// Ecosia:` helper comments where needed
- [x] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4464]: https://ecosia.atlassian.net/browse/MOB-4464