### PR TITLE
[MOB-4583] File Upload - Photo picker integration

### DIFF
--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadPhotoPicker.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadPhotoPicker.swift
@@ -1,0 +1,83 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+import Photos
+import PhotosUI
+import Ecosia
+import Shared
+
+extension OmniboxUploadPickerCoordinator {
+    func presentPhotoPicker(from viewController: UIViewController) {
+        requestPhotoLibraryAccessIfNeeded(from: viewController) { [weak self] granted in
+            guard let self, granted else { return }
+            self.showSystemPhotoPicker(from: viewController)
+        }
+    }
+
+    private func requestPhotoLibraryAccessIfNeeded(from viewController: UIViewController,
+                                                   completion: @escaping (Bool) -> Void) {
+        let status = PHPhotoLibrary.authorizationStatus(for: .readWrite)
+        switch status {
+        case .authorized, .limited:
+            completion(true)
+        case .notDetermined:
+            PHPhotoLibrary.requestAuthorization(for: .readWrite) { newStatus in
+                Task { @MainActor in
+                    if OmniboxUploadPhotoLibraryAuthorization.isAccessGranted(for: newStatus) {
+                        completion(true)
+                    } else {
+                        self.presentPhotoLibraryAccessDeniedAlert(on: viewController)
+                        completion(false)
+                    }
+                }
+            }
+        case .denied, .restricted:
+            presentPhotoLibraryAccessDeniedAlert(on: viewController)
+            completion(false)
+        @unknown default:
+            completion(false)
+        }
+    }
+
+    private func showSystemPhotoPicker(from viewController: UIViewController) {
+        var configuration = PHPickerConfiguration(photoLibrary: .shared())
+        configuration.selectionLimit = OmniboxUploadPhotoPickerUX.maxSelectionCount
+        configuration.filter = .images
+
+        let picker = PHPickerViewController(configuration: configuration)
+        picker.delegate = self
+        configurePopover(for: picker, from: viewController)
+        viewController.present(picker, animated: true)
+    }
+
+    private func presentPhotoLibraryAccessDeniedAlert(on viewController: UIViewController) {
+        let alert = UIAlertController(
+            title: String.localized(.uploadPhotoLibraryAccessTitle),
+            message: String.localized(.uploadPhotoLibraryAccessMessage),
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: String.localized(.cancel), style: .cancel))
+        alert.addAction(UIAlertAction(title: .OpenSettingsString, style: .default) { _ in
+            DefaultApplicationHelper().openSettings()
+        })
+        viewController.present(alert, animated: true)
+    }
+}
+
+extension OmniboxUploadPickerCoordinator: PHPickerViewControllerDelegate {
+    func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+        picker.dismiss(animated: true)
+
+        let items = results.map { result in
+            OmniboxUploadItem(
+                source: .photos,
+                fileName: result.itemProvider.suggestedName ?? "photo",
+                contentTypeIdentifier: result.itemProvider.registeredTypeIdentifiers.first
+            )
+        }
+        guard !items.isEmpty else { return }
+        delegate?.omniboxUploadDidSelect(items: items)
+    }
+}

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadPhotoPicker.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadPhotoPicker.swift
@@ -10,34 +10,31 @@ import Shared
 
 extension OmniboxUploadPickerCoordinator {
     func presentPhotoPicker(from viewController: UIViewController) {
-        requestPhotoLibraryAccessIfNeeded(from: viewController) { [weak self] granted in
-            guard let self, granted else { return }
-            self.showSystemPhotoPicker(from: viewController)
+        requestPhotoLibraryAccessIfNeeded(from: viewController) { [weak self] in
+            self?.showSystemPhotoPicker(from: viewController)
         }
     }
 
     private func requestPhotoLibraryAccessIfNeeded(from viewController: UIViewController,
-                                                   completion: @escaping (Bool) -> Void) {
+                                                   onGranted: @escaping @MainActor () -> Void) {
         let status = PHPhotoLibrary.authorizationStatus(for: .readWrite)
         switch status {
         case .authorized, .limited:
-            completion(true)
+            onGranted()
         case .notDetermined:
             PHPhotoLibrary.requestAuthorization(for: .readWrite) { newStatus in
                 Task { @MainActor in
                     if OmniboxUploadPhotoLibraryAuthorization.isAccessGranted(for: newStatus) {
-                        completion(true)
+                        onGranted()
                     } else {
                         self.presentPhotoLibraryAccessDeniedAlert(on: viewController)
-                        completion(false)
                     }
                 }
             }
         case .denied, .restricted:
             presentPhotoLibraryAccessDeniedAlert(on: viewController)
-            completion(false)
         @unknown default:
-            completion(false)
+            break
         }
     }
 

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadPhotoPickerUX.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadPhotoPickerUX.swift
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Photos
+
+enum OmniboxUploadPhotoPickerUX {
+    static let maxSelectionCount = 5
+}
+
+enum OmniboxUploadPhotoLibraryAuthorization {
+    static func isAccessGranted(for status: PHAuthorizationStatus) -> Bool {
+        status == .authorized || status == .limited
+    }
+}

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadPickerCoordinator.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadPickerCoordinator.swift
@@ -21,7 +21,7 @@ final class OmniboxUploadPickerCoordinator: NSObject {
         popoverSourceView = sourceView
 
         switch option {
-        case photos:
+        case .photos:
             presentPhotoPicker(from: viewController)
         case .camera:
             break // TODO: MOB-4584

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadPickerCoordinator.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadPickerCoordinator.swift
@@ -21,8 +21,8 @@ final class OmniboxUploadPickerCoordinator: NSObject {
         popoverSourceView = sourceView
 
         switch option {
-        case .photos:
-            break // TODO: MOB-4583
+        case photos:
+            presentPhotoPicker(from: viewController)
         case .camera:
             break // TODO: MOB-4584
         case .files:

--- a/firefox-ios/Client/Info.plist
+++ b/firefox-ios/Client/Info.plist
@@ -110,6 +110,8 @@
 	<string>Firefox uses your microphone to record and upload audio.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>This lets you save photos.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Ecosia needs photo library access so you can attach images from your camera roll.</string>
 	<key>NSUserActivityTypes</key>
 	<array>
 		<string>QuickActionIntent</string>

--- a/firefox-ios/Ecosia/L10N/String.swift
+++ b/firefox-ios/Ecosia/L10N/String.swift
@@ -304,5 +304,7 @@ extension String {
         case uploadFilesAccessibilityHint = "Opens the file browser"
         case uploadDrawerAccessibilityLabel = "Attach files"
         case uploadDismissAccessibilityHint = "Dismisses the attachment menu"
+        case uploadPhotoLibraryAccessTitle = "Allow access to your photos"
+        case uploadPhotoLibraryAccessMessage = "Ecosia needs photo library access so you can attach images from your camera roll."
     }
 }

--- a/firefox-ios/Ecosia/L10N/en.lproj/Ecosia.strings
+++ b/firefox-ios/Ecosia/L10N/en.lproj/Ecosia.strings
@@ -301,6 +301,8 @@
 "Opens the file browser" = "Opens the file browser";
 "Attach files" = "Attach files";
 "Dismisses the attachment menu" = "Dismisses the attachment menu";
+"Allow access to your photos" = "Allow access to your photos";
+"Ecosia needs photo library access so you can attach images from your camera roll." = "Ecosia needs photo library access so you can attach images from your camera roll.";
 
 // Product Tour
 "Go back" = "Go back";

--- a/firefox-ios/EcosiaTests/UI/NTP/OmniboxUploadPhotoPickerTests.swift
+++ b/firefox-ios/EcosiaTests/UI/NTP/OmniboxUploadPhotoPickerTests.swift
@@ -1,0 +1,24 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import Photos
+@testable import Client
+
+final class OmniboxUploadPhotoPickerTests: XCTestCase {
+
+    func testPhotoLibraryAccessAllowsAuthorizedAndLimited() {
+        XCTAssertTrue(OmniboxUploadPhotoLibraryAuthorization.isAccessGranted(for: .authorized))
+        XCTAssertTrue(OmniboxUploadPhotoLibraryAuthorization.isAccessGranted(for: .limited))
+    }
+
+    func testPhotoLibraryAccessRejectsDeniedAndRestricted() {
+        XCTAssertFalse(OmniboxUploadPhotoLibraryAuthorization.isAccessGranted(for: .denied))
+        XCTAssertFalse(OmniboxUploadPhotoLibraryAuthorization.isAccessGranted(for: .restricted))
+    }
+
+    func testPhotoPickerSelectionLimitIsFive() {
+        XCTAssertEqual(OmniboxUploadPhotoPickerUX.maxSelectionCount, 5)
+    }
+}


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-4583]

## Context

Follow-up to MOB-4582. Wire the Photos option from the upload drawer to the system photo picker.

## Approach

- Request photo library access before presenting `PHPickerViewController`. Handle limited access (iOS “Select Photos”) without blocking the flow. 
- Restrict selection to images only, cap at five photos, and show a settings prompt when access is denied. Add `NSPhotoLibraryUsageDescription` to `Info.plist`.

| Outcome |
| --------- |
| <img width="295" height="640" alt="Simulator Screen Recording - iPhone 17 Pro - 2026-06-22 at 21 10 51" src="https://github.com/user-attachments/assets/590d26cb-af1d-4374-be92-6c99f3271cfc" /> |

## Other

- Extracted photo picker logic into `OmniboxUploadPhotoPicker` and `OmniboxUploadPhotoPickerUX`
- Added Ecosia strings for the permission-denied alert
- Added unit tests for access rules and selection limit
- iPad popover anchoring reuses the shared `configurePopover` helper from the coordinator

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I wrote Unit Tests that confirm the expected behaviour
- [x] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [x] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4583]: https://ecosia.atlassian.net/browse/MOB-4583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ