### PR TITLE
ios-browser: Upgrade actions/checkout to v5

### DIFF
--- a/.github/workflows/merge_tests.yml
+++ b/.github/workflows/merge_tests.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - uses: ./.github/actions/setup-safe-chain
 

--- a/.github/workflows/snapshot_tests.yml
+++ b/.github/workflows/snapshot_tests.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           lfs: true
           submodules: true    

--- a/.github/workflows/swift_lint.yml
+++ b/.github/workflows/swift_lint.yml
@@ -11,7 +11,7 @@ jobs:
       image: ghcr.io/realm/swiftlint:0.63.2
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: SwiftLint
         run: |

--- a/.github/workflows/upload_release_notes_to_appstore.yml
+++ b/.github/workflows/upload_release_notes_to_appstore.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - uses: ./.github/actions/setup-safe-chain
 


### PR DESCRIPTION
## Ticket

No Ticket

## Description

Bumped `actions/checkout` from `v4` → `v5`

### why? 

GitHub Actions is deprecating Node.js 20 on runners. Starting **June 16, 2026**, Node.js 24 becomes the default, and Node.js 20 will be fully removed on **September 16, 2026**. `actions/checkout@v4` runs on Node.js 20 and will stop working as expected. 

<img width="1641" height="207" alt="Screenshot 2026-06-08 at 10 27 25" src="https://github.com/user-attachments/assets/32b70395-39b3-4070-9c82-fc5574a6ad9f" />

