### PR TITLE
[MOB-4553] Fix snowplow id parameter for web

### DIFF
--- a/firefox-ios/Client/Ecosia/Extensions/Tab+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/Tab+Ecosia.swift
@@ -1,0 +1,33 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Ecosia
+import Foundation
+
+extension Tab {
+
+    /// Applies all Ecosia-specific mutations to a `URLRequest` before it is handed
+    /// to WKWebView. Called from `Tab.loadRequest` as a single choke-point so every
+    /// navigation — URL bar, Omnibox, tab restoration, vertical-preserving rewrites —
+    /// picks up the changes without extra navigation cycles.
+    ///
+    /// Mutations applied, in order:
+    /// 1. **Cloudflare auth headers** – required for non-production environments.
+    /// 2. **Language-region header** – enriches SERP requests for market selection.
+    /// 3. **Snowplow user id parameter** – appended to Ecosia URLs so the web SERP can
+    ///    propagate it through its navigation links and link web Snowplow events back
+    ///    to the native analytics identity. `ecosified()` sends the null UUID for
+    ///    private tabs or when the user has opted out of analytics.
+    func ecosiaUpdatedRequest(_ request: URLRequest) -> URLRequest {
+        var updated = request
+        updated = updated.withCloudFlareAuthParameters()
+        if updated.url?.isEcosiaSearchQuery() == true {
+            updated.addLanguageRegionHeader()
+        }
+        if let url = updated.url, url.shouldEcosify(), !url.hasEcosiaUserId {
+            updated = URLRequest(url: url.ecosified(isIncognitoEnabled: isPrivate))
+        }
+        return updated
+    }
+}

--- a/firefox-ios/Client/Ecosia/Extensions/Tab+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/Tab+Ecosia.swift
@@ -26,7 +26,7 @@ extension Tab {
             updated.addLanguageRegionHeader()
         }
         if let url = updated.url, url.shouldEcosify(), !url.hasEcosiaUserId {
-            updated = URLRequest(url: url.ecosified(isIncognitoEnabled: isPrivate))
+            updated.url = url.ecosified(isIncognitoEnabled: isPrivate)
         }
         return updated
     }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Models/AddressToolbarContainerModel.swift
@@ -60,12 +60,8 @@ final class AddressToolbarContainerModel: Equatable {
             droppableUrl = url
         }
 
-        // Ecosia: Ecosify URL when needed; use Ecosia search/logo icon (legacy URLBarView behaviour).
-        let displayURL: URL? = {
-            if isEmptySearch { return nil }
-            guard let u = url else { return nil }
-            return u.shouldEcosify() ? u.ecosified(isIncognitoEnabled: isPrivateMode) : u
-        }()
+        // Ecosia: suppress URL display during the empty-search state (upstream passes `url` directly).
+        let displayURL: URL? = isEmptySearch ? nil : url
         /* Ecosia: Original flatMap returns nil for any regular URL (InternalURL returns nil for https:// URLs),
            so `nil ?? true` incorrectly treats all regular pages as home. Use map with `?? false` so that
            non-internal URLs evaluate to false (not home), while nil URL still defaults to true (home).

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -667,15 +667,10 @@ class Tab: NSObject, ThemeApplicable, FeatureFlaggable, ShareTab {
             if let url = request.url, url.isFileURL, request.isPrivileged {
                 return webView.loadFileURL(url, allowingReadAccessTo: url)
             }
-            /* Ecosia: Inject CloudFlare auth headers and language region header for search requests
+            /* Ecosia: Apply Ecosia-specific request mutations (Cloudflare auth, language header, _sp).
             return webView.load(request)
             */
-            var ecosiaUpdatedRequest = request
-            ecosiaUpdatedRequest = ecosiaUpdatedRequest.withCloudFlareAuthParameters()
-            if ecosiaUpdatedRequest.url?.isEcosiaSearchQuery() == true {
-                ecosiaUpdatedRequest.addLanguageRegionHeader()
-            }
-            return webView.load(ecosiaUpdatedRequest)
+            return webView.load(ecosiaUpdatedRequest(request))
         }
         return nil
     }

--- a/firefox-ios/Ecosia/Core/URL+Extensions.swift
+++ b/firefox-ios/Ecosia/Core/URL+Extensions.swift
@@ -172,6 +172,10 @@ extension URL {
         return urlWithoutUserId.appendingQueryItems([Self.item(name: .userId, value: userId)])
     }
 
+    public var hasEcosiaUserId: Bool {
+        components?.queryItems?.contains { $0.name == EcosiaQueryItemName.userId.rawValue } ?? false
+    }
+
     public var policy: Scheme.Policy {
         (scheme
             .flatMap(Scheme.init(rawValue:)) ?? .other)

--- a/firefox-ios/Ecosia/Core/URLRequest+Extensions.swift
+++ b/firefox-ios/Ecosia/Core/URLRequest+Extensions.swift
@@ -6,8 +6,16 @@ import Foundation
 
 extension URLRequest {
 
+    @discardableResult
     public mutating func withCloudFlareAuthParameters(environment: Environment = EcosiaEnvironment.current) -> URLRequest {
-        if let auth = environment.cloudFlareAuth {
+        withCloudFlareAuthParameters(auth: environment.cloudFlareAuth)
+    }
+
+    /// Internal overload that accepts auth directly, enabling unit tests to inject credentials
+    /// without relying on process-info environment variables.
+    @discardableResult
+    mutating func withCloudFlareAuthParameters(auth: Environment.CloudFlareAuth?) -> URLRequest {
+        if let auth {
             setValue(auth.id, forHTTPHeaderField: CloudflareKeyProvider.clientId)
             setValue(auth.secret, forHTTPHeaderField: CloudflareKeyProvider.clientSecret)
         }

--- a/firefox-ios/EcosiaTests/Core/URLRequestTests.swift
+++ b/firefox-ios/EcosiaTests/Core/URLRequestTests.swift
@@ -7,11 +7,51 @@ import XCTest
 
 final class URLRequestTests: XCTestCase {
 
+    private let ecosiaURL = URL(string: "https://www.ecosia.org/search")!
+
+    // MARK: - Language-region header
+
     func testAddLanguageRegionHeader() {
-        var request = URLRequest(url: URL(string: "https://www.ecosia.org/search")!)
+        var request = URLRequest(url: ecosiaURL)
         request.addLanguageRegionHeader()
 
-        let dashedLanguageAndRegion = Locale.current.identifier.replacingOccurrences(of: "_", with: "-").lowercased()
-        XCTAssertEqual(request.value(forHTTPHeaderField: "x-ecosia-app-language-region"), dashedLanguageAndRegion)
+        let expected = Locale.current.identifier.replacingOccurrences(of: "_", with: "-").lowercased()
+        XCTAssertEqual(request.value(forHTTPHeaderField: "x-ecosia-app-language-region"), expected)
+    }
+
+    func testAddLanguageRegionHeaderIsIdempotent() {
+        var request = URLRequest(url: ecosiaURL)
+        request.addLanguageRegionHeader()
+        request.addLanguageRegionHeader()
+
+        let expected = Locale.current.identifier.replacingOccurrences(of: "_", with: "-").lowercased()
+        XCTAssertEqual(request.value(forHTTPHeaderField: "x-ecosia-app-language-region"), expected)
+    }
+
+    // MARK: - Cloudflare auth headers
+
+    func testCloudFlareHeadersNotAddedWhenNoAuth() {
+        var request = URLRequest(url: ecosiaURL)
+        request.withCloudFlareAuthParameters(auth: nil)
+
+        XCTAssertNil(request.value(forHTTPHeaderField: CloudflareKeyProvider.clientId))
+        XCTAssertNil(request.value(forHTTPHeaderField: CloudflareKeyProvider.clientSecret))
+    }
+
+    func testCloudFlareHeadersAddedWhenAuthProvided() {
+        var request = URLRequest(url: ecosiaURL)
+        let auth = Environment.CloudFlareAuth(id: "test-client-id", secret: "test-client-secret")
+        request.withCloudFlareAuthParameters(auth: auth)
+
+        XCTAssertEqual(request.value(forHTTPHeaderField: CloudflareKeyProvider.clientId), "test-client-id")
+        XCTAssertEqual(request.value(forHTTPHeaderField: CloudflareKeyProvider.clientSecret), "test-client-secret")
+    }
+
+    func testCloudFlareHeadersNotAddedForProductionEnvironment() {
+        var request = URLRequest(url: ecosiaURL)
+        request.withCloudFlareAuthParameters(environment: .production)
+
+        XCTAssertNil(request.value(forHTTPHeaderField: CloudflareKeyProvider.clientId))
+        XCTAssertNil(request.value(forHTTPHeaderField: CloudflareKeyProvider.clientSecret))
     }
 }

--- a/firefox-ios/EcosiaTests/Core/URLTests.swift
+++ b/firefox-ios/EcosiaTests/Core/URLTests.swift
@@ -354,6 +354,28 @@ final class URLTests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(ecosified, URL(string: "https://ecosia.org?_sp=\(UUID(uuid: UUID_NULL).uuidString)"))
     }
 
+    // MARK: - `hasEcosiaUserId`
+
+    func testHasEcosiaUserIdReturnsFalseWhenAbsent() {
+        XCTAssertFalse(URL(string: "https://www.ecosia.org/search?q=cats")!.hasEcosiaUserId)
+    }
+
+    func testHasEcosiaUserIdReturnsTrueWhenPresent() {
+        XCTAssertTrue(URL(string: "https://www.ecosia.org/search?q=cats&_sp=abc123")!.hasEcosiaUserId)
+    }
+
+    func testHasEcosiaUserIdReturnsFalseWhenOtherParamsPresent() {
+        XCTAssertFalse(URL(string: "https://www.ecosia.org/search?q=cats&tt=iosapp")!.hasEcosiaUserId)
+    }
+
+    func testEcosifiedURLHasEcosiaUserId() {
+        User.shared.sendAnonymousUsageData = true
+        User.shared.cookieConsentValue = "a"
+        let url = URL(string: "https://www.ecosia.org/search?q=cats")!
+            .ecosified(isIncognitoEnabled: false, urlProvider: urlProvider)
+        XCTAssertTrue(url.hasEcosiaUserId)
+    }
+
     // MARK: - `policy`
 
     func testPolicyAllow() {

--- a/firefox-ios/EcosiaTests/UI/TabManagement/TabEcosiaExtensionTests.swift
+++ b/firefox-ios/EcosiaTests/UI/TabManagement/TabEcosiaExtensionTests.swift
@@ -1,0 +1,179 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import Common
+import WebKit
+@testable import Client
+@testable import Ecosia
+
+@MainActor
+final class TabEcosiaExtensionTests: XCTestCase {
+
+    private var windowUUID: WindowUUID!
+    private var savedAnalyticsId: UUID!
+    private var savedSendAnonymousUsageData: Bool!
+    private var savedCookieConsentValue: String?
+
+    override func setUp() {
+        super.setUp()
+        windowUUID = WindowUUID()
+        savedAnalyticsId = User.shared.analyticsId
+        savedSendAnonymousUsageData = User.shared.sendAnonymousUsageData
+        savedCookieConsentValue = User.shared.cookieConsentValue
+        User.shared.sendAnonymousUsageData = true
+        User.shared.cookieConsentValue = "a"
+    }
+
+    override func tearDown() {
+        User.shared.analyticsId = savedAnalyticsId
+        User.shared.sendAnonymousUsageData = savedSendAnonymousUsageData
+        User.shared.cookieConsentValue = savedCookieConsentValue
+        windowUUID = nil
+        super.tearDown()
+    }
+
+    // MARK: - _sp injection
+
+    func testSpAddedToEcosiaURL() {
+        let tab = makeTab(isPrivate: false)
+        let url = URL(string: "https://www.ecosia.org/search?q=cats&tt=iosapp")!
+        let result = tab.ecosiaUpdatedRequest(URLRequest(url: url))
+
+        XCTAssertTrue(result.url?.hasEcosiaUserId == true)
+        XCTAssertEqual(
+            result.url?.queryItem(named: "_sp"),
+            User.shared.analyticsId.uuidString
+        )
+    }
+
+    func testSpNotAddedToNonEcosiaURL() {
+        let tab = makeTab(isPrivate: false)
+        let url = URL(string: "https://example.com/search?q=cats")!
+        let result = tab.ecosiaUpdatedRequest(URLRequest(url: url))
+
+        XCTAssertFalse(result.url?.hasEcosiaUserId == true)
+    }
+
+    func testSpNotDuplicatedWhenAlreadyPresent() {
+        let tab = makeTab(isPrivate: false)
+        let existingSP = "existing-sp-value"
+        let url = URL(string: "https://www.ecosia.org/search?q=cats&_sp=\(existingSP)")!
+        let result = tab.ecosiaUpdatedRequest(URLRequest(url: url))
+
+        // guard !url.hasEcosiaUserId means the existing value is preserved unchanged
+        XCTAssertEqual(result.url?.queryItem(named: "_sp"), existingSP)
+    }
+
+    func testSpIsNullUUIDForPrivateTab() {
+        let tab = makeTab(isPrivate: true)
+        let url = URL(string: "https://www.ecosia.org/search?q=cats&tt=iosapp")!
+        let result = tab.ecosiaUpdatedRequest(URLRequest(url: url))
+
+        XCTAssertEqual(
+            result.url?.queryItem(named: "_sp"),
+            UUID(uuid: UUID_NULL).uuidString
+        )
+    }
+
+    func testSpIsNullUUIDWhenAnalyticsOptedOut() {
+        User.shared.sendAnonymousUsageData = false
+        let tab = makeTab(isPrivate: false)
+        let url = URL(string: "https://www.ecosia.org/search?q=cats&tt=iosapp")!
+        let result = tab.ecosiaUpdatedRequest(URLRequest(url: url))
+
+        XCTAssertEqual(
+            result.url?.queryItem(named: "_sp"),
+            UUID(uuid: UUID_NULL).uuidString
+        )
+    }
+
+    // MARK: - Language-region header
+
+    func testLanguageRegionHeaderAddedForSERPURL() {
+        let tab = makeTab(isPrivate: false)
+        let url = URL(string: "https://www.ecosia.org/search?q=cats")!
+        let result = tab.ecosiaUpdatedRequest(URLRequest(url: url))
+
+        let expected = Locale.current.identifier.replacingOccurrences(of: "_", with: "-").lowercased()
+        XCTAssertEqual(result.value(forHTTPHeaderField: "x-ecosia-app-language-region"), expected)
+    }
+
+    func testLanguageRegionHeaderNotAddedForNonSERPURL() {
+        let tab = makeTab(isPrivate: false)
+        let url = URL(string: "https://www.ecosia.org/")!
+        let result = tab.ecosiaUpdatedRequest(URLRequest(url: url))
+
+        XCTAssertNil(result.value(forHTTPHeaderField: "x-ecosia-app-language-region"))
+    }
+
+    // MARK: - loadRequest integration
+
+    func testLoadRequestPassesEcosifiedURLToWebView() {
+        let tab = makeTab(isPrivate: false)
+        tab.createWebview(configuration: WKWebViewConfiguration())
+
+        let expect = expectation(description: "decidePolicyFor called")
+        let spy = NavigationSpy(expectation: expect)
+        tab.navigationDelegate = spy
+
+        let url = URL(string: "https://www.ecosia.org/search?q=cats&tt=iosapp")!
+        tab.loadRequest(URLRequest(url: url))
+
+        waitForExpectations(timeout: 2)
+        XCTAssertTrue(spy.capturedURL?.hasEcosiaUserId == true,
+                      "loadRequest must pass the ecosified URL (with _sp) to WKWebView")
+    }
+
+    func testLoadRequestPassesNullUUIDForPrivateTab() {
+        let tab = makeTab(isPrivate: true)
+        tab.createWebview(configuration: WKWebViewConfiguration())
+
+        let expect = expectation(description: "decidePolicyFor called")
+        let spy = NavigationSpy(expectation: expect)
+        tab.navigationDelegate = spy
+
+        let url = URL(string: "https://www.ecosia.org/search?q=cats&tt=iosapp")!
+        tab.loadRequest(URLRequest(url: url))
+
+        waitForExpectations(timeout: 2)
+        XCTAssertEqual(spy.capturedURL?.queryItem(named: "_sp"),
+                       UUID(uuid: UUID_NULL).uuidString)
+    }
+
+    // MARK: - Helpers
+
+    private func makeTab(isPrivate: Bool) -> Client.Tab {
+        Client.Tab(profile: MockProfile(), isPrivate: isPrivate, windowUUID: windowUUID)
+    }
+}
+
+// MARK: - Navigation spy
+
+private final class NavigationSpy: NSObject, WKNavigationDelegate {
+    private(set) var capturedURL: URL?
+    private let expectation: XCTestExpectation
+
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationAction: WKNavigationAction
+    ) async -> WKNavigationActionPolicy {
+        capturedURL = navigationAction.request.url
+        expectation.fulfill()
+        return .cancel
+    }
+}
+
+private extension URL {
+    func queryItem(named name: String) -> String? {
+        URLComponents(url: self, resolvingAgainstBaseURL: false)?
+            .queryItems?
+            .first { $0.name == name }?
+            .value
+    }
+}

--- a/firefox-ios/EcosiaTests/UI/TabManagement/TabEcosiaExtensionTests.swift
+++ b/firefox-ios/EcosiaTests/UI/TabManagement/TabEcosiaExtensionTests.swift
@@ -11,9 +11,9 @@ import WebKit
 @MainActor
 final class TabEcosiaExtensionTests: XCTestCase {
 
-    private var windowUUID: WindowUUID!
-    private var savedAnalyticsId: UUID!
-    private var savedSendAnonymousUsageData: Bool!
+    private var windowUUID = WindowUUID()
+    private var savedAnalyticsId = UUID()
+    private var savedSendAnonymousUsageData = true
     private var savedCookieConsentValue: String?
 
     override func setUp() {


### PR DESCRIPTION
[MOB-4553]

## Context

Reported by BI, see ticket.

## Approach

Figured out the `AddressToolbarContainerModel` ecosification does not work for Omnibox. Not completely sure if it was even doing what was intended on the rest of the app (besides cosmetically), since we did not have on the upgrade [this change that used the ecosified url](https://github.com/ecosia/ios-browser/blob/2644f2aa06422e35f90b6fd98531d6feeaffbced/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift#L1652-L1657).

To make ecosification more resilient, applying it directly under `Tab.loadRequest` which happens earlier in the flow, before we even pass it to `WKWebView`.

Also refactored a bit to Ecosia custom code is in an extension, including ther additions like CF and location headers.

## Other

Extended tests to cover these scenarios - though couldn't run them to test, probably related to the pending [unit test fixing after upgrade ticket](https://ecosia.atlassian.net/browse/MOB-4384)? Leaving the tests anyway and not spending too long debugging for now since this is an important fix (verified manually too).

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [x] I added the `// Ecosia:` helper comments where needed
- [x] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4554]: https://ecosia.atlassian.net/browse/MOB-4553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MOB-4553]: https://ecosia.atlassian.net/browse/MOB-4553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ