### PR TITLE
[MOB-4589] File Upload - Sign-in sheet for logged-out users

### DIFF
--- a/firefox-ios/Client/Ecosia/Account/Auth/EcosiaAuth.swift
+++ b/firefox-ios/Client/Ecosia/Account/Auth/EcosiaAuth.swift
@@ -176,7 +176,7 @@ final class EcosiaAuth {
             onError: onErrorCallback
         )
 
-        await handleAuthenticationResult(result, isLogin: false)
+        await handleAuthenticationResult(result, isLogin: true)
     }
 
     private func handleAuthenticationResult(_ result: EcosiaAuthFlowResult, isLogin: Bool) async {

--- a/firefox-ios/Client/Ecosia/Account/Auth/EcosiaAuth.swift
+++ b/firefox-ios/Client/Ecosia/Account/Auth/EcosiaAuth.swift
@@ -120,6 +120,23 @@ final class EcosiaAuth {
         }
     }
 
+    /// Starts the sign-up authentication flow
+    func signUp() {
+        guard let browserViewController = browserViewController else {
+            fatalError("BrowserViewController not available for auth flow")
+        }
+
+        let flow = EcosiaAuthFlow(
+            type: .signUp,
+            authService: authService,
+            browserViewController: browserViewController
+        )
+
+        Task { @MainActor in
+            await performSignUp(flow)
+        }
+    }
+
     /// Starts the logout authentication flow
     func logout() {
         guard let browserViewController = browserViewController else {
@@ -148,18 +165,35 @@ final class EcosiaAuth {
             onError: onErrorCallback
         )
 
+        await handleAuthenticationResult(result, isLogin: true)
+    }
+
+    private func performSignUp(_ flow: EcosiaAuthFlow) async {
+        let result = await flow.startSignUp(
+            delayedCompletion: delayedCompletionTime,
+            onNativeAuthCompleted: onNativeAuthCompletedCallback,
+            onFlowCompleted: onAuthFlowCompletedCallback,
+            onError: onErrorCallback
+        )
+
+        await handleAuthenticationResult(result, isLogin: false)
+    }
+
+    private func handleAuthenticationResult(_ result: EcosiaAuthFlowResult, isLogin: Bool) async {
         switch result {
         case .success:
-            EcosiaLogger.auth.debug("Login flow completed successfully")
+            EcosiaLogger.auth.debug("Authentication flow completed successfully")
         case .failure(let error):
-            EcosiaLogger.auth.error("Login flow failed: \(error)")
+            EcosiaLogger.auth.error("Authentication flow failed: \(error)")
             if case .userCancelled = error {
-                Analytics.shared.accountSignInCancelled()
+                if isLogin {
+                    Analytics.shared.accountSignInCancelled()
+                }
             } else {
                 // Show error toast for non-cancellation errors
                 await MainActor.run {
                     if #available(iOS 16.0, *) {
-                        browserViewController?.showAuthFlowErrorToast(isLogin: true)
+                        browserViewController?.showAuthFlowErrorToast(isLogin: isLogin)
                     }
                 }
             }

--- a/firefox-ios/Client/Ecosia/Account/Auth/EcosiaAuth.swift
+++ b/firefox-ios/Client/Ecosia/Account/Auth/EcosiaAuth.swift
@@ -165,7 +165,7 @@ final class EcosiaAuth {
             onError: onErrorCallback
         )
 
-        await handleAuthenticationResult(result, isLogin: true)
+        await handleAuthenticationResult(result, context: .login)
     }
 
     private func performSignUp(_ flow: EcosiaAuthFlow) async {
@@ -176,24 +176,32 @@ final class EcosiaAuth {
             onError: onErrorCallback
         )
 
-        await handleAuthenticationResult(result, isLogin: true)
+        await handleAuthenticationResult(result, context: .signUp)
     }
 
-    private func handleAuthenticationResult(_ result: EcosiaAuthFlowResult, isLogin: Bool) async {
+    private enum AuthPresentationContext {
+        case login
+        case signUp
+
+        var usesSignInErrorToast: Bool { true }
+        var tracksSignInCancellation: Bool { self == .login }
+    }
+
+    private func handleAuthenticationResult(_ result: EcosiaAuthFlowResult, context: AuthPresentationContext) async {
         switch result {
         case .success:
             EcosiaLogger.auth.debug("Authentication flow completed successfully")
         case .failure(let error):
             EcosiaLogger.auth.error("Authentication flow failed: \(error)")
             if case .userCancelled = error {
-                if isLogin {
+                if context.tracksSignInCancellation {
                     Analytics.shared.accountSignInCancelled()
                 }
             } else {
                 // Show error toast for non-cancellation errors
                 await MainActor.run {
                     if #available(iOS 16.0, *) {
-                        browserViewController?.showAuthFlowErrorToast(isLogin: isLogin)
+                        browserViewController?.showAuthFlowErrorToast(isLogin: context.usesSignInErrorToast)
                     }
                 }
             }

--- a/firefox-ios/Client/Ecosia/Account/Auth/EcosiaAuthFlow.swift
+++ b/firefox-ios/Client/Ecosia/Account/Auth/EcosiaAuthFlow.swift
@@ -19,6 +19,7 @@ final class EcosiaAuthFlow {
 
     public enum FlowType {
         case login
+        case signUp
         case logout
     }
 
@@ -72,6 +73,21 @@ final class EcosiaAuthFlow {
         )
     }
 
+    public func startSignUp(
+        delayedCompletion: TimeInterval = 0.0,
+        onNativeAuthCompleted: (() -> Void)? = nil,
+        onFlowCompleted: ((Bool) -> Void)? = nil,
+        onError: ((AuthError) -> Void)? = nil
+    ) async -> EcosiaAuthFlowResult {
+        return await performAuthentication(
+            type: .signUp,
+            delayedCompletion: delayedCompletion,
+            onNativeAuthCompleted: onNativeAuthCompleted,
+            onFlowCompleted: onFlowCompleted,
+            onError: onError
+        )
+    }
+
     /// Starts the logout authentication flow
     /// - Parameters:
     ///   - delayedCompletion: Delay before calling onNativeAuthCompleted
@@ -109,7 +125,7 @@ final class EcosiaAuthFlow {
             switch type {
             case .login:
                 // Step 1: Native Auth0 authentication
-                try await performNativeAuthentication()
+                try await performNativeAuthentication(screenHint: .login)
 
                 // Step 2: Handle native auth completion callback
                 await handleNativeAuthCompleted(
@@ -118,6 +134,16 @@ final class EcosiaAuthFlow {
                 )
 
                 // Step 3: Session transfer and invisible tab flow
+                try await performSessionTransfer(onFlowCompleted: onFlowCompleted)
+
+            case .signUp:
+                try await performNativeAuthentication(screenHint: .signUp)
+
+                await handleNativeAuthCompleted(
+                    delayedCompletion: delayedCompletion,
+                    onNativeAuthCompleted: onNativeAuthCompleted
+                )
+
                 try await performSessionTransfer(onFlowCompleted: onFlowCompleted)
 
             case .logout:
@@ -142,15 +168,20 @@ final class EcosiaAuthFlow {
         }
     }
 
-    private func performNativeAuthentication() async throws {
+    private func performNativeAuthentication(screenHint: AuthScreenHint) async throws {
         // Debug: Simulate auth error if enabled
         if UserDefaults.standard.bool(forKey: SimulateAuthErrorSetting.debugKey) {
             EcosiaLogger.auth.info("🐛 [DEBUG] Simulating login error")
             throw AuthError.authenticationFailed(NSError(domain: "EcosiaDebug", code: -1, userInfo: [NSLocalizedDescriptionKey: "Debug: Simulated authentication error"]))
         }
 
-        EcosiaLogger.auth.info("Performing native Auth0 authentication")
-        try await authService.login()
+        EcosiaLogger.auth.info("Performing native Auth0 authentication (\(screenHint.rawValue))")
+        switch screenHint {
+        case .login:
+            try await authService.login()
+        case .signUp:
+            try await authService.signUp()
+        }
         EcosiaLogger.auth.info("Native Auth0 authentication completed")
     }
 

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
@@ -190,7 +190,7 @@ extension BrowserViewController {
 
         switch interceptedType {
         case .signUp, .signIn:
-            return handleSignInAndSignUpDetection(url, tab: tab)
+            return handleSignInAndSignUpDetection(url, tab: tab, interceptedType: interceptedType)
         case .signOut:
             return handleSignOutDetection(url)
         case .profile:
@@ -200,17 +200,21 @@ extension BrowserViewController {
         }
     }
 
-    private func handleSignInAndSignUpDetection(_ url: URL, tab: Tab) -> Bool {
+    private func handleSignInAndSignUpDetection(
+        _ url: URL,
+        tab: Tab,
+        interceptedType: EcosiaInterceptedURLType
+    ) -> Bool {
         guard let ecosiaAuth = ecosiaAuth else {
             EcosiaLogger.auth.notice("No EcosiaAuth instance available for authentication detection")
             return false
         }
 
         if !ecosiaAuth.isLoggedIn {
-            EcosiaLogger.auth.info("🔐 [WEB-AUTH] Sign-up URL detected in navigation: \(url)")
+            EcosiaLogger.auth.info("🔐 [WEB-AUTH] Auth URL detected in navigation: \(url)")
             EcosiaLogger.auth.info("🔐 [WEB-AUTH] Triggering native authentication flow")
 
-            ecosiaAuth
+            let configuredAuth = ecosiaAuth
                 .onNativeAuthCompleted {
                     EcosiaLogger.auth.info("🔐 [WEB-AUTH] Native authentication completed from navigation detection")
                 }
@@ -229,7 +233,15 @@ extension BrowserViewController {
                 .onError { error in
                     EcosiaLogger.auth.error("🔐 [WEB-AUTH] Authentication failed from navigation: \(error)")
                 }
-                .login()
+
+            switch interceptedType {
+            case .signUp:
+                configuredAuth.signUp()
+            case .signIn:
+                configuredAuth.login()
+            default:
+                configuredAuth.login()
+            }
         } else {
             EcosiaLogger.auth.notice("🔐 [WEB-AUTH] Inconsistent state detected: web thinks user is logged out but native doesn't")
             EcosiaLogger.auth.notice("🔐 [WEB-AUTH] Failing entire process to avoid user getting locked")

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Omnibox.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Omnibox.swift
@@ -135,20 +135,68 @@ extension BrowserViewController: NTPSearchBarDelegate {
         // (Standard AI Chat selectable, other modes disabled, sign-in CTA), so
         // always open it. Without Chat Modes the drawer is upload-only, which
         // still requires an account, so keep the existing signed-out gate.
-        if !ChatModesFeatureFlag.isEnabled, ecosiaAuth?.isLoggedIn == false {
+        if ChatModesFeatureFlag.isEnabled {
+            presentOmniboxUploadDrawer()
+            return
+        }
+
+        let isLoggedIn = ecosiaAuth?.isLoggedIn == true
+        let hasUploadScopes = EcosiaAuthenticationService.shared.hasConversationScopes
+        if !isLoggedIn || !hasUploadScopes {
             if #available(iOS 16.0, *), !AccountsDisabled.isActive {
-                presentAccountImpactFromNTPHeader()
+                guard ecosiaAuth != nil else { return }
+                presentOmniboxSignInSheetForUpload()
             } else {
-                ecosiaAuth?.login()
+                guard let auth = ecosiaAuth else { return }
+                configureOmniboxUploadAuthCallbacks(auth: auth, sheetState: omniboxSheetState)
+                    .onAuthFlowCompleted { [weak self] success in
+                        guard success else { return }
+                        self?.presentOmniboxUploadDrawer()
+                    }
+                    .login()
             }
             return
         }
         presentOmniboxUploadDrawer()
     }
 
-    fileprivate func presentAccountImpactFromNTPHeader() {
-        guard let homepage = contentContainer.contentController as? HomepageViewController else { return }
-        homepage.ecosiaAdapter?.headerViewModel?.presentAccountImpact()
+    fileprivate func configureOmniboxUploadAuthCallbacks(
+        auth: EcosiaAuth,
+        sheetState: NTPOmniboxSheetState?
+    ) -> EcosiaAuth {
+        auth
+            .onAuthFlowCompleted { [weak sheetState] success in
+                sheetState?.handleAuthenticationCompleted(success: success)
+            }
+            .onError { [weak sheetState] _ in
+                sheetState?.handleAuthenticationCompleted(success: false)
+            }
+    }
+
+    fileprivate func presentOmniboxSignInSheetForUpload() {
+        guard let homepage = contentContainer.contentController as? HomepageViewController,
+              let sheetState = homepage.ecosiaAdapter?.omniboxSheetState else { return }
+
+        homepage.presentOmniboxUploadSheetIfNeeded()
+        sheetState.presentSignInSheetForUpload(
+            onSignIn: { [weak self, weak sheetState] in
+                guard let self, let auth = self.ecosiaAuth else {
+                    sheetState?.cancelPendingUploadAfterSignIn()
+                    return
+                }
+                self.configureOmniboxUploadAuthCallbacks(auth: auth, sheetState: sheetState).login()
+            },
+            onSignUp: { [weak self, weak sheetState] in
+                guard let self, let auth = self.ecosiaAuth else {
+                    sheetState?.cancelPendingUploadAfterSignIn()
+                    return
+                }
+                self.configureOmniboxUploadAuthCallbacks(auth: auth, sheetState: sheetState).signUp()
+            },
+            onUploadDrawerRequested: { [weak self] in
+                self?.presentOmniboxUploadDrawer()
+            }
+        )
     }
 
     fileprivate var ntpOmniboxAnchorView: NTPSearchBarView? {

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Omnibox.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Omnibox.swift
@@ -147,14 +147,12 @@ extension BrowserViewController: NTPSearchBarDelegate {
                 guard ecosiaAuth != nil else { return }
                 presentOmniboxSignInSheetForUpload()
             } else {
-                guard let auth = ecosiaAuth else { return }
-                auth
-                    .onAuthFlowCompleted { [weak self] success in
-                        guard success else { return }
-                        self?.presentOmniboxUploadDrawer()
-                    }
-                    .onError { _ in }
-                    .login()
+                guard let auth = ecosiaAuth,
+                      let sheetState = omniboxSheetState else { return }
+                sheetState.armUploadDrawerAfterAuthentication { [weak self] in
+                    self?.presentOmniboxUploadDrawer()
+                }
+                configureOmniboxUploadAuthCallbacks(auth: auth, sheetState: sheetState).login()
             }
             return
         }

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Omnibox.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Omnibox.swift
@@ -148,11 +148,12 @@ extension BrowserViewController: NTPSearchBarDelegate {
                 presentOmniboxSignInSheetForUpload()
             } else {
                 guard let auth = ecosiaAuth else { return }
-                configureOmniboxUploadAuthCallbacks(auth: auth, sheetState: omniboxSheetState)
+                auth
                     .onAuthFlowCompleted { [weak self] success in
                         guard success else { return }
                         self?.presentOmniboxUploadDrawer()
                     }
+                    .onError { _ in }
                     .login()
             }
             return

--- a/firefox-ios/Client/Ecosia/UI/NTP/Header/NTPHeader.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/Header/NTPHeader.swift
@@ -183,6 +183,7 @@ struct NTPHeaderView: View {
                             )
                             .padding(.horizontal, .ecosia.space._m)
                             .dynamicHeightPresentationDetent()
+                            .presentationDragIndicator(.visible)
                         }
                         if let increment = viewModel.balanceIncrement {
                             BalanceIncrementAnimationView(

--- a/firefox-ios/Client/Ecosia/UI/NTP/Header/NTPHeaderViewModel.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/Header/NTPHeaderViewModel.swift
@@ -104,14 +104,8 @@ final class NTPHeaderViewModel: ObservableObject {
         auth.login()
     }
 
-    /// Presents the account impact sheet — the same flow as tapping `EcosiaAccountNavButton`.
-    func presentAccountImpact() {
-        showAccountImpactView = true
-        Analytics.shared.accountHeaderClicked()
-    }
-
-    func dismissAccountImpact() {
-        showAccountImpactView = false
+    func performSignUp() {
+        auth.signUp()
     }
 
     func performLogout() {
@@ -122,6 +116,15 @@ final class NTPHeaderViewModel: ObservableObject {
     @MainActor
     func refreshSeedState() {
         authStateProvider.refreshSeedState()
+    }
+
+    func presentAccountImpact() {
+        showAccountImpactView = true
+        Analytics.shared.accountHeaderClicked()
+    }
+
+    func dismissAccountImpact() {
+        showAccountImpactView = false
     }
 }
 

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/NTPOmniboxSheetPresenter.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/NTPOmniboxSheetPresenter.swift
@@ -10,12 +10,29 @@ import Ecosia
 @available(iOS 16.0, *)
 struct NTPOmniboxSheetPresenter: View {
     @ObservedObject var sheetState: NTPOmniboxSheetState
+    @ObservedObject private var authStateProvider = EcosiaAuthUIStateProvider.shared
     let windowUUID: WindowUUID
 
     var body: some View {
         Color.clear
             .frame(width: 0, height: 0)
             .allowsHitTesting(false)
+            .sheet(isPresented: $sheetState.showSignInSheet, onDismiss: {
+                sheetState.handleSignInSheetDismissed()
+            }) {
+                OmniboxUploadSignInSheet(
+                    windowUUID: windowUUID,
+                    onSignIn: {
+                        sheetState.handleSignInSheetSignInTapped()
+                    },
+                    onCreateAccount: {
+                        sheetState.handleSignInSheetCreateAccountTapped()
+                    },
+                    onDismiss: {
+                        sheetState.showSignInSheet = false
+                    }
+                )
+            }
             .sheet(isPresented: $sheetState.showUploadDrawer, onDismiss: {
                 sheetState.handleUploadDrawerDismissed()
             }) {
@@ -27,6 +44,11 @@ struct NTPOmniboxSheetPresenter: View {
                     onSelectChatMode: { mode in sheetState.handleChatModeSelected(mode) },
                     onLogin: { sheetState.handleLoginRequested() }
                 )
+            }
+            .onChange(of: authStateProvider.isLoggedIn) { isLoggedIn in
+                if isLoggedIn {
+                    sheetState.handleAuthenticationSucceeded()
+                }
             }
     }
 }

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/NTPOmniboxSheetPresenter.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/NTPOmniboxSheetPresenter.swift
@@ -10,7 +10,6 @@ import Ecosia
 @available(iOS 16.0, *)
 struct NTPOmniboxSheetPresenter: View {
     @ObservedObject var sheetState: NTPOmniboxSheetState
-    @ObservedObject private var authStateProvider = EcosiaAuthUIStateProvider.shared
     let windowUUID: WindowUUID
 
     var body: some View {
@@ -44,11 +43,6 @@ struct NTPOmniboxSheetPresenter: View {
                     onSelectChatMode: { mode in sheetState.handleChatModeSelected(mode) },
                     onLogin: { sheetState.handleLoginRequested() }
                 )
-            }
-            .onChange(of: authStateProvider.isLoggedIn) { isLoggedIn in
-                if isLoggedIn {
-                    sheetState.handleAuthenticationSucceeded()
-                }
             }
     }
 }

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/NTPOmniboxSheetState.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/NTPOmniboxSheetState.swift
@@ -42,16 +42,20 @@ final class NTPOmniboxSheetState: ObservableObject {
     private var onSignUp: (() -> Void)?
     private var onUploadDrawerRequested: (() -> Void)?
 
+    func armUploadDrawerAfterAuthentication(onUploadDrawerRequested: @escaping () -> Void) {
+        shouldPresentUploadDrawerAfterAuth = true
+        self.onUploadDrawerRequested = onUploadDrawerRequested
+    }
+
     func presentSignInSheetForUpload(
         onSignIn: @escaping () -> Void,
         onSignUp: @escaping () -> Void,
         onUploadDrawerRequested: @escaping () -> Void
     ) {
         pendingAuthAction = nil
-        shouldPresentUploadDrawerAfterAuth = true
+        armUploadDrawerAfterAuthentication(onUploadDrawerRequested: onUploadDrawerRequested)
         self.onSignIn = onSignIn
         self.onSignUp = onSignUp
-        self.onUploadDrawerRequested = onUploadDrawerRequested
         showSignInSheet = true
     }
 
@@ -92,10 +96,6 @@ final class NTPOmniboxSheetState: ObservableObject {
         let callback = onUploadDrawerRequested
         onUploadDrawerRequested = nil
         callback?()
-    }
-
-    func handleAuthenticationSucceeded() {
-        handleAuthenticationCompleted(success: true)
     }
 
     func cancelPendingUploadAfterSignIn() {

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/NTPOmniboxSheetState.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/NTPOmniboxSheetState.swift
@@ -8,6 +8,12 @@ import Ecosia
 @MainActor
 final class NTPOmniboxSheetState: ObservableObject {
     @Published var showUploadDrawer = false
+    @Published var showSignInSheet = false
+
+    private enum PendingAuthAction {
+        case signIn
+        case signUp
+    }
 
     /// The currently active chat mode, or `nil` when none is selected. Drives
     /// both the checkmark in the drawer and the mode chip on the omnibox, and
@@ -29,6 +35,80 @@ final class NTPOmniboxSheetState: ObservableObject {
     /// immediately (see below).
     private var pendingUploadOption: OmniboxUploadOption?
     private var pendingLogin = false
+
+    private var pendingAuthAction: PendingAuthAction?
+    private var shouldPresentUploadDrawerAfterAuth = false
+    private var onSignIn: (() -> Void)?
+    private var onSignUp: (() -> Void)?
+    private var onUploadDrawerRequested: (() -> Void)?
+
+    func presentSignInSheetForUpload(
+        onSignIn: @escaping () -> Void,
+        onSignUp: @escaping () -> Void,
+        onUploadDrawerRequested: @escaping () -> Void
+    ) {
+        pendingAuthAction = nil
+        shouldPresentUploadDrawerAfterAuth = true
+        self.onSignIn = onSignIn
+        self.onSignUp = onSignUp
+        self.onUploadDrawerRequested = onUploadDrawerRequested
+        showSignInSheet = true
+    }
+
+    func handleSignInSheetSignInTapped() {
+        pendingAuthAction = .signIn
+        showSignInSheet = false
+    }
+
+    func handleSignInSheetCreateAccountTapped() {
+        pendingAuthAction = .signUp
+        showSignInSheet = false
+    }
+
+    func handleSignInSheetDismissed() {
+        guard let action = pendingAuthAction else {
+            clearSignInSheetCallbacks()
+            return
+        }
+
+        pendingAuthAction = nil
+        switch action {
+        case .signIn:
+            onSignIn?()
+        case .signUp:
+            onSignUp?()
+        }
+        onSignIn = nil
+        onSignUp = nil
+    }
+
+    func handleAuthenticationCompleted(success: Bool) {
+        guard shouldPresentUploadDrawerAfterAuth else { return }
+        guard success else {
+            clearSignInSheetCallbacks()
+            return
+        }
+        shouldPresentUploadDrawerAfterAuth = false
+        let callback = onUploadDrawerRequested
+        onUploadDrawerRequested = nil
+        callback?()
+    }
+
+    func handleAuthenticationSucceeded() {
+        handleAuthenticationCompleted(success: true)
+    }
+
+    func cancelPendingUploadAfterSignIn() {
+        clearSignInSheetCallbacks()
+    }
+
+    private func clearSignInSheetCallbacks() {
+        pendingAuthAction = nil
+        shouldPresentUploadDrawerAfterAuth = false
+        onSignIn = nil
+        onSignUp = nil
+        onUploadDrawerRequested = nil
+    }
 
     func presentUploadDrawer(isAuthenticated: Bool,
                              onSelectUpload: @escaping (OmniboxUploadOption) -> Void,

--- a/firefox-ios/Ecosia/Account/Auth/Auth0ProviderProtocol.swift
+++ b/firefox-ios/Ecosia/Account/Auth/Auth0ProviderProtocol.swift
@@ -84,7 +84,7 @@ extension Auth0ProviderProtocol {
     public var credentialsManager: CredentialsManagerProtocol { EcosiaAuthenticationService.defaultCredentialsManager }
 
     public func startAuth(screenHint: AuthScreenHint) async throws -> Credentials {
-        return try await makeHttpsWebAuth()
+        try await webAuth
             .parameters(["screen_hint": screenHint.rawValue])
             .start()
     }

--- a/firefox-ios/Ecosia/Account/Auth/Auth0ProviderProtocol.swift
+++ b/firefox-ios/Ecosia/Account/Auth/Auth0ProviderProtocol.swift
@@ -84,7 +84,9 @@ extension Auth0ProviderProtocol {
     public var credentialsManager: CredentialsManagerProtocol { EcosiaAuthenticationService.defaultCredentialsManager }
 
     public func startAuth(screenHint: AuthScreenHint) async throws -> Credentials {
-        return try await webAuth.start()
+        return try await makeHttpsWebAuth()
+            .parameters(["screen_hint": screenHint.rawValue])
+            .start()
     }
 
     public func startAuth() async throws -> Credentials {

--- a/firefox-ios/Ecosia/Account/Auth/Auth0ProviderProtocol.swift
+++ b/firefox-ios/Ecosia/Account/Auth/Auth0ProviderProtocol.swift
@@ -19,9 +19,10 @@ public protocol Auth0ProviderProtocol {
 
     /// Starts the authentication process asynchronously and returns credentials.
     ///
+    /// - Parameter screenHint: The Auth0 Universal Login screen to present.
     /// - Returns: A `Credentials` object upon successful authentication.
     /// - Throws: An error if the authentication fails.
-    func startAuth() async throws -> Credentials
+    func startAuth(screenHint: AuthScreenHint) async throws -> Credentials
 
     /// Clears the current authentication session asynchronously.
     ///
@@ -82,8 +83,12 @@ extension Auth0ProviderProtocol {
 
     public var credentialsManager: CredentialsManagerProtocol { EcosiaAuthenticationService.defaultCredentialsManager }
 
-    public func startAuth() async throws -> Credentials {
+    public func startAuth(screenHint: AuthScreenHint) async throws -> Credentials {
         return try await webAuth.start()
+    }
+
+    public func startAuth() async throws -> Credentials {
+        try await startAuth(screenHint: .login)
     }
 
     public func clearSession() async throws {

--- a/firefox-ios/Ecosia/Account/Auth/AuthScreenHint.swift
+++ b/firefox-ios/Ecosia/Account/Auth/AuthScreenHint.swift
@@ -1,0 +1,11 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// Auth0 Universal Login screen hint passed via the `screen_hint` authorize parameter.
+public enum AuthScreenHint: String, Sendable {
+    case login
+    case signUp = "signup"
+}

--- a/firefox-ios/Ecosia/Account/Auth/EcosiaAuthenticationService.swift
+++ b/firefox-ios/Ecosia/Account/Auth/EcosiaAuthenticationService.swift
@@ -88,10 +88,20 @@ public final class EcosiaAuthenticationService: @unchecked Sendable {
     ///           `AuthError.credentialStorageFailed` if credential storage returns false.
     @discardableResult
     public func login() async throws -> AccountOrigin {
+        try await authenticate(screenHint: .login)
+    }
+
+    @discardableResult
+    public func signUp() async throws -> AccountOrigin {
+        try await authenticate(screenHint: .signUp)
+    }
+
+    @discardableResult
+    private func authenticate(screenHint: AuthScreenHint) async throws -> AccountOrigin {
         // First, attempt authentication
         let credentials: Credentials
         do {
-            credentials = try await auth0Provider.startAuth()
+            credentials = try await auth0Provider.startAuth(screenHint: screenHint)
             EcosiaLogger.auth.info("Authentication successful")
         } catch {
             EcosiaLogger.auth.error("Authentication failed: \(error)")
@@ -106,6 +116,11 @@ public final class EcosiaAuthenticationService: @unchecked Sendable {
             throw AuthError.authenticationFailed(error)
         }
 
+        return try await persistAuthenticatedCredentials(credentials)
+    }
+
+    @discardableResult
+    private func persistAuthenticatedCredentials(_ credentials: Credentials) async throws -> AccountOrigin {
         // Determine account origin from ID token claims
         let accountOrigin = credentials.accountOrigin
         EcosiaLogger.auth.info("Account origin: \(accountOrigin == .newAccount ? "new account" : "existing account")")
@@ -229,18 +244,7 @@ public final class EcosiaAuthenticationService: @unchecked Sendable {
     /**
      Renews credentials if they are renewable and close to expiration.
      
-     This method checks if the current credentials can be renewed (i.e., a valid refresh token exists)
-     and attempts to obtain new credentials using the refresh token. This is useful for maintaining
-     long-lived sessions without requiring user re-authentication.
-     
      - Note: This method will update the credential properties with the new tokens upon successful renewal.
-     
-     ## When to Use
-     
-     Call this method when:
-     - You detect that access tokens are expired or about to expire
-     - You want to proactively refresh tokens to maintain session continuity
-     - You encounter authentication errors that might be resolved by token renewal
      */
     public func renewCredentialsIfNeeded() async throws {
         guard auth0Provider.canRenewCredentials() else {

--- a/firefox-ios/Ecosia/Account/Auth/EcosiaAuthenticationService.swift
+++ b/firefox-ios/Ecosia/Account/Auth/EcosiaAuthenticationService.swift
@@ -91,6 +91,9 @@ public final class EcosiaAuthenticationService: @unchecked Sendable {
         try await authenticate(screenHint: .login)
     }
 
+    /// Creates a new account asynchronously and stores credentials if successful.
+    /// - Returns: An `AccountOrigin` indicating whether the user created a new account or signed in to an existing one.
+    /// - Throws: Same errors as `login()`.
     @discardableResult
     public func signUp() async throws -> AccountOrigin {
         try await authenticate(screenHint: .signUp)

--- a/firefox-ios/Ecosia/Account/Auth/NativeToWebSSOAuth0Provider.swift
+++ b/firefox-ios/Ecosia/Account/Auth/NativeToWebSSOAuth0Provider.swift
@@ -12,7 +12,6 @@ public struct NativeToWebSSOAuth0Provider: Auth0ProviderProtocol, @unchecked Sen
 
     public let settings: Auth0SettingsProviderProtocol
     public let credentialsManager: CredentialsManagerProtocol
-    public typealias SessionToken = String
     private let environment: Environment
 
     enum NativeToWebSSOError: Error, Equatable {
@@ -30,14 +29,19 @@ public struct NativeToWebSSOAuth0Provider: Auth0ProviderProtocol, @unchecked Sen
     }
 
     public var webAuth: WebAuth {
+        configuredWebAuth(screenHint: .login)
+    }
+
+    public func startAuth(screenHint: AuthScreenHint) async throws -> Credentials {
+        return try await configuredWebAuth(screenHint: screenHint).start()
+    }
+
+    private func configuredWebAuth(screenHint: AuthScreenHint) -> WebAuth {
         makeHttpsWebAuth()
             .useEphemeralSession()
             .audience(environment.urlProvider.authApiAudience.absoluteString)
             .scope(EcosiaAuthScopes.oauthScope)
-    }
-
-    public func startAuth() async throws -> Credentials {
-        return try await webAuth.start()
+            .parameters(["screen_hint": screenHint.rawValue])
     }
 
     /// Custom clearSession implementation that bypasses Auth0's default logout alert

--- a/firefox-ios/Ecosia/Account/Auth/WebAuth0Provider.swift
+++ b/firefox-ios/Ecosia/Account/Auth/WebAuth0Provider.swift
@@ -10,4 +10,10 @@ public struct WebAuth0Provider: Auth0ProviderProtocol {
     public var webAuth: WebAuth { makeHttpsWebAuth() }
 
     public init() {}
+
+    public func startAuth(screenHint: AuthScreenHint) async throws -> Credentials {
+        return try await makeHttpsWebAuth()
+            .parameters(["screen_hint": screenHint.rawValue])
+            .start()
+    }
 }

--- a/firefox-ios/Ecosia/UI/EcosiaAccessibilityIdentifiers.swift
+++ b/firefox-ios/Ecosia/UI/EcosiaAccessibilityIdentifiers.swift
@@ -49,4 +49,11 @@ public struct EcosiaAccessibilityIdentifiers {
     public struct AddressBar {
         public static let clearButton = "AddressBar.clearButton"
     }
+
+    public struct OmniboxUpload {
+        public static let signInSheetTitle = "omnibox_upload_sign_in_sheet_title"
+        public static let signInSheetBody = "omnibox_upload_sign_in_sheet_body"
+        public static let signInButton = "omnibox_upload_sign_in_button"
+        public static let createAccountButton = "omnibox_upload_create_account_button"
+    }
 }

--- a/firefox-ios/Ecosia/UI/NTP/Upload/OmniboxUploadSignInView.swift
+++ b/firefox-ios/Ecosia/UI/NTP/Upload/OmniboxUploadSignInView.swift
@@ -177,7 +177,7 @@ public struct OmniboxUploadSignInSheet: View {
 public struct OmniboxUploadSignInViewTheme: EcosiaThemeable {
     public var backgroundColor = Color.white
     public var textPrimaryColor = Color.black
-    public var ctaButtonTextColor = Color.green
+    public var ctaButtonTextColor = Color.white
     public var ctaButtonBackgroundColor = Color.green
     public var secondaryButtonTextColor = Color.black
     public var secondaryButtonBorderColor = Color.gray

--- a/firefox-ios/Ecosia/UI/NTP/Upload/OmniboxUploadSignInView.swift
+++ b/firefox-ios/Ecosia/UI/NTP/Upload/OmniboxUploadSignInView.swift
@@ -20,7 +20,6 @@ public struct OmniboxUploadSignInView: View {
     private let onDismiss: () -> Void
 
     @State private var theme = OmniboxUploadSignInViewTheme()
-    @ObservedObject private var authStateProvider = EcosiaAuthUIStateProvider.shared
 
     public init(
         windowUUID: WindowUUID,
@@ -57,11 +56,6 @@ public struct OmniboxUploadSignInView: View {
         .fixedSize(horizontal: false, vertical: true)
         .ecosiaThemed(windowUUID, $theme)
         .presentationBackgroundIfAvailable(theme.backgroundColor)
-        .onChange(of: authStateProvider.isLoggedIn) { isLoggedIn in
-            if isLoggedIn {
-                onDismiss()
-            }
-        }
     }
 
     private var actionButtons: some View {

--- a/firefox-ios/Ecosia/UI/NTP/Upload/OmniboxUploadSignInView.swift
+++ b/firefox-ios/Ecosia/UI/NTP/Upload/OmniboxUploadSignInView.swift
@@ -5,10 +5,11 @@
 import SwiftUI
 import Common
 
-/// Bottom-sheet content shown when a logged-out user tries to upload files from the NTP omnibox.
+/// Bottom-sheet content shown when upload from the NTP omnibox requires authentication.
 ///
 /// Presented from `BrowserViewController+Omnibox` via `NTPOmniboxSheetPresenter` on
-/// `HomepageViewController` when a logged-out user taps the omnibox upload button.
+/// `HomepageViewController` when the user taps the omnibox upload button while logged out
+/// or while missing conversation scopes needed for AI chat attachments.
 /// `NTPOmniboxSheetState` dismisses this sheet before starting auth and before opening
 /// the upload drawer.
 @available(iOS 16.0, *)

--- a/firefox-ios/Ecosia/UI/NTP/Upload/OmniboxUploadSignInView.swift
+++ b/firefox-ios/Ecosia/UI/NTP/Upload/OmniboxUploadSignInView.swift
@@ -1,0 +1,230 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import SwiftUI
+import Common
+
+/// Bottom-sheet content shown when a logged-out user tries to upload files from the NTP omnibox.
+///
+/// Presented from `BrowserViewController+Omnibox` via `NTPOmniboxSheetPresenter` on
+/// `HomepageViewController` when a logged-out user taps the omnibox upload button.
+/// `NTPOmniboxSheetState` dismisses this sheet before starting auth and before opening
+/// the upload drawer.
+@available(iOS 16.0, *)
+public struct OmniboxUploadSignInView: View {
+    private let windowUUID: WindowUUID
+    private let onSignIn: () -> Void
+    private let onCreateAccount: () -> Void
+    private let onDismiss: () -> Void
+
+    @State private var theme = OmniboxUploadSignInViewTheme()
+    @ObservedObject private var authStateProvider = EcosiaAuthUIStateProvider.shared
+
+    public init(
+        windowUUID: WindowUUID,
+        onSignIn: @escaping () -> Void,
+        onCreateAccount: @escaping () -> Void,
+        onDismiss: @escaping () -> Void
+    ) {
+        self.windowUUID = windowUUID
+        self.onSignIn = onSignIn
+        self.onCreateAccount = onCreateAccount
+        self.onDismiss = onDismiss
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: .ecosia.space._m) {
+            Text(String.localized(.signInToUploadFiles))
+                .font(.ecosia(size: .ecosia.font._2l, weight: .semibold))
+                .foregroundColor(theme.textPrimaryColor)
+                .accessibilityIdentifier(EcosiaAccessibilityIdentifiers.OmniboxUpload.signInSheetTitle)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.top, .ecosia.space._m)
+
+            Text(String.localized(.signInToUploadFilesMessage))
+                .font(.ecosia(size: .ecosia.font._l, weight: .regular))
+                .foregroundColor(theme.textPrimaryColor)
+                .multilineTextAlignment(.leading)
+                .fixedSize(horizontal: false, vertical: true)
+                .accessibilityIdentifier(EcosiaAccessibilityIdentifiers.OmniboxUpload.signInSheetBody)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            actionButtons
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .fixedSize(horizontal: false, vertical: true)
+        .ecosiaThemed(windowUUID, $theme)
+        .presentationBackgroundIfAvailable(theme.backgroundColor)
+        .onChange(of: authStateProvider.isLoggedIn) { isLoggedIn in
+            if isLoggedIn {
+                onDismiss()
+            }
+        }
+    }
+
+    private var actionButtons: some View {
+        VStack(spacing: .ecosia.space._1s) {
+            Button(action: handleSignInTap) {
+                signInButtonLabel
+            }
+            .accessibilityIdentifier(EcosiaAccessibilityIdentifiers.OmniboxUpload.signInButton)
+            .accessibilityLabel(String.localized(.signIn))
+            .accessibilityAddTraits(.isButton)
+
+            Button(action: handleCreateAccountTap) {
+                createAccountButtonLabel
+            }
+            .accessibilityIdentifier(EcosiaAccessibilityIdentifiers.OmniboxUpload.createAccountButton)
+            .accessibilityLabel(String.localized(.createAccount))
+            .accessibilityAddTraits(.isButton)
+        }
+    }
+
+    private var signInButtonLabel: some View {
+        HStack(spacing: .ecosia.space._2s) {
+            Image.ecosia("sign-in")
+                .renderingMode(.template)
+                .foregroundColor(theme.ctaButtonTextColor)
+                .accessibilityHidden(true)
+            Text(String.localized(.signIn))
+        }
+        .font(.subheadline)
+        .foregroundColor(theme.ctaButtonTextColor)
+        .padding(.ecosia.space._m)
+        .frame(maxWidth: .infinity)
+        .frame(height: UX.ctaButtonHeight)
+        .cornerRadius(.ecosia.borderRadius._m)
+        .background(theme.ctaButtonBackgroundColor)
+        .clipShape(Capsule())
+    }
+
+    private var createAccountButtonLabel: some View {
+        Text(String.localized(.createAccount))
+            .font(.subheadline)
+            .foregroundColor(theme.secondaryButtonTextColor)
+            .padding(.ecosia.space._m)
+            .frame(maxWidth: .infinity)
+            .frame(height: UX.ctaButtonHeight)
+            .overlay(
+                Capsule()
+                    .stroke(theme.secondaryButtonBorderColor, lineWidth: UX.secondaryButtonBorderWidth)
+            )
+    }
+
+    private func handleSignInTap() {
+        onSignIn()
+    }
+
+    private func handleCreateAccountTap() {
+        onCreateAccount()
+    }
+
+    private enum UX {
+        static let ctaButtonHeight: CGFloat = 40
+        static let secondaryButtonBorderWidth: CGFloat = 1
+    }
+}
+
+private enum OmniboxUploadSignInSheetUX {
+    /// Fallback detent while content height is measured.
+    static let minDetentHeight: CGFloat = 216
+}
+
+/// Sheet wrapper that sizes the detent from measured content so the subtitle can wrap.
+@available(iOS 16.0, *)
+public struct OmniboxUploadSignInSheet: View {
+    private let windowUUID: WindowUUID
+    private let onSignIn: () -> Void
+    private let onCreateAccount: () -> Void
+    private let onDismiss: () -> Void
+
+    public init(
+        windowUUID: WindowUUID,
+        onSignIn: @escaping () -> Void,
+        onCreateAccount: @escaping () -> Void,
+        onDismiss: @escaping () -> Void
+    ) {
+        self.windowUUID = windowUUID
+        self.onSignIn = onSignIn
+        self.onCreateAccount = onCreateAccount
+        self.onDismiss = onDismiss
+    }
+
+    public var body: some View {
+        VStack(spacing: 0) {
+            Spacer()
+                .frame(height: .ecosia.space._m)
+
+            OmniboxUploadSignInView(
+                windowUUID: windowUUID,
+                onSignIn: onSignIn,
+                onCreateAccount: onCreateAccount,
+                onDismiss: onDismiss
+            )
+        }
+        .padding(.horizontal, .ecosia.space._m)
+        .padding(.bottom, .ecosia.space._m)
+        .dynamicHeightPresentationDetent(
+            minHeight: OmniboxUploadSignInSheetUX.minDetentHeight,
+            padding: 0
+        )
+        .presentationDragIndicator(.visible)
+    }
+}
+
+@available(iOS 16.0, *)
+public struct OmniboxUploadSignInViewTheme: EcosiaThemeable {
+    public var backgroundColor = Color.white
+    public var textPrimaryColor = Color.black
+    public var ctaButtonTextColor = Color.green
+    public var ctaButtonBackgroundColor = Color.green
+    public var secondaryButtonTextColor = Color.black
+    public var secondaryButtonBorderColor = Color.gray
+
+    public init() {}
+
+    public mutating func applyTheme(theme: Theme) {
+        backgroundColor = Color(theme.colors.ecosia.backgroundPrimaryDecorative)
+        textPrimaryColor = Color(theme.colors.ecosia.textPrimary)
+        ctaButtonTextColor = Color(theme.colors.ecosia.buttonContentSecondaryStatic)
+        ctaButtonBackgroundColor = Color(theme.colors.ecosia.buttonBackgroundFeatured)
+        secondaryButtonTextColor = Color(theme.colors.ecosia.textPrimary)
+        secondaryButtonBorderColor = Color(theme.colors.ecosia.borderDecorative)
+    }
+}
+
+// MARK: - Conditional presentation background
+
+private extension View {
+    @ViewBuilder
+    func presentationBackgroundIfAvailable(_ color: Color) -> some View {
+        if #available(iOS 16.4, *) {
+            self.presentationBackground(color)
+        } else {
+            self
+        }
+    }
+}
+
+#if DEBUG
+@available(iOS 16.0, *)
+struct OmniboxUploadSignInView_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack(spacing: 0) {
+            Spacer()
+                .frame(height: .ecosia.space._m)
+
+            OmniboxUploadSignInView(
+                windowUUID: .XCTestDefaultUUID,
+                onSignIn: {},
+                onCreateAccount: {},
+                onDismiss: {}
+            )
+        }
+        .padding(.horizontal, .ecosia.space._m)
+        .padding(.bottom, .ecosia.space._m)
+        .previewLayout(.sizeThatFits)
+    }
+}
+#endif

--- a/firefox-ios/EcosiaTests/Account/Auth/AuthTests.swift
+++ b/firefox-ios/EcosiaTests/Account/Auth/AuthTests.swift
@@ -107,6 +107,7 @@ final class AuthTests: XCTestCase {
             _ = try await auth.signUp()
         } catch {
             XCTFail("Sign up should succeed, but failed with: \(error)")
+            return
         }
 
         // Assert

--- a/firefox-ios/EcosiaTests/Account/Auth/AuthTests.swift
+++ b/firefox-ios/EcosiaTests/Account/Auth/AuthTests.swift
@@ -83,11 +83,35 @@ final class AuthTests: XCTestCase {
 
         // Assert
         XCTAssertEqual(mockProvider.startAuthCallCount, 1)
+        XCTAssertEqual(mockProvider.lastAuthScreenHint, .login)
         XCTAssertEqual(mockProvider.storeCredentialsCallCount, 1)
         XCTAssertTrue(auth.isLoggedIn)
         XCTAssertEqual(auth.idToken, expectedCredentials.idToken)
         XCTAssertEqual(auth.accessToken, expectedCredentials.accessToken)
         XCTAssertEqual(auth.refreshToken, expectedCredentials.refreshToken)
+    }
+
+    func testSignUp_usesSignUpScreenHint() async {
+        // Arrange
+        mockProvider.mockCredentials = Credentials(
+            accessToken: "test-access-token",
+            tokenType: "Bearer",
+            idToken: "test-id-token",
+            refreshToken: "test-refresh-token",
+            expiresIn: Date().addingTimeInterval(3600),
+            scope: "openid profile email"
+        )
+
+        // Act
+        do {
+            _ = try await auth.signUp()
+        } catch {
+            XCTFail("Sign up should succeed, but failed with: \(error)")
+        }
+
+        // Assert
+        XCTAssertEqual(mockProvider.startAuthCallCount, 1)
+        XCTAssertEqual(mockProvider.lastAuthScreenHint, .signUp)
     }
 
     func testLogin_withAuthFailure_doesNotUpdateState() async {

--- a/firefox-ios/EcosiaTests/Account/Mocks/MockAuth0Provider.swift
+++ b/firefox-ios/EcosiaTests/Account/Mocks/MockAuth0Provider.swift
@@ -120,7 +120,7 @@ class MockAuth0Provider: Auth0ProviderProtocol, @unchecked Sendable {
             return mockCredentials
         }
 
-        return try await credentialsManager.renew()
+        return createMockCredentials()
     }
 
     // MARK: - Helper Methods

--- a/firefox-ios/EcosiaTests/Account/Mocks/MockAuth0Provider.swift
+++ b/firefox-ios/EcosiaTests/Account/Mocks/MockAuth0Provider.swift
@@ -116,6 +116,10 @@ class MockAuth0Provider: Auth0ProviderProtocol, @unchecked Sendable {
             throw NSError(domain: "MockAuth0Provider", code: 1007, userInfo: [NSLocalizedDescriptionKey: "Cannot renew credentials: no stored credentials"])
         }
 
+        if let mockCredentials {
+            return mockCredentials
+        }
+
         return try await credentialsManager.renew()
     }
 

--- a/firefox-ios/EcosiaTests/Account/Mocks/MockAuth0Provider.swift
+++ b/firefox-ios/EcosiaTests/Account/Mocks/MockAuth0Provider.swift
@@ -25,6 +25,7 @@ class MockAuth0Provider: Auth0ProviderProtocol, @unchecked Sendable {
 
     // MARK: - Call Tracking
     var startAuthCallCount = 0
+    var lastAuthScreenHint: AuthScreenHint?
     var clearSessionCallCount = 0
     var storeCredentialsCallCount = 0
     var retrieveCredentialsCallCount = 0
@@ -38,14 +39,19 @@ class MockAuth0Provider: Auth0ProviderProtocol, @unchecked Sendable {
     lazy var webAuth: WebAuth = Auth0.webAuth(clientId: "test-client", domain: "test.auth0.com")
 
     // MARK: - Mock Implementations
-    func startAuth() async throws -> Credentials {
+    func startAuth(screenHint: AuthScreenHint) async throws -> Credentials {
         startAuthCallCount += 1
+        lastAuthScreenHint = screenHint
 
         if shouldFailAuth {
             throw mockError ?? NSError(domain: "MockAuth0Provider", code: 1001, userInfo: [NSLocalizedDescriptionKey: "Mock auth failure"])
         }
 
         return mockCredentials ?? createMockCredentials()
+    }
+
+    func startAuth() async throws -> Credentials {
+        try await startAuth(screenHint: .login)
     }
 
     func clearSession() async throws {
@@ -110,7 +116,7 @@ class MockAuth0Provider: Auth0ProviderProtocol, @unchecked Sendable {
             throw NSError(domain: "MockAuth0Provider", code: 1007, userInfo: [NSLocalizedDescriptionKey: "Cannot renew credentials: no stored credentials"])
         }
 
-        return mockCredentials ?? createMockCredentials()
+        return try await credentialsManager.renew()
     }
 
     // MARK: - Helper Methods
@@ -139,6 +145,7 @@ class MockAuth0Provider: Auth0ProviderProtocol, @unchecked Sendable {
         hasStoredCredentials = false  // Clear stored credentials state
 
         startAuthCallCount = 0
+        lastAuthScreenHint = nil
         clearSessionCallCount = 0
         storeCredentialsCallCount = 0
         retrieveCredentialsCallCount = 0

--- a/firefox-ios/EcosiaTests/UI/NTP/OmniboxUploadDrawerTests.swift
+++ b/firefox-ios/EcosiaTests/UI/NTP/OmniboxUploadDrawerTests.swift
@@ -239,7 +239,7 @@ final class NTPOmniboxSheetStateTests: XCTestCase {
         XCTAssertTrue(didSignIn)
         XCTAssertFalse(didOpenDrawer)
 
-        state.handleAuthenticationSucceeded()
+        state.handleAuthenticationCompleted(success: true)
         XCTAssertTrue(didOpenDrawer)
     }
 
@@ -256,7 +256,7 @@ final class NTPOmniboxSheetStateTests: XCTestCase {
         state.handleSignInSheetDismissed()
 
         state.handleAuthenticationCompleted(success: false)
-        state.handleAuthenticationSucceeded()
+        state.handleAuthenticationCompleted(success: true)
         XCTAssertFalse(didOpenDrawer)
     }
 
@@ -273,7 +273,7 @@ final class NTPOmniboxSheetStateTests: XCTestCase {
         state.showSignInSheet = false
         state.handleSignInSheetDismissed()
 
-        state.handleAuthenticationSucceeded()
+        state.handleAuthenticationCompleted(success: true)
         XCTAssertFalse(didOpenDrawer)
     }
 
@@ -296,7 +296,7 @@ final class NTPOmniboxSheetStateTests: XCTestCase {
         XCTAssertTrue(didSignUp)
         XCTAssertFalse(didOpenDrawer)
 
-        state.handleAuthenticationSucceeded()
+        state.handleAuthenticationCompleted(success: true)
         XCTAssertTrue(didOpenDrawer)
     }
 }

--- a/firefox-ios/EcosiaTests/UI/NTP/OmniboxUploadDrawerTests.swift
+++ b/firefox-ios/EcosiaTests/UI/NTP/OmniboxUploadDrawerTests.swift
@@ -276,6 +276,29 @@ final class NTPOmniboxSheetStateTests: XCTestCase {
         state.handleAuthenticationSucceeded()
         XCTAssertFalse(didOpenDrawer)
     }
+
+    func testSignInSheetDismissalStartsSignUpAfterSheetCloses() {
+        let state = NTPOmniboxSheetState()
+        var didSignUp = false
+        var didOpenDrawer = false
+
+        state.presentSignInSheetForUpload(
+            onSignIn: {},
+            onSignUp: { didSignUp = true },
+            onUploadDrawerRequested: { didOpenDrawer = true }
+        )
+
+        state.handleSignInSheetCreateAccountTapped()
+        XCTAssertFalse(state.showSignInSheet)
+        XCTAssertFalse(didSignUp)
+
+        state.handleSignInSheetDismissed()
+        XCTAssertTrue(didSignUp)
+        XCTAssertFalse(didOpenDrawer)
+
+        state.handleAuthenticationSucceeded()
+        XCTAssertTrue(didOpenDrawer)
+    }
 }
 
 @MainActor

--- a/firefox-ios/EcosiaTests/UI/NTP/OmniboxUploadDrawerTests.swift
+++ b/firefox-ios/EcosiaTests/UI/NTP/OmniboxUploadDrawerTests.swift
@@ -243,6 +243,23 @@ final class NTPOmniboxSheetStateTests: XCTestCase {
         XCTAssertTrue(didOpenDrawer)
     }
 
+    func testAuthenticationFailureClearsPendingUploadDrawer() {
+        let state = NTPOmniboxSheetState()
+        var didOpenDrawer = false
+
+        state.presentSignInSheetForUpload(
+            onSignIn: {},
+            onSignUp: {},
+            onUploadDrawerRequested: { didOpenDrawer = true }
+        )
+        state.handleSignInSheetSignInTapped()
+        state.handleSignInSheetDismissed()
+
+        state.handleAuthenticationCompleted(success: false)
+        state.handleAuthenticationSucceeded()
+        XCTAssertFalse(didOpenDrawer)
+    }
+
     func testSignInSheetDismissWithoutActionClearsPendingUpload() {
         let state = NTPOmniboxSheetState()
         var didOpenDrawer = false

--- a/firefox-ios/EcosiaTests/UI/NTP/OmniboxUploadDrawerTests.swift
+++ b/firefox-ios/EcosiaTests/UI/NTP/OmniboxUploadDrawerTests.swift
@@ -218,6 +218,47 @@ final class NTPOmniboxSheetStateTests: XCTestCase {
         XCTAssertEqual(received, .files)
         XCTAssertFalse(didLogin)
     }
+
+    func testSignInSheetDismissalStartsSignInAfterSheetCloses() {
+        let state = NTPOmniboxSheetState()
+        var didSignIn = false
+        var didOpenDrawer = false
+
+        state.presentSignInSheetForUpload(
+            onSignIn: { didSignIn = true },
+            onSignUp: {},
+            onUploadDrawerRequested: { didOpenDrawer = true }
+        )
+        XCTAssertTrue(state.showSignInSheet)
+
+        state.handleSignInSheetSignInTapped()
+        XCTAssertFalse(state.showSignInSheet)
+        XCTAssertFalse(didSignIn)
+
+        state.handleSignInSheetDismissed()
+        XCTAssertTrue(didSignIn)
+        XCTAssertFalse(didOpenDrawer)
+
+        state.handleAuthenticationSucceeded()
+        XCTAssertTrue(didOpenDrawer)
+    }
+
+    func testSignInSheetDismissWithoutActionClearsPendingUpload() {
+        let state = NTPOmniboxSheetState()
+        var didOpenDrawer = false
+
+        state.presentSignInSheetForUpload(
+            onSignIn: {},
+            onSignUp: {},
+            onUploadDrawerRequested: { didOpenDrawer = true }
+        )
+
+        state.showSignInSheet = false
+        state.handleSignInSheetDismissed()
+
+        state.handleAuthenticationSucceeded()
+        XCTAssertFalse(didOpenDrawer)
+    }
 }
 
 @MainActor


### PR DESCRIPTION
[MOB-4589]

## Context

Follow-up to MOB-4586. 
Replace the temporary account-impact gate with a dedicated sign-in sheet when a logged-out user taps the upload button.

## Approach

- Present `OmniboxUploadSignInView` from `NTPOmniboxSheetState` with Sign in and Create account actions.
- Open the upload drawer after successful authentication via `NTPOmniboxSheetPresenter`.
- Add native sign-up flow support (`AuthScreenHint`, `EcosiaAuth.signUp()`, Auth0 `screen_hint` parameter).
- Gate upload on login state and conversation OAuth scopes; fall back to legacy login on iOS &lt; 16 or when accounts are disabled.
- Route web sign-in and sign-up URL detection to the matching native auth flow.

| Outcome |
| --- |
| <img width="295" height="640" alt="Simulator Screen Recording - iPhone 17 Pro - 2026-07-01 at 13 53 18" src="https://github.com/user-attachments/assets/3d6b722a-cd18-40f7-97bb-decfec499560" /> |

## Other

- Added Ecosia strings and accessibility identifiers for the sign-in sheet
- Added unit tests for sign-in sheet state and sign-up `screen_hint` wiring

## Before merging

### Checklist

- [ ] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [ ] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4589]: https://ecosia.atlassian.net/browse/MOB-4589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ