### PR TITLE
[MOB-4479] fix: Omnibox cards shifting. Fix layout on iPad

### DIFF
--- a/firefox-ios/Client/Ecosia/UI/NTP/Impact/NTPImpactCell.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/Impact/NTPImpactCell.swift
@@ -43,6 +43,13 @@ final class NTPImpactCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
         // rows inside) and pull TopSites up to fill the gap. Holding the
         // intrinsic height keeps the cards stable through the transition.
         stack.setContentCompressionResistancePriority(.required, for: .vertical)
+        // Ecosia: Refuse to be vertically stretched by an oversized cell.
+        // On iPad the impact section is sized to fill the remaining card
+        // height, which would otherwise drag this stack (and `.fill`
+        // distribute it across the tiles) into a giant block. Required
+        // hugging keeps it at its intrinsic height so the cell self-sizes
+        // via `.estimated` and the rows render at their natural height.
+        stack.setContentHuggingPriority(.required, for: .vertical)
         return stack
     }()
 
@@ -89,8 +96,11 @@ final class NTPImpactCell: UICollectionViewCell, ThemeApplicable, ReusableCell {
         stack.distribution = .fill
         stack.spacing = UX.cellsSpacing
         // Ecosia: see `contentStack` comment — hold the intrinsic stack
-        // height so the impact rows don't get squeezed during transitions.
+        // height so the impact rows don't get squeezed during transitions,
+        // and hug vertically so the tiles never inflate to fill an oversized
+        // section (iPad portrait was producing ~500pt-tall rows otherwise).
         stack.setContentCompressionResistancePriority(.required, for: .vertical)
+        stack.setContentHuggingPriority(.required, for: .vertical)
         return stack
     }()
 

--- a/firefox-ios/Client/Ecosia/UI/NTP/Impact/NTPImpactRowView.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/Impact/NTPImpactRowView.swift
@@ -178,15 +178,19 @@ final class NTPImpactRowView: UIView, ThemeApplicable {
     }
 
     private func setupConstraints() {
+        // Ecosia: Pin top/bottom equal (not greaterThanOrEqual/lessThanOrEqual) so the row's
+        // height is exactly `mainContainerView.height + padding * 2`. Without this the row has
+        // no derivable intrinsic height in the vertical axis, which lets `tilesStack`'s `.fill`
+        // distribution stretch the rows to fill an oversized impact section on iPad
+        // (the previously inequality-only setup gave the row infinite vertical freedom).
         NSLayoutConstraint.activate([
             glassBackground.topAnchor.constraint(equalTo: topAnchor),
             glassBackground.leadingAnchor.constraint(equalTo: leadingAnchor),
             glassBackground.trailingAnchor.constraint(equalTo: trailingAnchor),
             glassBackground.bottomAnchor.constraint(equalTo: bottomAnchor),
 
-            mainContainerView.centerYAnchor.constraint(equalTo: centerYAnchor),
-            mainContainerView.topAnchor.constraint(greaterThanOrEqualTo: topAnchor, constant: UX.padding),
-            mainContainerView.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor, constant: -UX.padding),
+            mainContainerView.topAnchor.constraint(equalTo: topAnchor, constant: UX.padding),
+            mainContainerView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -UX.padding),
             mainContainerView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: UX.padding),
             mainContainerView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -UX.padding),
 

--- a/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
+++ b/firefox-ios/Client/Frontend/Home/Homepage/HomepageViewController.swift
@@ -184,6 +184,12 @@ final class HomepageViewController: UIViewController,
         termsOfUseDelegate?.showTermsOfUse(context: .homepageOpened)
         // Ecosia: Trigger Ecosia data loading
         ecosiaViewWillAppear()
+        // Ecosia: The window-anchored wallpaper constraint installed by
+        // `extendEcosiaWallpaperToParentOnPad` can be torn down when this
+        // VC's view is removed from its superview during tab/content
+        // switches. Reset the gate so the next layout pass re-installs the
+        // constraint and the wallpaper card reaches the screen bottom again.
+        wallpaperExtendedToParent = false
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -924,18 +930,18 @@ final class HomepageViewController: UIViewController,
         updateNTPSearchBarHorizontalInset()
     }
 
-    /* Ecosia: On iPad the content container ends at overKeyboardContainer.top — well above
-     the screen bottom — because the address bar lives in the header. Replace the initial
-     view.bottomAnchor constraint with a cross-hierarchy constraint to BVC's view so the
-     wallpaper card fills the gap behind the translucent bottom toolbar. iPhone keeps the
+    /* Ecosia: On iPad the content container can end above the screen bottom (behind the
+     translucent bottom toolbar / safe area), and `parent?.view.bottomAnchor` doesn't always
+     reach the actual screen bottom. Anchor the wallpaper card to the host window's bottom
+     instead — that's the only anchor guaranteed to span the full display. iPhone keeps the
      simple view-local constraint (correct margin and corner radius above the address bar). */
     private func extendEcosiaWallpaperToParentOnPad() {
         guard traitCollection.userInterfaceIdiom == .pad,
               !wallpaperExtendedToParent,
-              let parentView = parent?.view else { return }
+              let window = view.window else { return }
         wallpaperBottomConstraint?.isActive = false
         let extended = wallpaperView.bottomAnchor.constraint(
-            equalTo: parentView.bottomAnchor,
+            equalTo: window.bottomAnchor,
             constant: -CGFloat.ecosia.space._m
         )
         extended.isActive = true


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-4479]

## Context

## Approach

## Other

## Before merging

### Checklist

- [ ] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [ ] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4479]: https://ecosia.atlassian.net/browse/MOB-4479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ