### PR TITLE
[MOB-4537] Restore URL autocomplete on the NTP omnibox

### DIFF
--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Omnibox.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Omnibox.swift
@@ -60,6 +60,10 @@ extension BrowserViewController: NTPSearchBarDelegate {
         showOmniboxSuggestions(searchTerm: searchTerm, anchorView: anchor)
     }
 
+    func ntpSearchBarNeedsSearchReset() {
+        searchLoader?.query = ""
+    }
+
     func ntpSearchBarDidBeginEditing() {
         // Mark the session active the moment the omnibox gains focus so an
         // abandoned focus (no text entered) is recorded the same way the URL

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPLocationTextView.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPLocationTextView.swift
@@ -1,0 +1,251 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+import Common
+
+/// Multiline text input for the NTP omnibox with URL-bar autocomplete behaviour
+/// ported from `LocationTextField` (marked-text suffix, hidden caret, backspace
+/// drops only the completion, submit/tap commits the full match).
+@MainActor
+protocol NTPLocationTextViewDelegate: AnyObject {
+    func locationTextView(_ textView: NTPLocationTextView, didEnterText text: String)
+    func locationTextViewNeedsSearchReset(_ textView: NTPLocationTextView)
+}
+
+final class NTPLocationTextView: UITextView {
+    weak var autocompleteDelegate: NTPLocationTextViewDelegate?
+
+    private var lastReplacement: String?
+    private var hideCursor = false
+    private var isSettingMarkedText = false
+    private var pendingFullSuggestion: String?
+    private var notifyTextChanged: (() -> Void)?
+
+    override init(frame: CGRect, textContainer: NSTextContainer?) {
+        super.init(frame: frame, textContainer: textContainer)
+        commonInit()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        commonInit()
+    }
+
+    private func commonInit() {
+        font = .preferredFont(forTextStyle: .body)
+        adjustsFontForContentSizeCategory = true
+        backgroundColor = .clear
+        textContainerInset = .zero
+        textContainer.lineFragmentPadding = 0
+        autocorrectionType = .no
+        autocapitalizationType = .none
+        spellCheckingType = .no
+        returnKeyType = .search
+        keyboardType = .webSearch
+        enablesReturnKeyAutomatically = true
+        textContentType = .URL
+
+        notifyTextChanged = debounce(0.1) { [weak self] in
+            guard let self, self.isFirstResponder else { return }
+            let query = self.normalizeString(self.textWithoutSuggestion() ?? "")
+            self.autocompleteDelegate?.locationTextView(self, didEnterText: query)
+        }
+    }
+
+    var hasActiveAutocomplete: Bool {
+        markedTextRange != nil
+    }
+
+    override var accessibilityValue: String? {
+        get { pendingFullSuggestion ?? text }
+        set { super.accessibilityValue = newValue }
+    }
+
+    func applyTheme(markedTextStyle: [NSAttributedString.Key: Any], textColor: UIColor, tintColor: UIColor) {
+        self.markedTextStyle = markedTextStyle
+        self.textColor = textColor
+        self.tintColor = tintColor
+    }
+
+    func setAutocompleteSuggestion(_ suggestion: String?) {
+        guard let suggestion else {
+            hideCursor = false
+            _ = removeCompletion()
+            return
+        }
+
+        let searchText = text ?? ""
+
+        guard isFirstResponder, markedTextRange == nil else {
+            hideCursor = false
+            return
+        }
+
+        let normalized = normalizeString(searchText)
+        guard suggestion.hasPrefix(normalized), normalized.count < suggestion.count else {
+            hideCursor = false
+            _ = removeCompletion()
+            return
+        }
+
+        let suggestionText = String(suggestion.dropFirst(normalized.count))
+        isSettingMarkedText = true
+        setMarkedText(suggestionText, selectedRange: NSRange())
+        pendingFullSuggestion = suggestion
+        isSettingMarkedText = false
+        hideCursor = true
+        forceResetCursor()
+    }
+
+    func applyCompletion() {
+        if let pendingFullSuggestion {
+            let committed = pendingFullSuggestion
+            _ = removeCompletion()
+            text = committed
+            hideCursor = false
+            selectedTextRange = textRange(from: endOfDocument, to: endOfDocument)
+            return
+        }
+
+        let committed = text ?? ""
+        let didRemoveCompletion = removeCompletion()
+        text = committed
+        hideCursor = false
+        if didRemoveCompletion {
+            selectedTextRange = textRange(from: endOfDocument, to: endOfDocument)
+        }
+    }
+
+    func clearText() {
+        text = ""
+        _ = removeCompletion()
+        autocompleteDelegate?.locationTextView(self, didEnterText: "")
+    }
+
+    func setTextWithoutSearching(_ value: String) {
+        text = value
+        hideCursor = markedTextRange != nil
+        _ = removeCompletion()
+    }
+
+    // MARK: - UITextInput
+
+    override func deleteBackward() {
+        lastReplacement = ""
+        hideCursor = false
+
+        guard markedTextRange == nil else {
+            _ = removeCompletion()
+            forceResetCursor()
+            return
+        }
+
+        super.deleteBackward()
+    }
+
+    override func touchesBegan(_ touches: Set<UITouch>, with: UIEvent?) {
+        guard isFirstResponder else {
+            super.touchesBegan(touches, with: with)
+            return
+        }
+        applyCompletion()
+        super.touchesBegan(touches, with: with)
+    }
+
+    override func caretRect(for position: UITextPosition) -> CGRect {
+        hideCursor ? .zero : super.caretRect(for: position)
+    }
+
+    override func setMarkedText(_ markedText: String?, selectedRange: NSRange) {
+        isSettingMarkedText = true
+        _ = removeCompletion()
+        super.setMarkedText(markedText, selectedRange: selectedRange)
+        isSettingMarkedText = false
+    }
+
+    // MARK: - Editing notifications
+
+    @objc
+    func editingChanged() {
+        guard !isSettingMarkedText else { return }
+
+        hideCursor = markedTextRange != nil
+
+        let isKeyboardReplacingText = lastReplacement != nil
+        if isKeyboardReplacingText, markedTextRange == nil {
+            notifyTextChanged?()
+        } else {
+            hideCursor = false
+        }
+    }
+
+    func willChange(range: NSRange, replacement: String) {
+        if lastReplacement == nil {
+            autocompleteDelegate?.locationTextViewNeedsSearchReset(self)
+        }
+        lastReplacement = replacement
+    }
+
+    func didEndEditing() {
+        lastReplacement = nil
+        selectedTextRange = nil
+    }
+
+    // MARK: - Private
+
+    @discardableResult
+    private func removeCompletion() -> Bool {
+        guard markedTextRange != nil else { return false }
+
+        pendingFullSuggestion = nil
+        hideCursor = false
+        unmarkText()
+        return true
+    }
+
+    private func textWithoutSuggestion() -> String? {
+        // Marked autocomplete is provisional; committed text is the typed prefix.
+        text
+    }
+
+    private func normalizeString(_ string: String) -> String {
+        string.lowercased().stringByTrimmingLeadingCharactersInSet(CharacterSet.whitespaces)
+    }
+
+    private func forceResetCursor() {
+        selectedTextRange = nil
+        selectedTextRange = textRange(from: endOfDocument, to: endOfDocument)
+    }
+
+    private func debounce(_ delay: TimeInterval, action: @escaping () -> Void) -> () -> Void {
+        let callback = Callback(handler: action)
+        var timer: Timer?
+
+        return {
+            timer?.invalidate()
+            timer = Timer(
+                timeInterval: delay,
+                target: callback,
+                selector: #selector(Callback.go),
+                userInfo: nil,
+                repeats: false
+            )
+            RunLoop.current.add(timer!, forMode: .default)
+        }
+    }
+}
+
+private final class Callback: NSObject {
+    private let handler: () -> Void
+
+    init(handler: @escaping () -> Void) {
+        self.handler = handler
+    }
+
+    @objc
+    func go() {
+        handler()
+    }
+}

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPLocationTextView.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPLocationTextView.swift
@@ -4,6 +4,7 @@
 
 import UIKit
 import Common
+import Shared
 
 /// Multiline text input for the NTP omnibox with URL-bar autocomplete behaviour
 /// ported from `LocationTextField` (marked-text suffix, hidden caret, backspace
@@ -217,35 +218,5 @@ final class NTPLocationTextView: UITextView {
     private func forceResetCursor() {
         selectedTextRange = nil
         selectedTextRange = textRange(from: endOfDocument, to: endOfDocument)
-    }
-
-    private func debounce(_ delay: TimeInterval, action: @escaping () -> Void) -> () -> Void {
-        let callback = Callback(handler: action)
-        var timer: Timer?
-
-        return {
-            timer?.invalidate()
-            timer = Timer(
-                timeInterval: delay,
-                target: callback,
-                selector: #selector(Callback.go),
-                userInfo: nil,
-                repeats: false
-            )
-            RunLoop.current.add(timer!, forMode: .default)
-        }
-    }
-}
-
-private final class Callback: NSObject {
-    private let handler: () -> Void
-
-    init(handler: @escaping () -> Void) {
-        self.handler = handler
-    }
-
-    @objc
-    func go() {
-        handler()
     }
 }

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPSearchBarView.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPSearchBarView.swift
@@ -17,6 +17,9 @@ protocol NTPSearchBarDelegate: AnyObject {
     func ntpSearchBarDidSubmit(_ searchTerm: String)
     /// Called on every keystroke so the browser can feed suggestions.
     func ntpSearchBarTextDidChange(_ searchTerm: String)
+    /// Called when the field needs SearchLoader reset without hiding the overlay
+    /// (first edit after focus), matching `locationTextFieldNeedsSearchReset`.
+    func ntpSearchBarNeedsSearchReset()
     /// Called when the text field becomes first responder.
     func ntpSearchBarDidBeginEditing()
     /// Called when the text field resigns first responder for any reason
@@ -80,20 +83,13 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable {
 
     weak var delegate: NTPSearchBarDelegate?
 
-    private lazy var textView: UITextView = .build { tv in
-        tv.font = .preferredFont(forTextStyle: .body)
-        tv.adjustsFontForContentSizeCategory = true
-        tv.backgroundColor = .clear
-        tv.textContainerInset = .zero
-        tv.textContainer.lineFragmentPadding = 0
-        tv.autocorrectionType = .no
-        tv.autocapitalizationType = .none
-        tv.spellCheckingType = .no
-        tv.returnKeyType = .search
-        tv.keyboardType = .webSearch
-        tv.enablesReturnKeyAutomatically = true
+    private lazy var textView: NTPLocationTextView = {
+        let tv = NTPLocationTextView()
+        tv.translatesAutoresizingMaskIntoConstraints = false
+        tv.autocompleteDelegate = self
         tv.accessibilityIdentifier = "NTPSearchBarTextField"
-    }
+        return tv
+    }()
 
     private lazy var placeholderLabel: UILabel = .build { label in
         label.font = .preferredFont(forTextStyle: .body)
@@ -172,7 +168,7 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable {
         get { textView.text ?? "" }
         set {
             let clamped = String(newValue.prefix(UX.maxLength))
-            textView.text = clamped
+            textView.setTextWithoutSearching(clamped)
             placeholderLabel.isHidden = !clamped.isEmpty
             updateSubmitState(for: clamped)
             updateCounter(for: clamped)
@@ -296,7 +292,10 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable {
     }
 
     @objc private func focusTextView() {
-        guard !textView.isFirstResponder else { return }
+        if textView.isFirstResponder {
+            textView.applyCompletion()
+            return
+        }
         textView.becomeFirstResponder()
     }
 
@@ -308,6 +307,7 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable {
     // MARK: Actions
 
     @objc private func submitTapped() {
+        applyCompletion()
         let text = (textView.text ?? "").trimmingCharacters(in: .whitespaces)
         guard !text.isEmpty else { return }
         textView.resignFirstResponder()
@@ -317,13 +317,12 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable {
     @objc private func clearTapped() {
         // Wipe the text but keep focus so the user can keep typing without
         // re-tapping the pill.
-        textView.text = ""
+        textView.clearText()
         placeholderLabel.isHidden = false
         updateSubmitState(for: "")
         updateCounter(for: "")
         updateClearButtonVisibility(for: "")
         updateLayoutForContent()
-        delegate?.ntpSearchBarTextDidChange("")
         onContentChange?("")
     }
 
@@ -433,9 +432,12 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable {
         let colors = theme.colors
 
         backgroundColor = colors.ecosia.backgroundElevation2
-        textView.textColor = colors.ecosia.textPrimary
-        textView.tintColor = colors.ecosia.textPrimary
         placeholderLabel.textColor = colors.ecosia.textSecondary
+        textView.applyTheme(
+            markedTextStyle: [.backgroundColor: colors.ecosia.backgroundTertiary],
+            textColor: colors.ecosia.textPrimary,
+            tintColor: colors.ecosia.textPrimary
+        )
         applyBorderColor()
         applySubmitButtonColors()
         applyCounterColor()
@@ -464,9 +466,36 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable {
 
     // MARK: Autocompletable
 
-    /// Inline gray-text URL completion is not supported by the multi-line
-    /// `UITextView` field. Suggestions still flow through the overlay.
-    func setAutocompleteSuggestion(_ suggestion: String?) {}
+    func setAutocompleteSuggestion(_ suggestion: String?) {
+        textView.setAutocompleteSuggestion(suggestion)
+    }
+
+    private func applyCompletion() {
+        textView.applyCompletion()
+    }
+
+    private func refreshChromeFromTextView() {
+        let text = textView.text ?? ""
+        placeholderLabel.isHidden = !text.isEmpty
+        updateSubmitState(for: text)
+        updateCounter(for: text)
+        updateClearButtonVisibility(for: text)
+        updateLayoutForContent()
+        onContentChange?(text)
+    }
+}
+
+// MARK: - NTPLocationTextViewDelegate
+
+extension NTPSearchBarView: NTPLocationTextViewDelegate {
+    func locationTextView(_ textView: NTPLocationTextView, didEnterText text: String) {
+        refreshChromeFromTextView()
+        delegate?.ntpSearchBarTextDidChange(text)
+    }
+
+    func locationTextViewNeedsSearchReset(_ textView: NTPLocationTextView) {
+        delegate?.ntpSearchBarNeedsSearchReset()
+    }
 }
 
 // MARK: - UITextViewDelegate
@@ -480,20 +509,16 @@ extension NTPSearchBarView: @MainActor @preconcurrency UITextViewDelegate {
     }
 
     func textViewDidEndEditing(_ textView: UITextView) {
+        (textView as? NTPLocationTextView)?.didEndEditing()
+        applyCompletion()
         applyBorderColor()
         onFocusChange?(false)
         delegate?.ntpSearchBarDidCancel()
     }
 
     func textViewDidChange(_ textView: UITextView) {
-        let text = textView.text ?? ""
-        placeholderLabel.isHidden = !text.isEmpty
-        updateSubmitState(for: text)
-        updateCounter(for: text)
-        updateClearButtonVisibility(for: text)
-        updateLayoutForContent()
-        delegate?.ntpSearchBarTextDidChange(text)
-        onContentChange?(text)
+        (textView as? NTPLocationTextView)?.editingChanged()
+        refreshChromeFromTextView()
     }
 
     func textView(_ textView: UITextView,
@@ -504,6 +529,9 @@ extension NTPSearchBarView: @MainActor @preconcurrency UITextViewDelegate {
             submitTapped()
             return false
         }
+
+        (textView as? NTPLocationTextView)?.willChange(range: range, replacement: text)
+
         // Hard cap. Block edits that would push past `maxLength` — typing past
         // the cap is rejected outright, and an oversize paste is dropped (we
         // don't silently truncate to avoid mangling the user's clipboard).

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -4771,6 +4771,20 @@ extension BrowserViewController: SearchViewControllerDelegate {
     }
 
     func setLocationView(text: String, search: Bool) {
+        /* Ecosia: When the NTP omnibox owns the suggestions overlay, mirror
+           highlight/append updates into the pill instead of the hidden URL bar.
+         */
+        if let homepage = contentContainer.contentController as? HomepageViewController,
+           let bar = homepage.ntpSearchBar,
+           searchController?.parent is HomepageViewController {
+            bar.text = text
+            if search {
+                showOmniboxSuggestions(searchTerm: text, anchorView: bar)
+                searchLoader?.setQueryWithoutAutocomplete(text)
+            }
+            return
+        }
+
         let toolbarAction = ToolbarAction(
             searchTerm: text,
             windowUUID: windowUUID,


### PR DESCRIPTION
Port LocationTextField-style inline completion to the homepage search pill so history and known sites autocomplete as you type and navigate directly on submit.

<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-4537]

## Context

On the redesigned NTP, the embedded omnibox replaced the native URL bar while the homepage is visible. 
Users reported that typing a known or previously visited site no longer behaved like the standard address bar: there was no inline URL completion as they typed, and submitting a partial match (e.g. `moz`) ran a search instead of navigating to the full URL (e.g. `mozilla.org`).

The suggestions overlay was wired up, but inline autocomplete never reached the pill. `NTPSearchBarView` implemented `Autocompletable` as a no-op, so `SearchLoader` had nowhere to render history/bookmark completions. Suggestion highlights also updated the hidden toolbar URL bar rather than the NTP pill.

## Approach

- **`NTPLocationTextView`** (new): port `LocationTextField` autocomplete behaviour to the NTP text input.
- **`NTPSearchBarView`**: replace the plain `UITextView` with `NTPLocationTextView`; forward `setAutocompleteSuggestion` and submit/clear through the shared completion path.
- **`BrowserViewController+Omnibox`**: add `ntpSearchBarNeedsSearchReset()` so the first edit after focus resets `SearchLoader` without tearing down the suggestions overlay (matches `locationTextFieldNeedsSearchReset` on the URL bar).

## Before merging

⚠️  As this is quite a sensitive change, I'll make a dedicated build off Firebase to test it out before merging.

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [x] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4537]: https://ecosia.atlassian.net/browse/MOB-4537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ