### PR TITLE
[MOB-4536] Restore Ecosia Suggest local results in search overlay

### DIFF
--- a/firefox-ios/Client/Ecosia/Extensions/SearchViewController+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/SearchViewController+Ecosia.swift
@@ -4,15 +4,90 @@
 
 import Foundation
 import UIKit
+import Shared
 import Common
 import Ecosia
 
 // MARK: - Table View Style
 extension SearchViewController {
-    /* Use .insetGrouped so sections display with rounded corners and edge margins,
+    /* Ecosia: Use .insetGrouped so sections display with rounded corners and edge margins,
        matching the visual style of Settings screens (e.g. HomePageSettingViewController).
      */
     override var tableViewStyle: UITableView.Style { .insetGrouped }
+}
+
+// MARK: - Ecosia Suggest Header
+extension SearchViewController {
+    private static let ecosiaSuggestSections: [SearchListSection] = [
+        .firefoxSuggestions,
+        .openedTabs,
+        .bookmarks,
+        .remoteTabs,
+        .history
+    ]
+
+    /* Ecosia: With `.insetGrouped`, the "Ecosia Suggest" header must sit on the first section
+       that actually has rows. Firefox attaches it to `firefoxSuggestions`, but when
+       remote suggestions are empty local results live in later sections — leaving a
+       large gap between the header and the first item.
+     */
+    func ecosiaSuggestHeaderSection(in tableView: UITableView) -> Int? {
+        guard viewModel.hasFirefoxSuggestions else { return nil }
+
+        return Self.ecosiaSuggestSections.first { section in
+            tableView.numberOfRows(inSection: section.rawValue) > 0
+        }?.rawValue
+    }
+
+    func shouldShowEcosiaSuggestHeader(for section: Int, in tableView: UITableView) -> Bool {
+        ecosiaSuggestHeaderSection(in: tableView) == section
+    }
+
+    /* Ecosia: Upstream uses `viewModel.shouldShowHeader(for:)` directly. With `.insetGrouped` we
+       relocate the Suggest header and suppress the empty `firefoxSuggestions` section header.
+     */
+    func shouldShowSearchSectionHeader(for section: Int, in tableView: UITableView) -> Bool {
+        if shouldShowEcosiaSuggestHeader(for: section, in: tableView) {
+            return true
+        }
+
+        if SearchListSection(rawValue: section) == .firefoxSuggestions {
+            return false
+        }
+
+        return viewModel.shouldShowHeader(for: section)
+    }
+
+    func configureEcosiaSuggestSectionHeader(_ headerView: SiteTableViewHeader) {
+        headerView.configure(
+            SiteTableViewHeaderModel(
+                title: .Search.SuggestSectionTitle,
+                accessory: .none
+            )
+        )
+        applySearchSectionHeaderStyle(headerView)
+    }
+
+    /* Ecosia: Match Settings section headers: secondary text colour and no divider lines.
+       SiteTableViewHeader enables top/bottom borders by default, which clash with
+       `.insetGrouped` section spacing in the search overlay.
+     */
+    func applySearchSectionHeaderStyle(_ headerView: SiteTableViewHeader) {
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
+        headerView.applyTheme(theme: theme)
+        headerView.textLabel?.textColor = theme.colors.textSecondary
+        headerView.showBorder(for: .top, false)
+        headerView.showBorder(for: .bottom, false)
+    }
+
+    /* Ecosia: Branded open-tab badge for "Switch to tab" and synced-tab rows.
+       Replaces Firefox's fixed-green `sync_open_tab` asset with the template `switchTab`
+       icon from Ecosia.xcassets, tinted to match the design system.
+     */
+    func openTabBadgeImage(for theme: Theme) -> UIImage? {
+        UIImage.templateImageNamed("switchTab")?
+            .tinted(withColor: theme.colors.ecosia.buttonBackgroundPrimary)
+    }
 }
 
 // MARK: - AI Chat Autocomplete Extensions
@@ -110,7 +185,7 @@ extension SearchViewController {
         pillContainer.addSubview(twinkleImageView)
         pillContainer.addSubview(aiSearchLabel)
 
-        /* Wrap the pill in a transparent container so the pill sits flush to the left
+        /* Ecosia: Wrap the pill in a transparent container so the pill sits flush to the left
            of the wrapper while the trailing gap (10 pt) creates visual separation from the
            cell's right edge.
          */

--- a/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -6,6 +6,7 @@ import UIKit
 import Shared
 import Storage
 import Common
+// Ecosia: Ecosia framework for AI Chat, icons, and search extension helpers.
 import Ecosia
 import SiteImageView
 
@@ -89,9 +90,11 @@ class SearchViewController: SiteTableViewController,
         return UIImage(named: StandardImageIdentifiers.Medium.bookmarkBadgeFillBlue50)!
     }()
 
+    /* Ecosia: Replaced by openTabBadgeImage(for:) using the branded switchTab asset.
     private lazy var openAndSyncTabBadge: UIImage = {
         return UIImage(named: ImageIdentifiers.syncOpenTab)!
     }()
+    */
 
     private lazy var searchButton: UIButton = .build { button in
         let image = UIImage(named: StandardImageIdentifiers.Large.search)?.withRenderingMode(.alwaysTemplate)
@@ -276,7 +279,9 @@ class SearchViewController: SiteTableViewController,
             tableView.topAnchor.constraint(equalTo: view.topAnchor),
             tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            // Ecosia: Extend table view to bottom since search engine container is hidden
+            /* Ecosia: Extend table view to bottom since search engine container is hidden.
+            tableView.bottomAnchor.constraint(equalTo: searchEngineScrollView.topAnchor)
+            */
             tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
     }
@@ -462,6 +467,10 @@ class SearchViewController: SiteTableViewController,
 
             searchTelemetry?.selectedResult = .searchSuggest
             // Assume that only the default search engine can provide search suggestions.
+            /* Ecosia: Use safeSuggestion and handle AI Chat row.
+            guard let suggestions = viewModel.suggestions,
+                  let suggestion = suggestions[safe: indexPath.row],
+            */
             guard let suggestion = safeSuggestion(at: indexPath.row),
                   let url = defaultEngine.searchURLForQuery(suggestion)
             else { return }
@@ -516,10 +525,10 @@ class SearchViewController: SiteTableViewController,
         _ tableView: UITableView,
         heightForHeaderInSection section: Int
     ) -> CGFloat {
+        /* Ecosia: Wrap upstream visibility to relocate the Suggest header for `.insetGrouped`.
         guard viewModel.shouldShowHeader(for: section) else { return 0 }
-        // Ecosia: Suppress headers for empty sections and for "Ecosia search" above suggestions.
-        guard tableView.numberOfRows(inSection: section) > 0 else { return 0 }
-        guard SearchListSection(rawValue: section) != .searchSuggestions else { return 0 }
+        */
+        guard shouldShowSearchSectionHeader(for: section, in: tableView) else { return 0 }
 
         return UITableView.automaticDimension
     }
@@ -532,10 +541,22 @@ class SearchViewController: SiteTableViewController,
         _ tableView: UITableView,
         viewForHeaderInSection section: Int
     ) -> UIView? {
+        /* Ecosia: Wrap upstream guard to relocate the Suggest header for `.insetGrouped`.
         guard viewModel.shouldShowHeader(for: section),
               let headerView = tableView.dequeueReusableHeaderFooterView(
                 withIdentifier: SiteTableViewHeader.cellIdentifier) as? SiteTableViewHeader
         else { return nil }
+        */
+        guard shouldShowSearchSectionHeader(for: section, in: tableView),
+              let headerView = tableView.dequeueReusableHeaderFooterView(
+                withIdentifier: SiteTableViewHeader.cellIdentifier) as? SiteTableViewHeader
+        else { return nil }
+
+        // Ecosia: Configure relocated "Ecosia Suggest" header on the first section with rows.
+        if shouldShowEcosiaSuggestHeader(for: section, in: tableView) {
+            configureEcosiaSuggestSectionHeader(headerView)
+            return headerView
+        }
 
         var title: String
         var accessory: SiteTableHeaderAccessory = .none
@@ -558,8 +579,10 @@ class SearchViewController: SiteTableViewController,
                 title = ""
             }
 
+        /* Ecosia: Handled by configureEcosiaSuggestSectionHeader on the first section with rows.
         case SearchListSection.firefoxSuggestions.rawValue:
             title = .Search.SuggestSectionTitle
+        */
         case SearchListSection.searchSuggestions.rawValue:
             title = viewModel.searchEnginesManager?.defaultEngine?.headerSearchTitle ?? ""
         default:  title = ""
@@ -570,9 +593,10 @@ class SearchViewController: SiteTableViewController,
             accessory: accessory
         )
         headerView.configure(viewModel)
+        /* Ecosia: Settings-style header appearance for `.insetGrouped` search sections.
         headerView.applyTheme(theme: currentTheme())
-        // Ecosia: Match Settings section header appearance — use textSecondary instead of textPrimary.
-        headerView.textLabel?.textColor = currentTheme().colors.textSecondary
+        */
+        applySearchSectionHeaderStyle(headerView)
         return headerView
     }
 
@@ -609,7 +633,9 @@ class SearchViewController: SiteTableViewController,
             case .trendingSearches:
                 viewModel.recordTrendingSearchesDisplayedEvent()
             case .searchSuggestions:
-                // Ecosia: Skip telemetry for AI Chat item
+                /* Ecosia: Skip telemetry for AI Chat item; use safe array access.
+                if let site = viewModel.suggestions?[indexPath.row] {
+                */
                 if !isAIChatRow(indexPath),
                    let site = safeSuggestion(at: indexPath.row) {
                     if searchTelemetry?.visibleSuggestions.contains(site) == false {
@@ -663,7 +689,10 @@ class SearchViewController: SiteTableViewController,
         case .trendingSearches:
             return viewModel.shouldShowTrendingSearches ? viewModel.trendingSearches.count : 0
         case .searchSuggestions:
-            // Ecosia: Use custom method that includes AI Chat item
+            /* Ecosia: Use custom method that includes AI Chat item.
+            guard let count = viewModel.suggestions?.count else { return 0 }
+            return count < 4 ? count : 4
+            */
             return numberOfRowsForSearchSuggestions()
         case .openedTabs:
             return !viewModel.isZeroSearchState ? viewModel.filteredOpenedTabs.count : 0
@@ -679,8 +708,7 @@ class SearchViewController: SiteTableViewController,
     }
 
     func numberOfSections(in tableView: UITableView) -> Int {
-        // Ecosia: Hide Firefox Suggest and only show 4 sections instead of all
-        return 4
+        return SearchListSection.allCases.count
     }
 
     func tableView(_ tableView: UITableView, didHighlightRowAt indexPath: IndexPath) {
@@ -699,6 +727,9 @@ class SearchViewController: SiteTableViewController,
                 handleAIChatHighlight(indexPath)
                 return
             }
+            /* Ecosia: Use safe array access.
+            guard let suggestion = viewModel.suggestions?[indexPath.item] else { return }
+            */
             guard let suggestion = safeSuggestion(at: indexPath.item) else { return }
             searchDelegate?.searchViewController(self, didHighlightText: suggestion, search: false)
         case .remoteTabs:
@@ -780,6 +811,9 @@ class SearchViewController: SiteTableViewController,
             }
 
         case .searchSuggestions:
+            /* Ecosia: Handle AI Chat row and use safe array access.
+            if let site = viewModel.suggestions?[indexPath.row] {
+            */
             // Ecosia: Check if this is the AI Chat item
             if isAIChatRow(indexPath) {
                 cell = configureAIChatCell(oneLineCell)
@@ -806,7 +840,10 @@ class SearchViewController: SiteTableViewController,
                 twoLineCell.descriptionLabel.isHidden = false
                 twoLineCell.titleLabel.text = openedTab.title ?? openedTab.lastTitle
                 twoLineCell.descriptionLabel.text = String.SearchSuggestionCellSwitchToTabLabel
+                /* Ecosia: Use branded switchTab badge instead of Firefox sync_open_tab.
                 twoLineCell.leftOverlayImageView.image = openAndSyncTabBadge
+                */
+                twoLineCell.leftOverlayImageView.image = openTabBadgeImage(for: currentTheme())
                 twoLineCell.leftImageView.layer.borderColor = UX.IconBorderColor.cgColor
                 twoLineCell.leftImageView.layer.borderWidth = UX.IconBorderWidth
                 if let urlString = openedTab.url?.absoluteString {
@@ -823,7 +860,10 @@ class SearchViewController: SiteTableViewController,
                 twoLineCell.descriptionLabel.isHidden = false
                 twoLineCell.titleLabel.text = remoteTab.title
                 twoLineCell.descriptionLabel.text = remoteClient.name
+                /* Ecosia: Use branded switchTab badge instead of Firefox sync_open_tab.
                 twoLineCell.leftOverlayImageView.image = openAndSyncTabBadge
+                */
+                twoLineCell.leftOverlayImageView.image = openTabBadgeImage(for: currentTheme())
                 twoLineCell.leftImageView.layer.borderColor = UX.IconBorderColor.cgColor
                 twoLineCell.leftImageView.layer.borderWidth = UX.IconBorderWidth
                 let urlString = remoteTab.URL.absoluteString
@@ -884,7 +924,9 @@ class SearchViewController: SiteTableViewController,
         shouldShowAccessoryView: Bool = true
     ) -> OneLineTableViewCellViewModel {
         let appendButton = UIButton(type: .roundedRect)
-        // Ecosia: Use searchAppend icon
+        /* Ecosia: Use searchAppend icon.
+        appendButton.setImage(searchAppendImage?.withRenderingMode(.alwaysTemplate), for: .normal)
+        */
         appendButton.setImage(UIImage.templateImageNamed("searchAppend"), for: .normal)
         appendButton.adjustsImageSizeForAccessibilityContentSizeCategory = true
         let action = UIAction { [weak self] _ in


### PR DESCRIPTION
Re-enable all search suggestion sections and fix insetGrouped header layout so local history, tabs, and bookmarks show correctly under Ecosia Suggest. Use branded switchTab badge and Settings-style section headers.

<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-4536]

## Context

Local Ecosia Suggest (history, bookmarks, open/synced tabs) disappeared from the search overlay after the v147 upgrade. Section headers were missing or detached from their results when remote suggestions are off.

## Approach

- Restore all search sections (`SearchListSection.allCases.count`) so local results show again.
- Relocate the **Ecosia Suggest** header to the first section with rows, fixing the large gap under `.insetGrouped`.
- Restore **Ecosia search** and other section headers; use Settings-style headers.
- Use the branded `switchTab` badge on open-tab and synced-tab rows.
- Keep Ecosia logic in `SearchViewController+Ecosia.swift`; upstream behaviour unchanged in core.

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [x] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4536]: https://ecosia.atlassian.net/browse/MOB-4536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ