### PR TITLE
[MOB-4585] File Upload - File picker integration

### DIFF
--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/NTPOmniboxSheetState.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/NTPOmniboxSheetState.swift
@@ -10,19 +10,27 @@ final class NTPOmniboxSheetState: ObservableObject {
     @Published var showUploadDrawer = false
 
     private var onUploadOptionSelected: ((OmniboxUploadOption) -> Void)?
+    private var pendingUploadOption: OmniboxUploadOption?
 
     func presentUploadDrawer(onSelect: @escaping (OmniboxUploadOption) -> Void) {
+        pendingUploadOption = nil
         onUploadOptionSelected = onSelect
         showUploadDrawer = true
     }
 
     func handleUploadOptionSelected(_ option: OmniboxUploadOption) {
+        pendingUploadOption = option
         showUploadDrawer = false
-        onUploadOptionSelected?(option)
-        onUploadOptionSelected = nil
     }
 
     func handleUploadDrawerDismissed() {
+        guard let option = pendingUploadOption else {
+            onUploadOptionSelected = nil
+            return
+        }
+        pendingUploadOption = nil
+        let callback = onUploadOptionSelected
         onUploadOptionSelected = nil
+        callback?(option)
     }
 }

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadFilePicker.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadFilePicker.swift
@@ -1,0 +1,41 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+import UniformTypeIdentifiers
+import Ecosia
+
+extension OmniboxUploadPickerCoordinator {
+    func presentFilesPicker(from viewController: UIViewController) {
+        let picker = UIDocumentPickerViewController(
+            forOpeningContentTypes: OmniboxUploadFileSelectionValidator.pickerContentTypes,
+            asCopy: true
+        )
+        picker.delegate = self
+        picker.allowsMultipleSelection = true
+        configurePopover(for: picker, from: viewController)
+        viewController.present(picker, animated: true)
+    }
+}
+
+extension OmniboxUploadPickerCoordinator: UIDocumentPickerDelegate {
+    func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {
+        controller.dismiss(animated: true)
+    }
+
+    func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
+        controller.dismiss(animated: true)
+
+        let allowedURLs = OmniboxUploadFileSelectionValidator.allowedURLs(from: urls)
+        let items = allowedURLs.map { url in
+            OmniboxUploadItem(
+                source: .files,
+                fileName: url.lastPathComponent,
+                contentTypeIdentifier: UTType(filenameExtension: url.pathExtension)?.identifier
+            )
+        }
+        guard !items.isEmpty else { return }
+        delegate?.omniboxUploadDidSelect(items: items)
+    }
+}

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadFileSelectionValidator.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadFileSelectionValidator.swift
@@ -1,0 +1,35 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import UniformTypeIdentifiers
+
+enum OmniboxUploadFileSelectionValidator {
+    static let maxFileCount = 5
+    static let blockedExtensions: Set<String> = ["app", "exe"]
+    private static let supportedExtensions: Set<String> = ["pdf", "txt", "doc", "jpg", "jpeg", "png"]
+
+    static var pickerContentTypes: [UTType] {
+        [
+            .pdf,
+            .plainText,
+            .jpeg,
+            .png,
+            UTType(filenameExtension: "doc"),
+            UTType(filenameExtension: "txt"),
+            UTType(filenameExtension: "jpg")
+        ].compactMap { $0 }
+    }
+
+    static func allowedURLs(from urls: [URL]) -> [URL] {
+        Array(urls.filter(isAllowed(_:)).prefix(maxFileCount))
+    }
+
+    static func isAllowed(_ url: URL) -> Bool {
+        let ext = url.pathExtension.lowercased()
+        guard !ext.isEmpty else { return false }
+        if blockedExtensions.contains(ext) { return false }
+        return supportedExtensions.contains(ext)
+    }
+}

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadPickerCoordinator.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadPickerCoordinator.swift
@@ -26,7 +26,7 @@ final class OmniboxUploadPickerCoordinator: NSObject {
         case .camera:
             break // TODO: MOB-4584
         case .files:
-            break // TODO: MOB-4585
+            presentFilesPicker(from: viewController)
         }
     }
 

--- a/firefox-ios/EcosiaTests/UI/NTP/OmniboxUploadDrawerTests.swift
+++ b/firefox-ios/EcosiaTests/UI/NTP/OmniboxUploadDrawerTests.swift
@@ -49,6 +49,32 @@ final class OmniboxUploadDrawerTests: XCTestCase {
 }
 
 @MainActor
+final class NTPOmniboxSheetStateTests: XCTestCase {
+
+    func testSelectedOptionIsDeliveredAfterDrawerDismisses() {
+        let state = NTPOmniboxSheetState()
+        var received: OmniboxUploadOption?
+        state.presentUploadDrawer { received = $0 }
+
+        state.handleUploadOptionSelected(.files)
+        XCTAssertFalse(state.showUploadDrawer)
+        XCTAssertNil(received)
+
+        state.handleUploadDrawerDismissed()
+        XCTAssertEqual(received, .files)
+    }
+
+    func testDismissWithoutSelectionDoesNotDeliverOption() {
+        let state = NTPOmniboxSheetState()
+        var received: OmniboxUploadOption?
+        state.presentUploadDrawer { received = $0 }
+
+        state.handleUploadDrawerDismissed()
+        XCTAssertNil(received)
+    }
+}
+
+@MainActor
 final class NTPSearchBarUploadDelegateTests: XCTestCase {
 
     override func setUp() {

--- a/firefox-ios/EcosiaTests/UI/NTP/OmniboxUploadFileSelectionValidatorTests.swift
+++ b/firefox-ios/EcosiaTests/UI/NTP/OmniboxUploadFileSelectionValidatorTests.swift
@@ -1,0 +1,32 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import Client
+
+final class OmniboxUploadFileSelectionValidatorTests: XCTestCase {
+
+    func testBlocksAppAndExeFiles() {
+        XCTAssertFalse(OmniboxUploadFileSelectionValidator.isAllowed(URL(fileURLWithPath: "/tmp/app.app")))
+        XCTAssertFalse(OmniboxUploadFileSelectionValidator.isAllowed(URL(fileURLWithPath: "/tmp/installer.exe")))
+    }
+
+    func testAllowsSupportedFormats() {
+        XCTAssertTrue(OmniboxUploadFileSelectionValidator.isAllowed(URL(fileURLWithPath: "/tmp/report.pdf")))
+        XCTAssertTrue(OmniboxUploadFileSelectionValidator.isAllowed(URL(fileURLWithPath: "/tmp/notes.txt")))
+        XCTAssertTrue(OmniboxUploadFileSelectionValidator.isAllowed(URL(fileURLWithPath: "/tmp/letter.doc")))
+        XCTAssertTrue(OmniboxUploadFileSelectionValidator.isAllowed(URL(fileURLWithPath: "/tmp/photo.jpg")))
+        XCTAssertTrue(OmniboxUploadFileSelectionValidator.isAllowed(URL(fileURLWithPath: "/tmp/photo.jpeg")))
+        XCTAssertTrue(OmniboxUploadFileSelectionValidator.isAllowed(URL(fileURLWithPath: "/tmp/photo.png")))
+    }
+
+    func testLimitsSelectionToFiveFiles() {
+        let urls = (1...7).map { URL(fileURLWithPath: "/tmp/file\($0).pdf") }
+        XCTAssertEqual(OmniboxUploadFileSelectionValidator.allowedURLs(from: urls).count, 5)
+    }
+
+    func testRejectsUnsupportedFormats() {
+        XCTAssertFalse(OmniboxUploadFileSelectionValidator.isAllowed(URL(fileURLWithPath: "/tmp/archive.zip")))
+    }
+}


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-4585]

## Context

Follow-up to MOB-4582. Wires the Files option from the upload drawer to the system document picker.

## Approach

- Present `UIDocumentPickerViewController` with supported content types (pdf, txt, doc, jpg, png). 
- Allow multi-select but cap at five files. Reject blocked extensions (`.app`, `.exe`) in a dedicated validator before handing results to the delegate.
- Extracted file picker logic into `OmniboxUploadFilePicker` and `OmniboxUploadFileSelectionValidator`
- Added unit tests for allowed formats, blocked extensions, and the five-file cap.

| Outcome |
| --------- |
| <img width="295" height="640" alt="Simulator Screen Recording - iPhone 17 Pro - 2026-06-22 at 21 36 38" src="https://github.com/user-attachments/assets/14287bbf-0eb2-4647-976e-606919c502fc" /> |

## Other

- iPad popover anchoring reuses the shared `configurePopover` helper from the coordinator
- Document picker does not require a separate permission prompt on iOS

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I wrote Unit Tests that confirm the expected behaviour
- [x] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [x] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4585]: https://ecosia.atlassian.net/browse/MOB-4585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ