### PR TITLE
[MOB-4300] Fix AI Search submission as regular query when using Browsing Suggestions

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -4711,7 +4711,7 @@ extension BrowserViewController: SearchViewControllerDelegate {
         // fallback below.
         let isOmniboxOverlay = self.searchController?.parent is HomepageViewController
         if isOmniboxOverlay {
-            let isAIChatURL = url.path.contains("/ai-chat")
+            let isAIChatURL = url.getEcosiaSearchVerticalPath() == URL.EcosiaSearchVertical.aiChat.rawValue
             if let searchTerm, !searchTerm.isEmpty, !isAIChatURL {
                 ntpSearchBarDidSubmit(searchTerm)
                 return

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -4704,9 +4704,15 @@ extension BrowserViewController: SearchViewControllerDelegate {
         // History/bookmark/remote-tab rows have no search term — fall back to
         // loading the URL directly, but still tear the omnibox down and force
         // the webview swap that the URL-bar overlay chain would normally do.
+        // The dedicated AI Chat row IS associated with a search term but its
+        // URL is already the AI chat endpoint — sending it through
+        // `ntpSearchBarDidSubmit` would rebuild a plain Ecosia search URL and
+        // drop the AI chat destination, so we treat that case like the URL
+        // fallback below.
         let isOmniboxOverlay = self.searchController?.parent is HomepageViewController
         if isOmniboxOverlay {
-            if let searchTerm, !searchTerm.isEmpty {
+            let isAIChatURL = url.path.contains("/ai-chat")
+            if let searchTerm, !searchTerm.isEmpty, !isAIChatURL {
                 ntpSearchBarDidSubmit(searchTerm)
                 return
             }

--- a/firefox-ios/Ecosia/Core/URL+Extensions.swift
+++ b/firefox-ios/Ecosia/Core/URL+Extensions.swift
@@ -20,6 +20,7 @@ extension URL {
         case images
         case news
         case videos
+        case aiChat = "ai-chat"
 
         init?(path: String) {
             let pathWithNoLeadingSlash = String(path.dropFirst())


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-4300]

## Context

Fix AI Search submission as regular query when using Browsing Suggestions.

## Approach

## Other

## Before merging

### Checklist

- [ ] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [ ] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4300]: https://ecosia.atlassian.net/browse/MOB-4300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ