### PR TITLE
[MOB-4662] Set test parameter on Ecosia URLs when using Micro instance

### DIFF
--- a/firefox-ios/Ecosia/Core/URL+Extensions.swift
+++ b/firefox-ios/Ecosia/Core/URL+Extensions.swift
@@ -183,10 +183,10 @@ extension URL {
         let automationTestValue = "automation"
         guard Analytics.shouldUseMicroInstance && EcosiaEnvironment.current != .production else { return self }
 
-        // Already carries the correct value — no mutation needed.
-        if self[.test] == automationTestValue { return self }
-
-        return appendingQueryItems([Self.item(name: .test, value: automationTestValue)])
+        guard var components = components else { return self }
+        components.queryItems?.removeAll(where: { $0.name == EcosiaQueryItemName.test.rawValue })
+        guard let urlWithoutTest = components.url else { return self }
+        return urlWithoutTest.appendingQueryItems([Self.item(name: .test, value: automationTestValue)])
     }
 
     public var hasEcosiaUserId: Bool { ecosiaUserId != nil }

--- a/firefox-ios/Ecosia/Core/URL+Extensions.swift
+++ b/firefox-ios/Ecosia/Core/URL+Extensions.swift
@@ -15,6 +15,7 @@ extension URL {
         autoRedirect = "ar",
         page = "p",
         query = "q",
+        test = "test",
         typeTag = "tt",
         userId = "_sp"
     }
@@ -145,6 +146,14 @@ extension URL {
     public func ecosified(isIncognitoEnabled: Bool, urlProvider: URLProvider = EcosiaEnvironment.current.urlProvider) -> URL {
         guard isEcosia(urlProvider) else { return self }
 
+        var url = ecosifiedWithUserId(isIncognitoEnabled: isIncognitoEnabled)
+        url = url.ecosifiedWithTestParam()
+        return url
+    }
+
+    // MARK: - Private helpers
+
+    private func ecosifiedWithUserId(isIncognitoEnabled: Bool) -> URL {
         /*
          The `sendAnonymousUsageData` is set by the native UX component in settings
          that determines whether the app would send the events to Snowplow.
@@ -165,6 +174,19 @@ extension URL {
         components.queryItems?.removeAll(where: { $0.name == EcosiaQueryItemName.userId.rawValue })
         guard let urlWithoutUserId = components.url else { return self }
         return urlWithoutUserId.appendingQueryItems([Self.item(name: .userId, value: userId)])
+    }
+
+    /// Appends `test=automation` to the URL when the Snowplow Micro instance is active and the
+    /// environment is not production. This lets automated test suites identify their own traffic
+    /// on the backend without affecting real users.
+    private func ecosifiedWithTestParam() -> URL {
+        let automationTestValue = "automation"
+        guard Analytics.shouldUseMicroInstance && EcosiaEnvironment.current != .production else { return self }
+
+        // Already carries the correct value — no mutation needed.
+        if self[.test] == automationTestValue { return self }
+
+        return appendingQueryItems([Self.item(name: .test, value: automationTestValue)])
     }
 
     public var hasEcosiaUserId: Bool { ecosiaUserId != nil }

--- a/firefox-ios/EcosiaTests/Core/URLTests.swift
+++ b/firefox-ios/EcosiaTests/Core/URLTests.swift
@@ -17,6 +17,7 @@ final class URLTests: XCTestCase, @unchecked Sendable {
 
     override func tearDown() {
         try? FileManager.default.removeItem(at: FileManager.user)
+        Analytics.shouldUseMicroInstance = false
     }
 
     // MARK: - `ecosiaSearchWithQuery`
@@ -352,6 +353,46 @@ final class URLTests: XCTestCase, @unchecked Sendable {
         let url = URL(string: "https://www.ecosia.org/search?q=cats")!
             .ecosified(isIncognitoEnabled: false, urlProvider: urlProvider)
         XCTAssertTrue(url.hasEcosiaUserId)
+    }
+
+    // MARK: - `ecosifiedWithTestParam` (test=automation)
+
+    func testEcosifiedWithTestParam_whenMicroInstanceDisabled_doesNotAppendTestParam() {
+        Analytics.shouldUseMicroInstance = false
+        let url = URL(string: "https://www.ecosia.org/search?q=trees")!
+            .ecosified(isIncognitoEnabled: false, urlProvider: urlProvider)
+        let testParam = URLComponents(url: url, resolvingAgainstBaseURL: false)?
+            .queryItems?.first(where: { $0.name == "test" })
+        XCTAssertNil(testParam)
+    }
+
+    func testEcosifiedWithTestParam_whenMicroInstanceEnabled_appendsTestAutomationParam() {
+        Analytics.shouldUseMicroInstance = true
+        let url = URL(string: "https://www.ecosia.org/search?q=trees")!
+            .ecosified(isIncognitoEnabled: false, urlProvider: urlProvider)
+        let testParam = URLComponents(url: url, resolvingAgainstBaseURL: false)?
+            .queryItems?.first(where: { $0.name == "test" })
+        XCTAssertEqual(testParam?.value, "automation")
+    }
+
+    func testEcosifiedWithTestParam_whenMicroInstanceEnabled_isIdempotent() {
+        Analytics.shouldUseMicroInstance = true
+        let url = URL(string: "https://www.ecosia.org/search?q=trees")!
+            .ecosified(isIncognitoEnabled: false, urlProvider: urlProvider)
+            .ecosified(isIncognitoEnabled: false, urlProvider: urlProvider)
+        let testParams = URLComponents(url: url, resolvingAgainstBaseURL: false)?
+            .queryItems?.filter { $0.name == "test" } ?? []
+        XCTAssertEqual(testParams.count, 1)
+        XCTAssertEqual(testParams.first?.value, "automation")
+    }
+
+    func testEcosifiedWithTestParam_whenMicroInstanceEnabled_nonEcosiaURLIsUnaffected() {
+        Analytics.shouldUseMicroInstance = true
+        let url = URL(string: "https://www.google.com/search?q=trees")!
+            .ecosified(isIncognitoEnabled: false, urlProvider: urlProvider)
+        let testParam = URLComponents(url: url, resolvingAgainstBaseURL: false)?
+            .queryItems?.first(where: { $0.name == "test" })
+        XCTAssertNil(testParam)
     }
 
     // MARK: - `policy`

--- a/firefox-ios/EcosiaTests/Core/URLTests.swift
+++ b/firefox-ios/EcosiaTests/Core/URLTests.swift
@@ -395,6 +395,16 @@ final class URLTests: XCTestCase, @unchecked Sendable {
         XCTAssertNil(testParam)
     }
 
+    func testEcosifiedWithTestParam_whenMicroInstanceEnabled_replacesExistingTestParamWithAutomation() {
+        Analytics.shouldUseMicroInstance = true
+        let url = URL(string: "https://www.ecosia.org/search?q=trees&test=foo")!
+            .ecosified(isIncognitoEnabled: false, urlProvider: urlProvider)
+        let testParams = URLComponents(url: url, resolvingAgainstBaseURL: false)?
+            .queryItems?.filter { $0.name == "test" } ?? []
+        XCTAssertEqual(testParams.count, 1)
+        XCTAssertEqual(testParams.first?.value, "automation")
+    }
+
     // MARK: - `policy`
 
     func testPolicyAllow() {


### PR DESCRIPTION
[MOB-4662]

## Context

We want to compare native and web events on automated tests (see ticket).

## Approach

Add `test=automation` parameter to Ecosia URLs, so that Web also target the Micro instance. Guard this so it only happens when necessary and never on production.

## Other

Refactored a bit the URL extension file so different parameters logic is separated.

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [ ] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4662]: https://ecosia.atlassian.net/browse/MOB-4662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ