### PR TITLE
Tuist setup CI fix: Update brew before install

### DIFF
--- a/tuist-setup.sh
+++ b/tuist-setup.sh
@@ -42,7 +42,7 @@ echo -e "${BLUE}═════════════════════�
 # Check if tuist is installed
 if ! command -v tuist &> /dev/null; then
     echo -e "${YELLOW}⚠️  Tuist not found. Installing...${NC}"
-    brew install tuist
+    brew update && brew install tuist
     echo -e "${GREEN}✓ Tuist installed${NC}\n"
 else
     echo -e "${GREEN}✓ Tuist found${NC}\n"

--- a/tuist-setup.sh
+++ b/tuist-setup.sh
@@ -42,7 +42,10 @@ echo -e "${BLUE}═════════════════════�
 # Check if tuist is installed
 if ! command -v tuist &> /dev/null; then
     echo -e "${YELLOW}⚠️  Tuist not found. Installing...${NC}"
-    brew update && brew install tuist
+    if [ -n "$HOMEBREW_NO_AUTO_UPDATE" ]; then
+        brew update
+    fi
+    brew install tuist
     echo -e "${GREEN}✓ Tuist installed${NC}\n"
 else
     echo -e "${GREEN}✓ Tuist found${NC}\n"


### PR DESCRIPTION
## Context

CI started failing (e.g. [this run](https://app.circleci.com/pipelines/github/ecosia/ios-browser/6737/workflows/dd99f4c9-940b-404c-8e35-59c7c689c11e/jobs/3049)).

## Investigation

CircleCI macOS runners have Homebrew auto-updates disabled (HOMEBREW_NO_AUTO_UPDATE=1). When the runner image is stale, Homebrew's cached cask API data can contain fields that the installed Homebrew version doesn't handle, causing a Ruby nil crash in cask_struct_generator.rb when resolving the Tuist cask.

## Fix

Running brew update before brew install tuist ensures the local cask metadata is fresh and avoids the crash.

It does add some time to CI though, we can still look for better alternatives but this seems like the quickest fix to unblock CI.