### PR TITLE
[MOB-4513] Hide keyboard input accessory view on AI chat

### DIFF
--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -1015,6 +1015,10 @@ extension Tab: TabWebViewDelegate {
     }
 
     func tabWebViewShouldShowAccessoryView(_ tabWebView: TabWebView) -> Bool {
+        // Ecosia: Hide the keyboard accessory bar on the AI chat vertical so the web "Ask follow up"
+        // input stays clean and prominent.
+        if url?.isEcosiaAIChat == true { return false }
+
         // Hide the default WKWebView accessory view panel for PDF documents and
         // there is no accessory view to display (but only for iPad cases)
         let isPDF = mimeType == MIMEType.PDF


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-4513]

## Context

Hide input accessory view when on AI chat

| AI Chat | Non-AI Chat |
|---|---|
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-06-10 at 15 55 51" src="https://github.com/user-attachments/assets/e27f0507-843d-4e4e-a149-a006c69e28e2" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-06-10 at 15 57 45" src="https://github.com/user-attachments/assets/a864fa59-1692-4b87-9665-24479ee8eb86" />|

## Approach

## Other

## Before merging

### Checklist

- [ ] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [ ] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4513]: https://ecosia.atlassian.net/browse/MOB-4513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ