### PR TITLE
Add SRE-2893 [safe-chain] enable safe-chain in all Github workflows

### DIFF
--- a/.github/actions/setup-safe-chain/action.yml
+++ b/.github/actions/setup-safe-chain/action.yml
@@ -1,0 +1,12 @@
+name: 'Setup safe-chain'
+description: 'Install aikidosec/safe-chain to guard against malicious dependencies'
+runs:
+  using: "composite"
+  steps:
+    - name: "Setup safe-chain"
+      shell: bash
+      run: |
+        curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.5.3/install-safe-chain.sh -o /tmp/install-safe-chain.sh
+        echo "0107cbbbf90159379756157e902acae512d62ffbd174307e42c5fe9f266792d3  /tmp/install-safe-chain.sh" | sha256sum -c -
+        sh /tmp/install-safe-chain.sh --ci
+        rm /tmp/install-safe-chain.sh

--- a/.github/workflows/merge_tests.yml
+++ b/.github/workflows/merge_tests.yml
@@ -29,6 +29,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/setup-safe-chain
+
       - name: Prepare environment
         uses: ./.github/actions/prepare_environment
         with:

--- a/.github/workflows/snapshot_tests.yml
+++ b/.github/workflows/snapshot_tests.yml
@@ -20,6 +20,8 @@ jobs:
           lfs: true
           submodules: true    
 
+      - uses: ./.github/actions/setup-safe-chain
+
       - name: Check for MARKETING_VERSION change
         id: check_marketing_version
         run: sh ./check_marketing_version.sh

--- a/.github/workflows/upload_release_notes_to_appstore.yml
+++ b/.github/workflows/upload_release_notes_to_appstore.yml
@@ -15,7 +15,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-          
+
+      - uses: ./.github/actions/setup-safe-chain
+
       - name: Install gems
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/SRE-2893)

## :bulb: Description

This enables safe-chain in all github workflows for this repo. Safe-chain prevents package managers like npm, uv, etc from downloading known malicious dependencies, turning potential pwns into simple failures.

## :movie_camera: Demos

n/a

## :pencil: Checklist
- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [n/a] I ensured unit tests pass and wrote tests for new code
- [n/a] If working on UI, I checked and implemented accessibility (Dynamic Text and VoiceOver)
- [n/a] If adding telemetry, I read the [data stewardship requirements](https://github.com/mozilla-mobile/firefox-ios/wiki/Adding-Glean-Telemetry-Events) and will request a data review
- [n/a] If adding or modifying strings, I read the [guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/How-to-add-and-modify-Strings) and will request a string review from l10n
- [n/a] If needed, I updated documentation and added comments to complex code

