### PR TITLE
[MOB-4301] Autocompact search bar on AI chat

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -414,7 +414,8 @@ workflows:
           name: Deploy ad-hoc version over Firebase + Upload to Browserstack
           filters:
             branches:
-              only: 
+              only:
+                - mk-mob-4301-compact-address-bar
                 - main
                 - develop
                 - /^main-\d+$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -414,8 +414,7 @@ workflows:
           name: Deploy ad-hoc version over Firebase + Upload to Browserstack
           filters:
             branches:
-              only:
-                - mk-mob-4301-compact-address-bar
+              only: 
                 - main
                 - develop
                 - /^main-\d+$/

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -4319,7 +4319,7 @@ class BrowserViewController: UIViewController,
         updateInContentHomePanel(tabManager.selectedTab?.url as URL?)
 
         (view as? ThemeApplicable)?.applyTheme(theme: currentTheme())
-        
+
         // Ecosia: When the user *abandons* editing (.cancelled) while still on the AI chat vertical,
         // snap the address bar back to the compact pill. We deliberately do NOT act on .finished:
         // that is a committed search/navigation, and this delegate fires before `tab.loadRequest`

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -796,9 +796,13 @@ class BrowserViewController: UIViewController,
             topBlurView.alpha = 1
         }
 
+        // Ecosia: On the AI chat vertical the address bar is pinned to its compact pill (scroll alpha 0),
+        // but we keep the navigation toolbar visible so the user retains tab navigation. Don't let the
+        // zero scroll alpha hide the bottom container (or its blur) there.
+        let keepBottomVisible = scrollController.pinsCompactAddressBar
         bottomContainer.isClearBackground = showNavToolbar && enableBlur
-        bottomBlurView.isHidden = (!showNavToolbar && !isBottomSearchBar && enableBlur) || isScrollAlphaZero
-        bottomContainer.isHidden = isScrollAlphaZero
+        bottomBlurView.isHidden = (!showNavToolbar && !isBottomSearchBar && enableBlur) || (isScrollAlphaZero && !keepBottomVisible)
+        bottomContainer.isHidden = isScrollAlphaZero && !keepBottomVisible
 
         if !isToolbarTranslucencyRefactorEnabled {
             let maskView = UIView(frame: CGRect(x: 0,
@@ -4315,14 +4319,19 @@ class BrowserViewController: UIViewController,
         updateInContentHomePanel(tabManager.selectedTab?.url as URL?)
 
         (view as? ThemeApplicable)?.applyTheme(theme: currentTheme())
-
-        // Ecosia: When the user dismisses editing while still on the AI chat vertical (no navigation away),
-        // snap the address bar back to the compact pill. If editing finished with a navigation off /ai-chat,
-        // the selected tab is no longer AI chat so we leave the (already expanded) bar as is.
-        let stillAIChat = isMinimalAddressBarEnabled && (tabManager.selectedTab?.url?.isEcosiaAIChat ?? false)
-        scrollController.pinsCompactAddressBar = stillAIChat
-        if stillAIChat {
-            scrollController.hideToolbars(animated: true)
+        
+        // Ecosia: When the user *abandons* editing (.cancelled) while still on the AI chat vertical,
+        // snap the address bar back to the compact pill. We deliberately do NOT act on .finished:
+        // that is a committed search/navigation, and this delegate fires before `tab.loadRequest`
+        // (see finishEditingAndSubmit) while `tab.url` is still the AI chat URL — re-collapsing here
+        // would interrupt the in-flight submission. The navigation flow (updateUIForReaderHomeStateForTab)
+        // sets the correct state for the destination URL instead.
+        if reason == .cancelled {
+            let stillAIChat = isMinimalAddressBarEnabled && (tabManager.selectedTab?.url?.isEcosiaAIChat ?? false)
+            scrollController.pinsCompactAddressBar = stillAIChat
+            if stillAIChat {
+                scrollController.hideToolbars(animated: true)
+            }
         }
     }
 
@@ -5250,7 +5259,11 @@ extension BrowserViewController: KeyboardHelperDelegate {
     }
 
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillHideWithState state: KeyboardState) {
-        if #available(iOS 26.0, *), isBottomSearchBar {
+        // Ecosia: This scroll-alpha reset restores the full bottom bar after the keyboard hides, but
+        // `scrollAlpha != 0` also un-hides the navigation toolbar (see `bottomContainer.isHidden`),
+        // so on the AI chat vertical it would expand our pinned compact pill into the full bar.
+        // Skip it when pinned; `keyboardDidHide` re-collapses the pill once the layout settles.
+        if #available(iOS 26.0, *), isBottomSearchBar, !scrollController.pinsCompactAddressBar {
             store.dispatch(
                 ToolbarAction(
                     scrollAlpha: 1,
@@ -5290,6 +5303,13 @@ extension BrowserViewController: KeyboardHelperDelegate {
                 actionType: ToolbarActionType.keyboardStateDidChange
             )
         )
+        // Ecosia: On the AI chat vertical the compact pill is pinned. Dismissing the keyboard after
+        // typing in the page's "Ask follow up" web input expands the toolbar (the navigation bar
+        // reappears); re-collapse it so the pill stays put. Skip while the URL bar itself is being
+        // edited (overlay mode owns the expanded bar and re-collapses on its own cancel/finish).
+        if !isEditing, !overlayManager.inOverlayMode, scrollController.pinsCompactAddressBar {
+            scrollController.hideToolbars(animated: false)
+        }
         tabManager.selectedTab?.setFindInPage(isBottomSearchBar: isBottomSearchBar,
                                               doesFindInPageBarExist: findInPageBar != nil)
         guard isSwipingTabsEnabled else { return }

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -2750,7 +2750,19 @@ class BrowserViewController: UIViewController,
 
     func updateUIForReaderHomeStateForTab(_ tab: Tab, focusUrlBar: Bool = false) {
         updateURLBarDisplayURL(tab)
+        /* Ecosia: Default to the minimal/compact address bar pill on the AI chat vertical.
+           On AI chat we start collapsed and pin it (so scroll doesn't toggle — see the scroll
+           controllers); on any other page we restore the normal expanded behaviour. Gated by
+           isMinimalAddressBarEnabled so non-minimal builds are unaffected.
         scrollController.showToolbars(animated: false)
+         */
+        let pinsCompact = isMinimalAddressBarEnabled && (tab.url?.isEcosiaAIChat ?? false)
+        scrollController.pinsCompactAddressBar = pinsCompact
+        if pinsCompact {
+            scrollController.hideToolbars(animated: false)
+        } else {
+            scrollController.showToolbars(animated: false)
+        }
 
         if let url = tab.url {
             if url.isReaderModeURL {
@@ -4303,6 +4315,15 @@ class BrowserViewController: UIViewController,
         updateInContentHomePanel(tabManager.selectedTab?.url as URL?)
 
         (view as? ThemeApplicable)?.applyTheme(theme: currentTheme())
+
+        // Ecosia: When the user dismisses editing while still on the AI chat vertical (no navigation away),
+        // snap the address bar back to the compact pill. If editing finished with a navigation off /ai-chat,
+        // the selected tab is no longer AI chat so we leave the (already expanded) bar as is.
+        let stillAIChat = isMinimalAddressBarEnabled && (tabManager.selectedTab?.url?.isEcosiaAIChat ?? false)
+        scrollController.pinsCompactAddressBar = stillAIChat
+        if stillAIChat {
+            scrollController.hideToolbars(animated: true)
+        }
     }
 
     func addressToolbarDidBeginDragInteraction() {
@@ -4923,6 +4944,14 @@ extension BrowserViewController: TabManagerDelegate {
             scrollController.tab = selectedTab
         } else {
             scrollController.tabProvider = TabProviderAdapter(selectedTab)
+        }
+
+        // Ecosia: Keep the compact-pill pin in sync with the newly selected tab so AI chat tabs
+        // start (and stay) collapsed while other tabs keep the normal scroll behaviour.
+        let pinsCompact = isMinimalAddressBarEnabled && (selectedTab.url?.isEcosiaAIChat ?? false)
+        scrollController.pinsCompactAddressBar = pinsCompact
+        if pinsCompact {
+            scrollController.hideToolbars(animated: false)
         }
 
         var needsReload = false

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -796,11 +796,16 @@ class BrowserViewController: UIViewController,
             topBlurView.alpha = 1
         }
 
-        // Ecosia: On the AI chat vertical the address bar is pinned to its compact pill (scroll alpha 0),
-        // but we keep the navigation toolbar visible so the user retains tab navigation. Don't let the
-        // zero scroll alpha hide the bottom container (or its blur) there.
+        // Ecosia: On the AI chat vertical the address bar is pinned to its compact pill (scroll alpha 0), but we
+        // keep the navigation toolbar visible so the user retains tab navigation. Don't let the zero scroll alpha
+        // hide the bottom container (or its blur) there.
         let keepBottomVisible = scrollController.pinsCompactAddressBar
         bottomContainer.isClearBackground = showNavToolbar && enableBlur
+        /* Ecosia: Keep the bottom container and its blur visible when the compact pill is pinned, even at zero
+           scroll alpha, so the navigation toolbar stays available on the AI chat vertical.
+        bottomBlurView.isHidden = (!showNavToolbar && !isBottomSearchBar && enableBlur) || isScrollAlphaZero
+        bottomContainer.isHidden = isScrollAlphaZero
+         */
         bottomBlurView.isHidden = (!showNavToolbar && !isBottomSearchBar && enableBlur) || (isScrollAlphaZero && !keepBottomVisible)
         bottomContainer.isHidden = isScrollAlphaZero && !keepBottomVisible
 
@@ -5259,10 +5264,20 @@ extension BrowserViewController: KeyboardHelperDelegate {
     }
 
     func keyboardHelper(_ keyboardHelper: KeyboardHelper, keyboardWillHideWithState state: KeyboardState) {
-        // Ecosia: This scroll-alpha reset restores the full bottom bar after the keyboard hides, but
-        // `scrollAlpha != 0` also un-hides the navigation toolbar (see `bottomContainer.isHidden`),
-        // so on the AI chat vertical it would expand our pinned compact pill into the full bar.
-        // Skip it when pinned; `keyboardDidHide` re-collapses the pill once the layout settles.
+        /* Ecosia: This scroll-alpha reset restores the full bottom bar after the keyboard hides, but
+           `scrollAlpha != 0` also un-hides the navigation toolbar (see `bottomContainer.isHidden`), so on the
+           AI chat vertical it would expand our pinned compact pill into the full bar. Skip it when pinned;
+           `keyboardDidHide` re-collapses the pill once the layout settles.
+        if #available(iOS 26.0, *), isBottomSearchBar {
+            store.dispatch(
+                ToolbarAction(
+                    scrollAlpha: 1,
+                    windowUUID: windowUUID,
+                    actionType: ToolbarActionType.scrollAlphaNeedsUpdate
+                )
+            )
+        }
+         */
         if #available(iOS 26.0, *), isBottomSearchBar, !scrollController.pinsCompactAddressBar {
             store.dispatch(
                 ToolbarAction(

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
@@ -387,20 +387,32 @@ final class LegacyTabScrollController: NSObject,
     }
 
     func hideToolbars(animated: Bool) {
-        // Ecosia: When the compact pill is pinned (AI chat vertical) always re-apply the collapsed
-        // offsets and scroll alpha, even if we already consider ourselves `.collapsed`. The
-        // keyboard-dismiss layout resets the bottom-container offset and bumps scroll alpha back up,
-        // so an early return here would let the address bar expand back to full size.
+        /* Ecosia: When the compact pill is pinned (AI chat vertical) always re-apply the collapsed offsets and
+           scroll alpha, even if we already consider ourselves `.collapsed`. The keyboard-dismiss layout resets
+           the bottom-container offset and bumps scroll alpha back up, so the original early return here would let
+           the address bar expand back to full size.
+        guard toolbarState != .collapsed else { return }
+         */
         guard toolbarState != .collapsed || pinsCompactAddressBar else { return }
 
         toolbarState = .collapsed
 
-        // Ecosia: On the AI chat vertical keep the navigation toolbar in place (offset 0) so the user
-        // retains tab navigation (new tab / tabs / menu) — only the address bar collapses to its pill.
-        // `updateBlurViews` keeps the bottom container visible there despite the zero scroll alpha.
+        // Ecosia: On the AI chat vertical keep the navigation toolbar in place (offset 0) so the user retains
+        // tab navigation (new tab / tabs / menu) — only the address bar collapses to its pill. `updateBlurViews`
+        // keeps the bottom container visible there despite the zero scroll alpha.
         let collapsedBottomOffset = pinsCompactAddressBar ? 0 : bottomContainerScrollHeight
 
         let actualDuration = TimeInterval(UX.toolbarBaseAnimationDuration * hideDurationRation)
+        /* Ecosia: Pass `collapsedBottomOffset` so the navigation toolbar stays in place (offset 0) when pinned.
+        animateToolbarsWithOffsets(
+            animated,
+            duration: actualDuration,
+            headerOffset: headerOffset,
+            bottomContainerOffset: bottomContainerScrollHeight,
+            overKeyboardOffset: overKeyboardScrollHeight,
+            alpha: 0,
+            completion: nil)
+         */
         animateToolbarsWithOffsets(
             animated,
             duration: actualDuration,
@@ -782,8 +794,14 @@ extension LegacyTabScrollController: UIScrollViewDelegate {
     /// Decelerate is true the scrolling movement will continue
     /// If the value is false, scrolling stops immediately upon touch-up.
     func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+        /* Ecosia: Also bail when the compact pill is pinned (AI chat vertical) so scroll doesn't toggle it.
         guard let tab,
-              // Ecosia: On the AI chat vertical the compact pill is pinned; ignore scroll-driven toggling.
+              !tabIsLoading(),
+              !scrollReachBottom(),
+              !tab.isFindInPageMode,
+              shouldUpdateUIWhenScrolling else { return }
+         */
+        guard let tab,
               !pinsCompactAddressBar,
               !tabIsLoading(),
               !scrollReachBottom(),

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
@@ -387,16 +387,25 @@ final class LegacyTabScrollController: NSObject,
     }
 
     func hideToolbars(animated: Bool) {
-        guard toolbarState != .collapsed else { return }
+        // Ecosia: When the compact pill is pinned (AI chat vertical) always re-apply the collapsed
+        // offsets and scroll alpha, even if we already consider ourselves `.collapsed`. The
+        // keyboard-dismiss layout resets the bottom-container offset and bumps scroll alpha back up,
+        // so an early return here would let the address bar expand back to full size.
+        guard toolbarState != .collapsed || pinsCompactAddressBar else { return }
 
         toolbarState = .collapsed
+
+        // Ecosia: On the AI chat vertical keep the navigation toolbar in place (offset 0) so the user
+        // retains tab navigation (new tab / tabs / menu) — only the address bar collapses to its pill.
+        // `updateBlurViews` keeps the bottom container visible there despite the zero scroll alpha.
+        let collapsedBottomOffset = pinsCompactAddressBar ? 0 : bottomContainerScrollHeight
 
         let actualDuration = TimeInterval(UX.toolbarBaseAnimationDuration * hideDurationRation)
         animateToolbarsWithOffsets(
             animated,
             duration: actualDuration,
             headerOffset: headerOffset,
-            bottomContainerOffset: bottomContainerScrollHeight,
+            bottomContainerOffset: collapsedBottomOffset,
             overKeyboardOffset: overKeyboardScrollHeight,
             alpha: 0,
             completion: nil)

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/LegacyTabScrollController.swift
@@ -96,6 +96,9 @@ final class LegacyTabScrollController: NSObject,
     private var lastContentOffsetY: CGFloat = 0
     private var scrollDirection: ScrollDirection = .down
     var toolbarState: ToolbarState = .visible
+    // Ecosia: Pin the compact pill on the AI chat vertical so scroll doesn't toggle it. Set by BrowserViewController.
+    // Satisfies the TabScrollHandlerProtocol requirement via LegacyTabScrollProvider.
+    var pinsCompactAddressBar = false
 
     private let windowUUID: WindowUUID
     private let logger: Logger
@@ -322,6 +325,10 @@ final class LegacyTabScrollController: NSObject,
             lastPanTranslation = 0
             return
         }
+
+        // Ecosia: On the AI chat vertical the compact pill is pinned; ignore scroll-driven toggling.
+        // Tap-to-expand is unaffected (separate path via createToolbarTapHandler).
+        guard !pinsCompactAddressBar else { return }
 
         guard !tabIsLoading() else { return }
 
@@ -767,6 +774,8 @@ extension LegacyTabScrollController: UIScrollViewDelegate {
     /// If the value is false, scrolling stops immediately upon touch-up.
     func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
         guard let tab,
+              // Ecosia: On the AI chat vertical the compact pill is pinned; ignore scroll-driven toggling.
+              !pinsCompactAddressBar,
               !tabIsLoading(),
               !scrollReachBottom(),
               !tab.isFindInPageMode,

--- a/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollHandler.swift
+++ b/firefox-ios/Client/Frontend/Browser/TabScrollController/TabScrollHandler.swift
@@ -11,6 +11,10 @@ protocol TabScrollHandlerProtocol: AnyObject {
     var tabProvider: TabProviderProtocol? { get set }
     var contentOffset: CGPoint { get }
 
+    // Ecosia: When pinned (e.g. on the AI chat vertical) the minimal/compact address bar pill stays put —
+    // scroll must not toggle it. Tap-to-expand uses a separate path and is unaffected.
+    var pinsCompactAddressBar: Bool { get set }
+
     func showToolbars(animated: Bool)
     func hideToolbars(animated: Bool)
     func configureRefreshControl()
@@ -89,6 +93,8 @@ final class TabScrollHandler: NSObject,
     private var scrollDirection: ScrollDirection = .down
     var toolbarDisplayState = ToolbarDisplayState()
     var lastValidState: ToolbarDisplayState = .expanded
+    // Ecosia: Pin the compact pill on the AI chat vertical so scroll doesn't toggle it. Set by BrowserViewController.
+    var pinsCompactAddressBar = false
     private var isStatusBarScrollToTop = false
     var didTapChangePreventScrollToTop = false
 
@@ -171,6 +177,10 @@ final class TabScrollHandler: NSObject,
     }
 
     func handleScroll(for translation: CGPoint) {
+        // Ecosia: On the AI chat vertical the compact pill is pinned; ignore scroll-driven toggling.
+        // Tap-to-expand is unaffected (separate path via createToolbarTapHandler).
+        guard !pinsCompactAddressBar else { return }
+
         // Ignore user scroll if the tab is loading or if the conditions to update view are not meet
         // voice over and webview's scroll content size is not enough to scroll
         guard !tabIsLoading(),
@@ -195,6 +205,9 @@ final class TabScrollHandler: NSObject,
     }
 
     func handleEndScrolling(for translation: CGPoint, velocity: CGPoint) {
+        // Ecosia: On the AI chat vertical the compact pill is pinned; ignore scroll-driven toggling.
+        guard !pinsCompactAddressBar else { return }
+
         // Ignore user scroll if the tab is loading or if the conditions to update view are not meet
         // voice over and webview's scroll content size is not enough to scroll
         guard !tabIsLoading(),

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -345,7 +345,16 @@ final class AddressToolbarContainer: UIView,
         guard self.model != newModel else { return }
 
         updateSkeletonAddressBarsAlpha(to: CGFloat(newModel.scrollAlpha))
+        /* Ecosia: Reset the accessory gradient whenever the keyboard is gone, regardless of scroll alpha.
+           The layer3 accessory gradient is sized to extend ~74pt below the address bar (over the navigation
+           toolbar). On the AI chat vertical we pin the compact pill at scroll alpha 0, so the original
+           `!scrollAlpha.isZero` guard never fires there — leaving the gradient stuck at full opacity and washing
+           out the navigation toolbar icons. It only ever needs to be visible while the keyboard accessory shows.
         if #available(iOS 26.0, *), !newModel.shouldShowKeyboard, !newModel.scrollAlpha.isZero {
+            accessoryViewGradient.opacity = 0
+        }
+         */
+        if #available(iOS 26.0, *), !newModel.shouldShowKeyboard {
             accessoryViewGradient.opacity = 0
         }
         // in case we are in edit mode but overlay is not active yet we have to activate it

--- a/firefox-ios/EcosiaTests/Core/URLTests.swift
+++ b/firefox-ios/EcosiaTests/Core/URLTests.swift
@@ -354,6 +354,22 @@ final class URLTests: XCTestCase, @unchecked Sendable {
         XCTAssertTrue(url.hasEcosiaUserId)
     }
 
+    // MARK: - `isEcosiaAIChat`
+
+    func testIsEcosiaAIChat_aiChatPath_returnsTrue() {
+        XCTAssertTrue(URL(string: "https://www.ecosia.org/ai-chat")!.isEcosiaAIChat)
+        XCTAssertTrue(URL(string: "https://www.ecosia.org/ai-chat?origin=newtabbutton&q=trees")!.isEcosiaAIChat)
+    }
+
+    func testIsEcosiaAIChat_searchVertical_returnsFalse() {
+        XCTAssertFalse(URL(string: "https://www.ecosia.org/search?q=trees")!.isEcosiaAIChat)
+        XCTAssertFalse(URL(string: "https://www.ecosia.org/")!.isEcosiaAIChat)
+    }
+
+    func testIsEcosiaAIChat_nonEcosiaHost_returnsFalse() {
+        XCTAssertFalse(URL(string: "https://example.com/ai-chat")!.isEcosiaAIChat)
+    }
+
     // MARK: - `policy`
 
     func testPolicyAllow() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/LegacyTabScrollControllerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/LegacyTabScrollControllerTests.swift
@@ -325,6 +325,44 @@ final class LegacyTabScrollControllerTests: XCTestCase {
         XCTAssertEqual(subject.toolbarState, .visible)
     }
 
+    // MARK: - Ecosia: pinsCompactAddressBar (AI chat vertical)
+
+    func test_pinsCompactAddressBar_handlePan_doesNotChangeState() {
+        let subject = createSubject()
+        setupTabScroll(with: subject)
+        subject.pinsCompactAddressBar = true
+
+        // Same translation that collapses the toolbar in testHandlePan_ScrollingUp.
+        mockGesture.gestureTranslation = CGPoint(x: 0, y: 100)
+        subject.handlePan(mockGesture)
+
+        XCTAssertEqual(subject.toolbarState, .visible, "Pinned compact bar must ignore scroll-driven toggling")
+    }
+
+    func test_pinsCompactAddressBar_scrollDidEndDragging_doesNotChangeState() {
+        let subject = createSubject()
+        setupTabScroll(with: subject)
+        subject.pinsCompactAddressBar = true
+
+        mockGesture.gestureTranslation = CGPoint(x: 0, y: 100)
+        subject.handlePan(mockGesture)
+        subject.scrollViewDidEndDragging(tab.webView!.scrollView, willDecelerate: true)
+
+        XCTAssertEqual(subject.toolbarState, .visible, "Pinned compact bar must ignore end-of-drag toggling")
+    }
+
+    func test_pinsCompactAddressBar_doesNotBlockTapExpand() {
+        let subject = createSubject()
+        setupTabScroll(with: subject)
+        subject.toolbarState = .collapsed
+        subject.pinsCompactAddressBar = true
+
+        let handler = subject.createToolbarTapHandler()
+        handler()
+
+        XCTAssertEqual(subject.toolbarState, .visible, "Tap must still expand the pinned compact bar")
+    }
+
     // MARK: - Setup
     private func setupTabScroll(with subject: LegacyTabScrollController) {
         tab.createWebview(configuration: .init())

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/TabScrollHandlerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Frontend/Browser/TabScrollHandlerTests.swift
@@ -405,6 +405,44 @@ final class TabScrollHandlerTests: XCTestCase {
         XCTAssertTrue(subject.toolbarDisplayState.isExpanded)
     }
 
+    // MARK: - Ecosia: pinsCompactAddressBar (AI chat vertical)
+
+    func test_pinsCompactAddressBar_suppressesScrollDownHide() {
+        let subject = createSubject()
+        subject.pinsCompactAddressBar = true
+
+        subject.handleScroll(for: CGPoint(x: 0, y: -50))
+        subject.handleEndScrolling(for: CGPoint(x: 0, y: -50), velocity: .zero)
+
+        XCTAssertEqual(delegate.hideCount, 0, "Pinned compact bar must ignore downward scroll")
+        XCTAssertEqual(delegate.showCount, 0)
+        XCTAssertTrue(delegate.updateCalls.isEmpty, "No transition progress while pinned")
+    }
+
+    func test_pinsCompactAddressBar_suppressesScrollUpShow_whenCollapsed() {
+        let subject = createSubject()
+        subject.hideToolbars(animated: true) // start collapsed
+        XCTAssertEqual(delegate.hideCount, 1)
+        subject.pinsCompactAddressBar = true
+
+        subject.handleScroll(for: CGPoint(x: 0, y: 60))
+        subject.handleEndScrolling(for: CGPoint(x: 0, y: 60), velocity: .zero)
+
+        XCTAssertEqual(delegate.showCount, 0, "Pinned compact bar must ignore upward scroll")
+        XCTAssertTrue(subject.toolbarDisplayState.isCollapsed)
+    }
+
+    func test_pinsCompactAddressBar_doesNotBlockTapExpand() {
+        let subject = createSubject()
+        subject.hideToolbars(animated: false)
+        subject.pinsCompactAddressBar = true
+
+        let handler = subject.createToolbarTapHandler()
+        handler()
+
+        XCTAssertTrue(subject.toolbarDisplayState.isExpanded, "Tap must still expand the pinned compact bar")
+    }
+
     // MARK: - Setup
 
     private func createSubject(contentSize: CGSize = CGSize(width: 200, height: 2000)) -> TabScrollHandler {


### PR DESCRIPTION
 <!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-4301]

## Context

Reduce address bar size to minimum when in AI chat.

| Regular Search | AI Chat |
|---|---|
|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-22 at 16 39 51" src="https://github.com/user-attachments/assets/f8e601b0-df3a-432a-b34f-2f9b31e3e24a" />| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-22 at 16 39 10" src="https://github.com/user-attachments/assets/9250643c-3ca4-4118-a9f2-5023590a22e2" />|


## Approach

Used regular compacted pill which is also shown when scrolling the view.

## Other

This needs extensive testing to ensure it won't affect other areas.

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [x] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4301]: https://ecosia.atlassian.net/browse/MOB-4301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ