### PR TITLE
[MOB-4584] File Upload - Camera capture integration

### DIFF
--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadCameraPicker.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadCameraPicker.swift
@@ -15,34 +15,31 @@ extension OmniboxUploadPickerCoordinator {
             return
         }
 
-        requestCameraAccessIfNeeded(from: viewController) { [weak self] granted in
-            guard let self, granted else { return }
-            self.showSystemCameraPicker(from: viewController)
+        requestCameraAccessIfNeeded(from: viewController) { [weak self] in
+            self?.showSystemCameraPicker(from: viewController)
         }
     }
 
     private func requestCameraAccessIfNeeded(from viewController: UIViewController,
-                                             completion: @escaping (Bool) -> Void) {
+                                             onGranted: @escaping @MainActor () -> Void) {
         let status = AVCaptureDevice.authorizationStatus(for: .video)
         switch status {
         case .authorized:
-            completion(true)
+            onGranted()
         case .notDetermined:
             AVCaptureDevice.requestAccess(for: .video) { granted in
                 Task { @MainActor in
                     if granted {
-                        completion(true)
+                        onGranted()
                     } else {
                         self.presentCameraAccessDeniedAlert(on: viewController)
-                        completion(false)
                     }
                 }
             }
         case .denied, .restricted:
             presentCameraAccessDeniedAlert(on: viewController)
-            completion(false)
         @unknown default:
-            completion(false)
+            break
         }
     }
 

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadCameraPicker.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadCameraPicker.swift
@@ -1,0 +1,103 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+import AVFoundation
+import UniformTypeIdentifiers
+import Ecosia
+import Shared
+
+extension OmniboxUploadPickerCoordinator {
+    func presentCameraPicker(from viewController: UIViewController) {
+        guard UIImagePickerController.isSourceTypeAvailable(.camera) else {
+            presentCameraUnavailableAlert(on: viewController)
+            return
+        }
+
+        requestCameraAccessIfNeeded(from: viewController) { [weak self] granted in
+            guard let self, granted else { return }
+            self.showSystemCameraPicker(from: viewController)
+        }
+    }
+
+    private func requestCameraAccessIfNeeded(from viewController: UIViewController,
+                                             completion: @escaping (Bool) -> Void) {
+        let status = AVCaptureDevice.authorizationStatus(for: .video)
+        switch status {
+        case .authorized:
+            completion(true)
+        case .notDetermined:
+            AVCaptureDevice.requestAccess(for: .video) { granted in
+                Task { @MainActor in
+                    if granted {
+                        completion(true)
+                    } else {
+                        self.presentCameraAccessDeniedAlert(on: viewController)
+                        completion(false)
+                    }
+                }
+            }
+        case .denied, .restricted:
+            presentCameraAccessDeniedAlert(on: viewController)
+            completion(false)
+        @unknown default:
+            completion(false)
+        }
+    }
+
+    private func showSystemCameraPicker(from viewController: UIViewController) {
+        let picker = UIImagePickerController()
+        picker.sourceType = .camera
+        picker.mediaTypes = OmniboxUploadCameraPickerUX.photoMediaTypes
+        picker.cameraCaptureMode = .photo
+        picker.delegate = self
+        configurePopover(for: picker, from: viewController)
+        viewController.present(picker, animated: true)
+    }
+
+    private func presentCameraAccessDeniedAlert(on viewController: UIViewController) {
+        let alert = UIAlertController(
+            title: String.localized(.uploadCameraAccessTitle),
+            message: String.localized(.uploadCameraAccessMessage),
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: String.localized(.cancel), style: .cancel))
+        alert.addAction(UIAlertAction(title: .OpenSettingsString, style: .default) { _ in
+            DefaultApplicationHelper().openSettings()
+        })
+        viewController.present(alert, animated: true)
+    }
+
+    private func presentCameraUnavailableAlert(on viewController: UIViewController) {
+        let alert = UIAlertController(
+            title: String.localized(.uploadCameraAccessTitle),
+            message: String.localized(.uploadCameraUnavailableMessage),
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: String.localized(.cancel), style: .cancel))
+        viewController.present(alert, animated: true)
+    }
+}
+
+extension OmniboxUploadPickerCoordinator: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+    func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+        picker.dismiss(animated: true)
+    }
+
+    func imagePickerController(_ picker: UIImagePickerController,
+                               didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
+        picker.dismiss(animated: true)
+
+        let fileName: String
+        if let url = info[.imageURL] as? URL {
+            fileName = url.lastPathComponent
+        } else {
+            fileName = "camera-photo"
+        }
+
+        delegate?.omniboxUploadDidSelect(items: [
+            OmniboxUploadItem(source: .camera, fileName: fileName, contentTypeIdentifier: UTType.image.identifier)
+        ])
+    }
+}

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadCameraPickerUX.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadCameraPickerUX.swift
@@ -1,0 +1,16 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import AVFoundation
+import UniformTypeIdentifiers
+
+enum OmniboxUploadCameraPickerUX {
+    static let photoMediaTypes = [UTType.image.identifier]
+}
+
+enum OmniboxUploadCameraAuthorization {
+    static func isAccessGranted(for status: AVAuthorizationStatus) -> Bool {
+        status == .authorized
+    }
+}

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadPickerCoordinator.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadPickerCoordinator.swift
@@ -24,7 +24,7 @@ final class OmniboxUploadPickerCoordinator: NSObject {
         case .photos:
             presentPhotoPicker(from: viewController)
         case .camera:
-            break // TODO: MOB-4584
+            presentCameraPicker(from: viewController)
         case .files:
             break // TODO: MOB-4585
         }

--- a/firefox-ios/Ecosia/L10N/String.swift
+++ b/firefox-ios/Ecosia/L10N/String.swift
@@ -306,5 +306,8 @@ extension String {
         case uploadDismissAccessibilityHint = "Dismisses the attachment menu"
         case uploadPhotoLibraryAccessTitle = "Allow access to your photos"
         case uploadPhotoLibraryAccessMessage = "Ecosia needs photo library access so you can attach images from your camera roll."
+        case uploadCameraAccessTitle = "Allow access to your camera"
+        case uploadCameraAccessMessage = "Ecosia needs camera access so you can take a photo to attach."
+        case uploadCameraUnavailableMessage = "A camera is not available on this device."
     }
 }

--- a/firefox-ios/Ecosia/L10N/en.lproj/Ecosia.strings
+++ b/firefox-ios/Ecosia/L10N/en.lproj/Ecosia.strings
@@ -303,6 +303,9 @@
 "Dismisses the attachment menu" = "Dismisses the attachment menu";
 "Allow access to your photos" = "Allow access to your photos";
 "Ecosia needs photo library access so you can attach images from your camera roll." = "Ecosia needs photo library access so you can attach images from your camera roll.";
+"Allow access to your camera" = "Allow access to your camera";
+"Ecosia needs camera access so you can take a photo to attach." = "Ecosia needs camera access so you can take a photo to attach.";
+"A camera is not available on this device." = "A camera is not available on this device.";
 
 // Product Tour
 "Go back" = "Go back";

--- a/firefox-ios/EcosiaTests/UI/NTP/OmniboxUploadCameraPickerTests.swift
+++ b/firefox-ios/EcosiaTests/UI/NTP/OmniboxUploadCameraPickerTests.swift
@@ -1,0 +1,23 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import AVFoundation
+import UniformTypeIdentifiers
+@testable import Client
+
+final class OmniboxUploadCameraPickerTests: XCTestCase {
+
+    func testCameraAuthorizationRequiresAuthorizedStatus() {
+        XCTAssertTrue(OmniboxUploadCameraAuthorization.isAccessGranted(for: .authorized))
+        XCTAssertFalse(OmniboxUploadCameraAuthorization.isAccessGranted(for: .denied))
+        XCTAssertFalse(OmniboxUploadCameraAuthorization.isAccessGranted(for: .restricted))
+        XCTAssertFalse(OmniboxUploadCameraAuthorization.isAccessGranted(for: .notDetermined))
+    }
+
+    func testCameraPickerOnlyAllowsPhotoCapture() {
+        XCTAssertEqual(OmniboxUploadCameraPickerUX.photoMediaTypes, [UTType.image.identifier])
+        XCTAssertFalse(OmniboxUploadCameraPickerUX.photoMediaTypes.contains(UTType.movie.identifier))
+    }
+}


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-4584]

## Context

Follow-up to MOB-4582. Wires the Camera option from the upload drawer to the system camera.

## Approach

- Request camera permission via `AVCaptureDevice` before presenting `UIImagePickerController`. Restrict capture to photos only (`cameraCaptureMode = .photo`, image media types). 
- Rely on the system camera UI for discard / retake. 
- Show alerts when access is denied or no camera is available (e.g. some iPads).
- Extracted camera logic into `OmniboxUploadCameraPicker` and `OmniboxUploadCameraPickerUX`
- Added Ecosia strings for permission-denied and camera-unavailable alerts

| Outcome |
| --------- |
| <img width="295" height="640" alt="Simulator Screen Recording - iPhone 17 Pro - 2026-06-22 at 21 32 36" src="https://github.com/user-attachments/assets/07259fe4-9bb2-4864-8011-26dce1b3af68" /> |

## Other

- Added unit tests for permission rules and photo-only media types
- iPad popover anchoring reuses the shared `configurePopover` helper from the coordinator

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I wrote Unit Tests that confirm the expected behaviour
- [x] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [x] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4584]: https://ecosia.atlassian.net/browse/MOB-4584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ