### PR TITLE
[MOB-4446] Set Snowplow Micro instance through Launch Argument

### DIFF
--- a/BrowserKit/Sources/Common/Constants/LaunchArguments.swift
+++ b/BrowserKit/Sources/Common/Constants/LaunchArguments.swift
@@ -26,6 +26,9 @@ public struct LaunchArguments {
     public static let SkipSplashScreenExperiment = "SKIP_SPLASH_SCREEN_EXPERIMENT"
     public static let ResetMicrosurveyExpirationCount = "RESET_MICROSURVEY_EXPIRATION_COUNT"
     public static let SkipAppleIntelligence = "SKIP_APPLE_INTELLIGENCE"
+    // Ecosia: Route analytics to the Snowplow Micro instance from launch (staging only). Used by
+    // acceptance tests to capture early attribution events (install/launch/resume).
+    public static let UseSnowplowMicroInstance = "USE_SNOWPLOW_MICRO_INSTANCE"
 
     // After the colon, put the name of the file to load from test bundle
     public static let LoadDatabasePrefix = "FIREFOX_LOAD_DB_NAMED:"

--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -64,6 +64,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate, FeatureFlaggable {
         willFinishLaunchingWithOptions
         launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
+        // Ecosia: Let acceptance tests route analytics to the Snowplow Micro instance from the first
+        // event (install/launch/resume). Persisted (not set) so it survives terminate/activate and
+        // doesn't create Analytics.shared before dependencies are ready. Staging-only.
+        if ProcessInfo.processInfo.arguments.contains("-UseSnowplowMicroInstance"),
+           EcosiaEnvironment.current == .staging {
+            Analytics.persistShouldUseMicroInstance(true)
+        }
+
         startRecordingStartupOpenURLTime()
         // Configure app information for BrowserKit, needed for logger
         BrowserKitInformation.shared.configure(buildChannel: AppConstants.buildChannel,

--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -67,7 +67,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, FeatureFlaggable {
         // Ecosia: Let acceptance tests route analytics to the Snowplow Micro instance from the first
         // event (install/launch/resume). Persisted (not set) so it survives terminate/activate and
         // doesn't create Analytics.shared before dependencies are ready. Staging-only.
-        if ProcessInfo.processInfo.arguments.contains("-UseSnowplowMicroInstance"),
+        if ProcessInfo.processInfo.arguments.contains(LaunchArguments.UseSnowplowMicroInstance),
            EcosiaEnvironment.current == .staging {
             Analytics.persistShouldUseMicroInstance(true)
         }

--- a/firefox-ios/Ecosia/Analytics/Analytics.swift
+++ b/firefox-ios/Ecosia/Analytics/Analytics.swift
@@ -28,6 +28,13 @@ open class Analytics {
         }
     }
 
+    /// Persists the Micro-instance preference without touching `Analytics.shared` (unlike the
+    /// `shouldUseMicroInstance` setter). Use at launch so the tracker is built against Micro during
+    /// its normal lazy init, avoiding premature initialization during startup.
+    public static func persistShouldUseMicroInstance(_ value: Bool) {
+        UserDefaults.standard.set(value, forKey: shouldUseMicroInstanceKey)
+    }
+
     nonisolated(unsafe) public static var shared = Analytics()
     private var tracker: TrackerController
     private var privateTracker: TrackerController

--- a/firefox-ios/EcosiaTests/Analytics/AnalyticsTests.swift
+++ b/firefox-ios/EcosiaTests/Analytics/AnalyticsTests.swift
@@ -16,6 +16,7 @@ final class AnalyticsTests: XCTestCase {
         // Remove any saved dates or flags after each test to avoid side effects between tests
         defaults.removeObject(forKey: "dayPassedCheckIdentifier")
         defaults.removeObject(forKey: "installCheckIdentifier")
+        defaults.removeObject(forKey: "shouldUseMicroInstance")
     }
 
     // MARK: - hasDayPassedSinceLastCheck Tests
@@ -168,5 +169,15 @@ final class AnalyticsTests: XCTestCase {
         let config = Analytics.makeNetworkConfig(environment: .production)
         XCTAssertEqual(config.endpoint?.asURL?.host, "sp.ecosia.org")
         XCTAssertNil(config.requestHeaders, "Production environment should not include Cloudflare authentication headers")
+    }
+
+    func test_persistShouldUseMicroInstance_enablesMicroEndpoint() {
+        Analytics.shouldUseMicroInstance = false
+
+        Analytics.persistShouldUseMicroInstance(true)
+
+        XCTAssertTrue(Analytics.shouldUseMicroInstance, "Persisting true should make shouldUseMicroInstance true")
+        let config = Analytics.makeNetworkConfig(environment: .staging)
+        XCTAssertEqual(URLProvider.staging.snowplowMicro, config.endpoint, "Default makeNetworkConfig should resolve to the Micro endpoint once persisted")
     }
 }


### PR DESCRIPTION
[MOB-4446] & [MOB-3779]

## Context

We need to enable Analytics acceptance tests to use the Micro instance from launch so we can track the very first events.

## Approach

Use a Launch Argument and set that as the first thing on `willFinishLaunchingWithOptions`.

Ran locally and it appeared on the Micro instance 🎉 
<img width="1153" height="349" alt="Screenshot 2026-06-24 at 16 46 28" src="https://github.com/user-attachments/assets/79627bbc-7f1e-4e5c-9015-94c908368048" />


## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [x] I added the `// Ecosia:` helper comments where needed
- [x] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4446]: https://ecosia.atlassian.net/browse/MOB-4446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MOB-3779]: https://ecosia.atlassian.net/browse/MOB-3779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ