### PR TITLE
[MOB-4580] Unable to scroll suggestions + addiition fixes

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
@@ -452,6 +452,11 @@ public class BrowserAddressToolbar: UIView,
         }
     }
 
+    // Ecosia: Live user-typed URL bar text (MOB-4580 overlay keyboard-dismiss checks).
+    public var overlayEditingText: String {
+        locationView.plainUserText
+    }
+
     // MARK: - LocationViewDelegate
     func locationViewDidEnterText(_ text: String) {
         toolbarDelegate?.searchSuggestions(searchTerm: text)

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
@@ -452,7 +452,6 @@ public class BrowserAddressToolbar: UIView,
         }
     }
 
-    // Ecosia: Live user-typed URL bar text (MOB-4580 overlay keyboard-dismiss checks).
     public var overlayEditingText: String {
         locationView.plainUserText
     }

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
@@ -452,6 +452,7 @@ public class BrowserAddressToolbar: UIView,
         }
     }
 
+    // Ecosia: Passthrough for live overlay text decisions in BVC.
     public var overlayEditingText: String {
         locationView.plainUserText
     }

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
@@ -35,6 +35,9 @@ class LocationTextField: UITextField, UITextFieldDelegate, ThemeApplicable {
     private var lastReplacement: String?
     private var hideCursor = false
     private var isSettingMarkedText = false
+    // Ecosia: When false, end-editing strips inline autocomplete without committing it
+    // (keyboard drag-dismiss while scrolling suggestions — MOB-4580).
+    var commitsAutocompleteOnEndEditing = true
     var clearButton: UIButton? {
         return value(forKey: "_clearButton") as? UIButton
     }
@@ -81,6 +84,11 @@ class LocationTextField: UITextField, UITextFieldDelegate, ThemeApplicable {
     }
 
     weak var accessibilityActionsSource: AccessibilityActionsSource?
+
+    /// User-typed text only, excluding any inline autocomplete marked suffix.
+    var plainUserText: String {
+        textWithoutSuggestion() ?? text ?? ""
+    }
 
     override var accessibilityCustomActions: [UIAccessibilityCustomAction]? {
         get {
@@ -185,6 +193,16 @@ class LocationTextField: UITextField, UITextFieldDelegate, ThemeApplicable {
 
     /// Commits the completion by setting the text and removing the highlight.
     private func applyCompletion() {
+        // Ecosia: Discard whitespace-only marked suffixes instead of committing them
+        // as trailing spaces when the keyboard dismisses during suggestion scrolling.
+        if let markedTextRange,
+           let marked = markedSuggestionText(in: text ?? "", range: markedTextRange),
+           marked.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            _ = removeCompletion()
+            hideCursor = false
+            return
+        }
+
         // Clear the current completion, then set the text without the attributed style.
         let text = (self.text ?? "")
         let didRemoveCompletion = removeCompletion()
@@ -195,6 +213,14 @@ class LocationTextField: UITextField, UITextFieldDelegate, ThemeApplicable {
         if didRemoveCompletion {
             selectedTextRange = textRange(from: endOfDocument, to: endOfDocument)
         }
+    }
+
+    private func markedSuggestionText(in text: String, range: UITextRange) -> String? {
+        let location = offset(from: beginningOfDocument, to: range.start)
+        let length = offset(from: range.start, to: range.end)
+        let nsRange = NSRange(location: location, length: length)
+        guard nsRange.location != NSNotFound else { return nil }
+        return (text as NSString).substring(with: nsRange)
     }
 
     /// Removes the autocomplete-highlighted. Returns true if a completion was actually removed
@@ -254,7 +280,12 @@ class LocationTextField: UITextField, UITextFieldDelegate, ThemeApplicable {
     }
 
     func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {
-        applyCompletion()
+        if commitsAutocompleteOnEndEditing {
+            applyCompletion()
+        } else if markedTextRange != nil {
+            _ = removeCompletion()
+            hideCursor = false
+        }
         return true
     }
 

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
@@ -85,8 +85,8 @@ class LocationTextField: UITextField, UITextFieldDelegate, ThemeApplicable {
 
     weak var accessibilityActionsSource: AccessibilityActionsSource?
 
-    /// User-typed text only, excluding any inline autocomplete marked suffix.
-    /// Read by `overlaySearchQuery` so Redux cannot lag behind the live field.
+    // Ecosia: User-typed text only (excludes inline autocomplete). Read by
+    // `overlaySearchQuery` so Redux cannot lag behind the live field.
     var plainUserText: String {
         textWithoutSuggestion() ?? text ?? ""
     }
@@ -216,6 +216,7 @@ class LocationTextField: UITextField, UITextFieldDelegate, ThemeApplicable {
         }
     }
 
+    // Ecosia: Read the marked autocomplete suffix without committing it.
     private func markedSuggestionText(in text: String, range: UITextRange) -> String? {
         let location = offset(from: beginningOfDocument, to: range.start)
         let length = offset(from: range.start, to: range.end)
@@ -281,6 +282,9 @@ class LocationTextField: UITextField, UITextFieldDelegate, ThemeApplicable {
     }
 
     func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {
+        /* Ecosia: Firefox always commits inline autocomplete on end-editing.
+        applyCompletion()
+        */
         if commitsAutocompleteOnEndEditing {
             applyCompletion()
         } else if markedTextRange != nil {

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
@@ -36,7 +36,7 @@ class LocationTextField: UITextField, UITextFieldDelegate, ThemeApplicable {
     private var hideCursor = false
     private var isSettingMarkedText = false
     // Ecosia: When false, end-editing strips inline autocomplete without committing it
-    // (keyboard drag-dismiss while scrolling suggestions — MOB-4580).
+    // (keyboard drag-dismiss while scrolling suggestions).
     var commitsAutocompleteOnEndEditing = true
     var clearButton: UIButton? {
         return value(forKey: "_clearButton") as? UIButton
@@ -86,6 +86,7 @@ class LocationTextField: UITextField, UITextFieldDelegate, ThemeApplicable {
     weak var accessibilityActionsSource: AccessibilityActionsSource?
 
     /// User-typed text only, excluding any inline autocomplete marked suffix.
+    /// Read by `overlaySearchQuery` so Redux cannot lag behind the live field.
     var plainUserText: String {
         textWithoutSuggestion() ?? text ?? ""
     }

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -48,6 +48,11 @@ final class LocationView: UIView,
     private var isURLTextFieldEmpty: Bool {
         urlTextField.text?.isEmpty == true
     }
+
+    // Ecosia: Live user-typed URL bar text (MOB-4580 overlay keyboard-dismiss checks).
+    var plainUserText: String {
+        urlTextField.plainUserText
+    }
     private var hasHomeIndicator: Bool {
         guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
               let window = windowScene.windows.first else { return false }
@@ -585,6 +590,9 @@ final class LocationView: UIView,
         // causing the keyboard to hide.
         // TODO: FXIOS-14618 don't fire the `keyboardWillHide` notification on device rotation
         let shouldShowKeyboard = configurationIsEditing && config.shouldShowKeyboard
+        // Ecosia: Keyboard hidden while overlay editing continues — do not commit inline
+        // autocomplete on resign (avoids trailing spaces when scrolling suggestions).
+        urlTextField.commitsAutocompleteOnEndEditing = shouldShowKeyboard
         _ = shouldShowKeyboard ? becomeFirstResponder() : resignFirstResponder()
 
         // Remove the default drop interaction from the URL text field so that our
@@ -797,6 +805,11 @@ final class LocationView: UIView,
         formatAndTruncateURLTextField(hasSearchTerm: searchTerm != nil)
         if isURLTextFieldEmpty {
             updateGradient()
+        } else if isEditing {
+            // Ecosia: Keyboard drag-dismiss resigns first responder while overlay editing
+            // continues. updateUIForSearchEngineDisplay adds icon-container leading inset
+            // inside the pill; keep the editing layout instead (MOB-4580).
+            updateUIForEditingDisplay()
         } else {
             /* Ecosia: Show search engine view (favicon) instead of lock icon when editing ends
             updateUIForLockIconDisplay()

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -594,7 +594,13 @@ final class LocationView: UIView,
         // Ecosia: Keyboard hidden while overlay editing continues — do not commit inline
         // autocomplete on resign (avoids trailing spaces when scrolling suggestions).
         urlTextField.commitsAutocompleteOnEndEditing = shouldShowKeyboard
-        _ = shouldShowKeyboard ? becomeFirstResponder() : resignFirstResponder()
+        if shouldShowKeyboard {
+            _ = becomeFirstResponder()
+        } else if configurationIsEditing && !config.didStartTyping {
+            // Do not resign while the user is typing — suggestion highlight updates
+            // can clear shouldShowKeyboard after keyboard drag-dismiss.
+            _ = resignFirstResponder()
+        }
 
         // Remove the default drop interaction from the URL text field so that our
         // custom drop interaction on the BVC can accept dropped URLs.

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -49,9 +49,11 @@ final class LocationView: UIView,
         urlTextField.text?.isEmpty == true
     }
 
+    // Ecosia: Passthrough for live overlay text decisions in BVC.
     var plainUserText: String {
         urlTextField.plainUserText
     }
+
     private var hasHomeIndicator: Bool {
         guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
               let window = windowScene.windows.first else { return false }

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -49,7 +49,6 @@ final class LocationView: UIView,
         urlTextField.text?.isEmpty == true
     }
 
-    // Ecosia: Live user-typed URL bar text (MOB-4580 overlay keyboard-dismiss checks).
     var plainUserText: String {
         urlTextField.plainUserText
     }
@@ -808,7 +807,7 @@ final class LocationView: UIView,
         } else if isEditing {
             // Ecosia: Keyboard drag-dismiss resigns first responder while overlay editing
             // continues. updateUIForSearchEngineDisplay adds icon-container leading inset
-            // inside the pill; keep the editing layout instead (MOB-4580).
+            // inside the pill; keep the editing layout instead.
             updateUIForEditingDisplay()
         } else {
             /* Ecosia: Show search engine view (favicon) instead of lock icon when editing ends

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
@@ -25,6 +25,30 @@ extension BrowserViewController: DefaultBrowserDelegate {
     }
 }
 
+// MARK: - NTP omnibox session
+extension BrowserViewController {
+
+    /// The homepage VC while the webview is frontmost (swiping-tabs keeps it as a child).
+    fileprivate var ecosiaEmbeddedHomepage: HomepageViewController? {
+        if let homepage = contentContainer.contentController as? HomepageViewController {
+            return homepage
+        }
+        return children.first { $0 is HomepageViewController } as? HomepageViewController
+    }
+
+    /// See `HomepageViewController.resetNTPOmniboxSession()`.
+    func ecosiaPrepareNTPOmniboxForDisplay() {
+        guard let homepage = ecosiaEmbeddedHomepage,
+              homepage.ntpSearchBar?.isFirstResponder == false else { return }
+        homepage.resetNTPOmniboxSession()
+    }
+
+    /// See `HomepageViewController.resetNTPOmniboxSession()`.
+    func ecosiaResetNTPOmniboxWhenLeavingNTP() {
+        ecosiaEmbeddedHomepage?.resetNTPOmniboxSession()
+    }
+}
+
 // MARK: - Default browser promo after search threshold
 extension BrowserViewController {
 

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Omnibox.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Omnibox.swift
@@ -101,6 +101,10 @@ extension BrowserViewController: NTPSearchBarDelegate {
         }
     }
 
+    func ntpSearchBarIsSuggestionsOverlayVisible() -> Bool {
+        searchController?.parent is HomepageViewController
+    }
+
     fileprivate var ntpOmniboxAnchorView: NTPSearchBarView? {
         (contentContainer.contentController as? HomepageViewController)?.ntpSearchBar
     }

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Omnibox.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Omnibox.swift
@@ -105,6 +105,10 @@ extension BrowserViewController: NTPSearchBarDelegate {
         searchController?.parent is HomepageViewController
     }
 
+    func ntpSearchBarNeedsSuggestionsLayoutUpdate() {
+        updateOmniboxSuggestionsScrollInsets()
+    }
+
     fileprivate var ntpOmniboxAnchorView: NTPSearchBarView? {
         (contentContainer.contentController as? HomepageViewController)?.ntpSearchBar
     }
@@ -140,15 +144,25 @@ extension BrowserViewController {
         searchController.searchTelemetry?.clearVisibleResults()
         searchController.searchTelemetry?.determineInteractionType()
         searchLoader?.query = searchTerm
+        updateOmniboxSuggestionsScrollInsets()
     }
 
     /// Tears down the suggestions overlay when the omnibox loses content/focus
     /// and routes autocomplete back to the standard URL bar.
     func hideOmniboxSuggestions() {
         searchLoader?.autocompleteView = addressToolbarContainer
+        if let searchController {
+            searchController.additionalSafeAreaInsets = .zero
+            let tableView = searchController.tableView
+            tableView.contentInset = .zero
+            tableView.verticalScrollIndicatorInsets = .zero
+            tableView.contentInsetAdjustmentBehavior = .automatic
+        }
         guard searchController?.parent != nil else { return }
         hideSearchController()
     }
+
+    fileprivate static let omniboxSuggestionsClearance: CGFloat = .ecosia.space._1s
 
     fileprivate func attachOmniboxSuggestions(anchorView: UIView) {
         guard let searchController else { return }
@@ -163,19 +177,11 @@ extension BrowserViewController {
         hostVC.addChild(searchController)
         host.addSubview(searchController.view)
         searchController.view.translatesAutoresizingMaskIntoConstraints = false
-        host.layoutIfNeeded()
-
-        // Pin the overlay above the omnibox pill so the table can scroll its
-        // last rows clear of the floating search bar (keyboard and multi-line
-        // growth move the pill; this constraint follows automatically).
         NSLayoutConstraint.activate([
             searchController.view.topAnchor.constraint(equalTo: host.safeAreaLayoutGuide.topAnchor),
             searchController.view.leadingAnchor.constraint(equalTo: host.leadingAnchor),
             searchController.view.trailingAnchor.constraint(equalTo: host.trailingAnchor),
-            searchController.view.bottomAnchor.constraint(
-                equalTo: anchorView.topAnchor,
-                constant: -.ecosia.space._1s
-            )
+            searchController.view.bottomAnchor.constraint(equalTo: host.bottomAnchor)
         ])
 
         // z-order back→front: suggestions overlay, focused-state scrim,
@@ -194,22 +200,63 @@ extension BrowserViewController {
             // suggestion isn't drawn underneath it. The view itself still
             // spans the safe area, so the keyboard-tracking footer stays put.
             host.layoutIfNeeded()
-            let topInset = closeButton.frame.maxY - host.safeAreaInsets.top
-            searchController.additionalSafeAreaInsets.top = max(0, topInset)
         }
 
         searchController.didMove(toParent: hostVC)
+        updateOmniboxSuggestionsScrollInsets()
         contentContainer.accessibilityElementsHidden = true
 
         // Re-enable interaction in case the previous attach left the table
         // disabled by the fast-tap path below.
         searchController.tableView.isUserInteractionEnabled = true
+        searchController.tableView.contentInsetAdjustmentBehavior = .never
         // Any drag on the suggestions list dismisses the keyboard so the user
         // can scan the full list. Resigning the textView's first responder
         // from this path fires `ntpSearchBarDidCancel`, which intentionally
         // no longer tears down the overlay — so the suggestions stay visible.
         searchController.tableView.keyboardDismissMode = .onDrag
         installOmniboxFastTap(on: searchController.tableView)
+    }
+
+    /// The suggestions overlay is full-bleed behind the floating omnibox. Inset
+    /// the table's safe area so the last rows can scroll clear of the pill as
+    /// the keyboard and multi-line growth move it.
+    fileprivate func updateOmniboxSuggestionsScrollInsets() {
+        guard let searchController,
+              searchController.parent is HomepageViewController,
+              let homepage = contentContainer.contentController as? HomepageViewController,
+              let omnibox = homepage.ntpSearchBar else { return }
+
+        homepage.view.layoutIfNeeded()
+
+        let topInset: CGFloat
+        if let closeButton = homepage.ntpOmniboxCloseButton {
+            topInset = max(0, closeButton.frame.maxY - homepage.view.safeAreaInsets.top)
+        } else {
+            topInset = 0
+        }
+
+        let omniboxFrame = searchController.view.convert(omnibox.bounds, from: omnibox)
+        let bottomInset = max(
+            0,
+            searchController.view.bounds.height - omniboxFrame.minY + Self.omniboxSuggestionsClearance
+        )
+
+        searchController.additionalSafeAreaInsets = UIEdgeInsets(
+            top: topInset,
+            left: 0,
+            bottom: bottomInset,
+            right: 0
+        )
+
+        // Mirror on the table too — it is edge-pinned, not safe-area-pinned.
+        let tableView = searchController.tableView
+        var contentInset = tableView.contentInset
+        contentInset.top = topInset
+        contentInset.bottom = bottomInset
+        tableView.contentInset = contentInset
+        tableView.verticalScrollIndicatorInsets.top = topInset
+        tableView.verticalScrollIndicatorInsets.bottom = bottomInset
     }
 
     /// Adds a tap gesture on the suggestions table that fires `didSelectRowAt`

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Omnibox.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Omnibox.swift
@@ -157,6 +157,9 @@ extension BrowserViewController {
             tableView.contentInset = .zero
             tableView.verticalScrollIndicatorInsets = .zero
             tableView.contentInsetAdjustmentBehavior = .automatic
+            tableView.isUserInteractionEnabled = true
+            tableView.keyboardDismissMode = .none
+            removeOmniboxFastTap(from: tableView)
         }
         guard searchController?.parent != nil else { return }
         hideSearchController()
@@ -275,6 +278,12 @@ extension BrowserViewController {
         // the table's own delayed selection from firing a second time.
         tap.cancelsTouchesInView = false
         tableView.addGestureRecognizer(tap)
+    }
+
+    private func removeOmniboxFastTap(from tableView: UITableView) {
+        tableView.gestureRecognizers?
+            .filter { $0.name == Self.omniboxFastTapName }
+            .forEach { tableView.removeGestureRecognizer($0) }
     }
 
     fileprivate static let omniboxFastTapName = "EcosiaOmniboxSuggestionFastTap"

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Omnibox.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Omnibox.swift
@@ -188,22 +188,14 @@ extension BrowserViewController {
         ])
 
         // z-order back→front: suggestions overlay, focused-state scrim,
-        // omnibox pill, floating close button. The scrim sits above the
-        // suggestions so the bottom of the list fades into the pill, but
-        // below the pill itself so the pill stays fully opaque.
+        // omnibox pill. The scrim sits above the suggestions so the bottom
+        // of the list fades into the pill, but below the pill itself so the
+        // pill stays fully opaque.
         if let homepage = hostVC as? HomepageViewController,
            let backdrop = homepage.ntpSearchBarBackdrop {
             host.bringSubviewToFront(backdrop)
         }
         host.bringSubviewToFront(anchorView)
-        if let homepage = hostVC as? HomepageViewController,
-           let closeButton = homepage.ntpOmniboxCloseButton {
-            host.bringSubviewToFront(closeButton)
-            // Push the table content down below the close button so the first
-            // suggestion isn't drawn underneath it. The view itself still
-            // spans the safe area, so the keyboard-tracking footer stays put.
-            host.layoutIfNeeded()
-        }
 
         searchController.didMove(toParent: hostVC)
         updateOmniboxSuggestionsScrollInsets()
@@ -232,12 +224,7 @@ extension BrowserViewController {
 
         homepage.view.layoutIfNeeded()
 
-        let topInset: CGFloat
-        if let closeButton = homepage.ntpOmniboxCloseButton {
-            topInset = max(0, closeButton.frame.maxY - homepage.view.safeAreaInsets.top)
-        } else {
-            topInset = 0
-        }
+        let topInset: CGFloat = 0
 
         let omniboxFrame = searchController.view.convert(omnibox.bounds, from: omnibox)
         let bottomInset = max(

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Omnibox.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Omnibox.swift
@@ -163,12 +163,19 @@ extension BrowserViewController {
         hostVC.addChild(searchController)
         host.addSubview(searchController.view)
         searchController.view.translatesAutoresizingMaskIntoConstraints = false
+        host.layoutIfNeeded()
 
+        // Pin the overlay above the omnibox pill so the table can scroll its
+        // last rows clear of the floating search bar (keyboard and multi-line
+        // growth move the pill; this constraint follows automatically).
         NSLayoutConstraint.activate([
             searchController.view.topAnchor.constraint(equalTo: host.safeAreaLayoutGuide.topAnchor),
             searchController.view.leadingAnchor.constraint(equalTo: host.leadingAnchor),
             searchController.view.trailingAnchor.constraint(equalTo: host.trailingAnchor),
-            searchController.view.bottomAnchor.constraint(equalTo: host.bottomAnchor)
+            searchController.view.bottomAnchor.constraint(
+                equalTo: anchorView.topAnchor,
+                constant: -.ecosia.space._1s
+            )
         ])
 
         // z-order back→front: suggestions overlay, focused-state scrim,

--- a/firefox-ios/Client/Ecosia/Extensions/HomepageViewController+EcosiaCells.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/HomepageViewController+EcosiaCells.swift
@@ -138,15 +138,6 @@ extension HomepageViewController {
         objc_setAssociatedObject(self, &AssociatedKeys.ntpSearchBarTrailingConstraint, constraint, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
     }
 
-    // Ecosia: Top-right close button shown only while the omnibox is in focus.
-    var ntpOmniboxCloseButton: UIButton? {
-        return objc_getAssociatedObject(self, &AssociatedKeys.ntpOmniboxCloseButton) as? UIButton
-    }
-
-    func setNTPOmniboxCloseButton(_ button: UIButton) {
-        objc_setAssociatedObject(self, &AssociatedKeys.ntpOmniboxCloseButton, button, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-    }
-
     // Ecosia: Active-state gradient scrim behind the focused pill.
     var ntpSearchBarBackdrop: NTPSearchBarBackdropView? {
         return objc_getAssociatedObject(self, &AssociatedKeys.ntpSearchBarBackdrop) as? NTPSearchBarBackdropView
@@ -166,6 +157,5 @@ private struct AssociatedKeys {
     nonisolated(unsafe) static var ntpSearchBarBottomConstraint: UInt8 = 0
     nonisolated(unsafe) static var ntpSearchBarLeadingConstraint: UInt8 = 0
     nonisolated(unsafe) static var ntpSearchBarTrailingConstraint: UInt8 = 0
-    nonisolated(unsafe) static var ntpOmniboxCloseButton: UInt8 = 0
     nonisolated(unsafe) static var ntpSearchBarBackdrop: UInt8 = 0
 }

--- a/firefox-ios/Client/Ecosia/Extensions/HomepageViewController+EcosiaSetup.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/HomepageViewController+EcosiaSetup.swift
@@ -288,6 +288,7 @@ extension HomepageViewController: @MainActor HomepageDataModelDelegate {
         ))
 
         ecosiaAdapter?.viewWillAppear()
+        resetNTPOmniboxForLanding()
         ecosiaAdapter?.refreshData(
             for: traitCollection,
             size: view.bounds.size
@@ -354,6 +355,14 @@ extension HomepageViewController: @MainActor HomepageDataModelDelegate {
             collectionView.contentInset.bottom = 0
             collectionView.verticalScrollIndicatorInsets.bottom = 0
         }
+    }
+
+    /// Clears the omnibox whenever the NTP becomes visible so the pill shows
+    /// only the placeholder — not stale query text or autocomplete suffixes
+    /// left over from a previous suggestions session.
+    func resetNTPOmniboxForLanding() {
+        guard let bar = ntpSearchBar, !bar.isFirstResponder else { return }
+        bar.text = ""
     }
 
     /// Called when view did disappear to clean up Ecosia resources

--- a/firefox-ios/Client/Ecosia/Extensions/HomepageViewController+EcosiaSetup.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/HomepageViewController+EcosiaSetup.swift
@@ -159,6 +159,7 @@ extension HomepageViewController: @MainActor HomepageDataModelDelegate {
         let recognizer = UITapGestureRecognizer(target: self,
                                                 action: #selector(handleTapOutsideOmnibox(_:)))
         recognizer.cancelsTouchesInView = false
+        recognizer.delegate = self
         view.addGestureRecognizer(recognizer)
     }
 
@@ -288,7 +289,6 @@ extension HomepageViewController: @MainActor HomepageDataModelDelegate {
         ))
 
         ecosiaAdapter?.viewWillAppear()
-        resetNTPOmniboxForLanding()
         ecosiaAdapter?.refreshData(
             for: traitCollection,
             size: view.bounds.size
@@ -357,14 +357,6 @@ extension HomepageViewController: @MainActor HomepageDataModelDelegate {
         }
     }
 
-    /// Clears the omnibox whenever the NTP becomes visible so the pill shows
-    /// only the placeholder — not stale query text or autocomplete suffixes
-    /// left over from a previous suggestions session.
-    func resetNTPOmniboxForLanding() {
-        guard let bar = ntpSearchBar, !bar.isFirstResponder else { return }
-        bar.text = ""
-    }
-
     /// Called when view did disappear to clean up Ecosia resources
     func ecosiaViewDidDisappear() {
         // Defensive: if the user navigated away while the omnibox was editing,
@@ -407,6 +399,28 @@ extension HomepageViewController: @MainActor HomepageDataModelDelegate {
         let wallpaperConfig = adapter.getNTPBackgroundConfiguration()
         let state = WallpaperState(windowUUID: windowUUID, wallpaperConfiguration: wallpaperConfig)
         return state
+    }
+}
+
+// MARK: - UIGestureRecognizerDelegate
+// Ecosia: Tap-outside must not steal touches from the suggestions overlay —
+// scrolling the list was dismissing the overlay and leaving a stale omnibox.
+extension HomepageViewController: UIGestureRecognizerDelegate {
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        !isTouchOnOmniboxSessionChrome(touch)
+    }
+
+    private func isTouchOnOmniboxSessionChrome(_ touch: UITouch) -> Bool {
+        var responder: UIResponder? = touch.view
+        while let current = responder {
+            if current === ntpSearchBar || current === ntpSearchBarBackdrop || current === ntpOmniboxCloseButton {
+                return true
+            }
+            if current is SearchViewController { return true }
+            if current === self { break }
+            responder = current.next
+        }
+        return false
     }
 }
 

--- a/firefox-ios/Client/Ecosia/Extensions/HomepageViewController+EcosiaSetup.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/HomepageViewController+EcosiaSetup.swift
@@ -367,15 +367,16 @@ extension HomepageViewController: @MainActor HomepageDataModelDelegate {
     /// without `viewDidDisappear`, so this must run on leave and on re-show.
     /// `requestsOverlayDismiss` is intentional here (leaving the NTP); keyboard
     /// drag-dismiss on the list must not route through this path.
-    func resetNTPOmniboxSession() {
-        guard let bar = ntpSearchBar else { return }
-        bar.text = ""
-        if bar.isFirstResponder {
-            _ = bar.resignFirstResponder()
-        }
+func resetNTPOmniboxSession() {
+    guard let bar = ntpSearchBar else { return }
+    bar.text = ""
+    if bar.isFirstResponder {
+        _ = bar.resignFirstResponder()
+    } else {
         bar.delegate?.ntpSearchBarDidCancel()
-        bar.delegate?.ntpSearchBarRequestsOverlayDismiss()
     }
+    bar.delegate?.ntpSearchBarRequestsOverlayDismiss()
+}
 
     /// Called when view did disappear to clean up Ecosia resources
     func ecosiaViewDidDisappear() {

--- a/firefox-ios/Client/Ecosia/Extensions/HomepageViewController+EcosiaSetup.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/HomepageViewController+EcosiaSetup.swift
@@ -109,6 +109,7 @@ extension HomepageViewController: @MainActor HomepageDataModelDelegate {
 
         searchBar.onContentChange = { [weak self] text in
             self?.handleOmniboxContentChange(text)
+            self?.ntpSearchBar?.delegate?.ntpSearchBarNeedsSuggestionsLayoutUpdate()
         }
         searchBar.onFocusChange = { [weak self] focused in
             self?.ntpSearchBarBackdrop?.setVisible(focused, animated: true)
@@ -443,6 +444,7 @@ extension HomepageViewController: KeyboardHelperDelegate {
             options: UIView.AnimationOptions(rawValue: UInt(state.animationCurve.rawValue << 16))
         ) {
             self.view.layoutIfNeeded()
+            self.ntpSearchBar?.delegate?.ntpSearchBarNeedsSuggestionsLayoutUpdate()
         }
     }
 
@@ -458,6 +460,7 @@ extension HomepageViewController: KeyboardHelperDelegate {
             options: UIView.AnimationOptions(rawValue: UInt(state.animationCurve.rawValue << 16))
         ) {
             self.view.layoutIfNeeded()
+            self.ntpSearchBar?.delegate?.ntpSearchBarNeedsSuggestionsLayoutUpdate()
         }
     }
 }

--- a/firefox-ios/Client/Ecosia/Extensions/HomepageViewController+EcosiaSetup.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/HomepageViewController+EcosiaSetup.swift
@@ -290,6 +290,9 @@ extension HomepageViewController: @MainActor HomepageDataModelDelegate {
         ))
 
         ecosiaAdapter?.viewWillAppear()
+        if ntpSearchBar?.isFirstResponder == false {
+            resetNTPOmniboxSession()
+        }
         ecosiaAdapter?.refreshData(
             for: traitCollection,
             size: view.bounds.size
@@ -358,17 +361,25 @@ extension HomepageViewController: @MainActor HomepageDataModelDelegate {
         }
     }
 
+    /// Clears omnibox text and tears down suggestion chrome. The pill is shared
+    /// across tabs — a query belongs on the SERP, not the next NTP. With
+    /// swiping-tabs the homepage can stay in the hierarchy under a webview
+    /// without `viewDidDisappear`, so this must run on leave and on re-show.
+    /// `requestsOverlayDismiss` is intentional here (leaving the NTP); keyboard
+    /// drag-dismiss on the list must not route through this path.
+    func resetNTPOmniboxSession() {
+        guard let bar = ntpSearchBar else { return }
+        bar.text = ""
+        if bar.isFirstResponder {
+            _ = bar.resignFirstResponder()
+        }
+        bar.delegate?.ntpSearchBarDidCancel()
+        bar.delegate?.ntpSearchBarRequestsOverlayDismiss()
+    }
+
     /// Called when view did disappear to clean up Ecosia resources
     func ecosiaViewDidDisappear() {
-        // Defensive: if the user navigated away while the omnibox was editing,
-        // tear down the suggestions overlay so the SearchLoader doesn't keep a
-        // dangling reference to this view's autocomplete sink. `didCancel`
-        // updates session state; `requestsOverlayDismiss` actually hides the
-        // overlay (the cancel callback no longer does that on its own so
-        // keyboard drag-dismiss can leave the list visible).
-        ntpSearchBar?.delegate?.ntpSearchBarDidCancel()
-        ntpSearchBar?.delegate?.ntpSearchBarRequestsOverlayDismiss()
-        _ = ntpSearchBar?.resignFirstResponder()
+        resetNTPOmniboxSession()
         ecosiaAdapter?.viewDidDisappear()
     }
 

--- a/firefox-ios/Client/Ecosia/Extensions/HomepageViewController+EcosiaSetup.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/HomepageViewController+EcosiaSetup.swift
@@ -38,8 +38,8 @@ extension HomepageViewController: @MainActor HomepageDataModelDelegate {
         let theme = themeManager.getCurrentTheme(for: windowUUID)
 
         // Active-state scrim sits behind the pill. Added before the pill so
-        // the pill (and the floating close button installed below) naturally
-        // render on top of it. Hidden by default — appears only on focus.
+        // the pill naturally renders on top of it. Hidden by default — appears
+        // only on focus.
         let backdrop = NTPSearchBarBackdropView()
         backdrop.translatesAutoresizingMaskIntoConstraints = false
         backdrop.applyTheme(theme: theme)
@@ -107,53 +107,16 @@ extension HomepageViewController: @MainActor HomepageDataModelDelegate {
         // keyboard fully dismisses, the omnibox loses focus naturally.
         homepageCollectionView?.keyboardDismissMode = .interactive
 
-        searchBar.onContentChange = { [weak self] text in
-            self?.handleOmniboxContentChange(text)
+        searchBar.onContentChange = { [weak self] _ in
             self?.ntpSearchBar?.delegate?.ntpSearchBarNeedsSuggestionsLayoutUpdate()
         }
         searchBar.onFocusChange = { [weak self] focused in
             self?.ntpSearchBarBackdrop?.setVisible(focused, animated: true)
         }
 
-        installOmniboxCloseButton()
         installOmniboxTapOutsideDismiss()
 
         KeyboardHelper.defaultHelper.addDelegate(self)
-    }
-
-    private func installOmniboxCloseButton() {
-        let button = UIButton(type: .system)
-        let symbolConfig = UIImage.SymbolConfiguration(pointSize: 14, weight: .semibold)
-        button.setImage(UIImage(systemName: "xmark", withConfiguration: symbolConfig), for: .normal)
-        button.translatesAutoresizingMaskIntoConstraints = false
-        button.layer.cornerRadius = 18
-        button.alpha = 0
-        button.isHidden = true
-        button.accessibilityLabel = String.localized(.close)
-        button.accessibilityIdentifier = "NTPOmniboxCloseButton"
-        button.addTarget(self, action: #selector(handleOmniboxCloseButtonTapped), for: .touchUpInside)
-        view.addSubview(button)
-
-        NSLayoutConstraint.activate([
-            button.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: .ecosia.space._m),
-            button.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -.ecosia.space._m),
-            button.widthAnchor.constraint(equalToConstant: 36),
-            button.heightAnchor.constraint(equalToConstant: 36)
-        ])
-
-        setNTPOmniboxCloseButton(button)
-        applyOmniboxCloseButtonTheme()
-    }
-
-    /// Paints the floating top-right close button using the same `layer5`
-    /// token as the autocomplete row backgrounds, so the button visually
-    /// belongs to the suggestions surface beneath it instead of reading as
-    /// a separate pill.
-    private func applyOmniboxCloseButtonTheme() {
-        guard let button = ntpOmniboxCloseButton else { return }
-        let colors = themeManager.getCurrentTheme(for: windowUUID).colors
-        button.backgroundColor = colors.layer5
-        button.tintColor = colors.ecosia.textPrimary
     }
 
     private func installOmniboxTapOutsideDismiss() {
@@ -162,34 +125,6 @@ extension HomepageViewController: @MainActor HomepageDataModelDelegate {
         recognizer.cancelsTouchesInView = false
         recognizer.delegate = self
         view.addGestureRecognizer(recognizer)
-    }
-
-    private func handleOmniboxContentChange(_ text: String) {
-        guard let button = ntpOmniboxCloseButton else { return }
-        let shouldShow = !text.isEmpty
-        guard shouldShow != !button.isHidden else { return }
-        if shouldShow {
-            button.isHidden = false
-            UIView.animate(withDuration: 0.2) { button.alpha = 1 }
-        } else {
-            UIView.animate(withDuration: 0.2,
-                           animations: { button.alpha = 0 },
-                           completion: { _ in button.isHidden = true })
-        }
-    }
-
-    @objc private func handleOmniboxCloseButtonTapped() {
-        guard let bar = ntpSearchBar else { return }
-        bar.text = ""
-        if bar.isFirstResponder {
-            _ = bar.resignFirstResponder()
-        }
-        // The bar's `didCancel` callback no longer hides the overlay (that
-        // would tear it down on every keyboard drag-dismiss too), so always
-        // request the explicit dismiss here. After a drag-dismiss the bar
-        // isn't first responder either, but the request still tears the
-        // suggestions overlay down.
-        bar.delegate?.ntpSearchBarRequestsOverlayDismiss()
     }
 
     @objc private func handleTapOutsideOmnibox(_ gesture: UITapGestureRecognizer) {
@@ -390,7 +325,6 @@ func resetNTPOmniboxSession() {
         ecosiaAdapter?.updateTheme(theme)
         ntpSearchBar?.applyTheme(theme: theme)
         ntpSearchBarBackdrop?.applyTheme(theme: theme)
-        applyOmniboxCloseButtonTheme()
     }
 
     /// Refreshes the Ecosia snapshot so the UI updates
@@ -426,7 +360,7 @@ extension HomepageViewController: UIGestureRecognizerDelegate {
     private func isTouchOnOmniboxSessionChrome(_ touch: UITouch) -> Bool {
         var responder: UIResponder? = touch.view
         while let current = responder {
-            if current === ntpSearchBar || current === ntpSearchBarBackdrop || current === ntpOmniboxCloseButton {
+            if current === ntpSearchBar || current === ntpSearchBarBackdrop {
                 return true
             }
             if current is SearchViewController { return true }

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPLocationTextView.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPLocationTextView.swift
@@ -160,7 +160,7 @@ final class NTPLocationTextView: UITextView {
     /// Drops any inline autocomplete suffix without changing committed text.
     /// Used when the suggestions overlay stays up after keyboard drag-dismiss.
     func stripInlineAutocomplete() {
-        if hasInlineCompletion {
+        if hasInlineCompletion || hasAutocompleteSuffixBeyondUserTypedText() {
             revertToUserTypedTextOnly()
         }
     }
@@ -283,6 +283,13 @@ final class NTPLocationTextView: UITextView {
         revertToUserTypedTextOnly()
         scheduleRevertToUserTypedTextOnly()
         return true
+    }
+
+    private func hasAutocompleteSuffixBeyondUserTypedText() -> Bool {
+        guard !userTypedText.isEmpty, let current = text else { return false }
+        let typed = normalizeString(userTypedText)
+        let normalized = normalizeString(current)
+        return normalized.hasPrefix(typed) && normalized != typed
     }
 
     private func shouldRevertCommittedAutocomplete() -> Bool {

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPLocationTextView.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPLocationTextView.swift
@@ -157,6 +157,11 @@ final class NTPLocationTextView: UITextView {
         removeInlineCompletion()
     }
 
+    /// Drops any inline autocomplete suffix without changing committed text.
+    func stripInlineAutocomplete() {
+        _ = removeCompletion()
+    }
+
     // MARK: - UITextInput
 
     override func deleteBackward() {

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPLocationTextView.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPLocationTextView.swift
@@ -160,7 +160,9 @@ final class NTPLocationTextView: UITextView {
     /// Drops any inline autocomplete suffix without changing committed text.
     /// Used when the suggestions overlay stays up after keyboard drag-dismiss.
     func stripInlineAutocomplete() {
-        _ = removeCompletion()
+        if hasInlineCompletion {
+            revertToUserTypedTextOnly()
+        }
     }
 
     // MARK: - UITextInput

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPLocationTextView.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPLocationTextView.swift
@@ -158,6 +158,7 @@ final class NTPLocationTextView: UITextView {
     }
 
     /// Drops any inline autocomplete suffix without changing committed text.
+    /// Used when the suggestions overlay stays up after keyboard drag-dismiss.
     func stripInlineAutocomplete() {
         _ = removeCompletion()
     }

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPSearchBarView.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPSearchBarView.swift
@@ -30,7 +30,7 @@ protocol NTPSearchBarDelegate: AnyObject {
     /// `ntpSearchBarRequestsOverlayDismiss` for explicit overlay teardown.
     func ntpSearchBarDidCancel()
     /// Called when the user explicitly asks the omnibox UI to dismiss
-    /// (tap-outside the pill, close-button tap, host view disappearing).
+    /// (tap-outside the pill, host view disappearing).
     /// The host is expected to tear down the suggestions overlay here.
     func ntpSearchBarRequestsOverlayDismiss()
     /// While the suggestions overlay is visible, keyboard drag-dismiss should
@@ -159,8 +159,7 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable {
     }
 
     /// Fires whenever the text content changes (including programmatic clears).
-    /// Use from the host to drive focus-only chrome that depends on having text
-    /// — for example, the top-right close button.
+    /// Use from the host to drive layout that depends on pill height changes.
     var onContentChange: ((String) -> Void)?
 
     /// Fires whenever the textView's first-responder state changes. Use from

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPSearchBarView.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPSearchBarView.swift
@@ -480,7 +480,7 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable {
 
     private func refreshChromeFromTextView() {
         let text = textView.text ?? ""
-        let hasVisibleContent = !text.isEmpty || textView.hasActiveAutocomplete
+        let hasVisibleContent = !text.isEmpty || textView.hasInlineCompletion
         placeholderLabel.isHidden = hasVisibleContent
         updateSubmitState(for: text)
         updateCounter(for: text)
@@ -518,7 +518,7 @@ extension NTPSearchBarView: @MainActor @preconcurrency UITextViewDelegate {
         if delegate?.ntpSearchBarIsSuggestionsOverlayVisible() == true {
             (textView as? NTPLocationTextView)?.stripInlineAutocomplete()
         } else {
-            applyCompletion()
+            (textView as? NTPLocationTextView)?.commitPendingSuggestionIfValid()
         }
         refreshChromeFromTextView()
         applyBorderColor()

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPSearchBarView.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPSearchBarView.swift
@@ -36,10 +36,13 @@ protocol NTPSearchBarDelegate: AnyObject {
     /// While the suggestions overlay is visible, keyboard drag-dismiss should
     /// strip inline autocomplete without committing the full suggestion.
     func ntpSearchBarIsSuggestionsOverlayVisible() -> Bool
+    /// Recompute suggestions scroll insets when the pill moves (keyboard or multi-line growth).
+    func ntpSearchBarNeedsSuggestionsLayoutUpdate()
 }
 
 extension NTPSearchBarDelegate {
     func ntpSearchBarIsSuggestionsOverlayVisible() -> Bool { false }
+    func ntpSearchBarNeedsSuggestionsLayoutUpdate() {}
 }
 
 /// Pill-shaped search input pinned to the bottom of the redesigned NTP. Replaces

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPSearchBarView.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPSearchBarView.swift
@@ -465,11 +465,13 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable {
 
     func setAutocompleteSuggestion(_ suggestion: String?) {
         textView.setAutocompleteSuggestion(suggestion)
+        refreshChromeFromTextView()
     }
 
     private func refreshChromeFromTextView() {
         let text = textView.text ?? ""
-        placeholderLabel.isHidden = !text.isEmpty
+        let hasVisibleContent = !text.isEmpty || textView.hasActiveAutocomplete
+        placeholderLabel.isHidden = hasVisibleContent
         updateSubmitState(for: text)
         updateCounter(for: text)
         updateClearButtonVisibility(for: text)
@@ -503,6 +505,8 @@ extension NTPSearchBarView: @MainActor @preconcurrency UITextViewDelegate {
 
     func textViewDidEndEditing(_ textView: UITextView) {
         (textView as? NTPLocationTextView)?.didEndEditing()
+        applyCompletion()
+        refreshChromeFromTextView()
         applyBorderColor()
         onFocusChange?(false)
         delegate?.ntpSearchBarDidCancel()

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPSearchBarView.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPSearchBarView.swift
@@ -33,6 +33,13 @@ protocol NTPSearchBarDelegate: AnyObject {
     /// (tap-outside the pill, close-button tap, host view disappearing).
     /// The host is expected to tear down the suggestions overlay here.
     func ntpSearchBarRequestsOverlayDismiss()
+    /// While the suggestions overlay is visible, keyboard drag-dismiss should
+    /// strip inline autocomplete without committing the full suggestion.
+    func ntpSearchBarIsSuggestionsOverlayVisible() -> Bool
+}
+
+extension NTPSearchBarDelegate {
+    func ntpSearchBarIsSuggestionsOverlayVisible() -> Bool { false }
 }
 
 /// Pill-shaped search input pinned to the bottom of the redesigned NTP. Replaces
@@ -505,7 +512,11 @@ extension NTPSearchBarView: @MainActor @preconcurrency UITextViewDelegate {
 
     func textViewDidEndEditing(_ textView: UITextView) {
         (textView as? NTPLocationTextView)?.didEndEditing()
-        applyCompletion()
+        if delegate?.ntpSearchBarIsSuggestionsOverlayVisible() == true {
+            (textView as? NTPLocationTextView)?.stripInlineAutocomplete()
+        } else {
+            applyCompletion()
+        }
         refreshChromeFromTextView()
         applyBorderColor()
         onFocusChange?(false)

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2120,6 +2120,7 @@ class BrowserViewController: UIViewController,
         // back to the NTP from a webview the omnibox should take over again
         // and the native address toolbar should hide.
         shouldHideAddressToolbar()
+        ecosiaPrepareNTPOmniboxForDisplay()
     }
 
     func showEmbeddedWebview() {
@@ -2154,6 +2155,7 @@ class BrowserViewController: UIViewController,
         // contentContainer — without this it stayed hidden for the lifetime
         // of the session after the first NTP submit.
         shouldHideAddressToolbar()
+        ecosiaResetNTPOmniboxWhenLeavingNTP()
     }
 
     /// Notifies UIKit that `supportedInterfaceOrientations` may have changed

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -5251,21 +5251,16 @@ extension BrowserViewController: KeyboardHelperDelegate {
     }
 
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardDidHideWithState state: KeyboardState) {
-        let toolbarState = store.state.screenState(ToolbarState.self, for: .toolbar, window: windowUUID)
-        let isEditing = toolbarState?.addressToolbar.isEditing == true
-        // Ecosia: Firefox only cleared shouldShowKeyboard when editing ended. While the
-        // user scrolls suggestions the keyboard hides but overlay mode continues —
-        // leaving shouldShowKeyboard true re-requests first responder on row highlight,
-        // which leaves the keyboard-spacer gap below the address bar.
-        if !isEditing || !shouldCancelEditing {
-            store.dispatch(
-                ToolbarAction(
-                    shouldShowKeyboard: false,
-                    windowUUID: windowUUID,
-                    actionType: ToolbarActionType.keyboardStateDidChange
-                )
+        // Ecosia: Always clear shouldShowKeyboard when the keyboard hides. Overlay
+        // editing can continue (see shouldCancelEditing) but highlight must not
+        // re-request first responder — that leaves the keyboard-spacer gap under the bar.
+        store.dispatch(
+            ToolbarAction(
+                shouldShowKeyboard: false,
+                windowUUID: windowUUID,
+                actionType: ToolbarActionType.keyboardStateDidChange
             )
-        }
+        )
         tabManager.selectedTab?.setFindInPage(isBottomSearchBar: isBottomSearchBar,
                                               doesFindInPageBarExist: findInPageBar != nil)
         guard isSwipingTabsEnabled else { return }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -5239,7 +5239,11 @@ extension BrowserViewController: KeyboardHelperDelegate {
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardDidHideWithState state: KeyboardState) {
         let toolbarState = store.state.screenState(ToolbarState.self, for: .toolbar, window: windowUUID)
         let isEditing = toolbarState?.addressToolbar.isEditing == true
-        if !isEditing {
+        // Ecosia: Firefox only cleared shouldShowKeyboard when editing ended. While the
+        // user scrolls suggestions the keyboard hides but overlay mode continues —
+        // leaving shouldShowKeyboard true re-requests first responder on row highlight,
+        // which leaves the keyboard-spacer gap below the address bar (MOB-4580).
+        if !isEditing || !shouldCancelEditing {
             store.dispatch(
                 ToolbarAction(
                     shouldShowKeyboard: false,
@@ -5300,11 +5304,16 @@ extension BrowserViewController: KeyboardHelperDelegate {
            the user sees on screen.
         guard shouldCancelEditing else { return }
          */
+        // Ecosia: Restore Firefox's guarded cancel (MOB-4580). The suggestions
+        // table uses `.onDrag` keyboard dismiss so scrolling the list hides the
+        // keyboard without meaning "leave overlay mode".
+        guard shouldCancelEditing else { return }
         overlayManager.cancelEditing(shouldCancelLoading: false)
     }
 
-    /* Ecosia: No longer consulted — `cancelEditingMode` now always cancels for non-omnibox surfaces.
-       Preserved for upstream merge context; remove with the next Firefox sync if still unused.
+    /* Ecosia: Firefox v147.5 — kept overlay stuck after a keyboard swipe on
+       the SERP because the URL bar pre-fills the page URL/query into
+       `searchTerm` before the user types.
     private var shouldCancelEditing: Bool {
         let newTabChoice = NewTabAccessors.getNewTabPage(profile.prefs)
         guard newTabChoice != .topSites, newTabChoice != .blankPage else { return false }
@@ -5318,6 +5327,56 @@ extension BrowserViewController: KeyboardHelperDelegate {
         return searchTerm == nil
     }
      */
+    // Ecosia: Keep the suggestions overlay when the user is searching (typed query,
+    // SERP re-focus with "test 2", etc.). Only tear down for URL-only re-focus
+    // (Ecosia stuck-bar fix). Uses live text-field contents so debounced Redux
+    // state cannot lag behind what the user already typed ("yt").
+    private var shouldCancelEditing: Bool {
+        guard searchController?.parent != nil,
+              !(searchController?.parent is HomepageViewController) else {
+            return true
+        }
+
+        let bar = store.state.screenState(ToolbarState.self, for: .toolbar, window: windowUUID)?.addressToolbar
+        if bar?.didStartTyping == true {
+            return false
+        }
+
+        let query = overlaySearchQuery
+        guard !query.isEmpty else { return true }
+
+        if query.looksLikeAURLOverlayQuery {
+            return true
+        }
+
+        return false
+    }
+
+    private var overlaySearchQuery: String {
+        let liveText = addressToolbarContainer.overlayLocationText
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if !liveText.isEmpty { return liveText }
+
+        if let query = searchController?.viewModel.searchQuery
+            .trimmingCharacters(in: .whitespacesAndNewlines), !query.isEmpty {
+            return query
+        }
+
+        if let term = store.state.screenState(ToolbarState.self, for: .toolbar, window: windowUUID)?
+            .addressToolbar.searchTerm?
+            .trimmingCharacters(in: .whitespacesAndNewlines), !term.isEmpty {
+            return term
+        }
+
+        return searchLoader?.query.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    }
+}
+
+private extension String {
+    // Mirrors SearchViewModel.looksLikeAURL — slash without spaces means page URL re-focus.
+    var looksLikeAURLOverlayQuery: Bool {
+        contains("/") && !contains(" ")
+    }
 }
 
 // MARK: JSPromptAlertControllerDelegate

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -5244,7 +5244,7 @@ extension BrowserViewController: KeyboardHelperDelegate {
         // Ecosia: Firefox only cleared shouldShowKeyboard when editing ended. While the
         // user scrolls suggestions the keyboard hides but overlay mode continues —
         // leaving shouldShowKeyboard true re-requests first responder on row highlight,
-        // which leaves the keyboard-spacer gap below the address bar (MOB-4580).
+        // which leaves the keyboard-spacer gap below the address bar.
         if !isEditing || !shouldCancelEditing {
             store.dispatch(
                 ToolbarAction(
@@ -5306,9 +5306,7 @@ extension BrowserViewController: KeyboardHelperDelegate {
            the user sees on screen.
         guard shouldCancelEditing else { return }
          */
-        // Ecosia: Restore Firefox's guarded cancel (MOB-4580). The suggestions
-        // table uses `.onDrag` keyboard dismiss so scrolling the list hides the
-        // keyboard without meaning "leave overlay mode".
+        // Ecosia: Guard cancel so suggestion scroll (keyboard hidden) keeps overlay alive.
         guard shouldCancelEditing else { return }
         overlayManager.cancelEditing(shouldCancelLoading: false)
     }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -3142,6 +3142,13 @@ class BrowserViewController: UIViewController,
         // This code snippet addresses an issue related to navigation between pages in the same tab FXIOS-7309.
         // Specifically, it checks if the URL bar is not currently focused (`!focusUrlBar`) and if it is
         // operating in an overlay mode (`urlBar.inOverlayMode`).
+        // Ecosia: Active search edit on a SERP (shouldCancelEditing false) with no back
+        // stack should not dismiss the overlay — same as keyboard drag-dismiss on suggestions.
+        if addressToolbarContainer.inOverlayMode,
+           !shouldCancelEditing,
+           tabManager.selectedTab?.canGoBack != true {
+            return
+        }
         dismissUrlBar()
         tabManager.selectedTab?.goBack()
     }
@@ -3150,6 +3157,11 @@ class BrowserViewController: UIViewController,
         // This code snippet addresses an issue related to navigation between pages in the same tab FXIOS-7309.
         // Specifically, it checks if the URL bar is not currently focused (`!focusUrlBar`) and if it is
         // operating in an overlay mode (`urlBar.inOverlayMode`).
+        if addressToolbarContainer.inOverlayMode,
+           !shouldCancelEditing,
+           tabManager.selectedTab?.canGoForward != true {
+            return
+        }
         dismissUrlBar()
         tabManager.selectedTab?.goForward()
     }
@@ -5332,8 +5344,7 @@ extension BrowserViewController: KeyboardHelperDelegate {
     // (Ecosia stuck-bar fix). Uses live text-field contents so debounced Redux
     // state cannot lag behind what the user already typed ("yt").
     private var shouldCancelEditing: Bool {
-        guard searchController?.parent != nil,
-              !(searchController?.parent is HomepageViewController) else {
+        if searchController?.parent is HomepageViewController {
             return true
         }
 

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -151,6 +151,7 @@ final class AddressToolbarContainer: UIView,
     /// and the Cancel button is visible (allowing the user to leave overlay mode).
     var inOverlayMode = false
 
+    // Ecosia: Passthrough for live overlay text decisions in BVC.
     var overlayLocationText: String {
         toolbar.overlayEditingText
     }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -151,7 +151,6 @@ final class AddressToolbarContainer: UIView,
     /// and the Cancel button is visible (allowing the user to leave overlay mode).
     var inOverlayMode = false
 
-    // Ecosia: Live URL-bar text for overlay keyboard-dismiss decisions (MOB-4580).
     var overlayLocationText: String {
         toolbar.overlayEditingText
     }

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -151,6 +151,11 @@ final class AddressToolbarContainer: UIView,
     /// and the Cancel button is visible (allowing the user to leave overlay mode).
     var inOverlayMode = false
 
+    // Ecosia: Live URL-bar text for overlay keyboard-dismiss decisions (MOB-4580).
+    var overlayLocationText: String {
+        toolbar.overlayEditingText
+    }
+
     init(isMinimalAddressBarEnabled: Bool, toolbarHelper: ToolbarHelperInterface = ToolbarHelper()) {
         self.isMinimalAddressBarEnabled = isMinimalAddressBarEnabled
         self.toolbarHelper = toolbarHelper

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -708,7 +708,6 @@ struct AddressBarState: StateType, Sendable, Equatable {
                Re-requesting the keyboard during touch-scroll leaves a gap under the bar.
             shouldShowKeyboard: true,
              */
-            // Ecosia: Keep keyboard dismissed while scrolling suggestions in overlay mode.
             shouldShowKeyboard: false,
             shouldSelectSearchTerm: false,
             isLoading: state.isLoading,
@@ -719,7 +718,6 @@ struct AddressBarState: StateType, Sendable, Equatable {
                tears down the suggestions overlay when the list is scrolled.
             didStartTyping: false,
              */
-            // Ecosia: Preserve typing state when overlay text updates during touch-scroll.
             didStartTyping: state.didStartTyping,
             isEmptySearch: isEmptySearch,
             alternativeSearchEngine: state.alternativeSearchEngine

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -715,7 +715,12 @@ struct AddressBarState: StateType, Sendable, Equatable {
             readerModeState: state.readerModeState,
             canSummarize: state.canSummarize,
             translationConfiguration: state.translationConfiguration,
+            /* Ecosia: Firefox resets didStartTyping so highlight can update the field.
+               Preserve it while the user is typing — resetting mid-keystroke overwrites
+               the text view and drops first responder.
             didStartTyping: false,
+             */
+            didStartTyping: state.didStartTyping,
             isEmptySearch: isEmptySearch,
             alternativeSearchEngine: state.alternativeSearchEngine
         )

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -705,20 +705,22 @@ struct AddressBarState: StateType, Sendable, Equatable {
             safeListedURLImageName: state.safeListedURLImageName,
             isEditing: true,
             /* Ecosia: Firefox sets shouldShowKeyboard true on location-view text updates.
-               Re-requesting the keyboard during touch-scroll leaves a gap under the bar.
+               Re-requesting the keyboard after drag-dismiss leaves a gap under the bar;
+               keyboardDidHide clears the flag — preserve state here instead of forcing true.
             shouldShowKeyboard: true,
              */
-            shouldShowKeyboard: false,
+            shouldShowKeyboard: state.shouldShowKeyboard,
             shouldSelectSearchTerm: false,
             isLoading: state.isLoading,
             readerModeState: state.readerModeState,
             canSummarize: state.canSummarize,
             translationConfiguration: state.translationConfiguration,
-            /* Ecosia: Firefox resets didStartTyping on location-view text updates, which
-               tears down the suggestions overlay when the list is scrolled.
+            /* Ecosia: Firefox resets didStartTyping so highlight can update the field.
+               Overlay teardown on scroll is handled in BVC.shouldCancelEditing via
+               overlaySearchQuery — not this flag.
             didStartTyping: false,
              */
-            didStartTyping: state.didStartTyping,
+            didStartTyping: false,
             isEmptySearch: isEmptySearch,
             alternativeSearchEngine: state.alternativeSearchEngine
         )

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -704,13 +704,23 @@ struct AddressBarState: StateType, Sendable, Equatable {
             lockIconNeedsTheming: state.lockIconNeedsTheming,
             safeListedURLImageName: state.safeListedURLImageName,
             isEditing: true,
+            /* Ecosia: Firefox sets shouldShowKeyboard true on location-view text updates.
+               Re-requesting the keyboard during touch-scroll leaves a gap under the bar.
             shouldShowKeyboard: true,
+             */
+            // Ecosia: Keep keyboard dismissed while scrolling suggestions in overlay mode.
+            shouldShowKeyboard: false,
             shouldSelectSearchTerm: false,
             isLoading: state.isLoading,
             readerModeState: state.readerModeState,
             canSummarize: state.canSummarize,
             translationConfiguration: state.translationConfiguration,
+            /* Ecosia: Firefox resets didStartTyping on location-view text updates, which
+               tears down the suggestions overlay when the list is scrolled.
             didStartTyping: false,
+             */
+            // Ecosia: Preserve typing state when overlay text updates during touch-scroll.
+            didStartTyping: state.didStartTyping,
             isEmptySearch: isEmptySearch,
             alternativeSearchEngine: state.alternativeSearchEngine
         )

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -715,11 +715,6 @@ struct AddressBarState: StateType, Sendable, Equatable {
             readerModeState: state.readerModeState,
             canSummarize: state.canSummarize,
             translationConfiguration: state.translationConfiguration,
-            /* Ecosia: Firefox resets didStartTyping so highlight can update the field.
-               Overlay teardown on scroll is handled in BVC.shouldCancelEditing via
-               overlaySearchQuery — not this flag.
-            didStartTyping: false,
-             */
             didStartTyping: false,
             isEmptySearch: isEmptySearch,
             alternativeSearchEngine: state.alternativeSearchEngine


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

## Context
Regression after the Upgrade + Omnibox work: scrolling suggestions with the keyboard up tore down the overlay, and the NTP omnibox could keep stale state across tab switches (found out additionally).
## Approach
Restore Firefox's guarded `cancelEditingMode()` and read live URL bar text via `plainUserText` so overlay teardown does not follow keyboard drag-dismiss. 

On the NTP, keep the suggestions overlay alive on resign-first-responder, route tap-outside through `UIGestureRecognizerDelegate` on the responder chain, and double-check the overlay with dynamic table insets as the omnibox moves.

Reset the shared omnibox in `resetNTPOmniboxSession()` when leaving or re-showing the homepage (swiping-tabs can skip `viewDidDisappear`).

## Other
While testing the scroll path we also fixed:
- `shouldShowKeyboard` / `didStartTyping` leaving a gap under the URL bar after keyboard drag-dismiss
- Inline autocomplete committing on end-editing while scrolling suggestions
- Placeholder overlapping stale omnibox text on homepage landing
- Trimmed redundant `// Ecosia:` comments
## Before merging
### Checklist
- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [x] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed
