### PR TITLE
[MOB-4553] Fix ecosification on web navigation

### DIFF
--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+EcosiaNavigationHandling.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+EcosiaNavigationHandling.swift
@@ -9,12 +9,34 @@ import Ecosia
 // MARK: - Ecosia Web View Event Handling
 extension BrowserViewController {
 
+    /// Single entry point for all Ecosia-specific processing in `decidePolicyFor`.
+    /// Runs vertical preservation, URL ecosification, and navigation tracking in order.
+    /// Returns `true` when a replacement navigation was started — caller is responsible for
+    /// calling `decisionHandler(.cancel)` and returning.
+    func ecosiaDecidePolicyForNavigation(
+        url: URL,
+        webView: WKWebView,
+        tab: Tab,
+        navigationAction: WKNavigationAction
+    ) -> Bool {
+        if ecosiaApplyVerticalPreservingSearchNavigationIfNeeded(
+            navigationURL: url,
+            currentPageURL: webView.url ?? tab.url,
+            navigationType: navigationAction.navigationType,
+            tab: tab
+        ) {
+            return true
+        }
+        if ecosiaEcosifyNavigationIfNeeded(url: url, tab: tab) {
+            return true
+        }
+        ecosiaHandleNavigationAction(url: url, navigationAction: navigationAction)
+        return false
+    }
+
     /// Handles any Ecosia-specific tracking when a navigation action is allowed.
     /// Stores a pending URL to be tracked at didCommit.
-    /// - Parameters:
-    ///   - url: The URL being navigated to
-    ///   - navigationAction: The navigation action that triggered this check
-    func ecosiaHandleNavigationAction(url: URL, navigationAction: WKNavigationAction) {
+    private func ecosiaHandleNavigationAction(url: URL, navigationAction: WKNavigationAction) {
         // Clear any stale pending tracking from a previous navigation
         pendingInappSearchUrl = nil
 
@@ -42,7 +64,7 @@ extension BrowserViewController {
 
     /// Rewrites in-page SERP navigations that target the default text vertical (`/search`) so they
     /// stay on the user's active vertical (e.g. Images). Returns `nil` when navigation should proceed unchanged.
-    func ecosiaSearchURLPreservingVertical(
+    private func ecosiaSearchURLPreservingVertical(
         navigationURL: URL,
         currentPageURL: URL?,
         navigationType: WKNavigationType
@@ -63,7 +85,7 @@ extension BrowserViewController {
 
     /// Returns `true` when navigation was rewritten to preserve the active SERP vertical.
     @discardableResult
-    func ecosiaApplyVerticalPreservingSearchNavigationIfNeeded(
+    private func ecosiaApplyVerticalPreservingSearchNavigationIfNeeded(
         navigationURL: URL,
         currentPageURL: URL?,
         navigationType: WKNavigationType,
@@ -80,23 +102,11 @@ extension BrowserViewController {
         return true
     }
 
-    /// Cancels navigation when it was rewritten to preserve the active SERP vertical.
-    func ecosiaCancelNavigationPreservingVerticalIfNeeded(
-        url: URL,
-        webView: WKWebView,
-        tab: Tab,
-        navigationAction: WKNavigationAction,
-        decisionHandler: @escaping @MainActor (WKNavigationActionPolicy) -> Void
-    ) -> Bool {
-        guard ecosiaApplyVerticalPreservingSearchNavigationIfNeeded(
-            navigationURL: url,
-            currentPageURL: webView.url ?? tab.url,
-            navigationType: navigationAction.navigationType,
-            tab: tab
-        ) else {
-            return false
-        }
-        decisionHandler(.cancel)
+    /// Ecosifies the navigation URL if it doesn't yet carry the Snowplow user id, reloading via
+    /// `tab.loadRequest()` so `ecosiaUpdatedRequest` runs. Returns `true` when a replacement was started.
+    private func ecosiaEcosifyNavigationIfNeeded(url: URL, tab: Tab) -> Bool {
+        guard url.shouldEcosify(), !url.hasEcosiaUserId else { return false }
+        tab.loadRequest(URLRequest(url: url.ecosified(isIncognitoEnabled: tab.isPrivate)))
         return true
     }
 }

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+EcosiaNavigationHandling.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+EcosiaNavigationHandling.swift
@@ -105,8 +105,9 @@ extension BrowserViewController {
     /// Ecosifies the navigation URL if it doesn't yet carry the Snowplow user id, reloading via
     /// `tab.loadRequest()` so `ecosiaUpdatedRequest` runs. Returns `true` when a replacement was started.
     private func ecosiaEcosifyNavigationIfNeeded(url: URL, tab: Tab) -> Bool {
-        guard url.shouldEcosify(), !url.hasEcosiaUserId else { return false }
-        tab.loadRequest(URLRequest(url: url.ecosified(isIncognitoEnabled: tab.isPrivate)))
+        let ecosified = url.ecosified(isIncognitoEnabled: tab.isPrivate)
+        guard ecosified != url else { return false }
+        tab.loadRequest(URLRequest(url: ecosified))
         return true
     }
 }

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+EcosiaNavigationHandling.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+EcosiaNavigationHandling.swift
@@ -19,6 +19,7 @@ extension BrowserViewController {
         tab: Tab,
         navigationAction: WKNavigationAction
     ) -> Bool {
+        guard navigationAction.targetFrame?.isMainFrame == true else { return false }
         if ecosiaApplyVerticalPreservingSearchNavigationIfNeeded(
             navigationURL: url,
             currentPageURL: webView.url ?? tab.url,

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+EcosiaNavigationHandling.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+EcosiaNavigationHandling.swift
@@ -103,7 +103,7 @@ extension BrowserViewController {
         return true
     }
 
-    /// Ecosifies the navigation URL if it doesn't yet carry the Snowplow user id, reloading via
+    /// Ecosifies the navigation URL if it carries an absent or outdated Snowplow user id, reloading via
     /// `tab.loadRequest()` so `ecosiaUpdatedRequest` runs. Returns `true` when a replacement was started.
     private func ecosiaEcosifyNavigationIfNeeded(url: URL, tab: Tab) -> Bool {
         let ecosified = url.ecosified(isIncognitoEnabled: tab.isPrivate)

--- a/firefox-ios/Client/Ecosia/Extensions/Tab+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/Tab+Ecosia.swift
@@ -25,9 +25,7 @@ extension Tab {
         if updated.url?.isEcosiaSearchQuery() == true {
             updated.addLanguageRegionHeader()
         }
-        if let url = updated.url, url.shouldEcosify(), !url.hasEcosiaUserId {
-            updated.url = url.ecosified(isIncognitoEnabled: isPrivate)
-        }
+        updated.url = updated.url.map { $0.ecosified(isIncognitoEnabled: isPrivate) }
         return updated
     }
 }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -608,17 +608,11 @@ extension BrowserViewController: WKNavigationDelegate {
                 return
             }
 
-            // Ecosia: Keep the active vertical for in-page `/search` navigations; run before tracking so analytics see the rewritten URL.
-            if ecosiaCancelNavigationPreservingVerticalIfNeeded(
-                url: url,
-                webView: webView,
-                tab: tab,
-                navigationAction: navigationAction,
-                decisionHandler: decisionHandler
-            ) { return }
-
-            // Ecosia: Handle navigation tracking
-            ecosiaHandleNavigationAction(url: url, navigationAction: navigationAction)
+            // Ecosia: Vertical preservation, URL ecosification, and navigation tracking.
+            if ecosiaDecidePolicyForNavigation(url: url, webView: webView, tab: tab, navigationAction: navigationAction) {
+                decisionHandler(.cancel)
+                return
+            }
 
             let isGoogleDomain = url.host?.contains("google") ?? false
             let isPrivate = tab.isPrivate

--- a/firefox-ios/Ecosia/Core/URL+Extensions.swift
+++ b/firefox-ios/Ecosia/Core/URL+Extensions.swift
@@ -144,7 +144,6 @@ extension URL {
 
     public func ecosified(isIncognitoEnabled: Bool, urlProvider: URLProvider = EcosiaEnvironment.current.urlProvider) -> URL {
         guard isEcosia(urlProvider),
-              !hasEcosiaUserId,
               var components = components
         else { return self }
 

--- a/firefox-ios/Ecosia/Core/URL+Extensions.swift
+++ b/firefox-ios/Ecosia/Core/URL+Extensions.swift
@@ -143,12 +143,7 @@ extension URL {
     }
 
     public func ecosified(isIncognitoEnabled: Bool, urlProvider: URLProvider = EcosiaEnvironment.current.urlProvider) -> URL {
-        guard isEcosia(urlProvider),
-              var components = components
-        else { return self }
-
-        // Remove existing userId if present
-        components.queryItems?.removeAll(where: { $0.name == EcosiaQueryItemName.userId.rawValue })
+        guard isEcosia(urlProvider) else { return self }
 
         /*
          The `sendAnonymousUsageData` is set by the native UX component in settings
@@ -163,12 +158,19 @@ extension URL {
                                     !User.shared.sendAnonymousUsageData
         let userId = shouldAnonymizeUserId ? UUID(uuid: UUID_NULL).uuidString : User.shared.analyticsId.uuidString
 
+        // Already carries the correct value — no mutation needed regardless of parameter position.
+        if ecosiaUserId == userId { return self }
+
+        guard var components = components else { return self }
+        components.queryItems?.removeAll(where: { $0.name == EcosiaQueryItemName.userId.rawValue })
         guard let urlWithoutUserId = components.url else { return self }
         return urlWithoutUserId.appendingQueryItems([Self.item(name: .userId, value: userId)])
     }
 
-    public var hasEcosiaUserId: Bool {
-        components?.queryItems?.contains { $0.name == EcosiaQueryItemName.userId.rawValue } ?? false
+    public var hasEcosiaUserId: Bool { ecosiaUserId != nil }
+
+    public var ecosiaUserId: String? {
+        components?.queryItems?.first { $0.name == EcosiaQueryItemName.userId.rawValue }?.value
     }
 
     public var policy: Scheme.Policy {

--- a/firefox-ios/Ecosia/Core/URL+Extensions.swift
+++ b/firefox-ios/Ecosia/Core/URL+Extensions.swift
@@ -142,13 +142,9 @@ extension URL {
         return nil
     }
 
-    /// Check whether the URL should be Ecosified. At the moment this is true for every Ecosia URL.
-    public func shouldEcosify(_ urlProvider: URLProvider = EcosiaEnvironment.current.urlProvider) -> Bool {
-        return isEcosia(urlProvider)
-    }
-
     public func ecosified(isIncognitoEnabled: Bool, urlProvider: URLProvider = EcosiaEnvironment.current.urlProvider) -> URL {
         guard isEcosia(urlProvider),
+              !hasEcosiaUserId,
               var components = components
         else { return self }
 

--- a/firefox-ios/EcosiaTests/Core/URLTests.swift
+++ b/firefox-ios/EcosiaTests/Core/URLTests.swift
@@ -266,8 +266,8 @@ final class URLTests: XCTestCase, @unchecked Sendable {
         let search = URL(string: "https://www.www.ecosia.org/search?q=foo")!.ecosified(isIncognitoEnabled: false, urlProvider: self.urlProvider)
         XCTAssertEqual(search, URL(string: "https://www.www.ecosia.org/search?q=foo&_sp=\(id.uuidString)"))
 
-        let alreadyPatched = URL(string: "https://www.www.ecosia.org/search?q=foo&_sp=12345")!.ecosified(isIncognitoEnabled: false)
-        XCTAssertEqual(alreadyPatched, URL(string: "https://www.www.ecosia.org/search?q=foo&_sp=12345"))
+        let alreadyPatched = URL(string: "https://ecosia.org/search?q=foo&_sp=old-value")!.ecosified(isIncognitoEnabled: false, urlProvider: self.urlProvider)
+        XCTAssertEqual(alreadyPatched, URL(string: "https://ecosia.org/search?q=foo&_sp=\(id.uuidString)"))
 
         let multiPatch = URL(string: "https://ecosia.org")!.ecosified(isIncognitoEnabled: false, urlProvider: self.urlProvider)
         XCTAssertEqual(multiPatch, URL(string: "https://ecosia.org?_sp=\(id.uuidString)"))

--- a/firefox-ios/EcosiaTests/Core/URLTests.swift
+++ b/firefox-ios/EcosiaTests/Core/URLTests.swift
@@ -242,28 +242,6 @@ final class URLTests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(ecosiaUrl.getEcosiaSearchPage(urlProvider), 1)
     }
 
-    // MARK: - `shouldEcosify`
-
-    func testAssertShouldEcosifyOnNonEcosiaURL() {
-        let nonSearchEcosiaURL = URL(string: "https://www.google.com")!
-        XCTAssertFalse(nonSearchEcosiaURL.shouldEcosify(urlProvider))
-    }
-
-    func testAssertShouldEcosifyOnAllEcosiaURLs() {
-        let ecosiaURLs = [
-            "https://ecosia.org",
-            "https://www.ecosia.org/search?q=foo",
-            "https://ecosia.org/image?q=test",
-            "https://ecosia.org/chat?q=test",
-            "https://ecosia.org/news?q=test",
-            "https://blog.ecosia.org/",
-            "https://www.ecosia.org/settings"
-        ]
-        ecosiaURLs.forEach { urlString in
-            XCTAssertTrue(URL(string: urlString)!.shouldEcosify(urlProvider))
-        }
-    }
-
     // MARK: - `ecosified`
 
     func testAvoidEcosifyWrongScheme() {

--- a/firefox-ios/EcosiaTests/UI/TabManagement/TabEcosiaExtensionTests.swift
+++ b/firefox-ios/EcosiaTests/UI/TabManagement/TabEcosiaExtensionTests.swift
@@ -56,7 +56,7 @@ final class TabEcosiaExtensionTests: XCTestCase {
         XCTAssertFalse(result.url?.hasEcosiaUserId == true)
     }
 
-    func testSpNotDuplicatedWhenAlreadyPresent() {
+    func testSpReplacedWhenAlreadyPresent() {
         let tab = makeTab(isPrivate: false)
         let url = URL(string: "https://www.ecosia.org/search?q=cats&_sp=existing-sp-value")!
         let result = tab.ecosiaUpdatedRequest(URLRequest(url: url))

--- a/firefox-ios/EcosiaTests/UI/TabManagement/TabEcosiaExtensionTests.swift
+++ b/firefox-ios/EcosiaTests/UI/TabManagement/TabEcosiaExtensionTests.swift
@@ -58,12 +58,11 @@ final class TabEcosiaExtensionTests: XCTestCase {
 
     func testSpNotDuplicatedWhenAlreadyPresent() {
         let tab = makeTab(isPrivate: false)
-        let existingSP = "existing-sp-value"
-        let url = URL(string: "https://www.ecosia.org/search?q=cats&_sp=\(existingSP)")!
+        let url = URL(string: "https://www.ecosia.org/search?q=cats&_sp=existing-sp-value")!
         let result = tab.ecosiaUpdatedRequest(URLRequest(url: url))
 
-        // guard !url.hasEcosiaUserId means the existing value is preserved unchanged
-        XCTAssertEqual(result.url?.queryItem(named: "_sp"), existingSP)
+        XCTAssertTrue(result.url?.hasEcosiaUserId == true)
+        XCTAssertEqual(result.url?.queryItem(named: "_sp"), User.shared.analyticsId.uuidString)
     }
 
     func testSpIsNullUUIDForPrivateTab() {


### PR DESCRIPTION
[MOB-4553]

## Context

Follow-up to https://github.com/ecosia/ios-browser/pull/1165 after a bug was found.

## Approach

Extend ecosification to `decidePolicyFor` so every navigation is included. Left `Tab.loadRequest` check since that will cover native cases earlier since checking on `decidePolicyFor` causing a cancelation and reloading (not a performance concern though since happens pre-network before any byte).

## Other

Refactored a bit:
* Grouped every Ecosia navigation handling into `ecosiaDecidePolicyForNavigation` for better maintainability
* Moved decision handler out for more clarity
* Cleaned up some unnecesary conditions and removed duplication
* Cleaned up tests

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [x] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4553]: https://ecosia.atlassian.net/browse/MOB-4553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ