### PR TITLE
[MOB-4481] Adjust Omnibox Search accessibility identifiers

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
@@ -272,6 +272,8 @@ class LocationTextField: UITextField, UITextFieldDelegate, ThemeApplicable {
               let clearButton = value(forKey: "_clearButton") as? UIButton
         else { return }
 
+        // Ecosia: Stamp the clear button so UI automation can locate it by accessibility ID.
+        clearButton.accessibilityIdentifier = "AddressBar.clearButton"
         tintedClearImage = image.withTintColor(clearButtonTintColor)
         clearButton.setImage(tintedClearImage, for: [])
     }

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Omnibox.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Omnibox.swift
@@ -152,6 +152,9 @@ extension BrowserViewController {
     func hideOmniboxSuggestions() {
         searchLoader?.autocompleteView = addressToolbarContainer
         if let searchController {
+            // Restore the modal accessibility scope set in attachOmniboxSuggestions.
+            searchController.view.superview?.accessibilityViewIsModal = false
+            UIAccessibility.post(notification: .screenChanged, argument: nil)
             searchController.additionalSafeAreaInsets = .zero
             let tableView = searchController.tableView
             tableView.contentInset = .zero
@@ -199,7 +202,11 @@ extension BrowserViewController {
 
         searchController.didMove(toParent: hostVC)
         updateOmniboxSuggestionsScrollInsets()
-        contentContainer.accessibilityElementsHidden = true
+        // Scope VoiceOver to the omnibox host so background NTP content is unreachable,
+        // without hiding contentContainer (which would also hide the suggestions inside it).
+        // Restored in hideOmniboxSuggestions.
+        host.accessibilityViewIsModal = true
+        UIAccessibility.post(notification: .screenChanged, argument: searchController.tableView)
 
         // Re-enable interaction in case the previous attach left the table
         // disabled by the fast-tap path below.

--- a/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -619,18 +619,26 @@ class SearchViewController: SiteTableViewController,
                        category: .lifecycle)
             return UITableViewCell()
         }
+        guard let section = SearchListSection(rawValue: indexPath.section) else {
+            return UITableViewCell()
+        }
         let cell = getCellForSection(twoLineImageOverlayCell,
                                      oneLineCell: oneLineTableViewCell,
-                                     for: SearchListSection(rawValue: indexPath.section)!,
+                                     for: section,
                                      indexPath)
         // Ecosia: Stamp each cell with a stable identifier and expose its text as the
         // accessibility label so UI automation can locate and read suggestions without
-        // traversing the child element hierarchy.
-        cell.accessibilityIdentifier = "\(EcosiaAccessibilityIdentifiers.Search.suggestionCellPrefix)_\(indexPath.row)"
+        // traversing the child element hierarchy. Section is included to prevent
+        // collisions across sections that share the same row index.
+        cell.accessibilityIdentifier = "\(EcosiaAccessibilityIdentifiers.Search.suggestionCellPrefix)_\(indexPath.section)_\(indexPath.row)"
         if let oneLine = cell as? OneLineTableViewCell {
             cell.accessibilityLabel = oneLine.titleLabel.text
         } else if let twoLine = cell as? TwoLineImageOverlayCell {
-            cell.accessibilityLabel = twoLine.titleLabel.text
+            let desc = twoLine.descriptionLabel.isHidden ? nil : twoLine.descriptionLabel.text
+            cell.accessibilityLabel = [twoLine.titleLabel.text, desc]
+                .compactMap { $0 }
+                .filter { !$0.isEmpty }
+                .joined(separator: ", ")
         }
         return cell
     }

--- a/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -619,10 +619,20 @@ class SearchViewController: SiteTableViewController,
                        category: .lifecycle)
             return UITableViewCell()
         }
-        return getCellForSection(twoLineImageOverlayCell,
-                                 oneLineCell: oneLineTableViewCell,
-                                 for: SearchListSection(rawValue: indexPath.section)!,
-                                 indexPath)
+        let cell = getCellForSection(twoLineImageOverlayCell,
+                                     oneLineCell: oneLineTableViewCell,
+                                     for: SearchListSection(rawValue: indexPath.section)!,
+                                     indexPath)
+        // Ecosia: Stamp each cell with a stable identifier and expose its text as the
+        // accessibility label so UI automation can locate and read suggestions without
+        // traversing the child element hierarchy.
+        cell.accessibilityIdentifier = "\(EcosiaAccessibilityIdentifiers.Search.suggestionCellPrefix)_\(indexPath.row)"
+        if let oneLine = cell as? OneLineTableViewCell {
+            cell.accessibilityLabel = oneLine.titleLabel.text
+        } else if let twoLine = cell as? TwoLineImageOverlayCell {
+            cell.accessibilityLabel = twoLine.titleLabel.text
+        }
+        return cell
     }
 
     override func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {

--- a/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/Search/SearchViewController.swift
@@ -619,6 +619,12 @@ class SearchViewController: SiteTableViewController,
                        category: .lifecycle)
             return UITableViewCell()
         }
+        /* Ecosia: Avoid force-unwrap and capture the cell to stamp accessibility identifiers.
+        return getCellForSection(twoLineImageOverlayCell,
+                                 oneLineCell: oneLineTableViewCell,
+                                 for: SearchListSection(rawValue: indexPath.section)!,
+                                 indexPath)
+        */
         guard let section = SearchListSection(rawValue: indexPath.section) else {
             return UITableViewCell()
         }

--- a/firefox-ios/Ecosia/UI/EcosiaAccessibilityIdentifiers.swift
+++ b/firefox-ios/Ecosia/UI/EcosiaAccessibilityIdentifiers.swift
@@ -41,4 +41,12 @@ public struct EcosiaAccessibilityIdentifiers {
         public static let findNext = "FindInPage.find_next"
         public static let findClose = "FindInPage.close"
     }
+
+    public struct Search {
+        public static let suggestionCellPrefix = "searchSuggestion"
+    }
+
+    public struct AddressBar {
+        public static let clearButton = "AddressBar.clearButton"
+    }
 }


### PR DESCRIPTION
[MOB-4481]

## Context

Automated tests were failing with new Omnibox changes.

Necessary for https://github.com/ecosia/mobile-acceptance-testing/pull/204.

## Approach

Adjust accessibility locators for tests to read.

Turns out the biggest root cause wasn't missing accessibility labels, but the fact that the container for omnibox search suggestions was hidden from accessibility. @DK1DA is there maybe a explicit reason for that I am missing?

## Other

Keep VoiceOver accessibility in mind.

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [x] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4481]: https://ecosia.atlassian.net/browse/MOB-4481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ