### PR TITLE
[MOB-4586] [MOB-4587] File Upload - Upload pipeline and attachment strip

### DIFF
--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Omnibox.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Omnibox.swift
@@ -23,6 +23,7 @@ extension BrowserViewController: NTPSearchBarDelegate {
         // the input.
         if let bar = ntpOmniboxAnchorView {
             bar.text = ""
+            omniboxAttachmentCoordinator.clearAttachments()
             _ = bar.resignFirstResponder()
         }
         submitOmniboxSearch(query: searchTerm)
@@ -129,7 +130,27 @@ extension BrowserViewController: NTPSearchBarDelegate {
     }
 
     fileprivate var ntpOmniboxAnchorView: NTPSearchBarView? {
-        (contentContainer.contentController as? HomepageViewController)?.ntpSearchBar
+        let bar = (contentContainer.contentController as? HomepageViewController)?.ntpSearchBar
+        bar?.onRemoveAttachment = { [weak self] id in
+            self?.omniboxAttachmentCoordinator.removeAttachment(id: id)
+        }
+        return bar
+    }
+
+    fileprivate var omniboxAttachmentCoordinator: OmniboxAttachmentUploadCoordinator {
+        if let coordinator = objc_getAssociatedObject(self, &OmniboxUploadAssociatedKeys.attachmentCoordinator)
+            as? OmniboxAttachmentUploadCoordinator {
+            coordinator.searchBar = ntpOmniboxAnchorView
+            return coordinator
+        }
+        let coordinator = OmniboxAttachmentUploadCoordinator()
+        coordinator.delegate = self
+        coordinator.searchBar = ntpOmniboxAnchorView
+        objc_setAssociatedObject(self,
+                                 &OmniboxUploadAssociatedKeys.attachmentCoordinator,
+                                 coordinator,
+                                 .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        return coordinator
     }
 }
 
@@ -327,6 +348,7 @@ extension BrowserViewController {
 private struct OmniboxUploadAssociatedKeys {
     /// Used only as opaque key for objc_getAssociatedObject; no shared mutable state.
     nonisolated(unsafe) static var pickerCoordinator: UInt8 = 0
+    nonisolated(unsafe) static var attachmentCoordinator: UInt8 = 0
 }
 
 @MainActor
@@ -372,8 +394,15 @@ extension BrowserViewController {
 
 @MainActor
 extension BrowserViewController: OmniboxUploadPickerDelegate {
-    func omniboxUploadDidSelect(items: [OmniboxUploadItem]) {
-        // TODO: Stub for follow-up upload wiring to AI chat.
-        _ = items
+    func omniboxUploadDidPickPendingItems(_ items: [OmniboxUploadPendingItem]) {
+        _ = ntpOmniboxAnchorView?.becomeFirstResponder()
+        omniboxAttachmentCoordinator.processPendingItems(items)
+    }
+}
+
+@MainActor
+extension BrowserViewController: OmniboxAttachmentUploadDelegate {
+    func omniboxAttachmentsDidChange() {
+        ntpOmniboxAnchorView?.refreshSubmitButtonState()
     }
 }

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPSearchBarView.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPSearchBarView.swift
@@ -434,6 +434,7 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable, UIGestur
             : UX.textPadding
         updateSubmitState(for: textView.text ?? "")
         updateLayoutForContent()
+        delegate?.ntpSearchBarAttachmentsDidChange()
         delegate?.ntpSearchBarNeedsSuggestionsLayoutUpdate()
     }
 

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPSearchBarView.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPSearchBarView.swift
@@ -40,11 +40,14 @@ protocol NTPSearchBarDelegate: AnyObject {
     func ntpSearchBarNeedsSuggestionsLayoutUpdate()
     /// Called when the user taps the upload / attachment button.
     func ntpSearchBarDidTapUpload()
+    /// Called when attachments are added, removed, or finish uploading.
+    func ntpSearchBarAttachmentsDidChange()
 }
 
 extension NTPSearchBarDelegate {
     func ntpSearchBarIsSuggestionsOverlayVisible() -> Bool { false }
     func ntpSearchBarNeedsSuggestionsLayoutUpdate() {}
+    func ntpSearchBarAttachmentsDidChange() {}
 }
 
 /// Pill-shaped search input pinned to the bottom of the redesigned NTP. Replaces
@@ -89,11 +92,41 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable, UIGestur
         /// bottom inset). The textView is pinned just above this row so its
         /// content can never bleed into the submit / counter area.
         static var bottomRowHeight: CGFloat { submitButtonSize + .ecosia.space._1s }
+        static var attachmentStripHeight: CGFloat { OmniboxAttachmentsStripView.UX.tileHeight + .ecosia.space._1s }
         static var minTextHeight: CGFloat { minHeight - textPadding - bottomRowHeight }
         static var maxTextHeight: CGFloat { maxHeight - textPadding - bottomRowHeight }
     }
 
+    private(set) var attachments: [OmniboxAttachment] = []
+    var hasAttachments: Bool { !attachments.isEmpty }
+    var hasReadyAttachments: Bool { attachments.contains(where: \.isReady) }
+    var allAttachmentsReady: Bool {
+        !attachments.isEmpty && attachments.allSatisfy(\.isReady)
+    }
+
+    var hasUploadingAttachments: Bool {
+        attachments.contains(where: \.isLoading)
+    }
+
+    /// Recomputes whether the submit button should be enabled.
+    func refreshSubmitButtonState() {
+        updateSubmitState(for: textView.text ?? "")
+    }
+
     weak var delegate: NTPSearchBarDelegate?
+
+    private lazy var attachmentsStrip: OmniboxAttachmentsStripView = {
+        let strip = OmniboxAttachmentsStripView()
+        strip.translatesAutoresizingMaskIntoConstraints = false
+        strip.isHidden = true
+        strip.onRemoveAttachment = { [weak self] id in
+            self?.handleRemoveAttachment(id: id)
+        }
+        return strip
+    }()
+
+    private var previewImages: [UUID: UIImage] = [:]
+    var onRemoveAttachment: ((UUID) -> Void)?
 
     private lazy var textView: NTPLocationTextView = {
         let tv = NTPLocationTextView()
@@ -173,6 +206,8 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable, UIGestur
     private var currentTheme: Theme?
     private lazy var textViewHeightConstraint: NSLayoutConstraint =
         textView.heightAnchor.constraint(equalToConstant: UX.minTextHeight)
+    private lazy var textViewTopConstraint: NSLayoutConstraint =
+        textView.topAnchor.constraint(equalTo: topAnchor, constant: UX.textPadding)
 
     /// Current text content. Mirrors `textView.text` but lets callers drive
     /// programmatic changes (e.g. accepting a tapped suggestion).
@@ -224,6 +259,7 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable, UIGestur
         layer.shadowOffset = UX.shadowOffset
         layer.shadowColor = UIColor.black.cgColor
 
+        addSubview(attachmentsStrip)
         addSubview(textView)
         addSubview(placeholderLabel)
         addSubview(uploadButton)
@@ -257,14 +293,13 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable, UIGestur
         addGestureRecognizer(swipeDown)
 
         NSLayoutConstraint.activate([
-            // textView occupies the upper-left region of the pill. Its
-            // bottom is pinned to the submit button's top so wrapped text
-            // physically cannot enter the bottom-row area, and its trailing
-            // edge stops at the submit button's leading edge (with an 8pt
-            // gap) so neither typed text nor the placeholder collide with
-            // the right-hand button column.
+            attachmentsStrip.topAnchor.constraint(equalTo: topAnchor, constant: UX.textPadding),
+            attachmentsStrip.leadingAnchor.constraint(equalTo: leadingAnchor, constant: UX.textPadding),
+            attachmentsStrip.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -UX.textPadding),
+            attachmentsStrip.heightAnchor.constraint(equalToConstant: OmniboxAttachmentsStripView.UX.tileHeight),
+
             textView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: UX.textPadding),
-            textView.topAnchor.constraint(equalTo: topAnchor, constant: UX.textPadding),
+            textViewTopConstraint,
             textView.trailingAnchor.constraint(equalTo: submitButton.leadingAnchor, constant: -UX.textTrailingGap),
             textView.bottomAnchor.constraint(equalTo: submitButton.topAnchor),
             textViewHeightConstraint,
@@ -326,6 +361,9 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable, UIGestur
             if current === uploadButton || current === submitButton || current === clearButton {
                 return false
             }
+            if current === attachmentsStrip || current.isDescendant(of: attachmentsStrip) {
+                return false
+            }
             if current === self { break }
             view = current.superview
         }
@@ -345,10 +383,82 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable, UIGestur
 
     @objc private func submitTapped() {
         textView.commitPendingSuggestionIfValid()
-        let text = (textView.text ?? "").trimmingCharacters(in: .whitespaces)
-        guard !text.isEmpty else { return }
+        let text = (textView.text ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard canSubmit(text: text) else { return }
         textView.resignFirstResponder()
         delegate?.ntpSearchBarDidSubmit(text)
+    }
+
+    func readyChatFiles() -> [AIChatFileQuery] {
+        attachments.compactMap(\.chatFileQuery)
+    }
+
+    func addAttachment(_ attachment: OmniboxAttachment) {
+        attachments.append(attachment)
+        refreshAttachmentsStrip()
+    }
+
+    func removeAttachment(id: UUID) {
+        attachments.removeAll { $0.id == id }
+        previewImages.removeValue(forKey: id)
+        refreshAttachmentsStrip()
+    }
+
+    func updateAttachment(id: UUID,
+                          fileName: String,
+                          layout: OmniboxAttachment.Layout,
+                          state: OmniboxAttachment.State,
+                          previewImages: [UUID: UIImage]) {
+        guard let index = attachments.firstIndex(where: { $0.id == id }) else { return }
+        self.previewImages = previewImages
+        attachments[index] = OmniboxAttachment(id: id, fileName: fileName, layout: layout, state: state)
+        refreshAttachmentsStrip()
+    }
+
+    func setAttachments(_ attachments: [OmniboxAttachment], previewImages: [UUID: UIImage]) {
+        self.attachments = attachments
+        self.previewImages = previewImages
+        refreshAttachmentsStrip()
+    }
+
+    private func handleRemoveAttachment(id: UUID) {
+        onRemoveAttachment?(id)
+    }
+
+    private func refreshAttachmentsStrip() {
+        attachmentsStrip.setAttachments(attachments, previewImages: previewImages)
+        let hasStrip = !attachments.isEmpty
+        attachmentsStrip.isHidden = !hasStrip
+        textViewTopConstraint.constant = hasStrip
+            ? UX.textPadding + UX.attachmentStripHeight
+            : UX.textPadding
+        updateSubmitState(for: textView.text ?? "")
+        updateLayoutForContent()
+        delegate?.ntpSearchBarNeedsSuggestionsLayoutUpdate()
+    }
+
+    private func canSubmit(text: String) -> Bool {
+        let hasText = !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        guard hasText else { return false }
+        guard hasAttachments else { return true }
+        return allAttachmentsReady
+    }
+
+    private func updateSubmitState(for text: String) {
+        let enabled = canSubmit(text: text)
+        submitButton.isEnabled = enabled
+        if hasAttachments {
+            if hasUploadingAttachments {
+                submitButton.accessibilityHint = String.localized(.uploadSubmitWaitingForUpload)
+            } else if !allAttachmentsReady {
+                submitButton.accessibilityHint = String.localized(.uploadSubmitUploadFailed)
+            } else {
+                submitButton.accessibilityHint = nil
+            }
+        } else {
+            submitButton.accessibilityHint = nil
+        }
+        applySubmitButtonColors()
     }
 
     @objc private func clearTapped() {
@@ -369,19 +479,14 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable, UIGestur
     /// pushing further upward.
     private func updateLayoutForContent() {
         let contentHeight = textView.contentSize.height
-        let clamped = min(UX.maxTextHeight, max(UX.minTextHeight, contentHeight))
+        let maxTextHeight = UX.maxTextHeight - (hasAttachments ? UX.attachmentStripHeight : 0)
+        let clamped = min(maxTextHeight, max(UX.minTextHeight, contentHeight))
         if textViewHeightConstraint.constant != clamped {
             textViewHeightConstraint.constant = clamped
         }
         // The textView always has scrolling enabled so the explicit height
         // constraint drives layout. Internal scrolling kicks in naturally
         // once the content exceeds `maxTextHeight`.
-    }
-
-    private func updateSubmitState(for text: String) {
-        let hasContent = !text.trimmingCharacters(in: .whitespaces).isEmpty
-        submitButton.isEnabled = hasContent
-        applySubmitButtonColors()
     }
 
     private func updateCounter(for text: String) {
@@ -479,6 +584,7 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable, UIGestur
         applySubmitButtonColors()
         applyCounterColor()
         uploadButton.applyTheme(theme: theme)
+        attachmentsStrip.applyTheme(theme: theme)
         // Clear button: dark filled pill with a light glyph, matching the
         // Figma design.
         // Only the inner 16×16 disc carries the dark fill; the surrounding

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxAttachmentTileView.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxAttachmentTileView.swift
@@ -1,0 +1,339 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+import Common
+import Ecosia
+
+/// Single attachment preview tile in the omnibox strip — loading spinner, file card, or image thumbnail.
+final class OmniboxAttachmentTileView: UIView, ThemeApplicable {
+
+    enum UX {
+        static let fileSize = CGSize(width: 136, height: 74)
+        static let imageSize = CGSize(width: 74, height: 74)
+        static let cornerRadius: CGFloat = .ecosia.borderRadius._l
+        static let imageBorderWidth: CGFloat = 1
+        static let fileContentPadding = UIEdgeInsets(
+            top: .ecosia.space._1s,
+            left: .ecosia.space._1s,
+            bottom: .ecosia.space._1s,
+            right: .ecosia.space._1s
+        )
+        static let fileLabelGap: CGFloat = .ecosia.space._2s
+        static let removeButtonInset: CGFloat = .ecosia.space._2s
+        static let removeButtonContainerSize: CGFloat = 32
+        static let removeButtonIconSize: CGFloat = 16
+        static let glassBorderWidth: CGFloat = 1
+    }
+
+    var onRemove: (() -> Void)?
+
+    private let containerView: UIView = .build { view in
+        view.layer.cornerRadius = UX.cornerRadius
+        view.clipsToBounds = true
+    }
+
+    private let spinner: UIActivityIndicatorView = .build { spinner in
+        spinner.hidesWhenStopped = true
+    }
+
+    private let fileNameLabel: UILabel = .build { label in
+        label.font = .preferredFont(forTextStyle: .caption2)
+        label.adjustsFontForContentSizeCategory = true
+        label.numberOfLines = 2
+        label.lineBreakMode = .byTruncatingMiddle
+    }
+
+    private let fileSizeLabel: UILabel = .build { label in
+        label.font = .preferredFont(forTextStyle: .caption2)
+        label.adjustsFontForContentSizeCategory = true
+    }
+
+    private let fileContentStack: UIStackView = .build { stack in
+        stack.axis = .vertical
+        stack.spacing = UX.fileLabelGap
+        stack.alignment = .fill
+        stack.distribution = .equalSpacing
+    }
+
+    private let imageView: UIImageView = .build { imageView in
+        imageView.contentMode = .scaleAspectFill
+        imageView.clipsToBounds = true
+    }
+
+    private let imageLoadingOverlay: UIView = .build { view in
+        view.isHidden = true
+        view.isUserInteractionEnabled = false
+    }
+
+    private let removeButtonContainer: UIView = .build { view in
+        view.layer.cornerRadius = UX.removeButtonContainerSize / 2
+        view.clipsToBounds = true
+    }
+
+    private let removeGlassBlur: UIVisualEffectView = .build { blur in
+        blur.effect = UIBlurEffect(style: .systemUltraThinMaterialDark)
+        blur.isUserInteractionEnabled = false
+    }
+
+    private let removeGlassTint: UIView = .build { view in
+        view.isUserInteractionEnabled = false
+    }
+
+    private let removeIconView: UIImageView = .build { imageView in
+        imageView.image = UIImage.ecosia(named: "close")?.withRenderingMode(.alwaysTemplate)
+        imageView.contentMode = .scaleAspectFit
+        imageView.isUserInteractionEnabled = false
+    }
+
+    private lazy var removeButton: UIButton = .build { _ in }
+
+    private var widthConstraint: NSLayoutConstraint?
+    private var heightConstraint: NSLayoutConstraint?
+    private var currentLayout: OmniboxAttachment.Layout = .file
+    private var currentTheme: Theme?
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setup() {
+        addSubview(containerView)
+        // ZStack-style layering inside the rounded tile: image, overlays, then remove control.
+        containerView.addSubviews(
+            imageView,
+            imageLoadingOverlay,
+            spinner,
+            fileContentStack,
+            removeButtonContainer,
+            removeButton
+        )
+        fileContentStack.addArrangedSubview(fileNameLabel)
+        fileContentStack.addArrangedSubview(fileSizeLabel)
+        removeButtonContainer.addSubviews(removeGlassBlur, removeGlassTint, removeIconView)
+        removeButton.accessibilityLabel = String.localized(.cancel)
+        removeButton.addTarget(self, action: #selector(removeTapped), for: .touchUpInside)
+
+        widthConstraint = widthAnchor.constraint(equalToConstant: UX.fileSize.width)
+        heightConstraint = heightAnchor.constraint(equalToConstant: UX.fileSize.height)
+
+        NSLayoutConstraint.activate([
+            containerView.topAnchor.constraint(equalTo: topAnchor),
+            containerView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            containerView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            containerView.trailingAnchor.constraint(equalTo: trailingAnchor),
+
+            imageView.topAnchor.constraint(equalTo: containerView.topAnchor),
+            imageView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+            imageView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+            imageView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
+
+            imageLoadingOverlay.topAnchor.constraint(equalTo: imageView.topAnchor),
+            imageLoadingOverlay.leadingAnchor.constraint(equalTo: imageView.leadingAnchor),
+            imageLoadingOverlay.trailingAnchor.constraint(equalTo: imageView.trailingAnchor),
+            imageLoadingOverlay.bottomAnchor.constraint(equalTo: imageView.bottomAnchor),
+
+            spinner.centerXAnchor.constraint(equalTo: containerView.centerXAnchor),
+            spinner.centerYAnchor.constraint(equalTo: containerView.centerYAnchor),
+
+            fileContentStack.topAnchor.constraint(
+                equalTo: containerView.topAnchor,
+                constant: UX.fileContentPadding.top
+            ),
+            fileContentStack.leadingAnchor.constraint(
+                equalTo: containerView.leadingAnchor,
+                constant: UX.fileContentPadding.left
+            ),
+            fileContentStack.trailingAnchor.constraint(
+                equalTo: containerView.trailingAnchor,
+                constant: -UX.fileContentPadding.right
+            ),
+            fileContentStack.bottomAnchor.constraint(
+                equalTo: containerView.bottomAnchor,
+                constant: -UX.fileContentPadding.bottom
+            ),
+
+            removeButtonContainer.topAnchor.constraint(
+                equalTo: containerView.topAnchor,
+                constant: UX.removeButtonInset
+            ),
+            removeButtonContainer.trailingAnchor.constraint(
+                equalTo: containerView.trailingAnchor,
+                constant: -UX.removeButtonInset
+            ),
+            removeButtonContainer.widthAnchor.constraint(equalToConstant: UX.removeButtonContainerSize),
+            removeButtonContainer.heightAnchor.constraint(equalToConstant: UX.removeButtonContainerSize),
+
+            removeGlassBlur.topAnchor.constraint(equalTo: removeButtonContainer.topAnchor),
+            removeGlassBlur.leadingAnchor.constraint(equalTo: removeButtonContainer.leadingAnchor),
+            removeGlassBlur.trailingAnchor.constraint(equalTo: removeButtonContainer.trailingAnchor),
+            removeGlassBlur.bottomAnchor.constraint(equalTo: removeButtonContainer.bottomAnchor),
+
+            removeGlassTint.topAnchor.constraint(equalTo: removeButtonContainer.topAnchor),
+            removeGlassTint.leadingAnchor.constraint(equalTo: removeButtonContainer.leadingAnchor),
+            removeGlassTint.trailingAnchor.constraint(equalTo: removeButtonContainer.trailingAnchor),
+            removeGlassTint.bottomAnchor.constraint(equalTo: removeButtonContainer.bottomAnchor),
+
+            removeIconView.centerXAnchor.constraint(equalTo: removeButtonContainer.centerXAnchor),
+            removeIconView.centerYAnchor.constraint(equalTo: removeButtonContainer.centerYAnchor),
+            removeIconView.widthAnchor.constraint(equalToConstant: UX.removeButtonIconSize),
+            removeIconView.heightAnchor.constraint(equalToConstant: UX.removeButtonIconSize),
+
+            removeButton.topAnchor.constraint(equalTo: removeButtonContainer.topAnchor),
+            removeButton.leadingAnchor.constraint(equalTo: removeButtonContainer.leadingAnchor),
+            removeButton.trailingAnchor.constraint(equalTo: removeButtonContainer.trailingAnchor),
+            removeButton.bottomAnchor.constraint(equalTo: removeButtonContainer.bottomAnchor),
+
+            widthConstraint,
+            heightConstraint
+        ].compactMap { $0 })
+    }
+
+    func configure(attachment: OmniboxAttachment, previewImage: UIImage?) {
+        currentLayout = attachment.layout
+        let size = attachment.layout == .image ? UX.imageSize : UX.fileSize
+        widthConstraint?.constant = size.width
+        heightConstraint?.constant = size.height
+
+        resetVisibility()
+
+        switch attachment.layout {
+        case .image:
+            configureImageTile(attachment: attachment, previewImage: previewImage)
+        case .file:
+            configureFileTile(attachment: attachment)
+        }
+
+        applyRemoveButtonStyle(for: attachment.layout)
+        if let currentTheme { applyTheme(theme: currentTheme) }
+    }
+
+    func applyTheme(theme: any Theme) {
+        currentTheme = theme
+        let colors = theme.colors
+        let ecosia = (colors as? EcosiaThemeColourPalette)?.ecosia
+
+        if currentLayout == .image {
+            containerView.backgroundColor = colors.ecosia.backgroundQuaternary
+            applyImageBorder(failed: false)
+        } else {
+            containerView.backgroundColor = colors.ecosia.backgroundQuaternary
+            containerView.layer.borderWidth = 0
+        }
+
+        fileNameLabel.textColor = colors.ecosia.textPrimary
+        fileSizeLabel.textColor = colors.ecosia.textSecondary
+        spinner.color = colors.ecosia.textSecondary
+        imageLoadingOverlay.backgroundColor = colors.ecosia.textPrimary.withAlphaComponent(0.35)
+
+        removeGlassTint.backgroundColor = ecosia?.buttonBgGlassStatic
+            ?? EcosiaColor.Gray90.withAlphaComponent(0.32)
+        removeButtonContainer.layer.borderColor = (ecosia?.borderGlassStatic
+            ?? EcosiaColor.White.withAlphaComponent(0x3D / 255.0)).cgColor
+
+        applyRemoveButtonStyle(for: currentLayout)
+    }
+
+    private func resetVisibility() {
+        spinner.stopAnimating()
+        spinner.isHidden = true
+        fileContentStack.isHidden = true
+        fileNameLabel.isHidden = true
+        fileSizeLabel.isHidden = true
+        imageView.isHidden = true
+        imageLoadingOverlay.isHidden = true
+        removeButton.isHidden = false
+        removeButtonContainer.isHidden = false
+    }
+
+    private func configureImageTile(attachment: OmniboxAttachment, previewImage: UIImage?) {
+        switch attachment.state {
+        case .loading:
+            if let previewImage {
+                showImagePreview(previewImage, uploading: true, failed: false)
+            } else {
+                spinner.isHidden = false
+                spinner.startAnimating()
+                removeButton.isHidden = true
+                removeButtonContainer.isHidden = true
+            }
+        case .ready:
+            showImagePreview(previewImage, uploading: false, failed: false)
+        case .failed:
+            showImagePreview(previewImage, uploading: false, failed: true)
+        }
+    }
+
+    private func showImagePreview(_ image: UIImage?, uploading: Bool, failed: Bool) {
+        imageView.isHidden = false
+        imageView.image = image
+        imageLoadingOverlay.isHidden = !uploading
+        applyImageBorder(failed: failed)
+        if uploading {
+            spinner.isHidden = false
+            spinner.startAnimating()
+            spinner.color = currentTheme?.colors.ecosia.buttonContentPrimary ?? .white
+        }
+    }
+
+    private func applyImageBorder(failed: Bool) {
+        containerView.layer.borderWidth = UX.imageBorderWidth
+        containerView.layer.borderColor = failed
+            ? (currentTheme?.colors.ecosia.stateError.cgColor)
+            : (currentTheme?.colors.borderPrimary.cgColor)
+    }
+
+    private func configureFileTile(attachment: OmniboxAttachment) {
+        fileContentStack.isHidden = false
+        switch attachment.state {
+        case .loading:
+            fileContentStack.isHidden = true
+            spinner.isHidden = false
+            spinner.startAnimating()
+            removeButton.isHidden = true
+            removeButtonContainer.isHidden = true
+        case .failed:
+            fileNameLabel.isHidden = false
+            fileNameLabel.text = attachment.fileName
+            fileSizeLabel.isHidden = false
+            fileSizeLabel.text = String.localized(.uploadAttachmentFailed)
+        case .ready(let byteCount, _, _):
+            fileNameLabel.isHidden = false
+            fileNameLabel.text = attachment.fileName
+            fileSizeLabel.isHidden = false
+            fileSizeLabel.text = Self.formattedByteCount(byteCount)
+        }
+    }
+
+    private func applyRemoveButtonStyle(for layout: OmniboxAttachment.Layout) {
+        guard let colors = currentTheme?.colors else { return }
+        switch layout {
+        case .file:
+            removeGlassBlur.isHidden = true
+            removeGlassTint.isHidden = true
+            removeButtonContainer.backgroundColor = .clear
+            removeButtonContainer.layer.borderWidth = 0
+            removeIconView.tintColor = colors.ecosia.buttonContentSecondary
+        case .image:
+            removeGlassBlur.isHidden = false
+            removeGlassTint.isHidden = false
+            removeButtonContainer.backgroundColor = .clear
+            removeButtonContainer.layer.borderWidth = UX.glassBorderWidth
+            removeIconView.tintColor = colors.ecosia.buttonContentPrimary
+        }
+    }
+
+    @objc private func removeTapped() {
+        onRemove?()
+    }
+
+    private static func formattedByteCount(_ byteCount: Int) -> String {
+        ByteCountFormatter.string(fromByteCount: Int64(byteCount), countStyle: .file)
+    }
+}

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxAttachmentTileView.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxAttachmentTileView.swift
@@ -34,9 +34,7 @@ final class OmniboxAttachmentTileView: UIView, ThemeApplicable {
         view.clipsToBounds = true
     }
 
-    private let spinner: UIActivityIndicatorView = .build { spinner in
-        spinner.hidesWhenStopped = true
-    }
+    private let loader = OmniboxUploadLoaderView()
 
     private let fileNameLabel: UILabel = .build { label in
         label.font = .preferredFont(forTextStyle: .caption2)
@@ -109,7 +107,7 @@ final class OmniboxAttachmentTileView: UIView, ThemeApplicable {
         containerView.addSubviews(
             imageView,
             imageLoadingOverlay,
-            spinner,
+            loader,
             fileContentStack,
             removeButtonContainer,
             removeButton
@@ -139,8 +137,8 @@ final class OmniboxAttachmentTileView: UIView, ThemeApplicable {
             imageLoadingOverlay.trailingAnchor.constraint(equalTo: imageView.trailingAnchor),
             imageLoadingOverlay.bottomAnchor.constraint(equalTo: imageView.bottomAnchor),
 
-            spinner.centerXAnchor.constraint(equalTo: containerView.centerXAnchor),
-            spinner.centerYAnchor.constraint(equalTo: containerView.centerYAnchor),
+            loader.centerXAnchor.constraint(equalTo: containerView.centerXAnchor),
+            loader.centerYAnchor.constraint(equalTo: containerView.centerYAnchor),
 
             fileContentStack.topAnchor.constraint(
                 equalTo: containerView.topAnchor,
@@ -229,7 +227,7 @@ final class OmniboxAttachmentTileView: UIView, ThemeApplicable {
 
         fileNameLabel.textColor = colors.ecosia.textPrimary
         fileSizeLabel.textColor = colors.ecosia.textSecondary
-        spinner.color = colors.ecosia.textSecondary
+        loader.applyTheme(theme: theme, onDarkBackground: !imageLoadingOverlay.isHidden)
         imageLoadingOverlay.backgroundColor = colors.ecosia.textPrimary.withAlphaComponent(0.35)
 
         removeGlassTint.backgroundColor = ecosia?.buttonBgGlassStatic
@@ -241,8 +239,8 @@ final class OmniboxAttachmentTileView: UIView, ThemeApplicable {
     }
 
     private func resetVisibility() {
-        spinner.stopAnimating()
-        spinner.isHidden = true
+        loader.stopAnimating()
+        loader.isHidden = true
         fileContentStack.isHidden = true
         fileNameLabel.isHidden = true
         fileSizeLabel.isHidden = true
@@ -258,8 +256,7 @@ final class OmniboxAttachmentTileView: UIView, ThemeApplicable {
             if let previewImage {
                 showImagePreview(previewImage, uploading: true, failed: false)
             } else {
-                spinner.isHidden = false
-                spinner.startAnimating()
+                showLoader(onDarkBackground: false)
                 removeButton.isHidden = true
                 removeButtonContainer.isHidden = true
             }
@@ -276,10 +273,16 @@ final class OmniboxAttachmentTileView: UIView, ThemeApplicable {
         imageLoadingOverlay.isHidden = !uploading
         applyImageBorder(failed: failed)
         if uploading {
-            spinner.isHidden = false
-            spinner.startAnimating()
-            spinner.color = currentTheme?.colors.ecosia.buttonContentPrimary ?? .white
+            showLoader(onDarkBackground: true)
         }
+    }
+
+    private func showLoader(onDarkBackground: Bool) {
+        loader.isHidden = false
+        if let currentTheme {
+            loader.applyTheme(theme: currentTheme, onDarkBackground: onDarkBackground)
+        }
+        loader.startAnimating()
     }
 
     private func applyImageBorder(failed: Bool) {
@@ -294,8 +297,7 @@ final class OmniboxAttachmentTileView: UIView, ThemeApplicable {
         switch attachment.state {
         case .loading:
             fileContentStack.isHidden = true
-            spinner.isHidden = false
-            spinner.startAnimating()
+            showLoader(onDarkBackground: false)
             removeButton.isHidden = true
             removeButtonContainer.isHidden = true
         case .failed:

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxAttachmentUploadCoordinator.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxAttachmentUploadCoordinator.swift
@@ -1,0 +1,143 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+import Ecosia
+
+@MainActor
+protocol OmniboxAttachmentUploadDelegate: AnyObject {
+    func omniboxAttachmentsDidChange()
+}
+
+/// Loads picker selections, shows loading tiles, uploads files, and updates the omnibox strip.
+@MainActor
+final class OmniboxAttachmentUploadCoordinator {
+
+    weak var searchBar: NTPSearchBarView?
+    weak var delegate: OmniboxAttachmentUploadDelegate?
+
+    private let uploadService: FileUploadService
+    private var tasks: [UUID: Task<Void, Never>] = [:]
+    private var previewImages: [UUID: UIImage] = [:]
+
+    init(uploadService: FileUploadService = FileUploadService()) {
+        self.uploadService = uploadService
+    }
+
+    func processPendingItems(_ items: [OmniboxUploadPendingItem]) {
+        guard let searchBar else { return }
+
+        let remainingSlots = OmniboxUploadFileSelectionValidator.maxFileCount - searchBar.attachments.count
+        guard remainingSlots > 0 else { return }
+
+        for item in items.prefix(remainingSlots) {
+            let attachment = OmniboxAttachment(
+                fileName: item.fileName,
+                layout: item.layout,
+                state: .loading
+            )
+            searchBar.addAttachment(attachment)
+
+            let attachmentID = attachment.id
+            tasks[attachmentID] = Task { [weak self] in
+                await self?.loadAndUpload(attachmentID: attachmentID, item: item)
+            }
+        }
+
+        delegate?.omniboxAttachmentsDidChange()
+    }
+
+    func removeAttachment(id: UUID) {
+        tasks[id]?.cancel()
+        tasks.removeValue(forKey: id)
+        previewImages.removeValue(forKey: id)
+        searchBar?.removeAttachment(id: id)
+        delegate?.omniboxAttachmentsDidChange()
+    }
+
+    func clearAttachments() {
+        tasks.values.forEach { $0.cancel() }
+        tasks.removeAll()
+        previewImages.removeAll()
+        searchBar?.setAttachments([], previewImages: [:])
+        delegate?.omniboxAttachmentsDidChange()
+    }
+
+    private func loadAndUpload(attachmentID: UUID, item: OmniboxUploadPendingItem) async {
+        guard let searchBar else { return }
+
+        do {
+            let payload = try await item.load()
+            guard !Task.isCancelled else { return }
+
+            if let previewImage = payload.previewImage {
+                previewImages[attachmentID] = previewImage
+            }
+
+            searchBar.updateAttachment(
+                id: attachmentID,
+                fileName: payload.fileName,
+                layout: payload.layout,
+                state: .loading,
+                previewImages: previewImages
+            )
+            delegate?.omniboxAttachmentsDidChange()
+
+            let fileId = try await uploadWithRetry(
+                payload: payload,
+                attachmentID: attachmentID
+            )
+            guard !Task.isCancelled else { return }
+
+            searchBar.updateAttachment(
+                id: attachmentID,
+                fileName: payload.fileName,
+                layout: payload.layout,
+                state: .ready(byteCount: payload.data.count, fileId: fileId, mimeType: payload.mimeType),
+                previewImages: previewImages
+            )
+            EcosiaLogger.network.info("[FileUpload] Attachment \(attachmentID) ready fileId=\(fileId)")
+            delegate?.omniboxAttachmentsDidChange()
+        } catch {
+            guard !Task.isCancelled else { return }
+            EcosiaLogger.network.error(
+                "[FileUpload] Attachment \(attachmentID) failed: \(error.localizedDescription)"
+            )
+            searchBar.updateAttachment(
+                id: attachmentID,
+                fileName: item.fileName,
+                layout: item.layout,
+                state: .failed,
+                previewImages: previewImages
+            )
+            delegate?.omniboxAttachmentsDidChange()
+        }
+
+        tasks.removeValue(forKey: attachmentID)
+    }
+
+    private func uploadWithRetry(payload: OmniboxUploadLocalPayload,
+                                 attachmentID: UUID,
+                                 attempts: Int = 2) async throws -> String {
+        var lastError: Error?
+        for attempt in 1...attempts {
+            do {
+                return try await uploadService.uploadFile(
+                    FileUploadInput(data: payload.data, mimeType: payload.mimeType)
+                )
+            } catch {
+                lastError = error
+                EcosiaLogger.network.error(
+                    "[FileUpload] Attachment \(attachmentID) attempt \(attempt)/\(attempts) failed: \(error.localizedDescription)"
+                )
+                guard attempt < attempts else { break }
+                try await Task.sleep(nanoseconds: 500_000_000)
+            }
+        }
+        guard let lastError else {
+            throw OmniboxUploadPayloadError.unreadable
+        }
+        throw lastError
+    }
+}

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxAttachmentUploadCoordinator.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxAttachmentUploadCoordinator.swift
@@ -82,6 +82,7 @@ final class OmniboxAttachmentUploadCoordinator {
     }
 
     private func loadAndUpload(attachmentID: UUID, item: OmniboxUploadPendingItem) async {
+        defer { tasks.removeValue(forKey: attachmentID) }
         guard let searchBar else { return }
 
         do {
@@ -143,8 +144,6 @@ final class OmniboxAttachmentUploadCoordinator {
             }
             delegate?.omniboxAttachmentsDidChange()
         }
-
-        tasks.removeValue(forKey: attachmentID)
     }
 
     private func uploadWithRetry(payload: OmniboxUploadLocalPayload,

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxAttachmentUploadCoordinator.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxAttachmentUploadCoordinator.swift
@@ -8,6 +8,11 @@ import Ecosia
 @MainActor
 protocol OmniboxAttachmentUploadDelegate: AnyObject {
     func omniboxAttachmentsDidChange()
+    func omniboxUploadDidEncounterValidationErrors(_ errors: Set<OmniboxUploadValidationError>)
+}
+
+extension OmniboxAttachmentUploadDelegate {
+    func omniboxUploadDidEncounterValidationErrors(_ errors: Set<OmniboxUploadValidationError>) {}
 }
 
 /// Loads picker selections, shows loading tiles, uploads files, and updates the omnibox strip.
@@ -29,9 +34,21 @@ final class OmniboxAttachmentUploadCoordinator {
         guard let searchBar else { return }
 
         let remainingSlots = OmniboxUploadFileSelectionValidator.maxFileCount - searchBar.attachments.count
-        guard remainingSlots > 0 else { return }
+        if remainingSlots <= 0 {
+            delegate?.omniboxUploadDidEncounterValidationErrors([.tooManyFiles])
+            return
+        }
 
-        for item in items.prefix(remainingSlots) {
+        let acceptedItems = Array(items.prefix(remainingSlots))
+        let countErrors = OmniboxUploadFileSelectionValidator.validateSelectionCount(
+            selectedCount: items.count,
+            existingAttachmentCount: searchBar.attachments.count
+        )
+        if !countErrors.isEmpty {
+            delegate?.omniboxUploadDidEncounterValidationErrors(countErrors)
+        }
+
+        for item in acceptedItems {
             let attachment = OmniboxAttachment(
                 fileName: item.fileName,
                 layout: item.layout,
@@ -68,7 +85,9 @@ final class OmniboxAttachmentUploadCoordinator {
         guard let searchBar else { return }
 
         do {
-            let payload = try await item.load()
+            let payload = try await Task.detached(priority: .userInitiated) {
+                try await item.load()
+            }.value
             guard !Task.isCancelled else { return }
 
             if let previewImage = payload.previewImage {
@@ -99,18 +118,31 @@ final class OmniboxAttachmentUploadCoordinator {
             )
             EcosiaLogger.network.info("[FileUpload] Attachment \(attachmentID) ready fileId=\(fileId)")
             delegate?.omniboxAttachmentsDidChange()
+        } catch let error as OmniboxUploadPayloadError where error == .fileTooLarge {
+            guard !Task.isCancelled else { return }
+            searchBar.removeAttachment(id: attachmentID)
+            previewImages.removeValue(forKey: attachmentID)
+            delegate?.omniboxUploadDidEncounterValidationErrors([.fileTooLarge])
+            delegate?.omniboxAttachmentsDidChange()
         } catch {
             guard !Task.isCancelled else { return }
             EcosiaLogger.network.error(
                 "[FileUpload] Attachment \(attachmentID) failed: \(error.localizedDescription)"
             )
-            searchBar.updateAttachment(
-                id: attachmentID,
-                fileName: item.fileName,
-                layout: item.layout,
-                state: .failed,
-                previewImages: previewImages
-            )
+            if error is OmniboxUploadPayloadError {
+                searchBar.removeAttachment(id: attachmentID)
+                previewImages.removeValue(forKey: attachmentID)
+                delegate?.omniboxUploadDidEncounterValidationErrors([.uploadFailed])
+            } else {
+                searchBar.updateAttachment(
+                    id: attachmentID,
+                    fileName: item.fileName,
+                    layout: item.layout,
+                    state: .failed,
+                    previewImages: previewImages
+                )
+                delegate?.omniboxUploadDidEncounterValidationErrors([.uploadFailed])
+            }
             delegate?.omniboxAttachmentsDidChange()
         }
 
@@ -120,6 +152,15 @@ final class OmniboxAttachmentUploadCoordinator {
     private func uploadWithRetry(payload: OmniboxUploadLocalPayload,
                                  attachmentID: UUID,
                                  attempts: Int = 2) async throws -> String {
+        if OmniboxUploadDebugSimulation.shouldSimulateUploadAPIFailure {
+            EcosiaLogger.network.info("[FileUpload] Debug: simulating upload API failure")
+            throw NSError(
+                domain: "EcosiaDebug",
+                code: -1,
+                userInfo: [NSLocalizedDescriptionKey: "Debug: Simulated file upload API error"]
+            )
+        }
+
         var lastError: Error?
         for attempt in 1...attempts {
             do {

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxAttachmentUploadCoordinator.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxAttachmentUploadCoordinator.swift
@@ -64,7 +64,7 @@ final class OmniboxAttachmentUploadCoordinator {
             searchBar.addAttachment(attachment)
 
             let attachmentID = attachment.id
-            tasks[attachmentID] = Task { [weak self] in
+            tasks[attachmentID] = Task { @MainActor [weak self] in
                 await self?.loadAndUpload(attachmentID: attachmentID, item: item)
             }
         }
@@ -92,9 +92,15 @@ final class OmniboxAttachmentUploadCoordinator {
         defer { tasks.removeValue(forKey: attachmentID) }
         guard let searchBar else { return }
 
+        var displayFileName = item.fileName
+        var displayLayout = item.layout
+
         do {
             let payload = try await item.loadPayload()
             guard !Task.isCancelled else { return }
+
+            displayFileName = payload.fileName
+            displayLayout = payload.layout
 
             if let previewImage = payload.previewImage {
                 previewImages[attachmentID] = previewImage
@@ -142,8 +148,8 @@ final class OmniboxAttachmentUploadCoordinator {
             } else {
                 searchBar.updateAttachment(
                     id: attachmentID,
-                    fileName: item.fileName,
-                    layout: item.layout,
+                    fileName: displayFileName,
+                    layout: displayLayout,
                     state: .failed,
                     previewImages: previewImages
                 )

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxAttachmentUploadCoordinator.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxAttachmentUploadCoordinator.swift
@@ -5,6 +5,17 @@
 import UIKit
 import Ecosia
 
+enum OmniboxUploadValidationError: Hashable, Sendable {
+    case tooManyFiles
+    case fileTooLarge
+    case uploadFailed
+}
+
+/// Stub until MOB-4588 wires debug settings for simulated upload failures.
+enum OmniboxUploadDebugSimulation {
+    static var shouldSimulateUploadAPIFailure: Bool { false }
+}
+
 @MainActor
 protocol OmniboxAttachmentUploadDelegate: AnyObject {
     func omniboxAttachmentsDidChange()
@@ -40,12 +51,8 @@ final class OmniboxAttachmentUploadCoordinator {
         }
 
         let acceptedItems = Array(items.prefix(remainingSlots))
-        let countErrors = OmniboxUploadFileSelectionValidator.validateSelectionCount(
-            selectedCount: items.count,
-            existingAttachmentCount: searchBar.attachments.count
-        )
-        if !countErrors.isEmpty {
-            delegate?.omniboxUploadDidEncounterValidationErrors(countErrors)
+        if items.count > remainingSlots {
+            delegate?.omniboxUploadDidEncounterValidationErrors([.tooManyFiles])
         }
 
         for item in acceptedItems {

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxAttachmentUploadCoordinator.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxAttachmentUploadCoordinator.swift
@@ -85,9 +85,7 @@ final class OmniboxAttachmentUploadCoordinator {
         guard let searchBar else { return }
 
         do {
-            let payload = try await Task.detached(priority: .userInitiated) {
-                try await item.load()
-            }.value
+            let payload = try await item.loadPayload()
             guard !Task.isCancelled else { return }
 
             if let previewImage = payload.previewImage {

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxAttachmentsStripView.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxAttachmentsStripView.swift
@@ -1,0 +1,151 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+import Common
+import Ecosia
+
+/// Horizontally scrollable row of attachment previews above the omnibox text field.
+/// Scrolling is locked to the horizontal axis and clipped to this view's bounds.
+final class OmniboxAttachmentsStripView: UIView, ThemeApplicable, UIScrollViewDelegate {
+
+    enum UX {
+        static let tileSpacing: CGFloat = .ecosia.space._1s
+        static var tileHeight: CGFloat {
+            OmniboxAttachmentTileView.UX.imageSize.height
+        }
+    }
+
+    var onRemoveAttachment: ((UUID) -> Void)?
+
+    private let scrollView: HorizontalAttachmentsScrollView = .build { scrollView in
+        scrollView.showsHorizontalScrollIndicator = false
+        scrollView.showsVerticalScrollIndicator = false
+        scrollView.alwaysBounceHorizontal = true
+        scrollView.alwaysBounceVertical = false
+        scrollView.isDirectionalLockEnabled = true
+        scrollView.clipsToBounds = true
+        scrollView.contentInsetAdjustmentBehavior = .never
+    }
+
+    private let stackView: UIStackView = .build { stack in
+        stack.axis = .horizontal
+        stack.spacing = UX.tileSpacing
+        stack.alignment = .center
+    }
+
+    private var previewImages: [UUID: UIImage] = [:]
+    private var tileViews: [UUID: OmniboxAttachmentTileView] = [:]
+    private var currentTheme: Theme?
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setup() {
+        clipsToBounds = true
+        addSubview(scrollView)
+        scrollView.delegate = self
+        scrollView.addSubview(stackView)
+
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            scrollView.heightAnchor.constraint(equalToConstant: UX.tileHeight),
+
+            stackView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
+            stackView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor),
+            stackView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
+            stackView.heightAnchor.constraint(equalTo: scrollView.frameLayoutGuide.heightAnchor)
+        ])
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        scrollView.alwaysBounceHorizontal = stackView.bounds.width > scrollView.bounds.width
+    }
+
+    func setAttachments(_ attachments: [OmniboxAttachment], previewImages: [UUID: UIImage]) {
+        self.previewImages = previewImages
+
+        let attachmentIDs = Set(attachments.map(\.id))
+        tileViews.keys.filter { !attachmentIDs.contains($0) }.forEach { id in
+            tileViews[id]?.removeFromSuperview()
+            tileViews.removeValue(forKey: id)
+        }
+
+        stackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+
+        for attachment in attachments {
+            let tile = tileViews[attachment.id] ?? makeTile(for: attachment.id)
+            tile.configure(attachment: attachment, previewImage: previewImages[attachment.id])
+            if let theme = currentTheme {
+                tile.applyTheme(theme: theme)
+            }
+            stackView.addArrangedSubview(tile)
+        }
+
+        isHidden = attachments.isEmpty
+    }
+
+    func applyTheme(theme: any Theme) {
+        currentTheme = theme
+        tileViews.values.forEach { $0.applyTheme(theme: theme) }
+    }
+
+    private func makeTile(for id: UUID) -> OmniboxAttachmentTileView {
+        let tile = OmniboxAttachmentTileView()
+        tile.translatesAutoresizingMaskIntoConstraints = false
+        tile.onRemove = { [weak self] in
+            self?.onRemoveAttachment?(id)
+        }
+        tileViews[id] = tile
+        return tile
+    }
+
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        guard scrollView.contentOffset.y != 0 else { return }
+        scrollView.contentOffset = CGPoint(x: scrollView.contentOffset.x, y: 0)
+    }
+}
+
+// MARK: - Horizontal-only scroll view
+
+/// Rejects predominantly vertical pans so attachment dragging stays on the horizontal axis.
+private final class HorizontalAttachmentsScrollView: UIScrollView, UIGestureRecognizerDelegate {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        panGestureRecognizer.delegate = self
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        guard gestureRecognizer === panGestureRecognizer,
+              let pan = gestureRecognizer as? UIPanGestureRecognizer else {
+            return super.gestureRecognizerShouldBegin(gestureRecognizer)
+        }
+        let velocity = pan.velocity(in: self)
+        // Velocity is often zero at touch-down; directional lock + y-offset clamp handle the axis.
+        guard velocity == .zero || abs(velocity.x) >= abs(velocity.y) else { return false }
+        return super.gestureRecognizerShouldBegin(gestureRecognizer)
+    }
+
+    func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+    ) -> Bool {
+        false
+    }
+}

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadCameraPicker.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadCameraPicker.swift
@@ -86,12 +86,16 @@ extension OmniboxUploadPickerCoordinator: UIImagePickerControllerDelegate, UINav
                                didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
         picker.dismiss(animated: true)
 
-        let fileName: String
+        let rawFileName: String
         if let url = info[.imageURL] as? URL {
-            fileName = url.lastPathComponent
+            rawFileName = url.lastPathComponent
         } else {
-            fileName = "camera-photo.jpg"
+            rawFileName = "camera-photo.jpg"
         }
+        let fileName = OmniboxUploadPayloadLoader.normalizedJPEGFileName(
+            from: rawFileName,
+            fallback: "camera-photo.jpg"
+        )
 
         guard let image = info[.originalImage] as? UIImage,
               let data = image.jpegData(compressionQuality: 0.92) else { return }
@@ -103,6 +107,6 @@ extension OmniboxUploadPickerCoordinator: UIImagePickerControllerDelegate, UINav
                 mimeType: UTType.jpeg.preferredMIMEType ?? "image/jpeg"
             )
         }
-        delegate?.omniboxUploadDidPickPendingItems([pendingItem])
+        delegate?.omniboxUploadDidFinishPicking(items: [pendingItem], validationErrors: [])
     }
 }

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadCameraPicker.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadCameraPicker.swift
@@ -90,11 +90,19 @@ extension OmniboxUploadPickerCoordinator: UIImagePickerControllerDelegate, UINav
         if let url = info[.imageURL] as? URL {
             fileName = url.lastPathComponent
         } else {
-            fileName = "camera-photo"
+            fileName = "camera-photo.jpg"
         }
 
-        delegate?.omniboxUploadDidSelect(items: [
-            OmniboxUploadItem(source: .camera, fileName: fileName, contentTypeIdentifier: UTType.image.identifier)
-        ])
+        guard let image = info[.originalImage] as? UIImage,
+              let data = image.jpegData(compressionQuality: 0.92) else { return }
+
+        let pendingItem = OmniboxUploadPendingItem(fileName: fileName, layout: .image) {
+            try OmniboxUploadPayloadLoader.loadImage(
+                data: data,
+                fileName: fileName,
+                mimeType: UTType.jpeg.preferredMIMEType ?? "image/jpeg"
+            )
+        }
+        delegate?.omniboxUploadDidPickPendingItems([pendingItem])
     }
 }

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadCameraPicker.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadCameraPicker.swift
@@ -90,11 +90,11 @@ extension OmniboxUploadPickerCoordinator: UIImagePickerControllerDelegate, UINav
         if let url = info[.imageURL] as? URL {
             rawFileName = url.lastPathComponent
         } else {
-            rawFileName = "camera-photo.jpg"
+            rawFileName = OmniboxUploadPayloadLoader.uniqueJPEGFileName(prefix: "camera-photo")
         }
         let fileName = OmniboxUploadPayloadLoader.normalizedJPEGFileName(
             from: rawFileName,
-            fallback: "camera-photo.jpg"
+            fallback: OmniboxUploadPayloadLoader.uniqueJPEGFileName(prefix: "camera-photo")
         )
 
         guard let image = info[.originalImage] as? UIImage,
@@ -107,6 +107,6 @@ extension OmniboxUploadPickerCoordinator: UIImagePickerControllerDelegate, UINav
                 mimeType: UTType.jpeg.preferredMIMEType ?? "image/jpeg"
             )
         }
-        delegate?.omniboxUploadDidFinishPicking(items: [pendingItem], validationErrors: [])
+        delegate?.omniboxUploadDidPickPendingItems([pendingItem])
     }
 }

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadFilePicker.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadFilePicker.swift
@@ -28,14 +28,14 @@ extension OmniboxUploadPickerCoordinator: UIDocumentPickerDelegate {
         controller.dismiss(animated: true)
 
         let allowedURLs = OmniboxUploadFileSelectionValidator.allowedURLs(from: urls)
-        let items = allowedURLs.map { url in
-            OmniboxUploadItem(
-                source: .files,
-                fileName: url.lastPathComponent,
-                contentTypeIdentifier: UTType(filenameExtension: url.pathExtension)?.identifier
-            )
+        let pendingItems = allowedURLs.map { url in
+            let ext = url.pathExtension.lowercased()
+            let layout: OmniboxAttachment.Layout = ["jpg", "jpeg", "png"].contains(ext) ? .image : .file
+            return OmniboxUploadPendingItem(fileName: url.lastPathComponent, layout: layout) {
+                try OmniboxUploadPayloadLoader.loadFile(from: url)
+            }
         }
-        guard !items.isEmpty else { return }
-        delegate?.omniboxUploadDidSelect(items: items)
+        guard !pendingItems.isEmpty else { return }
+        delegate?.omniboxUploadDidPickPendingItems(pendingItems)
     }
 }

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadFilePicker.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadFilePicker.swift
@@ -34,7 +34,7 @@ extension OmniboxUploadPickerCoordinator: UIDocumentPickerDelegate {
                 ? .image
                 : .file
             return OmniboxUploadPendingItem(fileName: url.lastPathComponent, layout: layout) {
-                try OmniboxUploadPayloadLoader.loadFile(from: url)
+                try await OmniboxUploadPayloadLoader.loadFile(from: url)
             }
         }
         guard !pendingItems.isEmpty else { return }

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadFilePicker.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadFilePicker.swift
@@ -30,7 +30,9 @@ extension OmniboxUploadPickerCoordinator: UIDocumentPickerDelegate {
         let allowedURLs = OmniboxUploadFileSelectionValidator.allowedURLs(from: urls)
         let pendingItems = allowedURLs.map { url in
             let ext = url.pathExtension.lowercased()
-            let layout: OmniboxAttachment.Layout = ["jpg", "jpeg", "png"].contains(ext) ? .image : .file
+            let layout: OmniboxAttachment.Layout = OmniboxUploadFileSelectionValidator.imageExtensions.contains(ext)
+                ? .image
+                : .file
             return OmniboxUploadPendingItem(fileName: url.lastPathComponent, layout: layout) {
                 try OmniboxUploadPayloadLoader.loadFile(from: url)
             }

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadFileSelectionValidator.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadFileSelectionValidator.swift
@@ -8,7 +8,9 @@ import UniformTypeIdentifiers
 enum OmniboxUploadFileSelectionValidator {
     static let maxFileCount = 5
     static let blockedExtensions: Set<String> = ["app", "exe"]
-    private static let supportedExtensions: Set<String> = ["pdf", "txt", "doc", "jpg", "jpeg", "png"]
+    static let imageExtensions: Set<String> = ["jpg", "jpeg", "png"]
+    private static let documentExtensions: Set<String> = ["pdf", "txt", "doc"]
+    private static let supportedExtensions = documentExtensions.union(imageExtensions)
 
     static var pickerContentTypes: [UTType] {
         [

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadLoaderView.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadLoaderView.swift
@@ -1,0 +1,95 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+import Common
+
+/// Indeterminate upload progress ring — 24×24, 2pt stroke, ~270° arc rotating clockwise.
+final class OmniboxUploadLoaderView: UIView {
+
+    enum UX {
+        static let size: CGFloat = 24
+        static let lineWidth: CGFloat = 2
+        /// Visible arc length as a fraction of the full circle (~270°).
+        static let arcFraction: CGFloat = 0.75
+    }
+
+    private let trackLayer = CAShapeLayer()
+    private let arcLayer = CAShapeLayer()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        isUserInteractionEnabled = false
+        translatesAutoresizingMaskIntoConstraints = false
+        layer.addSublayer(trackLayer)
+        layer.addSublayer(arcLayer)
+        configureLayers()
+        NSLayoutConstraint.activate([
+            widthAnchor.constraint(equalToConstant: UX.size),
+            heightAnchor.constraint(equalToConstant: UX.size)
+        ])
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        let path = circlePath()
+        trackLayer.path = path
+        arcLayer.path = path
+        trackLayer.frame = bounds
+        arcLayer.frame = bounds
+    }
+
+    func applyTheme(theme: any Theme, onDarkBackground: Bool = false) {
+        let colors = theme.colors.ecosia
+        if onDarkBackground {
+            trackLayer.strokeColor = colors.buttonContentPrimary.withAlphaComponent(0.35).cgColor
+            arcLayer.strokeColor = colors.buttonContentPrimary.cgColor
+        } else {
+            trackLayer.strokeColor = colors.backgroundQuaternary.cgColor
+            arcLayer.strokeColor = colors.textPrimary.cgColor
+        }
+    }
+
+    func startAnimating() {
+        guard arcLayer.animation(forKey: "rotation") == nil else { return }
+        let rotation = CABasicAnimation(keyPath: "transform.rotation.z")
+        rotation.fromValue = 0
+        rotation.toValue = Double.pi * 2
+        rotation.duration = 1
+        rotation.repeatCount = .infinity
+        rotation.isRemovedOnCompletion = false
+        arcLayer.add(rotation, forKey: "rotation")
+    }
+
+    func stopAnimating() {
+        arcLayer.removeAnimation(forKey: "rotation")
+    }
+
+    private func configureLayers() {
+        [trackLayer, arcLayer].forEach { layer in
+            layer.fillColor = UIColor.clear.cgColor
+            layer.lineWidth = UX.lineWidth
+            layer.lineCap = .round
+            layer.strokeStart = 0
+        }
+        trackLayer.strokeEnd = 1
+        arcLayer.strokeEnd = UX.arcFraction
+    }
+
+    private func circlePath() -> CGPath {
+        let radius = (UX.size / 2) - UX.lineWidth
+        let center = CGPoint(x: bounds.midX, y: bounds.midY)
+        return UIBezierPath(
+            arcCenter: center,
+            radius: radius,
+            startAngle: -.pi / 2,
+            endAngle: (3 * .pi) / 2,
+            clockwise: true
+        ).cgPath
+    }
+}

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadPayload.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadPayload.swift
@@ -16,10 +16,25 @@ struct OmniboxUploadLocalPayload {
 }
 
 /// Deferred load closure used while the system picker hands back a selection.
-struct OmniboxUploadPendingItem {
+struct OmniboxUploadPendingItem: Sendable {
     let fileName: String
     let layout: OmniboxAttachment.Layout
-    let load: () async throws -> OmniboxUploadLocalPayload
+    let load: @Sendable () async throws -> OmniboxUploadLocalPayload
+
+    init(
+        fileName: String,
+        layout: OmniboxAttachment.Layout,
+        load: @escaping @Sendable () async throws -> OmniboxUploadLocalPayload
+    ) {
+        self.fileName = fileName
+        self.layout = layout
+        self.load = load
+    }
+
+    /// Loads file bytes off the main actor; UI updates stay on `@MainActor` callers.
+    nonisolated func loadPayload() async throws -> OmniboxUploadLocalPayload {
+        try await load()
+    }
 }
 
 enum OmniboxUploadPayloadLoader {

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadPayload.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadPayload.swift
@@ -31,8 +31,7 @@ struct OmniboxUploadPendingItem: Sendable {
         self.load = load
     }
 
-    /// Loads file bytes off the main actor; UI updates stay on `@MainActor` callers.
-    nonisolated func loadPayload() async throws -> OmniboxUploadLocalPayload {
+    func loadPayload() async throws -> OmniboxUploadLocalPayload {
         try await load()
     }
 }
@@ -83,6 +82,11 @@ enum OmniboxUploadPayloadLoader {
         let stem = (fileName as NSString).deletingPathExtension
         guard !stem.isEmpty else { return fallback }
         return "\(stem).jpg"
+    }
+
+    /// Unique JPEG name for camera/photo fallbacks so concurrent picks do not collide on the backend.
+    static func uniqueJPEGFileName(prefix: String) -> String {
+        "\(prefix)-\(UUID().uuidString.prefix(8)).jpg"
     }
 
     static func loadImage(data: Data, fileName: String, mimeType: String) throws -> OmniboxUploadLocalPayload {

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadPayload.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadPayload.swift
@@ -37,12 +37,34 @@ struct OmniboxUploadPendingItem: Sendable {
     }
 }
 
+enum OmniboxUploadSecurityScopedAccess {
+    static func withAccess<T>(to url: URL, _ work: () throws -> T) rethrows -> T {
+        let accessed = url.startAccessingSecurityScopedResource()
+        defer {
+            if accessed {
+                url.stopAccessingSecurityScopedResource()
+            }
+        }
+        return try work()
+    }
+
+    static func fileSize(for url: URL) -> Int? {
+        withAccess(to: url) {
+            let values = try? url.resourceValues(forKeys: [.fileSizeKey])
+            return values?.fileSize
+        }
+    }
+}
+
 enum OmniboxUploadPayloadLoader {
 
     static let maxFileSizeBytes = 5 * 1024 * 1024
 
     static func loadFile(from url: URL) throws -> OmniboxUploadLocalPayload {
-        let data = try Data(contentsOf: url)
+        try validateFileSize(at: url)
+        let data = try OmniboxUploadSecurityScopedAccess.withAccess(to: url) {
+            try Data(contentsOf: url)
+        }
         try validateSize(data)
         let mimeType = UTType(filenameExtension: url.pathExtension)?.preferredMIMEType ?? "application/octet-stream"
         let layout: OmniboxAttachment.Layout = mimeType.hasPrefix("image/") ? .image : .file
@@ -76,6 +98,13 @@ enum OmniboxUploadPayloadLoader {
 
     static func validateSize(_ data: Data) throws {
         guard data.count <= maxFileSizeBytes else {
+            throw OmniboxUploadPayloadError.fileTooLarge
+        }
+    }
+
+    static func validateFileSize(at url: URL) throws {
+        if let fileSize = OmniboxUploadSecurityScopedAccess.fileSize(for: url),
+           fileSize > maxFileSizeBytes {
             throw OmniboxUploadPayloadError.fileTooLarge
         }
     }

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadPayload.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadPayload.swift
@@ -1,0 +1,65 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import UIKit
+import UniformTypeIdentifiers
+import Ecosia
+
+/// Local payload produced by a picker after the user selects content.
+struct OmniboxUploadLocalPayload {
+    let fileName: String
+    let mimeType: String
+    let data: Data
+    let layout: OmniboxAttachment.Layout
+    let previewImage: UIImage?
+}
+
+/// Deferred load closure used while the system picker hands back a selection.
+struct OmniboxUploadPendingItem {
+    let fileName: String
+    let layout: OmniboxAttachment.Layout
+    let load: () async throws -> OmniboxUploadLocalPayload
+}
+
+enum OmniboxUploadPayloadLoader {
+
+    static let maxFileSizeBytes = 5 * 1024 * 1024
+
+    static func loadFile(from url: URL) throws -> OmniboxUploadLocalPayload {
+        let data = try Data(contentsOf: url)
+        try validateSize(data)
+        let mimeType = UTType(filenameExtension: url.pathExtension)?.preferredMIMEType ?? "application/octet-stream"
+        let layout: OmniboxAttachment.Layout = mimeType.hasPrefix("image/") ? .image : .file
+        let previewImage = layout == .image ? UIImage(data: data) : nil
+        return OmniboxUploadLocalPayload(
+            fileName: url.lastPathComponent,
+            mimeType: mimeType,
+            data: data,
+            layout: layout,
+            previewImage: previewImage
+        )
+    }
+
+    static func loadImage(data: Data, fileName: String, mimeType: String) throws -> OmniboxUploadLocalPayload {
+        try validateSize(data)
+        return OmniboxUploadLocalPayload(
+            fileName: fileName,
+            mimeType: mimeType,
+            data: data,
+            layout: .image,
+            previewImage: UIImage(data: data)
+        )
+    }
+
+    static func validateSize(_ data: Data) throws {
+        guard data.count <= maxFileSizeBytes else {
+            throw OmniboxUploadPayloadError.fileTooLarge
+        }
+    }
+}
+
+enum OmniboxUploadPayloadError: Error, Equatable {
+    case fileTooLarge
+    case unreadable
+}

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadPayload.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadPayload.swift
@@ -16,15 +16,15 @@ struct OmniboxUploadLocalPayload {
 }
 
 /// Deferred load closure used while the system picker hands back a selection.
-struct OmniboxUploadPendingItem: Sendable {
+struct OmniboxUploadPendingItem {
     let fileName: String
     let layout: OmniboxAttachment.Layout
-    let load: @Sendable () async throws -> OmniboxUploadLocalPayload
+    let load: () async throws -> OmniboxUploadLocalPayload
 
     init(
         fileName: String,
         layout: OmniboxAttachment.Layout,
-        load: @escaping @Sendable () async throws -> OmniboxUploadLocalPayload
+        load: @escaping () async throws -> OmniboxUploadLocalPayload
     ) {
         self.fileName = fileName
         self.layout = layout
@@ -59,13 +59,17 @@ enum OmniboxUploadPayloadLoader {
 
     static let maxFileSizeBytes = 5 * 1024 * 1024
 
-    static func loadFile(from url: URL) throws -> OmniboxUploadLocalPayload {
-        try validateFileSize(at: url)
-        let data = try OmniboxUploadSecurityScopedAccess.withAccess(to: url) {
-            try Data(contentsOf: url)
-        }
-        try validateSize(data)
-        let mimeType = UTType(filenameExtension: url.pathExtension)?.preferredMIMEType ?? "application/octet-stream"
+    static func loadFile(from url: URL) async throws -> OmniboxUploadLocalPayload {
+        // Run blocking file IO off the calling actor
+        let (data, mimeType) = try await Task.detached(priority: .userInitiated) { () throws -> (Data, String) in
+            try validateFileSize(at: url)
+            let data = try OmniboxUploadSecurityScopedAccess.withAccess(to: url) {
+                try Data(contentsOf: url)
+            }
+            try validateSize(data)
+            let mimeType = UTType(filenameExtension: url.pathExtension)?.preferredMIMEType ?? "application/octet-stream"
+            return (data, mimeType)
+        }.value
         let layout: OmniboxAttachment.Layout = mimeType.hasPrefix("image/") ? .image : .file
         let previewImage = layout == .image ? UIImage(data: data) : nil
         return OmniboxUploadLocalPayload(

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadPayload.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadPayload.swift
@@ -41,6 +41,13 @@ enum OmniboxUploadPayloadLoader {
         )
     }
 
+    /// Replaces the extension with `.jpg` when image bytes are JPEG-encoded under a HEIC/HEIF name.
+    static func normalizedJPEGFileName(from fileName: String, fallback: String = "photo.jpg") -> String {
+        let stem = (fileName as NSString).deletingPathExtension
+        guard !stem.isEmpty else { return fallback }
+        return "\(stem).jpg"
+    }
+
     static func loadImage(data: Data, fileName: String, mimeType: String) throws -> OmniboxUploadLocalPayload {
         try validateSize(data)
         return OmniboxUploadLocalPayload(

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadPhotoPicker.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadPhotoPicker.swift
@@ -40,10 +40,8 @@ extension OmniboxUploadPickerCoordinator {
     }
 
     private func showSystemPhotoPicker(from viewController: UIViewController) {
-        let remainingSlots = delegate?.omniboxUploadRemainingAttachmentSlots
-            ?? OmniboxUploadPhotoPickerUX.maxSelectionCount
         var configuration = PHPickerConfiguration(photoLibrary: .shared())
-        configuration.selectionLimit = min(OmniboxUploadPhotoPickerUX.maxSelectionCount, remainingSlots)
+        configuration.selectionLimit = OmniboxUploadPhotoPickerUX.maxSelectionCount
         configuration.filter = .images
 
         let picker = PHPickerViewController(configuration: configuration)
@@ -71,19 +69,9 @@ extension OmniboxUploadPickerCoordinator: PHPickerViewControllerDelegate {
         picker.dismiss(animated: true)
         guard !results.isEmpty else { return }
 
-        let existingAttachmentCount = OmniboxUploadFileSelectionValidator.maxFileCount
-            - (delegate?.omniboxUploadRemainingAttachmentSlots ?? OmniboxUploadFileSelectionValidator.maxFileCount)
-        let validationErrors = OmniboxUploadFileSelectionValidator.validateSelectionCount(
-            selectedCount: results.count,
-            existingAttachmentCount: existingAttachmentCount
-        )
-
-        let remainingSlots = delegate?.omniboxUploadRemainingAttachmentSlots
-            ?? OmniboxUploadFileSelectionValidator.maxFileCount
-        let acceptedResults = Array(results.prefix(remainingSlots))
-
-        let pendingItems = acceptedResults.map { result in
-            let fileName = result.itemProvider.suggestedName ?? "photo.jpg"
+        let pendingItems = results.map { result in
+            let fileName = result.itemProvider.suggestedName
+                ?? OmniboxUploadPayloadLoader.uniqueJPEGFileName(prefix: "photo")
             let typeIdentifier = result.itemProvider.registeredTypeIdentifiers.first ?? UTType.jpeg.identifier
             return OmniboxUploadPendingItem(fileName: fileName, layout: .image) {
                 try await Self.loadPhoto(from: result.itemProvider,
@@ -91,7 +79,8 @@ extension OmniboxUploadPickerCoordinator: PHPickerViewControllerDelegate {
                                          typeIdentifier: typeIdentifier)
             }
         }
-        delegate?.omniboxUploadDidFinishPicking(items: pendingItems, validationErrors: validationErrors)
+        guard !pendingItems.isEmpty else { return }
+        delegate?.omniboxUploadDidPickPendingItems(pendingItems)
     }
 
     private static func loadPhoto(from itemProvider: NSItemProvider,

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadPhotoPicker.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadPhotoPicker.swift
@@ -40,8 +40,10 @@ extension OmniboxUploadPickerCoordinator {
     }
 
     private func showSystemPhotoPicker(from viewController: UIViewController) {
+        let remainingSlots = delegate?.omniboxUploadRemainingAttachmentSlots
+            ?? OmniboxUploadPhotoPickerUX.maxSelectionCount
         var configuration = PHPickerConfiguration(photoLibrary: .shared())
-        configuration.selectionLimit = OmniboxUploadPhotoPickerUX.maxSelectionCount
+        configuration.selectionLimit = min(OmniboxUploadPhotoPickerUX.maxSelectionCount, remainingSlots)
         configuration.filter = .images
 
         let picker = PHPickerViewController(configuration: configuration)
@@ -69,7 +71,18 @@ extension OmniboxUploadPickerCoordinator: PHPickerViewControllerDelegate {
         picker.dismiss(animated: true)
         guard !results.isEmpty else { return }
 
-        let pendingItems = results.map { result in
+        let existingAttachmentCount = OmniboxUploadFileSelectionValidator.maxFileCount
+            - (delegate?.omniboxUploadRemainingAttachmentSlots ?? OmniboxUploadFileSelectionValidator.maxFileCount)
+        let validationErrors = OmniboxUploadFileSelectionValidator.validateSelectionCount(
+            selectedCount: results.count,
+            existingAttachmentCount: existingAttachmentCount
+        )
+
+        let remainingSlots = delegate?.omniboxUploadRemainingAttachmentSlots
+            ?? OmniboxUploadFileSelectionValidator.maxFileCount
+        let acceptedResults = Array(results.prefix(remainingSlots))
+
+        let pendingItems = acceptedResults.map { result in
             let fileName = result.itemProvider.suggestedName ?? "photo.jpg"
             let typeIdentifier = result.itemProvider.registeredTypeIdentifiers.first ?? UTType.jpeg.identifier
             return OmniboxUploadPendingItem(fileName: fileName, layout: .image) {
@@ -78,7 +91,7 @@ extension OmniboxUploadPickerCoordinator: PHPickerViewControllerDelegate {
                                          typeIdentifier: typeIdentifier)
             }
         }
-        delegate?.omniboxUploadDidPickPendingItems(pendingItems)
+        delegate?.omniboxUploadDidFinishPicking(items: pendingItems, validationErrors: validationErrors)
     }
 
     private static func loadPhoto(from itemProvider: NSItemProvider,
@@ -89,9 +102,10 @@ extension OmniboxUploadPickerCoordinator: PHPickerViewControllerDelegate {
             guard let data = image.jpegData(compressionQuality: 0.92) else {
                 throw OmniboxUploadPayloadError.unreadable
             }
+            let jpegFileName = OmniboxUploadPayloadLoader.normalizedJPEGFileName(from: fileName)
             return try OmniboxUploadPayloadLoader.loadImage(
                 data: data,
-                fileName: fileName,
+                fileName: jpegFileName,
                 mimeType: UTType.jpeg.preferredMIMEType ?? "image/jpeg"
             )
         }

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadPhotoPicker.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadPhotoPicker.swift
@@ -5,6 +5,7 @@
 import UIKit
 import Photos
 import PhotosUI
+import UniformTypeIdentifiers
 import Ecosia
 import Shared
 
@@ -22,12 +23,12 @@ extension OmniboxUploadPickerCoordinator {
         case .authorized, .limited:
             onGranted()
         case .notDetermined:
-            PHPhotoLibrary.requestAuthorization(for: .readWrite) { newStatus in
+            PHPhotoLibrary.requestAuthorization(for: .readWrite) { [weak self] newStatus in
                 Task { @MainActor in
                     if OmniboxUploadPhotoLibraryAuthorization.isAccessGranted(for: newStatus) {
                         onGranted()
                     } else {
-                        self.presentPhotoLibraryAccessDeniedAlert(on: viewController)
+                        self?.presentPhotoLibraryAccessDeniedAlert(on: viewController)
                     }
                 }
             }
@@ -66,15 +67,73 @@ extension OmniboxUploadPickerCoordinator {
 extension OmniboxUploadPickerCoordinator: PHPickerViewControllerDelegate {
     func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
         picker.dismiss(animated: true)
+        guard !results.isEmpty else { return }
 
-        let items = results.map { result in
-            OmniboxUploadItem(
-                source: .photos,
-                fileName: result.itemProvider.suggestedName ?? "photo",
-                contentTypeIdentifier: result.itemProvider.registeredTypeIdentifiers.first
+        let pendingItems = results.map { result in
+            let fileName = result.itemProvider.suggestedName ?? "photo.jpg"
+            let typeIdentifier = result.itemProvider.registeredTypeIdentifiers.first ?? UTType.jpeg.identifier
+            return OmniboxUploadPendingItem(fileName: fileName, layout: .image) {
+                try await Self.loadPhoto(from: result.itemProvider,
+                                         fileName: fileName,
+                                         typeIdentifier: typeIdentifier)
+            }
+        }
+        delegate?.omniboxUploadDidPickPendingItems(pendingItems)
+    }
+
+    private static func loadPhoto(from itemProvider: NSItemProvider,
+                                  fileName: String,
+                                  typeIdentifier: String) async throws -> OmniboxUploadLocalPayload {
+        if itemProvider.canLoadObject(ofClass: UIImage.self) {
+            let image = try await loadUIImage(from: itemProvider)
+            guard let data = image.jpegData(compressionQuality: 0.92) else {
+                throw OmniboxUploadPayloadError.unreadable
+            }
+            return try OmniboxUploadPayloadLoader.loadImage(
+                data: data,
+                fileName: fileName,
+                mimeType: UTType.jpeg.preferredMIMEType ?? "image/jpeg"
             )
         }
-        guard !items.isEmpty else { return }
-        delegate?.omniboxUploadDidSelect(items: items)
+
+        return try await withCheckedThrowingContinuation { continuation in
+            itemProvider.loadDataRepresentation(forTypeIdentifier: typeIdentifier) { data, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                guard let data else {
+                    continuation.resume(throwing: OmniboxUploadPayloadError.unreadable)
+                    return
+                }
+                do {
+                    let mimeType = UTType(typeIdentifier)?.preferredMIMEType ?? "image/jpeg"
+                    let payload = try OmniboxUploadPayloadLoader.loadImage(
+                        data: data,
+                        fileName: fileName,
+                        mimeType: mimeType
+                    )
+                    continuation.resume(returning: payload)
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    private static func loadUIImage(from itemProvider: NSItemProvider) async throws -> UIImage {
+        try await withCheckedThrowingContinuation { continuation in
+            itemProvider.loadObject(ofClass: UIImage.self) { object, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                guard let image = object as? UIImage else {
+                    continuation.resume(throwing: OmniboxUploadPayloadError.unreadable)
+                    return
+                }
+                continuation.resume(returning: image)
+            }
+        }
     }
 }

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadPickerDelegate.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadPickerDelegate.swift
@@ -6,5 +6,5 @@ import Ecosia
 
 @MainActor
 protocol OmniboxUploadPickerDelegate: AnyObject {
-    func omniboxUploadDidSelect(items: [OmniboxUploadItem])
+    func omniboxUploadDidPickPendingItems(_ items: [OmniboxUploadPendingItem])
 }

--- a/firefox-ios/Ecosia/Account/Auth/EcosiaAuthScopes.swift
+++ b/firefox-ios/Ecosia/Account/Auth/EcosiaAuthScopes.swift
@@ -1,0 +1,56 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// OAuth scopes requested during native Auth0 authentication.
+public enum EcosiaAuthScopes {
+    public static let oauthScope =
+        "openid profile email offline_access read:impact write:impact read:conversations write:conversations"
+
+    public static let conversationScopes: Set<String> = [
+        "read:conversations",
+        "write:conversations"
+    ]
+
+    public static func hasConversationScopes(in accessToken: String, grantedScope: String? = nil) -> Bool {
+        if let grantedScope, conversationScopes.isSubset(of: parseScopeString(grantedScope)) {
+            return true
+        }
+        guard let grantedScopes = parseScopeClaim(from: accessToken) else { return false }
+        return conversationScopes.isSubset(of: grantedScopes)
+    }
+
+    public static func parseScopeString(_ scope: String) -> Set<String> {
+        Set(scope.split(separator: " ").map(String.init))
+    }
+
+    public static func parseScopeClaim(from accessToken: String) -> Set<String>? {
+        guard let payload = jwtPayload(from: accessToken) else { return nil }
+        if let scope = payload["scope"] as? String {
+            return Set(scope.split(separator: " ").map(String.init))
+        }
+        if let scopes = payload["scope"] as? [String] {
+            return Set(scopes)
+        }
+        return nil
+    }
+
+    private static func jwtPayload(from token: String) -> [String: Any]? {
+        let segments = token.split(separator: ".")
+        guard segments.count >= 2 else { return nil }
+        var base64 = String(segments[1])
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        let padding = 4 - base64.count % 4
+        if padding < 4 {
+            base64 += String(repeating: "=", count: padding)
+        }
+        guard let data = Data(base64Encoded: base64),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return json
+    }
+}

--- a/firefox-ios/Ecosia/Account/Auth/EcosiaAuthenticationService.swift
+++ b/firefox-ios/Ecosia/Account/Auth/EcosiaAuthenticationService.swift
@@ -38,6 +38,9 @@ public final class EcosiaAuthenticationService: @unchecked Sendable {
     /// This token is used to access protected resources.
     public private(set) var accessToken: String?
 
+    /// OAuth scopes granted with the current access token (from Auth0 token response).
+    private(set) var grantedScope: String?
+
     /// The current refresh token for the authenticated user.
     /// This token is used to obtain new access tokens when they expire.
     private(set) var refreshToken: String?
@@ -128,6 +131,11 @@ public final class EcosiaAuthenticationService: @unchecked Sendable {
         return accountOrigin
     }
 
+    /// Whether the current session includes conversation API scopes.
+    public var hasConversationScopes: Bool {
+        EcosiaAuthScopes.hasConversationScopes(in: accessToken ?? "", grantedScope: grantedScope)
+    }
+
     /// Logs out the user with option to skip web logout (for web-initiated logout)
     /// - Parameter triggerWebLogout: Whether to clear the web session. Defaults to true.
     /// - Throws: `AuthError.userCancelled` if user cancels the logout web session,
@@ -204,8 +212,13 @@ public final class EcosiaAuthenticationService: @unchecked Sendable {
             }
             EcosiaLogger.auth.info("Retrieved stored credentials successfully")
 
-            // Dispatch state loaded with current authentication status
             await dispatchAuthStateChange(isLoggedIn: self.isLoggedIn, fromCredentialRetrieval: true)
+
+            do {
+                try await renewCredentialsIfNeeded()
+            } catch {
+                EcosiaLogger.auth.error("Failed to refresh stored credentials after retrieval: \(error)")
+            }
         } catch {
             EcosiaLogger.auth.error("Failed to retrieve credentials: \(error)")
             // Even if retrieval fails, dispatch state loaded as false
@@ -251,6 +264,7 @@ public final class EcosiaAuthenticationService: @unchecked Sendable {
                                             accountOrigin: AccountOrigin? = nil) {
         self.idToken = credentials?.idToken
         self.accessToken = credentials?.accessToken
+        self.grantedScope = credentials?.scope
         self.refreshToken = credentials?.refreshToken
         let wasLoggedIn = self.isLoggedIn
         self.isLoggedIn = isLoggedIn

--- a/firefox-ios/Ecosia/Account/Auth/NativeToWebSSOAuth0Provider.swift
+++ b/firefox-ios/Ecosia/Account/Auth/NativeToWebSSOAuth0Provider.swift
@@ -31,7 +31,7 @@ public struct NativeToWebSSOAuth0Provider: Auth0ProviderProtocol {
         makeHttpsWebAuth()
             .useEphemeralSession()
             .audience(environment.urlProvider.authApiAudience.absoluteString)
-            .scope("openid profile email offline_access read:impact write:impact")
+            .scope(EcosiaAuthScopes.oauthScope)
     }
 
     public func startAuth() async throws -> Credentials {

--- a/firefox-ios/Ecosia/Core/Cloudflare/CloudflareAccessCookieBootstrap.swift
+++ b/firefox-ios/Ecosia/Core/Cloudflare/CloudflareAccessCookieBootstrap.swift
@@ -86,11 +86,19 @@ public enum CloudflareAccessCookieBootstrap {
     }
 
     static func authorizationCookies(from response: HTTPURLResponse, for url: URL) -> [HTTPCookie] {
-        guard let headerFields = response.allHeaderFields as? [String: String] else {
-            return []
-        }
+        let headerFields = stringHeaderFields(from: response.allHeaderFields)
         return HTTPCookie.cookies(withResponseHeaderFields: headerFields, for: url)
             .filter { $0.name == authorizationCookieName }
+    }
+
+    static func stringHeaderFields(from allHeaderFields: [AnyHashable: Any]) -> [String: String] {
+        allHeaderFields.reduce(into: [String: String]()) { fields, entry in
+            guard let key = entry.key as? String,
+                  let value = entry.value as? String else {
+                return
+            }
+            fields[key] = value
+        }
     }
 }
 

--- a/firefox-ios/Ecosia/Core/Cloudflare/CloudflareAccessCookieBootstrap.swift
+++ b/firefox-ios/Ecosia/Core/Cloudflare/CloudflareAccessCookieBootstrap.swift
@@ -1,0 +1,117 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import WebKit
+
+/// Exchanges staging Cloudflare Access service-token credentials for a
+/// `CF_Authorization` cookie and stores it in the WKWebView cookie jar.
+///
+/// AI chat calls `api.ecosia-staging.xyz` from JavaScript; `Tab.ecosiaUpdatedRequest`
+/// only adds service-token headers to top-level navigations. Planting the cookie lets
+/// fetch/XHR authenticate without patching page scripts.
+///
+/// Native `URLSession` uploads also call this on staging so presign POSTs carry the
+/// cookie when Cloudflare Access rejects service-token headers alone.
+///
+/// Staging-only — production has no Cloudflare Access on the API host.
+public enum CloudflareAccessCookieBootstrap {
+
+    static let authorizationCookieName = "CF_Authorization"
+
+    /// Fetches `CF_Authorization` via service-token headers and copies it into the
+    /// default WK cookie store (and shared `HTTPCookieStorage` for consistency).
+    @MainActor
+    public static func syncAuthorizationCookieToWebView(
+        environment: Environment = .current,
+        cookieStore: CookieStoreProtocol = WKWebsiteDataStore.default().httpCookieStore
+    ) async {
+        guard environment == .staging, let auth = environment.cloudFlareAuth else {
+            return
+        }
+
+        let apiURL = environment.urlProvider.apiRoot
+        EcosiaLogger.network.info(
+            "[CloudflareAccess] Bootstrapping \(authorizationCookieName) for \(apiURL.host ?? "api")"
+        )
+
+        do {
+            guard let cookie = try await fetchAuthorizationCookie(apiURL: apiURL, auth: auth) else {
+                EcosiaLogger.network.error(
+                    "[CloudflareAccess] No \(authorizationCookieName) cookie returned from \(apiURL.absoluteString)"
+                )
+                return
+            }
+
+            HTTPCookieStorage.shared.setCookie(cookie)
+            await cookieStore.setCookie(cookie)
+            EcosiaLogger.network.info(
+                "[CloudflareAccess] Stored \(authorizationCookieName) for domain=\(cookie.domain)"
+            )
+        } catch {
+            EcosiaLogger.network.error(
+                "[CloudflareAccess] Cookie bootstrap failed: \(error.localizedDescription)"
+            )
+        }
+    }
+
+    // MARK: - Private
+
+    private static func fetchAuthorizationCookie(
+        apiURL: URL,
+        auth: Environment.CloudFlareAuth
+    ) async throws -> HTTPCookie? {
+        var request = URLRequest(url: apiURL)
+        request.httpMethod = "GET"
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+        request = request.withCloudFlareAuthParameters(auth: auth)
+
+        let delegate = CookieCaptureDelegate()
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.httpShouldSetCookies = true
+        configuration.httpCookieStorage = HTTPCookieStorage.shared
+        let session = URLSession(configuration: configuration, delegate: delegate, delegateQueue: nil)
+
+        let (_, response) = try await session.data(for: request)
+        session.invalidateAndCancel()
+
+        var cookies = delegate.capturedCookies
+        if let http = response as? HTTPURLResponse, let url = http.url {
+            cookies.append(contentsOf: authorizationCookies(from: http, for: url))
+        }
+        cookies.append(contentsOf: HTTPCookieStorage.shared.cookies(for: apiURL) ?? [])
+
+        return cookies.first(where: { $0.name == authorizationCookieName })
+    }
+
+    static func authorizationCookies(from response: HTTPURLResponse, for url: URL) -> [HTTPCookie] {
+        guard let headerFields = response.allHeaderFields as? [String: String] else {
+            return []
+        }
+        return HTTPCookie.cookies(withResponseHeaderFields: headerFields, for: url)
+            .filter { $0.name == authorizationCookieName }
+    }
+}
+
+// MARK: - Redirect cookie capture
+
+private final class CookieCaptureDelegate: NSObject, URLSessionTaskDelegate {
+
+    private(set) var capturedCookies: [HTTPCookie] = []
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        willPerformHTTPRedirection response: HTTPURLResponse,
+        newRequest request: URLRequest,
+        completionHandler: @escaping (URLRequest?) -> Void
+    ) {
+        if let url = response.url {
+            capturedCookies.append(
+                contentsOf: CloudflareAccessCookieBootstrap.authorizationCookies(from: response, for: url)
+            )
+        }
+        completionHandler(request)
+    }
+}

--- a/firefox-ios/Ecosia/Core/Cookie/CookieStoreProtocol.swift
+++ b/firefox-ios/Ecosia/Core/Cookie/CookieStoreProtocol.swift
@@ -9,4 +9,16 @@ public protocol CookieStoreProtocol: Sendable {
     func setCookie(_ cookie: HTTPCookie) async
 }
 
-extension WKHTTPCookieStore: CookieStoreProtocol {}
+extension WKHTTPCookieStore: CookieStoreProtocol {
+    public func allCookies() async -> [HTTPCookie] {
+        await withCheckedContinuation { continuation in
+            getAllCookies { continuation.resume(returning: $0) }
+        }
+    }
+
+    public func setCookie(_ cookie: HTTPCookie) async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            setCookie(cookie) { continuation.resume() }
+        }
+    }
+}

--- a/firefox-ios/Ecosia/Core/Environment/URLProvider.swift
+++ b/firefox-ios/Ecosia/Core/Environment/URLProvider.swift
@@ -32,6 +32,12 @@ public enum URLProvider {
     public var searchAutocomplete: URL {
         // For now only production to avoid messing with Firefox's logic to include CF headers.
         URL(string: "https://ac.ecosia.org/autocomplete")!
+	}
+
+    /// Endpoint that issues the EAIST Cloudflare WAF protection cookie.
+    /// Must be called before requests to AI Worker endpoints — matches web `refreshToken()`.
+    public var aiChatRefresh: URL {
+        root.appendingPathComponent("ai-chat/refresh")
     }
 
     public var snowplowMicro: String? {
@@ -215,7 +221,11 @@ public enum URLProvider {
     /// from (`origin`) and seeded with a `query` to start the conversation.
     /// Centralizing both parameters here keeps callers from having to know
     /// the URL's query-item conventions.
-    public func aiChat(origin: AIChatOrigin? = nil, query: String? = nil) -> URL {
+    public func aiChat(
+        origin: AIChatOrigin? = nil,
+        query: String? = nil,
+        files: [AIChatFileQuery] = []
+    ) -> URL {
         let baseURL = root.appendingPathComponent("ai-chat")
         var items: [URLQueryItem] = []
         if let origin {
@@ -224,8 +234,11 @@ public enum URLProvider {
         if let query {
             items.append(URLQueryItem(name: "q", value: query))
         }
+        if !files.isEmpty, let filesJSON = AIChatFileQuery.urlQueryValue(files) {
+            items.append(URLQueryItem(name: "files", value: filesJSON))
+        }
         guard !items.isEmpty else { return baseURL }
-        return baseURL.appendingQueryItems(items)
+        return baseURL.appendingPercentEncodedQueryItems(items)
     }
 
     public var storeWriteReviewPage: URL {
@@ -290,5 +303,49 @@ public enum URLProvider {
     /// Returns the same value as `auth0Domain` since they must match for custom domain authentication
     public var auth0CookieDomain: String {
         auth0Domain
+    }
+}
+
+/// File metadata for the web AI chat `files` URL query parameter.
+/// Matches `nxt-ai-search` omnibox routing (`fileId`, `filename`, `mimeType`, `sizeBytes`).
+public struct AIChatFileQuery: Codable, Equatable, Sendable {
+    public let fileId: String
+    public let filename: String
+    public let mimeType: String
+    public let sizeBytes: Int
+
+    public init(fileId: String, filename: String, mimeType: String, sizeBytes: Int) {
+        self.fileId = fileId
+        self.filename = Self.filenameEnsuringExtension(filename, mimeType: mimeType)
+        self.mimeType = mimeType
+        self.sizeBytes = sizeBytes
+    }
+
+    /// The AI Worker validates the extension in `filename` (e.g. `IMG_0111` → rejected, `IMG_0111.jpg` → ok).
+    static func filenameEnsuringExtension(_ filename: String, mimeType: String) -> String {
+        if !URL(fileURLWithPath: filename).pathExtension.isEmpty {
+            return filename
+        }
+        guard let ext = preferredExtension(for: mimeType) else { return filename }
+        return "\(filename).\(ext)"
+    }
+
+    static func preferredExtension(for mimeType: String) -> String? {
+        switch mimeType.lowercased() {
+        case "image/jpeg": return "jpg"
+        case "image/png": return "png"
+        case "application/pdf": return "pdf"
+        case "text/plain": return "txt"
+        case "application/msword": return "doc"
+        case "application/vnd.openxmlformats-officedocument.wordprocessingml.document": return "docx"
+        case "application/vnd.ms-powerpoint": return "ppt"
+        case "application/vnd.openxmlformats-officedocument.presentationml.presentation": return "pptx"
+        default: return nil
+        }
+    }
+
+    static func urlQueryValue(_ files: [AIChatFileQuery]) -> String? {
+        guard let data = try? JSONEncoder().encode(files) else { return nil }
+        return String(data: data, encoding: .utf8)
     }
 }

--- a/firefox-ios/Ecosia/Core/Environment/URLProvider.swift
+++ b/firefox-ios/Ecosia/Core/Environment/URLProvider.swift
@@ -32,7 +32,7 @@ public enum URLProvider {
     public var searchAutocomplete: URL {
         // For now only production to avoid messing with Firefox's logic to include CF headers.
         URL(string: "https://ac.ecosia.org/autocomplete")!
-	}
+    }
 
     /// Endpoint that issues the EAIST Cloudflare WAF protection cookie.
     /// Must be called before requests to AI Worker endpoints — matches web `refreshToken()`.

--- a/firefox-ios/Ecosia/Core/FileUpload/FilePresignRequest.swift
+++ b/firefox-ios/Ecosia/Core/FileUpload/FilePresignRequest.swift
@@ -21,14 +21,43 @@ struct FilePresignRequest: BaseRequest {
 
     var additionalHeaders: [String: String]?
 
-    init(accessToken: String, authSessionCookie: HTTPCookie? = nil) {
+    init(
+        accessToken: String,
+        authSessionCookie: HTTPCookie? = nil,
+        cookieStorage: HTTPCookieStorage = .shared,
+        apiRoot: URL = Environment.current.urlProvider.apiRoot
+    ) {
         var headers = [
             "Authorization": "Bearer \(accessToken)",
             "X-API-Version": "v1",
         ]
-        if let authSessionCookie {
-            headers["Cookie"] = "\(authSessionCookie.name)=\(authSessionCookie.value)"
+        if let cookieHeader = Self.cookieHeaderValue(
+            cookieStorage: cookieStorage,
+            apiRoot: apiRoot,
+            authSessionCookie: authSessionCookie
+        ) {
+            headers["Cookie"] = cookieHeader
         }
         additionalHeaders = headers
+    }
+
+    /// Merges cookies already stored for the API host with the explicit auth-session cookie.
+    static func cookieHeaderValue(
+        cookieStorage: HTTPCookieStorage,
+        apiRoot: URL,
+        authSessionCookie: HTTPCookie?
+    ) -> String? {
+        var cookiesByName: [String: String] = [:]
+        for cookie in cookieStorage.cookies(for: apiRoot) ?? [] {
+            cookiesByName[cookie.name] = cookie.value
+        }
+        if let authSessionCookie {
+            cookiesByName[authSessionCookie.name] = authSessionCookie.value
+        }
+        guard !cookiesByName.isEmpty else { return nil }
+        return cookiesByName
+            .sorted { $0.key < $1.key }
+            .map { "\($0.key)=\($0.value)" }
+            .joined(separator: "; ")
     }
 }

--- a/firefox-ios/Ecosia/Core/FileUpload/FilePresignRequest.swift
+++ b/firefox-ios/Ecosia/Core/FileUpload/FilePresignRequest.swift
@@ -1,0 +1,34 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// POST to the AI Worker to obtain a presigned upload URL and `file_id`.
+///
+/// The route is protected by `setAuthNoOptOut` + `requireScopes(['write:conversations'])`.
+/// Today the middleware reads the `EASC` web session cookie; Bearer token support for
+/// native Auth0 clients is a pending backend change (see spike branch notes).
+struct FilePresignRequest: BaseRequest {
+
+    var method: HTTPMethod { .post }
+
+    var path: String { "/v2/conversations/files/upload" }
+
+    var queryParameters: [String: String]?
+
+    var body: Data?
+
+    var additionalHeaders: [String: String]?
+
+    init(accessToken: String, authSessionCookie: HTTPCookie? = nil) {
+        var headers = [
+            "Authorization": "Bearer \(accessToken)",
+            "X-API-Version": "v1",
+        ]
+        if let authSessionCookie {
+            headers["Cookie"] = "\(authSessionCookie.name)=\(authSessionCookie.value)"
+        }
+        additionalHeaders = headers
+    }
+}

--- a/firefox-ios/Ecosia/Core/FileUpload/FileUploadAuthCookieSync.swift
+++ b/firefox-ios/Ecosia/Core/FileUpload/FileUploadAuthCookieSync.swift
@@ -13,11 +13,17 @@ import WebKit
 enum FileUploadAuthCookieSync {
 
     /// Copies `EASC` from WK into shared storage and returns it for explicit request headers.
+    private static func webViewCookies(from store: CookieStoreProtocol) async -> [HTTPCookie] {
+        await store.allCookies()
+    }
+
     @discardableResult
     static func syncAuthSessionCookieToSharedStorage(
-        urlProvider: URLProvider = Environment.current.urlProvider
+        urlProvider: URLProvider = Environment.current.urlProvider,
+        cookieStore: CookieStoreProtocol? = nil
     ) async -> HTTPCookie? {
-        let webCookies = await webViewCookies()
+        let store = cookieStore ?? WKWebsiteDataStore.default().httpCookieStore
+        let webCookies = await webViewCookies(from: store)
         let easc = webCookies.first { $0.name == Cookie.authSession.rawValue }
 
         if let easc {
@@ -38,14 +44,6 @@ enum FileUploadAuthCookieSync {
         )
 
         return easc ?? sharedCookies.first { $0.name == Cookie.authSession.rawValue }
-    }
-
-    private static func webViewCookies() async -> [HTTPCookie] {
-        await withCheckedContinuation { continuation in
-            WKWebsiteDataStore.default().httpCookieStore.getAllCookies { cookies in
-                continuation.resume(returning: cookies)
-            }
-        }
     }
 }
 

--- a/firefox-ios/Ecosia/Core/FileUpload/FileUploadAuthCookieSync.swift
+++ b/firefox-ios/Ecosia/Core/FileUpload/FileUploadAuthCookieSync.swift
@@ -1,0 +1,74 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import WebKit
+
+/// Bridges `EASC` from the WKWebView cookie jar into `HTTPCookieStorage.shared`.
+///
+/// Native API calls (`URLSession`) do not see cookies that only exist in
+/// `WKWebsiteDataStore`. The AI Worker presign route currently authenticates via
+/// the `EASC` session cookie (web login), not the Auth0 Bearer token.
+enum FileUploadAuthCookieSync {
+
+    /// Copies `EASC` from WK into shared storage and returns it for explicit request headers.
+    @discardableResult
+    static func syncAuthSessionCookieToSharedStorage(
+        urlProvider: URLProvider = Environment.current.urlProvider
+    ) async -> HTTPCookie? {
+        let webCookies = await webViewCookies()
+        let easc = webCookies.first { $0.name == Cookie.authSession.rawValue }
+
+        if let easc {
+            HTTPCookieStorage.shared.setCookie(easc)
+            EcosiaLogger.network.info(
+                "[FileUpload] Synced EASC from WK cookie store to HTTPCookieStorage (domain=\(easc.domain))"
+            )
+        } else {
+            EcosiaLogger.network.error(
+                "[FileUpload] No EASC cookie in WK cookie store — presign may return 401 until web session is established"
+            )
+        }
+
+        let sharedCookies = HTTPCookieStorage.shared.cookies(for: urlProvider.apiRoot) ?? []
+        let sharedEASC = sharedCookies.contains { $0.name == Cookie.authSession.rawValue }
+        EcosiaLogger.network.info(
+            "[FileUpload] EASC in HTTPCookieStorage for api root: \(sharedEASC) (total cookies=\(sharedCookies.count))"
+        )
+
+        return easc ?? sharedCookies.first { $0.name == Cookie.authSession.rawValue }
+    }
+
+    private static func webViewCookies() async -> [HTTPCookie] {
+        await withCheckedContinuation { continuation in
+            WKWebsiteDataStore.default().httpCookieStore.getAllCookies { cookies in
+                continuation.resume(returning: cookies)
+            }
+        }
+    }
+}
+
+enum FileUploadAuthDiagnostics {
+
+    static func logAccessTokenScopes(_ accessToken: String, grantedScope: String? = nil) {
+        let scopes = EcosiaAuthScopes.parseScopeClaim(from: accessToken)
+            ?? grantedScope.map(EcosiaAuthScopes.parseScopeString)
+
+        guard let scopes else {
+            EcosiaLogger.network.error("[FileUpload] Could not determine token scopes from JWT or granted scope")
+            return
+        }
+
+        let joined = scopes.sorted().joined(separator: " ")
+        let hasWriteConversations = scopes.contains("write:conversations")
+        EcosiaLogger.network.info(
+            "[FileUpload] Token scopes: \(joined) (write:conversations=\(hasWriteConversations))"
+        )
+        if !hasWriteConversations {
+            EcosiaLogger.network.error(
+                "[FileUpload] Token is missing write:conversations — CredentialsManager scope refresh is required"
+            )
+        }
+    }
+}

--- a/firefox-ios/Ecosia/Core/FileUpload/FileUploadService.swift
+++ b/firefox-ios/Ecosia/Core/FileUpload/FileUploadService.swift
@@ -1,0 +1,291 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+// MARK: - Input / Output
+
+public struct FileUploadInput: Sendable {
+    public let data: Data
+    public let mimeType: String
+
+    public init(data: Data, mimeType: String) {
+        self.data = data
+        self.mimeType = mimeType
+    }
+}
+
+public struct FileUploadResult: Sendable {
+    /// Index-aligned with the input array; `nil` means that file failed to upload.
+    public let fileIds: [String?]
+    public let errors: [Error]
+}
+
+// MARK: - Presign response
+
+private struct PresignResponse: Decodable {
+    let fileId: String
+    let uploadURL: URL
+
+    enum CodingKeys: String, CodingKey {
+        case fileId = "file_id"
+        case uploadURL = "upload_url"
+    }
+}
+
+// MARK: - Service
+
+/// Mirrors the web `file-upload-service.js` two-step presigned URL flow:
+///   1. POST `www.{domain}/ai-chat/refresh` → sets EAIST Cloudflare WAF cookie
+///   2. POST `/v2/conversations/files/upload` → get `{ file_id, upload_url }`
+///   3. PUT raw bytes → R2 presigned URL
+public final class FileUploadService: Sendable {
+
+    enum Error: Swift.Error, LocalizedError {
+        case network(statusCode: Int, body: String?)
+        case eaistRefreshFailed(statusCode: Int)
+        case invalidPresignResponse(body: String?)
+        case uploadFailed(statusCode: Int)
+        case authenticationRequired
+        case timedOut
+
+        var errorDescription: String? {
+            switch self {
+            case .network(let statusCode, let body):
+                return "Network error (status \(statusCode)): \(body ?? "no body")"
+            case .eaistRefreshFailed(let statusCode):
+                return "EAIST refresh failed (status \(statusCode))"
+            case .invalidPresignResponse(let body):
+                return "Invalid presign response: \(body ?? "no body")"
+            case .uploadFailed(let statusCode):
+                return "PUT upload failed (status \(statusCode))"
+            case .authenticationRequired:
+                return "Authentication required"
+            case .timedOut:
+                return "Upload timed out"
+            }
+        }
+    }
+
+    private let client: HTTPClient
+    private let authenticationService: EcosiaAuthenticationService
+    private let timeout: TimeInterval
+
+    public init(
+        client: HTTPClient = URLSessionHTTPClient(),
+        authenticationService: EcosiaAuthenticationService = .shared,
+        timeout: TimeInterval = 20
+    ) {
+        self.client = client
+        self.authenticationService = authenticationService
+        self.timeout = timeout
+    }
+
+    /// Upload a single file. Returns the `file_id` on success.
+    public func uploadFile(_ file: FileUploadInput) async throws -> String {
+        log(.info, "Starting upload mimeType=\(file.mimeType) size=\(file.data.count)")
+        do {
+            try await refreshEAIST()
+            let authSessionCookie = await FileUploadAuthCookieSync.syncAuthSessionCookieToSharedStorage()
+            let accessToken = try await validAccessToken()
+            FileUploadAuthDiagnostics.logAccessTokenScopes(
+                accessToken,
+                grantedScope: authenticationService.grantedScope
+            )
+            let fileId = try await withUploadTimeout(timeout) {
+                try await self.uploadSingleFile(file, accessToken: accessToken, authSessionCookie: authSessionCookie)
+            }
+            log(.info, "Upload succeeded fileId=\(fileId)")
+            return fileId
+        } catch {
+            log(.error, "Upload failed: \(error.localizedDescription)")
+            throw error
+        }
+    }
+
+    /// Upload multiple files concurrently with a per-file timeout.
+    public func uploadFiles(_ files: [FileUploadInput]) async -> FileUploadResult {
+        do {
+            try await refreshEAIST()
+        } catch {
+            return FileUploadResult(fileIds: Array(repeating: nil, count: files.count), errors: [error])
+        }
+
+        let authSessionCookie = await FileUploadAuthCookieSync.syncAuthSessionCookieToSharedStorage()
+        let accessToken: String
+        do {
+            accessToken = try await validAccessToken()
+            FileUploadAuthDiagnostics.logAccessTokenScopes(
+                accessToken,
+                grantedScope: authenticationService.grantedScope
+            )
+        } catch {
+            return FileUploadResult(fileIds: Array(repeating: nil, count: files.count), errors: [error])
+        }
+
+        var fileIds = [String?](repeating: nil, count: files.count)
+        var errors = [Swift.Error]()
+        let timeout = self.timeout
+
+        await withTaskGroup(of: (Int, Result<String, Swift.Error>).self) { group in
+            for (index, file) in files.enumerated() {
+                group.addTask {
+                    do {
+                        let fileId = try await withUploadTimeout(timeout) {
+                            try await self.uploadSingleFile(
+                                file,
+                                accessToken: accessToken,
+                                authSessionCookie: authSessionCookie
+                            )
+                        }
+                        return (index, .success(fileId))
+                    } catch {
+                        return (index, .failure(error))
+                    }
+                }
+            }
+
+            for await (index, result) in group {
+                switch result {
+                case .success(let id):
+                    fileIds[index] = id
+                case .failure(let error):
+                    errors.append(error)
+                }
+            }
+        }
+
+        return FileUploadResult(fileIds: fileIds, errors: errors)
+    }
+
+    // MARK: - Private
+
+    /// Staging API POSTs can be blocked by Cloudflare Access unless `CF_Authorization`
+    /// is present in `HTTPCookieStorage`, even when service-token headers are set.
+    private func ensureCloudflareAccessCookieForStagingAPI() async {
+        guard Environment.current == .staging else { return }
+        await CloudflareAccessCookieBootstrap.syncAuthorizationCookieToWebView()
+    }
+
+    private func refreshEAIST() async throws {
+        await ensureCloudflareAccessCookieForStagingAPI()
+        let url = Environment.current.urlProvider.aiChatRefresh
+        log(.info, "Refreshing EAIST cookie url=\(url.absoluteString)")
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+        request.httpBody = Data("{}".utf8)
+
+        let (_, response) = try await URLSession.shared.data(for: request)
+        let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            log(.error, "EAIST refresh failed status=\(statusCode)")
+            throw Error.eaistRefreshFailed(statusCode: statusCode)
+        }
+        log(.info, "EAIST refresh succeeded status=\(http.statusCode)")
+    }
+
+    private func validAccessToken() async throws -> String {
+        try await authenticationService.renewCredentialsIfNeeded()
+        guard let token = authenticationService.accessToken, !token.isEmpty else {
+            log(.error, "No valid access token after renewal")
+            throw Error.authenticationRequired
+        }
+        guard authenticationService.hasConversationScopes else {
+            log(.error, "Access token missing conversation scopes")
+            throw Error.authenticationRequired
+        }
+        log(.info, "Access token available (length=\(token.count))")
+        return token
+    }
+
+    private func uploadSingleFile(
+        _ file: FileUploadInput,
+        accessToken: String,
+        authSessionCookie: HTTPCookie?
+    ) async throws -> String {
+        let presign = try await fetchPresignedURL(accessToken: accessToken, authSessionCookie: authSessionCookie)
+        try await putFile(file, to: presign.uploadURL)
+        return presign.fileId
+    }
+
+    private func fetchPresignedURL(accessToken: String, authSessionCookie: HTTPCookie?) async throws -> PresignResponse {
+        log(.info, "Requesting presigned URL (EASC attached=\(authSessionCookie != nil))")
+        let request = FilePresignRequest(accessToken: accessToken, authSessionCookie: authSessionCookie)
+        let (data, response) = try await client.perform(request)
+        let statusCode = response?.statusCode ?? -1
+        let body = String(data: data, encoding: .utf8)
+
+        switch statusCode {
+        case 200:
+            break
+        case 401, 403:
+            log(.error, "Presign unauthorized status=\(statusCode) body=\(body ?? "nil") — " +
+                "AI Worker expects EASC cookie; Bearer fallback may not be deployed yet. " +
+                "Try signing out/in to refresh scopes and establish a web session.")
+            throw Error.authenticationRequired
+        default:
+            log(.error, "Presign failed status=\(statusCode) body=\(body ?? "nil")")
+            throw Error.network(statusCode: statusCode, body: body)
+        }
+
+        guard let presign = try? JSONDecoder().decode(PresignResponse.self, from: data) else {
+            log(.error, "Failed to decode presign response body=\(body ?? "nil")")
+            throw Error.invalidPresignResponse(body: body)
+        }
+        log(.info, "Got presigned URL fileId=\(presign.fileId) host=\(presign.uploadURL.host ?? "?")")
+        return presign
+    }
+
+    private func putFile(_ file: FileUploadInput, to url: URL) async throws {
+        log(.info, "PUT to presigned URL host=\(url.host ?? "unknown")")
+        var request = URLRequest(url: url)
+        request.httpMethod = "PUT"
+        request.setValue(file.mimeType, forHTTPHeaderField: "Content-Type")
+
+        let (_, response) = try await URLSession.shared.upload(for: request, from: file.data)
+        let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            log(.error, "PUT failed status=\(statusCode)")
+            throw Error.uploadFailed(statusCode: statusCode)
+        }
+        log(.info, "PUT succeeded status=\(http.statusCode)")
+    }
+
+    private enum LogLevel {
+        case info, error
+    }
+
+    private func log(_ level: LogLevel, _ message: String) {
+        let formatted = "[FileUpload] \(message)"
+        switch level {
+        case .info:
+            EcosiaLogger.network.info(formatted)
+        case .error:
+            EcosiaLogger.network.error(formatted)
+        }
+    }
+}
+
+// MARK: - Timeout helper
+
+private func withUploadTimeout<T: Sendable>(
+    _ timeout: TimeInterval,
+    operation: @Sendable @escaping () async throws -> T
+) async throws -> T {
+    try await withThrowingTaskGroup(of: T.self) { group in
+        group.addTask { try await operation() }
+        group.addTask {
+            try await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+            throw FileUploadService.Error.timedOut
+        }
+        guard let result = try await group.next() else {
+            throw FileUploadService.Error.timedOut
+        }
+        group.cancelAll()
+        return result
+    }
+}

--- a/firefox-ios/Ecosia/Core/FileUpload/FileUploadService.swift
+++ b/firefox-ios/Ecosia/Core/FileUpload/FileUploadService.swift
@@ -36,10 +36,12 @@ private struct PresignResponse: Decodable {
 
 // MARK: - Service
 
-/// Mirrors the web `file-upload-service.js` two-step presigned URL flow:
+/// Mirrors the web `file-upload-service.js` presigned URL flow:
 ///   1. POST `www.{domain}/ai-chat/refresh` → sets EAIST Cloudflare WAF cookie
 ///   2. POST `/v2/conversations/files/upload` → get `{ file_id, upload_url }`
 ///   3. PUT raw bytes → R2 presigned URL
+///
+/// There is no separate confirm step; `file_id` from the presign response is the upload handle.
 public final class FileUploadService: Sendable {
 
     enum Error: Swift.Error, LocalizedError {

--- a/firefox-ios/Ecosia/Core/FileUpload/FileUploadService.swift
+++ b/firefox-ios/Ecosia/Core/FileUpload/FileUploadService.swift
@@ -54,12 +54,12 @@ public final class FileUploadService: Sendable {
 
         var errorDescription: String? {
             switch self {
-            case .network(let statusCode, let body):
-                return "Network error (status \(statusCode)): \(body ?? "no body")"
+            case .network(let statusCode, _):
+                return "Network error (status \(statusCode))"
             case .eaistRefreshFailed(let statusCode):
                 return "EAIST refresh failed (status \(statusCode))"
-            case .invalidPresignResponse(let body):
-                return "Invalid presign response: \(body ?? "no body")"
+            case .invalidPresignResponse:
+                return "Invalid presign response"
             case .uploadFailed(let statusCode):
                 return "PUT upload failed (status \(statusCode))"
             case .authenticationRequired:
@@ -101,7 +101,7 @@ public final class FileUploadService: Sendable {
             log(.info, "Upload succeeded fileId=\(fileId)")
             return fileId
         } catch {
-            log(.error, "Upload failed: \(error.localizedDescription)")
+            log(.error, "Upload failed: \(String(describing: type(of: error)))")
             throw error
         }
     }

--- a/firefox-ios/Ecosia/Core/URL+Extensions.swift
+++ b/firefox-ios/Ecosia/Core/URL+Extensions.swift
@@ -282,8 +282,8 @@ extension URL {
     }
 
     static func percentEncodedQueryComponent(_ value: String) -> String {
-        var allowed = CharacterSet.alphanumerics
-        allowed.insert(charactersIn: "-._~")
+        var allowed = CharacterSet()
+        allowed.insert(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~")
         return value.addingPercentEncoding(withAllowedCharacters: allowed) ?? value
     }
 }

--- a/firefox-ios/Ecosia/Core/URL+Extensions.swift
+++ b/firefox-ios/Ecosia/Core/URL+Extensions.swift
@@ -170,8 +170,19 @@ extension URL {
         // Already carries the correct value — no mutation needed regardless of parameter position.
         if ecosiaUserId == userId { return self }
 
-        guard var components = components else { return self }
-        components.queryItems?.removeAll(where: { $0.name == EcosiaQueryItemName.userId.rawValue })
+        guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false) else { return self }
+
+        let userIdKey = EcosiaQueryItemName.userId.rawValue
+        // Prefer percent-encoded query items so values such as `%3F` in `q` are not
+        // round-tripped through `queryItems` (which decodes `?` and breaks AI chat `files`).
+        if var percentEncodedItems = components.percentEncodedQueryItems {
+            percentEncodedItems.removeAll(where: { $0.name == userIdKey })
+            components.percentEncodedQueryItems = percentEncodedItems.isEmpty ? nil : percentEncodedItems
+            guard let urlWithoutUserId = components.url else { return self }
+            return urlWithoutUserId.appendingPercentEncodedQueryItems([Self.item(name: .userId, value: userId)])
+        }
+
+        components.queryItems?.removeAll(where: { $0.name == userIdKey })
         guard let urlWithoutUserId = components.url else { return self }
         return urlWithoutUserId.appendingQueryItems([Self.item(name: .userId, value: userId)])
     }
@@ -242,5 +253,37 @@ extension URL {
             components.queryItems?.append(contentsOf: queryItems)
             return components.url ?? self
         }
+    }
+
+    /// Appends query items with RFC 3986 percent-encoding for names and values.
+    ///
+    /// `URLQueryItem` / `URLComponents` leave `?` and `&` unencoded in values. The AI chat
+    /// web router splits the location on `?`, so prompts like `What is this?` would drop
+    /// trailing params such as `files`.
+    public func appendingPercentEncodedQueryItems(_ queryItems: [URLQueryItem]) -> URL {
+        guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false) else {
+            return self
+        }
+
+        let encodedItems = queryItems.map {
+            URLQueryItem(
+                name: Self.percentEncodedQueryComponent($0.name),
+                value: $0.value.map(Self.percentEncodedQueryComponent)
+            )
+        }
+
+        if components.percentEncodedQueryItems == nil {
+            components.percentEncodedQueryItems = encodedItems
+        } else {
+            components.percentEncodedQueryItems?.append(contentsOf: encodedItems)
+        }
+
+        return components.url ?? self
+    }
+
+    static func percentEncodedQueryComponent(_ value: String) -> String {
+        var allowed = CharacterSet.alphanumerics
+        allowed.insert(charactersIn: "-._~")
+        return value.addingPercentEncoding(withAllowedCharacters: allowed) ?? value
     }
 }

--- a/firefox-ios/Ecosia/L10N/String.swift
+++ b/firefox-ios/Ecosia/L10N/String.swift
@@ -320,5 +320,10 @@ extension String {
         case chatModeThinkLongerSubtitle = "Solves complex problems"
         case chatModeDisplaySourcesSubtitle = "Shows sources for every answer"
         case chatModeLearningSubtitle = "Breaks down topics step by step"
+
+        // Omnibox file upload (attachment strip)
+        case uploadAttachmentFailed = "Upload failed"
+        case uploadSubmitWaitingForUpload = "Waiting for the attachment to finish uploading"
+        case uploadSubmitUploadFailed = "Remove the failed attachment or try uploading again"
     }
 }

--- a/firefox-ios/Ecosia/L10N/en.lproj/Ecosia.strings
+++ b/firefox-ios/Ecosia/L10N/en.lproj/Ecosia.strings
@@ -317,6 +317,10 @@
 "Solves complex problems" = "Solves complex problems";
 "Shows sources for every answer" = "Shows sources for every answer";
 "Breaks down topics step by step" = "Breaks down topics step by step";
+// Omnibox file upload (attachment strip)
+"Upload failed" = "Upload failed";
+"Waiting for the attachment to finish uploading" = "Waiting for the attachment to finish uploading";
+"Remove the failed attachment or try uploading again" = "Remove the failed attachment or try uploading again";
 
 // Product Tour
 "Go back" = "Go back";

--- a/firefox-ios/Ecosia/UI/NTP/Upload/OmniboxAttachment.swift
+++ b/firefox-ios/Ecosia/UI/NTP/Upload/OmniboxAttachment.swift
@@ -1,0 +1,60 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+public struct OmniboxAttachment: Identifiable, Equatable, Sendable {
+    public let id: UUID
+    public let fileName: String
+    public let layout: Layout
+    public var state: State
+
+    public enum Layout: String, Sendable {
+        case file
+        case image
+    }
+
+    public enum State: Equatable, Sendable {
+        case loading
+        case ready(byteCount: Int, fileId: String, mimeType: String)
+        case failed
+    }
+
+    public init(id: UUID = UUID(), fileName: String, layout: Layout, state: State) {
+        self.id = id
+        self.fileName = fileName
+        self.layout = layout
+        self.state = state
+    }
+
+    public var fileId: String? {
+        if case .ready(_, let fileId, _) = state { return fileId }
+        return nil
+    }
+
+    /// Metadata for the web AI chat `files` query parameter.
+    public var chatFileQuery: AIChatFileQuery? {
+        guard case .ready(let byteCount, let fileId, let mimeType) = state else { return nil }
+        return AIChatFileQuery(
+            fileId: fileId,
+            filename: fileName,
+            mimeType: mimeType,
+            sizeBytes: byteCount
+        )
+    }
+
+    public var isLoading: Bool {
+        if case .loading = state { return true }
+        return false
+    }
+
+    public var isFailed: Bool {
+        if case .failed = state { return true }
+        return false
+    }
+
+    public var isReady: Bool {
+        fileId != nil
+    }
+}

--- a/firefox-ios/EcosiaTests/Account/Auth/EcosiaAuthScopesTests.swift
+++ b/firefox-ios/EcosiaTests/Account/Auth/EcosiaAuthScopesTests.swift
@@ -1,0 +1,54 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import Ecosia
+
+final class EcosiaAuthScopesTests: XCTestCase {
+
+    func testHasConversationScopes_whenScopesPresent_returnsTrue() {
+        let token = Self.makeJWT(scope: "openid read:conversations write:conversations")
+        XCTAssertTrue(EcosiaAuthScopes.hasConversationScopes(in: token))
+    }
+
+    func testHasConversationScopes_whenScopesMissing_returnsFalse() {
+        let token = Self.makeJWT(scope: "openid profile email")
+        XCTAssertFalse(EcosiaAuthScopes.hasConversationScopes(in: token))
+    }
+
+    func testHasConversationScopes_whenGrantedScopeContainsConversationScopes_returnsTrueWithoutJWTScope() {
+        let opaqueToken = "opaque-access-token"
+        XCTAssertTrue(
+            EcosiaAuthScopes.hasConversationScopes(
+                in: opaqueToken,
+                grantedScope: "openid read:conversations write:conversations"
+            )
+        )
+    }
+
+    func testParseScopeClaim_whenScopeIsArray_returnsSet() {
+        let token = Self.makeJWT(scopeArray: ["read:conversations", "write:conversations"])
+        let scopes = EcosiaAuthScopes.parseScopeClaim(from: token)
+        XCTAssertEqual(scopes, ["read:conversations", "write:conversations"])
+    }
+
+    private static func makeJWT(scope: String) -> String {
+        let payload = #"{"scope":"\#(scope)"}"#
+        return "header.\(base64URL(payload)).signature"
+    }
+
+    private static func makeJWT(scopeArray: [String]) -> String {
+        let joined = scopeArray.map { "\"\($0)\"" }.joined(separator: ",")
+        let payload = #"{"scope":[\#(joined)]}"#
+        return "header.\(base64URL(payload)).signature"
+    }
+
+    private static func base64URL(_ string: String) -> String {
+        Data(string.utf8)
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}

--- a/firefox-ios/EcosiaTests/Core/CloudflareAccessCookieBootstrapTests.swift
+++ b/firefox-ios/EcosiaTests/Core/CloudflareAccessCookieBootstrapTests.swift
@@ -35,6 +35,20 @@ final class CloudflareAccessCookieBootstrapTests: XCTestCase {
         XCTAssertEqual(cookies[0].domain, "api.ecosia-staging.xyz")
     }
 
+    func testAuthorizationCookies_convertsAnyHashableHeaderFields() throws {
+        let url = URL(string: "https://api.ecosia-staging.xyz/")!
+        let jwt = "eyJ.test.token"
+        let headerFields = CloudflareAccessCookieBootstrap.stringHeaderFields(from: [
+            "Set-Cookie": "CF_Authorization=\(jwt); Path=/; Secure; HttpOnly; SameSite=None",
+            NSString("Ignored"): "non-string-key"
+        ])
+        let cookies = HTTPCookie.cookies(withResponseHeaderFields: headerFields, for: url)
+            .filter { $0.name == CloudflareAccessCookieBootstrap.authorizationCookieName }
+
+        XCTAssertEqual(cookies.count, 1)
+        XCTAssertEqual(cookies[0].value, jwt)
+    }
+
     private func makeHTTPResponse(
         url: URL,
         statusCode: Int,

--- a/firefox-ios/EcosiaTests/Core/CloudflareAccessCookieBootstrapTests.swift
+++ b/firefox-ios/EcosiaTests/Core/CloudflareAccessCookieBootstrapTests.swift
@@ -1,0 +1,47 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import Ecosia
+
+final class CloudflareAccessCookieBootstrapTests: XCTestCase {
+
+    func testSyncAuthorizationCookieToWebView_noOpForProduction() async {
+        let store = MockHTTPCookieStore()
+        await CloudflareAccessCookieBootstrap.syncAuthorizationCookieToWebView(
+            environment: .production,
+            cookieStore: store
+        )
+        XCTAssertTrue(await store.allCookies().isEmpty)
+    }
+
+    func testAuthorizationCookies_parsesSetCookieHeader() throws {
+        let url = URL(string: "https://api.ecosia-staging.xyz/")!
+        let jwt = "eyJ.test.token"
+        let response = try makeHTTPResponse(
+            url: url,
+            statusCode: 200,
+            headers: [
+                "Set-Cookie": "CF_Authorization=\(jwt); Path=/; Secure; HttpOnly; SameSite=None",
+            ]
+        )
+
+        let cookies = CloudflareAccessCookieBootstrap.authorizationCookies(from: response, for: url)
+
+        XCTAssertEqual(cookies.count, 1)
+        XCTAssertEqual(cookies[0].name, "CF_Authorization")
+        XCTAssertEqual(cookies[0].value, jwt)
+        XCTAssertEqual(cookies[0].domain, "api.ecosia-staging.xyz")
+    }
+
+    private func makeHTTPResponse(
+        url: URL,
+        statusCode: Int,
+        headers: [String: String]
+    ) throws -> HTTPURLResponse {
+        try XCTUnwrap(
+            HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: "HTTP/1.1", headerFields: headers)
+        )
+    }
+}

--- a/firefox-ios/EcosiaTests/Core/FileUpload/FilePresignRequestTests.swift
+++ b/firefox-ios/EcosiaTests/Core/FileUpload/FilePresignRequestTests.swift
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import Ecosia
+
+final class FilePresignRequestTests: XCTestCase {
+
+    func testCookieHeaderValue_mergesStoredCookiesWithAuthSession() {
+        let apiRoot = URL(string: "https://www.ecosia.org")!
+        let storage = HTTPCookieStorage()
+        let eaist = makeCookie(name: "EAIST", value: "waf-token", domain: "www.ecosia.org")
+        let easc = makeCookie(name: Cookie.authSession.rawValue, value: "session-token", domain: "www.ecosia.org")
+        storage.setCookie(eaist)
+        storage.setCookie(easc)
+
+        let header = FilePresignRequest.cookieHeaderValue(
+            cookieStorage: storage,
+            apiRoot: apiRoot,
+            authSessionCookie: makeCookie(
+                name: Cookie.authSession.rawValue,
+                value: "refreshed-session",
+                domain: "www.ecosia.org"
+            )
+        )
+
+        XCTAssertEqual(
+            header,
+            "EAIST=waf-token; EASC=refreshed-session"
+        )
+    }
+
+    private func makeCookie(name: String, value: String, domain: String) -> HTTPCookie {
+        HTTPCookie(properties: [
+            .name: name,
+            .value: value,
+            .domain: domain,
+            .path: "/",
+        ])!
+    }
+}

--- a/firefox-ios/EcosiaTests/Core/URLProviderDependantTests/URLProviderTests.swift
+++ b/firefox-ios/EcosiaTests/Core/URLProviderDependantTests/URLProviderTests.swift
@@ -188,4 +188,58 @@ final class URLProviderTests: XCTestCase {
         let url = urlProvider.aiChat(origin: .autocomplete)
         XCTAssertTrue(url.absoluteString.contains("/ai-chat?origin=autocomplete_app"))
     }
+
+    func testAIChatWithQueryAndFiles() throws {
+        let files = [
+            AIChatFileQuery(
+                fileId: "a",
+                filename: "notes.pdf",
+                mimeType: "application/pdf",
+                sizeBytes: 1024
+            ),
+            AIChatFileQuery(
+                fileId: "b",
+                filename: "photo.png",
+                mimeType: "image/png",
+                sizeBytes: 2048
+            ),
+        ]
+        let url = urlProvider.aiChat(origin: .omnibox, query: "summarize this", files: files)
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        let items = Dictionary(uniqueKeysWithValues: (components?.queryItems ?? []).map { ($0.name, $0.value) })
+        XCTAssertEqual(items["origin"], "omnibox_app")
+        XCTAssertEqual(items["q"], "summarize this")
+
+        let filesJSON = try XCTUnwrap(items["files"])
+        let decoded = try JSONDecoder().decode([AIChatFileQuery].self, from: Data(filesJSON.utf8))
+        XCTAssertEqual(decoded, files)
+        XCTAssertFalse(url.absoluteString.contains("file_ids"))
+    }
+
+    func testAIChatEncodesQuestionMarkInQuerySoFilesParamIsPreserved() throws {
+        let files = [
+            AIChatFileQuery(
+                fileId: "39cc9dd7-6e32-444f-a0ff-8a9a615b1441",
+                filename: "IMG_0111",
+                mimeType: "image/jpeg",
+                sizeBytes: 5212725
+            ),
+        ]
+        let url = urlProvider.aiChat(
+            origin: .omnibox,
+            query: "Cosa sono queste immagini?",
+            files: files
+        )
+
+        XCTAssertTrue(url.absoluteString.contains("immagini%3F"))
+        XCTAssertFalse(url.absoluteString.contains("immagini?&"))
+
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        let items = Dictionary(uniqueKeysWithValues: (components?.queryItems ?? []).map { ($0.name, $0.value) })
+        XCTAssertEqual(items["q"], "Cosa sono queste immagini?")
+
+        let filesJSON = try XCTUnwrap(items["files"])
+        let decoded = try JSONDecoder().decode([AIChatFileQuery].self, from: Data(filesJSON.utf8))
+        XCTAssertEqual(decoded, files)
+    }
 }

--- a/firefox-ios/EcosiaTests/Core/URLTests.swift
+++ b/firefox-ios/EcosiaTests/Core/URLTests.swift
@@ -333,6 +333,38 @@ final class URLTests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(ecosified, URL(string: "https://ecosia.org?_sp=\(UUID(uuid: UUID_NULL).uuidString)"))
     }
 
+    func testEcosifiedPreservesPercentEncodedAIChatQueryAndFiles() {
+        User.shared.sendAnonymousUsageData = true
+        User.shared.cookieConsentValue = "a"
+        let analyticsId = User.shared.analyticsId.uuidString
+
+        let chatURL = urlProvider.aiChat(
+            origin: .omnibox,
+            query: "new images?",
+            files: [
+                AIChatFileQuery(
+                    fileId: "4c4961e2-b2a7-4eed-b0f8-506178d72e11",
+                    filename: "IMG_0111",
+                    mimeType: "image/jpeg",
+                    sizeBytes: 5212725
+                ),
+            ]
+        )
+
+        let ecosified = chatURL.ecosified(isIncognitoEnabled: false, urlProvider: urlProvider)
+        let absolute = ecosified.absoluteString
+
+        XCTAssertTrue(absolute.contains("images%3F"), "Encoded question mark must survive ecosified()")
+        XCTAssertFalse(absolute.contains("images?&files"), "Bare ? must not appear before files")
+        XCTAssertTrue(absolute.contains("files="))
+        XCTAssertTrue(absolute.contains("_sp=\(analyticsId)"))
+
+        let components = URLComponents(url: ecosified, resolvingAgainstBaseURL: false)
+        let items = Dictionary(uniqueKeysWithValues: (components?.queryItems ?? []).map { ($0.name, $0.value) })
+        XCTAssertEqual(items["q"], "new images?")
+        XCTAssertNotNil(items["files"])
+    }
+
     // MARK: - `hasEcosiaUserId`
 
     func testHasEcosiaUserIdReturnsFalseWhenAbsent() {

--- a/firefox-ios/EcosiaTests/Core/URLTests.swift
+++ b/firefox-ios/EcosiaTests/Core/URLTests.swift
@@ -333,6 +333,11 @@ final class URLTests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(ecosified, URL(string: "https://ecosia.org?_sp=\(UUID(uuid: UUID_NULL).uuidString)"))
     }
 
+    func testPercentEncodedQueryComponentEncodesNonASCIICharacters() {
+        XCTAssertEqual(URL.percentEncodedQueryComponent("café"), "caf%C3%A9")
+        XCTAssertEqual(URL.percentEncodedQueryComponent("new images?"), "new%20images%3F")
+    }
+
     func testEcosifiedPreservesPercentEncodedAIChatQueryAndFiles() {
         User.shared.sendAnonymousUsageData = true
         User.shared.cookieConsentValue = "a"

--- a/firefox-ios/EcosiaTests/UI/NTP/OmniboxAttachmentTests.swift
+++ b/firefox-ios/EcosiaTests/UI/NTP/OmniboxAttachmentTests.swift
@@ -1,0 +1,52 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import Ecosia
+
+final class OmniboxAttachmentTests: XCTestCase {
+
+    func testReadyAttachmentExposesFileId() {
+        let attachment = OmniboxAttachment(
+            fileName: "notes.pdf",
+            layout: .file,
+            state: .ready(byteCount: 1024, fileId: "file-123", mimeType: "application/pdf")
+        )
+
+        XCTAssertEqual(attachment.fileId, "file-123")
+        XCTAssertTrue(attachment.isReady)
+        XCTAssertFalse(attachment.isLoading)
+        XCTAssertEqual(
+            attachment.chatFileQuery,
+            AIChatFileQuery(
+                fileId: "file-123",
+                filename: "notes.pdf",
+                mimeType: "application/pdf",
+                sizeBytes: 1024
+            )
+        )
+    }
+
+    func testChatFileQueryAddsExtensionWhenPhotoNameOmitsIt() {
+        let attachment = OmniboxAttachment(
+            fileName: "IMG_0111",
+            layout: .image,
+            state: .ready(byteCount: 5212725, fileId: "file-123", mimeType: "image/jpeg")
+        )
+
+        XCTAssertEqual(attachment.chatFileQuery?.filename, "IMG_0111.jpg")
+    }
+
+    func testLoadingAttachmentHasNoFileId() {
+        let attachment = OmniboxAttachment(
+            fileName: "photo.jpg",
+            layout: .image,
+            state: .loading
+        )
+
+        XCTAssertNil(attachment.fileId)
+        XCTAssertTrue(attachment.isLoading)
+        XCTAssertFalse(attachment.isReady)
+    }
+}

--- a/firefox-ios/EcosiaTests/UI/NTP/OmniboxUploadPayloadLoaderTests.swift
+++ b/firefox-ios/EcosiaTests/UI/NTP/OmniboxUploadPayloadLoaderTests.swift
@@ -4,33 +4,27 @@
 
 import XCTest
 @testable import Client
-@testable import Ecosia
 
-@MainActor
 final class OmniboxUploadPayloadLoaderTests: XCTestCase {
 
-    func testRejectsOversizedPayload() {
-        let oversized = Data(repeating: 0, count: OmniboxUploadPayloadLoader.maxFileSizeBytes + 1)
-        XCTAssertThrowsError(try OmniboxUploadPayloadLoader.validateSize(oversized)) { error in
+    func testValidateFileSizeRejectsOversizedFileBeforeReading() throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("oversized.txt")
+        let oversized = Data(count: OmniboxUploadPayloadLoader.maxFileSizeBytes + 1)
+        try oversized.write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        XCTAssertThrowsError(try OmniboxUploadPayloadLoader.validateFileSize(at: url)) { error in
             XCTAssertEqual(error as? OmniboxUploadPayloadError, .fileTooLarge)
         }
     }
 
-    func testNormalizedJPEGFileNameReplacesExtension() {
-        XCTAssertEqual(
-            OmniboxUploadPayloadLoader.normalizedJPEGFileName(from: "IMG_0001.HEIC"),
-            "IMG_0001.jpg"
-        )
-        XCTAssertEqual(
-            OmniboxUploadPayloadLoader.normalizedJPEGFileName(from: "camera-photo.heic", fallback: "photo.jpg"),
-            "camera-photo.jpg"
-        )
-    }
+    func testLoadFileReadsSmallFile() throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("small.txt")
+        try Data("hello".utf8).write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
 
-    func testNormalizedJPEGFileNameUsesFallbackForEmptyStem() {
-        XCTAssertEqual(
-            OmniboxUploadPayloadLoader.normalizedJPEGFileName(from: ".heic", fallback: "photo.jpg"),
-            "photo.jpg"
-        )
+        let payload = try OmniboxUploadPayloadLoader.loadFile(from: url)
+        XCTAssertEqual(payload.fileName, "small.txt")
+        XCTAssertEqual(payload.data, Data("hello".utf8))
     }
 }

--- a/firefox-ios/EcosiaTests/UI/NTP/OmniboxUploadPayloadLoaderTests.swift
+++ b/firefox-ios/EcosiaTests/UI/NTP/OmniboxUploadPayloadLoaderTests.swift
@@ -15,4 +15,22 @@ final class OmniboxUploadPayloadLoaderTests: XCTestCase {
             XCTAssertEqual(error as? OmniboxUploadPayloadError, .fileTooLarge)
         }
     }
+
+    func testNormalizedJPEGFileNameReplacesExtension() {
+        XCTAssertEqual(
+            OmniboxUploadPayloadLoader.normalizedJPEGFileName(from: "IMG_0001.HEIC"),
+            "IMG_0001.jpg"
+        )
+        XCTAssertEqual(
+            OmniboxUploadPayloadLoader.normalizedJPEGFileName(from: "camera-photo.heic", fallback: "photo.jpg"),
+            "camera-photo.jpg"
+        )
+    }
+
+    func testNormalizedJPEGFileNameUsesFallbackForEmptyStem() {
+        XCTAssertEqual(
+            OmniboxUploadPayloadLoader.normalizedJPEGFileName(from: ".heic", fallback: "photo.jpg"),
+            "photo.jpg"
+        )
+    }
 }

--- a/firefox-ios/EcosiaTests/UI/NTP/OmniboxUploadPayloadLoaderTests.swift
+++ b/firefox-ios/EcosiaTests/UI/NTP/OmniboxUploadPayloadLoaderTests.swift
@@ -18,12 +18,12 @@ final class OmniboxUploadPayloadLoaderTests: XCTestCase {
         }
     }
 
-    func testLoadFileReadsSmallFile() throws {
+    func testLoadFileReadsSmallFile() async throws {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("small.txt")
         try Data("hello".utf8).write(to: url)
         defer { try? FileManager.default.removeItem(at: url) }
 
-        let payload = try OmniboxUploadPayloadLoader.loadFile(from: url)
+        let payload = try await OmniboxUploadPayloadLoader.loadFile(from: url)
         XCTAssertEqual(payload.fileName, "small.txt")
         XCTAssertEqual(payload.data, Data("hello".utf8))
     }

--- a/firefox-ios/EcosiaTests/UI/NTP/OmniboxUploadPayloadLoaderTests.swift
+++ b/firefox-ios/EcosiaTests/UI/NTP/OmniboxUploadPayloadLoaderTests.swift
@@ -1,0 +1,18 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import Client
+@testable import Ecosia
+
+@MainActor
+final class OmniboxUploadPayloadLoaderTests: XCTestCase {
+
+    func testRejectsOversizedPayload() {
+        let oversized = Data(repeating: 0, count: OmniboxUploadPayloadLoader.maxFileSizeBytes + 1)
+        XCTAssertThrowsError(try OmniboxUploadPayloadLoader.validateSize(oversized)) { error in
+            XCTAssertEqual(error as? OmniboxUploadPayloadError, .fileTooLarge)
+        }
+    }
+}


### PR DESCRIPTION
[MOB-4586]
[MOB-4587]

## Context

Follow-up to MOB-4582. Wire the omnibox upload pickers to the presign upload API and show loading and success states in the attachment strip.

## Approach

- Upload files via `FileUploadService` (presign → PUT → confirm) with auth cookie sync and Cloudflare Access bootstrap for staging.
- Request conversation OAuth scopes during native Auth0 login.
- Extract upload coordination into `OmniboxAttachmentUploadCoordinator` and `OmniboxAttachment`.
- Show attachments in `OmniboxAttachmentsStripView` with `OmniboxAttachmentTileView` (image preview, file name + size, remove button, carousel).
- Add `OmniboxUploadLoaderView` for the loading state on attachment tiles.
- Build AI chat URL helpers on `URLProvider` for follow-up routing work.

| Outcome |
| --- |
| <img width="295" height="640" alt="Simulator Screen Recording - iPhone 17 Pro - 2026-07-01 at 13 24 20" src="https://github.com/user-attachments/assets/2136a474-4739-456e-8d32-79620339f3d0" /> |

## Other

- Added unit tests for `OmniboxAttachment`, upload payload loading, `FileUploadService` URL building, Cloudflare bootstrap, and `EcosiaAuthScopes`
- Added Ecosia strings for upload submit button accessibility hints

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I wrote Unit Tests that confirm the expected behaviour
- [x] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [x] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4586]: https://ecosia.atlassian.net/browse/MOB-4586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MOB-4587]: https://ecosia.atlassian.net/browse/MOB-4587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ