### PR TITLE
[MOB-4300] Follow-up on `ai-search`

### DIFF
--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -4711,8 +4711,7 @@ extension BrowserViewController: SearchViewControllerDelegate {
         // fallback below.
         let isOmniboxOverlay = self.searchController?.parent is HomepageViewController
         if isOmniboxOverlay {
-            let isAIChatURL = url.getEcosiaSearchVerticalPath() == URL.EcosiaSearchVertical.aiChat.rawValue
-            if let searchTerm, !searchTerm.isEmpty, !isAIChatURL {
+            if let searchTerm, !searchTerm.isEmpty, !url.isEcosiaAIChat {
                 ntpSearchBarDidSubmit(searchTerm)
                 return
             }

--- a/firefox-ios/Ecosia/Core/URL+Extensions.swift
+++ b/firefox-ios/Ecosia/Core/URL+Extensions.swift
@@ -5,7 +5,11 @@
 import Foundation
 
 extension URL {
-
+    
+    public var isEcosiaAIChat: Bool {
+        isEcosia() && path.contains("ai-chat")
+    }
+    
     public enum EcosiaQueryItemName: String {
         case
         autoRedirect = "ar",
@@ -20,7 +24,6 @@ extension URL {
         case images
         case news
         case videos
-        case aiChat = "ai-chat"
 
         init?(path: String) {
             let pathWithNoLeadingSlash = String(path.dropFirst())

--- a/firefox-ios/Ecosia/Core/URL+Extensions.swift
+++ b/firefox-ios/Ecosia/Core/URL+Extensions.swift
@@ -5,11 +5,11 @@
 import Foundation
 
 extension URL {
-    
+
     public var isEcosiaAIChat: Bool {
         isEcosia() && path.contains("ai-chat")
     }
-    
+
     public enum EcosiaQueryItemName: String {
         case
         autoRedirect = "ar",


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-4300]

## Context

Because of an unseen issue we spotted as part of this https://github.com/ecosia/ios-browser/pull/1152#issuecomment-4499448721, we had to review and simplify the `ai-chat` check.

## Approach

- Make sure we don't treat it as a vertical (such as: images, videos...)

## Other

- Improved the check making sure `isEcosia`

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [ ] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4300]: https://ecosia.atlassian.net/browse/MOB-4300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ