### PR TITLE
[MOB-4590] File Upload - AI chat routing with attachments

### DIFF
--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
@@ -28,6 +28,14 @@ extension BrowserViewController: DefaultBrowserDelegate {
 // MARK: - NTP omnibox session
 extension BrowserViewController {
 
+    /// Shows the embedded webview for a tab captured before async work (e.g. attachment submit).
+    func showEmbeddedWebview(for tab: Tab) {
+        if tabManager.selectedTab !== tab {
+            tabManager.selectTab(tab)
+        }
+        showEmbeddedWebview()
+    }
+
     /// The homepage VC while the webview is frontmost (swiping-tabs keeps it as a child).
     fileprivate var ecosiaEmbeddedHomepage: HomepageViewController? {
         if let homepage = contentContainer.contentController as? HomepageViewController {

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Omnibox.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Omnibox.swift
@@ -6,6 +6,7 @@ import UIKit
 import Shared
 import Ecosia
 import Common
+import WebKit
 
 // MARK: NTPSearchBarDelegate
 // Ecosia: Routes the embedded NTP omnibox into the existing browser navigation
@@ -19,6 +20,7 @@ extension BrowserViewController: NTPSearchBarDelegate {
         // pipeline records the omnibox submit the same way the URL bar would.
         searchSessionState = .engaged
         hideOmniboxSuggestions()
+        let chatFiles = ntpOmniboxAnchorView?.readyChatFiles() ?? []
         // Clear the omnibox so the user returns to a fresh pill next time the
         // homepage is shown — the submitted query lives on the SERP, not in
         // the input.
@@ -32,8 +34,20 @@ extension BrowserViewController: NTPSearchBarDelegate {
         // stays selected across submissions until the user deselects it.
         if let mode = omniboxSheetState?.selectedChatMode {
             submitOmniboxChatMode(mode, query: searchTerm)
+        } else if !chatFiles.isEmpty {
+            guard let tab = tabManager.selectedTab else { return }
+            let cookieStore = tab.webView?.configuration.websiteDataStore.httpCookieStore
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                await CloudflareAccessCookieBootstrap.syncAuthorizationCookieToWebView(
+                    cookieStore: cookieStore ?? WKWebsiteDataStore.default().httpCookieStore
+                )
+                submitOmniboxSearch(query: searchTerm, chatFiles: chatFiles, tab: tab)
+                showEmbeddedWebview(for: tab)
+            }
+            return
         } else {
-            submitOmniboxSearch(query: searchTerm)
+            submitOmniboxSearch(query: searchTerm, chatFiles: chatFiles)
         }
         // Force the swap to the webview. Without URL bar overlay mode, the
         // standard `addressToolbar(_:didLeaveOverlayModeForReason:)` chain
@@ -51,32 +65,47 @@ extension BrowserViewController: NTPSearchBarDelegate {
         finishEditingAndSubmit(url, visitType: .typed, forTab: tab)
     }
 
-    /// Builds the search URL for an omnibox submission (direct typed submit
-    /// or autocomplete row tap) and loads it. Pasted URLs navigate directly;
-    /// everything else goes through Ecosia's `urlProvider` via
-    /// `URL.ecosiaSearchWithQuery` with `autoRedirect: true`, which appends
-    /// the `ar=1` parameter so the backend can decide whether the query
-    /// lands on AI search or the standard SERP — the client never makes that
-    /// call itself.
-    private func submitOmniboxSearch(query: String) {
-        guard let tab = tabManager.selectedTab else { return }
+    /// Builds the navigation URL for an omnibox submission.
+    /// Pasted URLs navigate directly only when there are no attachments.
+    /// Queries with attachments always open AI chat with the uploaded `files` metadata.
+    /// Otherwise the query goes through Ecosia search with `ar=1` so the backend can decide
+    /// between AI search and the standard SERP.
+    private func submitOmniboxSearch(query: String, chatFiles: [AIChatFileQuery] = [], tab: Tab? = nil) {
+        guard let tab = tab ?? tabManager.selectedTab else { return }
+        let destinationURL = OmniboxSubmitRouting.destinationURL(query: query, chatFiles: chatFiles)
 
-        if let url = URIFixup.getURL(query) {
-            finishEditingAndSubmit(url, visitType: .typed, forTab: tab)
-            return
+        if !chatFiles.isEmpty {
+            EcosiaLogger.network.info(
+                "[Omnibox] Routing to AI chat (files=\(chatFiles.count), host=\(destinationURL.host ?? "unknown"))"
+            )
         }
 
-        let searchURL = URL.ecosiaSearchWithQuery(query, autoRedirect: true)
-        finishEditingAndSubmit(searchURL, visitType: .typed, forTab: tab)
+        finishEditingAndSubmit(destinationURL, visitType: .typed, forTab: tab)
     }
 
     func ntpSearchBarTextDidChange(_ searchTerm: String) {
         guard let anchor = ntpOmniboxAnchorView else { return }
+        if anchor.hasAttachments {
+            hideOmniboxSuggestions()
+            return
+        }
         if searchTerm.isEmpty {
             hideOmniboxSuggestions()
             return
         }
         showOmniboxSuggestions(searchTerm: searchTerm, anchorView: anchor)
+    }
+
+    func ntpSearchBarAttachmentsDidChange() {
+        guard let anchor = ntpOmniboxAnchorView else { return }
+        if anchor.hasAttachments {
+            hideOmniboxSuggestions()
+        } else {
+            let searchTerm = anchor.normalizedSearchQuery(for: anchor.text)
+            if !searchTerm.isEmpty {
+                showOmniboxSuggestions(searchTerm: searchTerm, anchorView: anchor)
+            }
+        }
     }
 
     func ntpSearchBarNeedsSearchReset() {
@@ -505,6 +534,7 @@ extension BrowserViewController: OmniboxUploadPickerDelegate, OmniboxAttachmentU
 
     func omniboxAttachmentsDidChange() {
         ntpOmniboxAnchorView?.refreshSubmitButtonState()
+        ntpSearchBarAttachmentsDidChange()
     }
 
     func omniboxUploadDidEncounterValidationErrors(_ errors: Set<OmniboxUploadValidationError>) {

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPLocationTextView.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPLocationTextView.swift
@@ -330,6 +330,10 @@ final class NTPLocationTextView: UITextView {
         string.lowercased().stringByTrimmingLeadingCharactersInSet(CharacterSet.whitespaces)
     }
 
+    func normalizedSearchQuery(for text: String) -> String {
+        normalizeString(text)
+    }
+
     private func forceResetCursor() {
         selectedTextRange = nil
         selectedTextRange = textRange(from: endOfDocument, to: endOfDocument)

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPSearchBarView.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPSearchBarView.swift
@@ -270,6 +270,10 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable, UIGestur
         }
     }
 
+    func normalizedSearchQuery(for text: String) -> String {
+        textView.normalizedSearchQuery(for: text)
+    }
+
     // MARK: Init
 
     override init(frame: CGRect) {

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/OmniboxSubmitRouting.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/OmniboxSubmitRouting.swift
@@ -1,0 +1,26 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import Shared
+import Ecosia
+
+/// Resolves omnibox submission URLs for text queries, pasted URLs, and attachment uploads.
+enum OmniboxSubmitRouting {
+    static func destinationURL(
+        query: String,
+        chatFiles: [AIChatFileQuery],
+        urlProvider: URLProvider = Environment.current.urlProvider
+    ) -> URL {
+        if chatFiles.isEmpty, let url = URIFixup.getURL(query) {
+            return url
+        }
+
+        if !chatFiles.isEmpty {
+            return urlProvider.aiChat(origin: .omnibox, query: query, files: chatFiles)
+        }
+
+        return URL.ecosiaSearchWithQuery(query, autoRedirect: true)
+    }
+}

--- a/firefox-ios/EcosiaTests/UI/NTP/OmniboxSubmitRoutingTests.swift
+++ b/firefox-ios/EcosiaTests/UI/NTP/OmniboxSubmitRoutingTests.swift
@@ -1,0 +1,49 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import Client
+@testable import Ecosia
+
+final class OmniboxSubmitRoutingTests: XCTestCase {
+
+    func testRoutesPastedURLWhenNoAttachments() {
+        let url = OmniboxSubmitRouting.destinationURL(
+            query: "https://example.com/path",
+            chatFiles: []
+        )
+
+        XCTAssertEqual(url.absoluteString, "https://example.com/path")
+    }
+
+    func testRoutesToAIChatWhenAttachmentsPresent() throws {
+        let files = [
+            AIChatFileQuery(
+                fileId: "file-1",
+                filename: "doc.pdf",
+                mimeType: "application/pdf",
+                sizeBytes: 1024
+            )
+        ]
+        let url = OmniboxSubmitRouting.destinationURL(query: "summarize this", chatFiles: files)
+        let items = Dictionary(
+            uniqueKeysWithValues: (URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? [])
+                .map { ($0.name, $0.value) }
+        )
+
+        XCTAssertEqual(items["q"], "summarize this")
+        XCTAssertNotNil(items["files"])
+    }
+
+    func testRoutesToEcosiaSearchForPlainQueryWithoutAttachments() throws {
+        let url = OmniboxSubmitRouting.destinationURL(query: "trees", chatFiles: [])
+        let items = Dictionary(
+            uniqueKeysWithValues: (URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? [])
+                .map { ($0.name, $0.value) }
+        )
+
+        XCTAssertEqual(items["q"], "trees")
+        XCTAssertEqual(items["ar"], "1")
+    }
+}


### PR DESCRIPTION
[MOB-4590]

## Context

ℹ️ The base branch is a branch that is cumulative for all the work

Follow-up to MOB-4586. Route omnibox submissions with ready attachments to AI chat and forward uploaded file metadata in the navigation URL.

## Approach

- On omnibox submit, collect ready attachment metadata via `readyChatFiles()` and build the AI chat URL with `URLProvider.aiChat(origin:query:files:)`.
- Sync Cloudflare Access cookies to the webview before navigating when attachments are present.
- Hide search suggestions while attachments are attached; restore them when the last attachment is removed.
- Clear attachments and omnibox text after submit.

| Outcome |
| --- |
| <img width="295" height="640" alt="Simulator Screen Recording - iPhone 17 Pro - 2026-07-01 at 13 51 28" src="https://github.com/user-attachments/assets/d1ca121a-426a-4041-b55b-717448483ba9" /> |

## Other

- Submit remains blocked while uploads are still in progress via existing submit button state from MOB-4586

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [x] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [x] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4590]: https://ecosia.atlassian.net/browse/MOB-4590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ