### PR TITLE
[MOB-4610] Fix bookmarks panel crash when empty state view was never shown.

### DIFF
--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
@@ -126,10 +126,18 @@ final class BookmarksViewController: SiteTableViewController,
         return button
     }()
 
-    // Stored optionally so deinit can clean up without triggering lazy init (which would
-    // assign delegate = self while the view controller is deallocating).
+    /* Ecosia: Store empty bookmarks view lazily
+    private lazy var emptyBookmarksView: EmptyBookmarksView = {
+        let view = EmptyBookmarksView(initialBottomMargin: 0)
+        view.delegate = self
+        return view
+    }()
+    */
+    // Ecosia: Store optionally so deinit can clean up without triggering lazy init
+    // (assigning delegate = self while the view controller is deallocating).
     private var emptyBookmarksView: EmptyBookmarksView?
 
+    // Ecosia: Create empty bookmarks view on demand when the empty state is shown.
     private func ensureEmptyBookmarksView() -> EmptyBookmarksView {
         if let emptyBookmarksView {
             return emptyBookmarksView
@@ -186,6 +194,10 @@ final class BookmarksViewController: SiteTableViewController,
             // FXIOS-11315: Necessary to prevent BookmarksFolderEmptyStateView from being retained in memory
             a11yEmptyStateScrollView.removeFromSuperview()
             */
+            /* Ecosia: Remove lazy empty bookmarks view from hierarchy on teardown
+            emptyBookmarksView.removeFromSuperview()
+            */
+            // Ecosia: Only clean up if already created — avoid lazy init during deallocation.
             emptyBookmarksView?.delegate = nil
             emptyBookmarksView?.removeFromSuperview()
             emptyBookmarksView = nil

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
@@ -126,18 +126,15 @@ final class BookmarksViewController: SiteTableViewController,
         return button
     }()
 
-    /* Ecosia: Store empty bookmarks view lazily
+    /* Ecosia: Lazy empty bookmarks view crashed in deinit when delegate was set during teardown
     private lazy var emptyBookmarksView: EmptyBookmarksView = {
         let view = EmptyBookmarksView(initialBottomMargin: 0)
         view.delegate = self
         return view
     }()
     */
-    // Ecosia: Store optionally so deinit can clean up without triggering lazy init
-    // (assigning delegate = self while the view controller is deallocating).
     private var emptyBookmarksView: EmptyBookmarksView?
 
-    // Ecosia: Create empty bookmarks view on demand when the empty state is shown.
     private func ensureEmptyBookmarksView() -> EmptyBookmarksView {
         if let emptyBookmarksView {
             return emptyBookmarksView
@@ -194,10 +191,9 @@ final class BookmarksViewController: SiteTableViewController,
             // FXIOS-11315: Necessary to prevent BookmarksFolderEmptyStateView from being retained in memory
             a11yEmptyStateScrollView.removeFromSuperview()
             */
-            /* Ecosia: Remove lazy empty bookmarks view from hierarchy on teardown
+            /* Ecosia: Lazy empty bookmarks view crashed in deinit — only clean up if already created
             emptyBookmarksView.removeFromSuperview()
             */
-            // Ecosia: Only clean up if already created — avoid lazy init during deallocation.
             emptyBookmarksView?.delegate = nil
             emptyBookmarksView?.removeFromSuperview()
             emptyBookmarksView = nil

--- a/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
+++ b/firefox-ios/Client/Frontend/Library/Bookmarks/BookmarksViewController.swift
@@ -126,11 +126,19 @@ final class BookmarksViewController: SiteTableViewController,
         return button
     }()
 
-    private lazy var emptyBookmarksView: EmptyBookmarksView = {
+    // Stored optionally so deinit can clean up without triggering lazy init (which would
+    // assign delegate = self while the view controller is deallocating).
+    private var emptyBookmarksView: EmptyBookmarksView?
+
+    private func ensureEmptyBookmarksView() -> EmptyBookmarksView {
+        if let emptyBookmarksView {
+            return emptyBookmarksView
+        }
         let view = EmptyBookmarksView(initialBottomMargin: 0)
         view.delegate = self
+        emptyBookmarksView = view
         return view
-    }()
+    }
 
     // MARK: - Init
 
@@ -178,7 +186,9 @@ final class BookmarksViewController: SiteTableViewController,
             // FXIOS-11315: Necessary to prevent BookmarksFolderEmptyStateView from being retained in memory
             a11yEmptyStateScrollView.removeFromSuperview()
             */
-            emptyBookmarksView.removeFromSuperview()
+            emptyBookmarksView?.delegate = nil
+            emptyBookmarksView?.removeFromSuperview()
+            emptyBookmarksView = nil
         }
     }
 
@@ -448,17 +458,18 @@ final class BookmarksViewController: SiteTableViewController,
         let showEmptyState = viewModel.bookmarkNodes.isEmpty && !tableView.isEditing
 
         if showEmptyState {
-            if emptyBookmarksView.superview == nil {
-                emptyBookmarksView.frame = view.bounds
-                emptyBookmarksView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-                view.addSubview(emptyBookmarksView)
+            let emptyView = ensureEmptyBookmarksView()
+            if emptyView.superview == nil {
+                emptyView.frame = view.bounds
+                emptyView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+                view.addSubview(emptyView)
             }
-            emptyBookmarksView.applyTheme(theme: currentTheme())
-            view.bringSubviewToFront(emptyBookmarksView)
-            emptyBookmarksView.isHidden = false
+            emptyView.applyTheme(theme: currentTheme())
+            view.bringSubviewToFront(emptyView)
+            emptyView.isHidden = false
         } else {
-            emptyBookmarksView.isHidden = true
-            emptyBookmarksView.removeFromSuperview()
+            emptyBookmarksView?.isHidden = true
+            emptyBookmarksView?.removeFromSuperview()
         }
     }
 
@@ -524,7 +535,7 @@ final class BookmarksViewController: SiteTableViewController,
     }
     */
     private func setupEmptyStateView() {
-        emptyBookmarksView.applyTheme(theme: currentTheme())
+        ensureEmptyBookmarksView().applyTheme(theme: currentTheme())
     }
 
     // MARK: - UITableViewDataSource | UITableViewDelegate

--- a/firefox-ios/EcosiaTests/UI/Bookmarks/BookmarksViewControllerTests.swift
+++ b/firefox-ios/EcosiaTests/UI/Bookmarks/BookmarksViewControllerTests.swift
@@ -10,16 +10,12 @@ import XCTest
 // Ecosia: Lifecycle tests for the Ecosia empty bookmarks state on BookmarksViewController.
 @MainActor
 final class BookmarksViewControllerTests: XCTestCase {
-    private var profile: MockProfile!
-
     override func setUp() {
         super.setUp()
         DependencyHelperMock().bootstrapDependencies()
-        profile = MockProfile()
     }
 
     override func tearDown() {
-        profile = nil
         DependencyHelperMock().reset()
         super.tearDown()
     }
@@ -70,7 +66,7 @@ final class BookmarksViewControllerTests: XCTestCase {
 
     private func createSubject(bookmarkNodes: [FxBookmarkNode]) -> BookmarksViewController {
         let viewModel = BookmarksPanelViewModel(
-            profile: profile,
+            profile: MockProfile(),
             bookmarksHandler: BookmarksHandlerMock(),
             bookmarkFolderGUID: BookmarkRoots.MobileFolderGUID
         )

--- a/firefox-ios/EcosiaTests/UI/Bookmarks/BookmarksViewControllerTests.swift
+++ b/firefox-ios/EcosiaTests/UI/Bookmarks/BookmarksViewControllerTests.swift
@@ -1,0 +1,83 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Storage
+import XCTest
+
+@testable import Client
+
+// Ecosia: Lifecycle tests for the Ecosia empty bookmarks state on BookmarksViewController.
+@MainActor
+final class BookmarksViewControllerTests: XCTestCase {
+    private var profile: MockProfile!
+
+    override func setUp() {
+        super.setUp()
+        DependencyHelperMock().bootstrapDependencies()
+        profile = MockProfile()
+    }
+
+    override func tearDown() {
+        profile = nil
+        DependencyHelperMock().reset()
+        super.tearDown()
+    }
+
+    // Regression: deinit must not create EmptyBookmarksView (delegate = self) during teardown.
+    func test_deinit_whenEmptyStateWasNeverShown_doesNotLeak() {
+        let subject = createSubject(
+            bookmarkNodes: [
+                MockFxBookmarkNode(
+                    type: .bookmark,
+                    guid: "bookmark-guid",
+                    parentGUID: nil,
+                    position: 0,
+                    isRoot: false,
+                    title: "Saved bookmark"
+                )
+            ]
+        )
+        trackForMemoryLeaks(subject)
+    }
+
+    func test_viewWillAppear_whenBookmarksAreEmpty_showsEmptyBookmarksView() {
+        let subject = createSubject(bookmarkNodes: [])
+        subject.loadViewIfNeeded()
+        subject.viewWillAppear(false)
+
+        XCTAssertTrue(subject.view.subviews.contains { $0 is EmptyBookmarksView })
+    }
+
+    func test_viewWillAppear_whenBookmarksExist_hidesEmptyBookmarksView() {
+        let subject = createSubject(
+            bookmarkNodes: [
+                MockFxBookmarkNode(
+                    type: .bookmark,
+                    guid: "bookmark-guid",
+                    parentGUID: nil,
+                    position: 0,
+                    isRoot: false,
+                    title: "Saved bookmark"
+                )
+            ]
+        )
+        subject.loadViewIfNeeded()
+        subject.viewWillAppear(false)
+
+        XCTAssertFalse(subject.view.subviews.contains { $0 is EmptyBookmarksView })
+    }
+
+    private func createSubject(bookmarkNodes: [FxBookmarkNode]) -> BookmarksViewController {
+        let viewModel = BookmarksPanelViewModel(
+            profile: profile,
+            bookmarksHandler: BookmarksHandlerMock(),
+            bookmarkFolderGUID: BookmarkRoots.MobileFolderGUID
+        )
+        viewModel.bookmarkNodes = bookmarkNodes
+
+        let subject = BookmarksViewController(viewModel: viewModel, windowUUID: .XCTestDefaultUUID)
+        trackForMemoryLeaks(subject)
+        return subject
+    }
+}


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

## Context
High-volume crash in `BookmarksViewController` when user closes the app with bookmarks open (can be background, force kill).

## Approach

ℹ️ while the fix was pretty straightforward, the path to reach to it, not equally a piece of cake. Info 👇  

Quick investigation as the issue was pretty self-explanatory:

- Stack trace points at `emptyBookmarksView.getter` → `view.delegate = self` inside `BookmarksViewController.deinit`. 
- The empty state view was a `lazy var` whose initializer assigns `delegate = self`. 
- If the user never saw the empty bookmarks state (like they had bookmarks _between the upgrades_ especially), that lazy initializer had never run. `deinit` then accessed `emptyBookmarksView` for the first time, creating a weak reference to `self` while the view controller was already deallocating — ObjC runtime abort (`Termination Reason: OBJC 1`).

### Fix
Replace the lazy property with an optional stored `EmptyBookmarksView`, created only when the empty state is actually shown via `ensureEmptyBookmarksView()`.

## Other

Added `EcosiaTests/UI/Bookmarks/BookmarksViewControllerTests.swift` with lifecycle coverage:
- Deallocation when the empty state was never shown (regression for the crash)
- Empty state visibility when bookmarks list is empty vs non-empty

## Before merging
### Checklist
- [ ] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [x] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed