### PR TITLE
[MOB-4687] Branch Firebase build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,6 +276,10 @@ jobs:
           paths:
             - bash.env
 
+  # On-demand branch QA builds trigger this job via the CircleCI API (parameter
+  # run-firebase-deploy) — see .github/workflows/branch_firebase_build.yml. It also serves
+  # the manual-firebase-deploy workflow. SPM packages are cached here (branch builds are the
+  # most frequent Firebase builds) to avoid re-resolving/compiling dependencies every run.
   build-and-deploy-firebase:
     <<: *environment_common
     <<: *macos_common
@@ -302,6 +306,11 @@ jobs:
           key: 1-gems-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
+      # Restore SPM packages into firefox-ios/SourcePackages/ (gym reuses this dir via
+      # cloned_source_packages_path in the build_ecosia_app lane). Keyed on the committed
+      # Package.resolved so the cache invalidates only when dependencies change.
+      - restore_cache:
+          key: 1-spm-{{ checksum "firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved" }}
       - run:
           name: Verify github
           command: for ip in $(dig @8.8.8.8 github.com +short); do ssh-keyscan github.com,$ip; ssh-keyscan $ip; done 2>/dev/null >> ~/.ssh/known_hosts
@@ -321,6 +330,10 @@ jobs:
               echo "🚀 PRODUCTION: Building Ecosia app"
               bundle exec fastlane build_ecosia_app
             fi
+      - save_cache:
+          key: 1-spm-{{ checksum "firefox-ios/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved" }}
+          paths:
+            - firefox-ios/SourcePackages
       - run:
           name: Upload to Firebase (with dry-run support)
           command: |

--- a/.github/workflows/branch_firebase_build.yml
+++ b/.github/workflows/branch_firebase_build.yml
@@ -75,28 +75,38 @@ jobs:
 
       - name: Trigger CircleCI pipeline
         id: trigger
+        # This project uses CircleCI's new pipelines architecture (GitHub App), so the
+        # legacy `/project/gh/<org>/<repo>/pipeline` endpoint returns "Project not found".
+        # New pipelines trigger via `/pipeline/run` with a pipeline definition_id (a
+        # non-secret UUID from Project Settings > Pipelines, stored as the repo variable
+        # CIRCLECI_PIPELINE_DEFINITION_ID).
         env:
           CIRCLECI_TOKEN: ${{ secrets.CIRCLECI_TOKEN }}
+          DEFINITION_ID: ${{ vars.CIRCLECI_PIPELINE_DEFINITION_ID }}
           BRANCH: ${{ steps.pr.outputs.branch }}
         run: |
           if [ -z "$CIRCLECI_TOKEN" ]; then
             echo "::error::CIRCLECI_TOKEN secret is not set. Create a CircleCI API token and add it as a repo secret."
             exit 1
           fi
-          PAYLOAD=$(jq -n --arg branch "$BRANCH" \
-            '{branch: $branch, parameters: {"run-firebase-deploy": true}}')
+          if [ -z "$DEFINITION_ID" ]; then
+            echo "::error::CIRCLECI_PIPELINE_DEFINITION_ID variable is not set. Copy the pipeline definition ID from CircleCI Project Settings > Pipelines and add it as a repo variable."
+            exit 1
+          fi
+          PAYLOAD=$(jq -n --arg branch "$BRANCH" --arg def "$DEFINITION_ID" \
+            '{definition_id: $def, config: {branch: $branch}, checkout: {branch: $branch}, parameters: {"run-firebase-deploy": true}}')
           RESPONSE=$(curl -sS -X POST \
-            "https://circleci.com/api/v2/project/gh/ecosia/ios-browser/pipeline" \
+            "https://circleci.com/api/v2/project/github/ecosia/ios-browser/pipeline/run" \
             -H "Circle-Token: $CIRCLECI_TOKEN" \
             -H "Content-Type: application/json" \
             -d "$PAYLOAD")
           echo "$RESPONSE"
-          PIPELINE_NUMBER=$(echo "$RESPONSE" | jq -r '.number // empty')
-          if [ -z "$PIPELINE_NUMBER" ]; then
-            echo "::error::CircleCI did not return a pipeline number. Response above."
+          PIPELINE_ID=$(echo "$RESPONSE" | jq -r '.id // empty')
+          if [ -z "$PIPELINE_ID" ]; then
+            echo "::error::CircleCI did not return a pipeline id. Response above."
             exit 1
           fi
-          echo "pipeline_url=https://app.circleci.com/pipelines/github/ecosia/ios-browser?branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "pipeline_url=https://app.circleci.com/pipelines/github/ecosia?project=a8d1b3b6-86e0-4d72-bea5-e73ad105e0dc" >> "$GITHUB_OUTPUT"
 
       - name: Comment on PR
         env:

--- a/.github/workflows/branch_firebase_build.yml
+++ b/.github/workflows/branch_firebase_build.yml
@@ -4,9 +4,10 @@ name: Branch Firebase QA Build
 # code while reviewing it. This does NOT build on every push — it only fires when someone
 # explicitly opts in, to keep CircleCI macOS credits under control.
 #
-# Two ways to request a build:
-#   - Add the `needs-qa` label to the PR.
-#   - Comment `/qa` on the PR.
+# To request a build, add the `needs-qa` label to the PR. Adding a label requires repo
+# access (triage or higher), so it is not open to arbitrary users. A `/qa` comment trigger
+# was intentionally not used: a comment's author_association is not a reliable permission
+# signal, so it could let a non-write user reach CI secrets.
 #
 # The actual build runs on CircleCI: this workflow just triggers the existing
 # `manual-firebase-deploy` workflow (job `build-and-deploy-firebase`, Firebase only, no
@@ -17,13 +18,11 @@ name: Branch Firebase QA Build
 on:
   pull_request:
     types: [labeled]
-  issue_comment:
-    types: [created]
 
 concurrency:
-  # Coalesce repeated requests on the same PR so a re-label / re-comment supersedes an
-  # in-flight trigger instead of stacking builds.
-  group: branch-firebase-build-${{ github.event.pull_request.number || github.event.issue.number }}
+  # Coalesce repeated requests on the same PR so a re-label supersedes an in-flight trigger
+  # instead of stacking builds.
+  group: branch-firebase-build-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 permissions:
@@ -33,17 +32,9 @@ permissions:
 
 jobs:
   trigger-firebase-build:
-    # Gate: `needs-qa` label added, OR a `/qa` comment on a pull request (not a plain issue).
-    # Applying a label already requires write access, so the label path is inherently
-    # trusted. The comment path fires for anyone on a public repo, so it is additionally
-    # restricted to users with write access (OWNER/MEMBER/COLLABORATOR) to prevent
-    # arbitrary users from triggering builds that reach CI secrets.
-    if: >
-      (github.event_name == 'pull_request' && github.event.label.name == 'needs-qa') ||
-      (github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request != null &&
-        startsWith(github.event.comment.body, '/qa') &&
-        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
+    # Trigger only when the `needs-qa` label is added to a PR. Adding a label requires repo
+    # access (triage or higher), so it is not open to arbitrary users.
+    if: github.event_name == 'pull_request' && github.event.label.name == 'needs-qa'
     runs-on: ubuntu-latest
     name: Trigger CircleCI Firebase build
     steps:
@@ -54,24 +45,12 @@ jobs:
       - name: Resolve PR branch and number
         id: pr
         env:
-          GH_TOKEN: ${{ github.token }}
-          EVENT_NAME: ${{ github.event_name }}
-          REPO: ${{ github.repository }}
-          PR_EVENT_NUMBER: ${{ github.event.pull_request.number }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          if [ "$EVENT_NAME" = "pull_request" ]; then
-            PR_NUMBER="$PR_EVENT_NUMBER"
-            BRANCH="$PR_HEAD_REF"
-          else
-            # issue_comment: fetch the PR to get its head branch.
-            PR_NUMBER="$ISSUE_NUMBER"
-            BRANCH=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefName --jq '.headRefName')
-          fi
           printf 'number=%s\n' "$PR_NUMBER" >> "$GITHUB_OUTPUT"
-          printf 'branch=%s\n' "$BRANCH" >> "$GITHUB_OUTPUT"
-          echo "Requesting Firebase QA build for PR #$PR_NUMBER (branch: $BRANCH)"
+          printf 'branch=%s\n' "$PR_HEAD_REF" >> "$GITHUB_OUTPUT"
+          echo "Requesting Firebase QA build for PR #$PR_NUMBER (branch: $PR_HEAD_REF)"
 
       - name: Trigger CircleCI pipeline
         id: trigger
@@ -101,12 +80,14 @@ jobs:
             -H "Content-Type: application/json" \
             -d "$PAYLOAD")
           echo "$RESPONSE"
-          PIPELINE_ID=$(echo "$RESPONSE" | jq -r '.id // empty')
-          if [ -z "$PIPELINE_ID" ]; then
-            echo "::error::CircleCI did not return a pipeline id. Response above."
+          # Link directly to this run by pipeline number (CircleCI redirects this short form
+          # to the pipeline in the new UI; the id UUID is not usable in the URL path).
+          PIPELINE_NUMBER=$(echo "$RESPONSE" | jq -r '.number // empty')
+          if [ -z "$PIPELINE_NUMBER" ]; then
+            echo "::error::CircleCI did not return a pipeline number. Response above."
             exit 1
           fi
-          echo "pipeline_url=https://app.circleci.com/pipelines/github/ecosia?project=a8d1b3b6-86e0-4d72-bea5-e73ad105e0dc" >> "$GITHUB_OUTPUT"
+          echo "pipeline_url=https://app.circleci.com/pipelines/github/ecosia/ios-browser/$PIPELINE_NUMBER" >> "$GITHUB_OUTPUT"
 
       - name: Comment on PR
         env:

--- a/.github/workflows/branch_firebase_build.yml
+++ b/.github/workflows/branch_firebase_build.yml
@@ -34,9 +34,16 @@ permissions:
 jobs:
   trigger-firebase-build:
     # Gate: `needs-qa` label added, OR a `/qa` comment on a pull request (not a plain issue).
+    # Applying a label already requires write access, so the label path is inherently
+    # trusted. The comment path fires for anyone on a public repo, so it is additionally
+    # restricted to users with write access (OWNER/MEMBER/COLLABORATOR) to prevent
+    # arbitrary users from triggering builds that reach CI secrets.
     if: >
       (github.event_name == 'pull_request' && github.event.label.name == 'needs-qa') ||
-      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && startsWith(github.event.comment.body, '/qa'))
+      (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request != null &&
+        startsWith(github.event.comment.body, '/qa') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
     name: Trigger CircleCI Firebase build
     steps:

--- a/.github/workflows/branch_firebase_build.yml
+++ b/.github/workflows/branch_firebase_build.yml
@@ -47,21 +47,30 @@ jobs:
     runs-on: ubuntu-latest
     name: Trigger CircleCI Firebase build
     steps:
+      # SECURITY: never interpolate ${{ github.* }} values (especially the
+      # attacker-controllable PR head branch name) directly into a run: script - git refs
+      # legitimately allow shell metacharacters, so that would enable command injection.
+      # All context values are passed via env and referenced as quoted shell variables.
       - name: Resolve PR branch and number
         id: pr
         env:
           GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          REPO: ${{ github.repository }}
+          PR_EVENT_NUMBER: ${{ github.event.pull_request.number }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            PR_NUMBER="${{ github.event.pull_request.number }}"
-            BRANCH="${{ github.event.pull_request.head.ref }}"
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            PR_NUMBER="$PR_EVENT_NUMBER"
+            BRANCH="$PR_HEAD_REF"
           else
             # issue_comment: fetch the PR to get its head branch.
-            PR_NUMBER="${{ github.event.issue.number }}"
-            BRANCH=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json headRefName --jq '.headRefName')
+            PR_NUMBER="$ISSUE_NUMBER"
+            BRANCH=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefName --jq '.headRefName')
           fi
-          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
-          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          printf 'number=%s\n' "$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          printf 'branch=%s\n' "$BRANCH" >> "$GITHUB_OUTPUT"
           echo "Requesting Firebase QA build for PR #$PR_NUMBER (branch: $BRANCH)"
 
       - name: Trigger CircleCI pipeline
@@ -92,9 +101,13 @@ jobs:
       - name: Comment on PR
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          BRANCH: ${{ steps.pr.outputs.branch }}
+          PIPELINE_URL: ${{ steps.trigger.outputs.pipeline_url }}
         run: |
-          gh pr comment "${{ steps.pr.outputs.number }}" --repo "${{ github.repository }}" --body \
-          "🚀 Firebase QA build requested for \`${{ steps.pr.outputs.branch }}\`. Track it on [CircleCI](${{ steps.trigger.outputs.pipeline_url }}); once green it appears in Firebase App Distribution for the \`ecosia-internal-testers\` group."
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body \
+          "🚀 Firebase QA build requested for \`$BRANCH\`. Track it on [CircleCI]($PIPELINE_URL); once green it appears in Firebase App Distribution for the \`ecosia-internal-testers\` group."
 
       - name: Remove needs-qa label
         # Only relevant when triggered by the label; drop it so a future request is an
@@ -102,4 +115,6 @@ jobs:
         if: github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh pr edit "${{ steps.pr.outputs.number }}" --repo "${{ github.repository }}" --remove-label "needs-qa" || true
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "needs-qa" || true

--- a/.github/workflows/branch_firebase_build.yml
+++ b/.github/workflows/branch_firebase_build.yml
@@ -116,8 +116,10 @@ jobs:
           BRANCH: ${{ steps.pr.outputs.branch }}
           PIPELINE_URL: ${{ steps.trigger.outputs.pipeline_url }}
         run: |
-          gh pr comment "$PR_NUMBER" --repo "$REPO" --body \
-          "🚀 Firebase QA build requested for \`$BRANCH\`. Track it on [CircleCI]($PIPELINE_URL); once green it appears in Firebase App Distribution for the \`ecosia-internal-testers\` group."
+          # Build the body with printf (%s for untrusted values, so the branch name is
+          # never interpreted); backticks in the single-quoted format are literal markdown.
+          BODY=$(printf '🚀 Firebase QA build requested.\n\n- **Branch:** `%s`\n- **Pipeline:** [CircleCI](%s)' "$BRANCH" "$PIPELINE_URL")
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$BODY"
 
       - name: Remove needs-qa label
         # Only relevant when triggered by the label; drop it so a future request is an

--- a/.github/workflows/branch_firebase_build.yml
+++ b/.github/workflows/branch_firebase_build.yml
@@ -1,0 +1,98 @@
+name: Branch Firebase QA Build
+
+# On-demand Firebase App Distribution build for a PR branch, so reviewers can QA a peer's
+# code while reviewing it. This does NOT build on every push — it only fires when someone
+# explicitly opts in, to keep CircleCI macOS credits under control.
+#
+# Two ways to request a build:
+#   - Add the `needs-qa` label to the PR.
+#   - Comment `/qa` on the PR.
+#
+# The actual build runs on CircleCI: this workflow just triggers the existing
+# `manual-firebase-deploy` workflow (job `build-and-deploy-firebase`, Firebase only, no
+# BrowserStack) via the CircleCI v2 API, passing the PR head branch and
+# `run-firebase-deploy: true`. Requires repo secret CIRCLECI_TOKEN (a CircleCI API token
+# with pipeline-trigger scope on ecosia/ios-browser).
+
+on:
+  pull_request:
+    types: [labeled]
+  issue_comment:
+    types: [created]
+
+concurrency:
+  # Coalesce repeated requests on the same PR so a re-label / re-comment supersedes an
+  # in-flight trigger instead of stacking builds.
+  group: branch-firebase-build-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  trigger-firebase-build:
+    # Gate: `needs-qa` label added, OR a `/qa` comment on a pull request (not a plain issue).
+    if: >
+      (github.event_name == 'pull_request' && github.event.label.name == 'needs-qa') ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && startsWith(github.event.comment.body, '/qa'))
+    runs-on: ubuntu-latest
+    name: Trigger CircleCI Firebase build
+    steps:
+      - name: Resolve PR branch and number
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            PR_NUMBER="${{ github.event.pull_request.number }}"
+            BRANCH="${{ github.event.pull_request.head.ref }}"
+          else
+            # issue_comment: fetch the PR to get its head branch.
+            PR_NUMBER="${{ github.event.issue.number }}"
+            BRANCH=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json headRefName --jq '.headRefName')
+          fi
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "Requesting Firebase QA build for PR #$PR_NUMBER (branch: $BRANCH)"
+
+      - name: Trigger CircleCI pipeline
+        id: trigger
+        env:
+          CIRCLECI_TOKEN: ${{ secrets.CIRCLECI_TOKEN }}
+          BRANCH: ${{ steps.pr.outputs.branch }}
+        run: |
+          if [ -z "$CIRCLECI_TOKEN" ]; then
+            echo "::error::CIRCLECI_TOKEN secret is not set. Create a CircleCI API token and add it as a repo secret."
+            exit 1
+          fi
+          PAYLOAD=$(jq -n --arg branch "$BRANCH" \
+            '{branch: $branch, parameters: {"run-firebase-deploy": true}}')
+          RESPONSE=$(curl -sS -X POST \
+            "https://circleci.com/api/v2/project/gh/ecosia/ios-browser/pipeline" \
+            -H "Circle-Token: $CIRCLECI_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD")
+          echo "$RESPONSE"
+          PIPELINE_NUMBER=$(echo "$RESPONSE" | jq -r '.number // empty')
+          if [ -z "$PIPELINE_NUMBER" ]; then
+            echo "::error::CircleCI did not return a pipeline number. Response above."
+            exit 1
+          fi
+          echo "pipeline_url=https://app.circleci.com/pipelines/github/ecosia/ios-browser?branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Comment on PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr comment "${{ steps.pr.outputs.number }}" --repo "${{ github.repository }}" --body \
+          "🚀 Firebase QA build requested for \`${{ steps.pr.outputs.branch }}\`. Track it on [CircleCI](${{ steps.trigger.outputs.pipeline_url }}); once green it appears in Firebase App Distribution for the \`ecosia-internal-testers\` group."
+
+      - name: Remove needs-qa label
+        # Only relevant when triggered by the label; drop it so a future request is an
+        # explicit, deliberate re-label rather than lingering.
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh pr edit "${{ steps.pr.outputs.number }}" --repo "${{ github.repository }}" --remove-label "needs-qa" || true

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -48,6 +48,9 @@ platform :ios do
       export_method: "ad-hoc",
       configuration: "Development_Firebase",
       xcargs: firebase_archive_args,
+      # Resolve SPM packages into a fixed dir so CI can cache them across runs
+      # (see the SPM restore_cache/save_cache steps in .circleci/config.yml).
+      cloned_source_packages_path: "firefox-ios/SourcePackages",
       export_options: {iCloudContainerEnvironment: 'Development'}
     )
   end


### PR DESCRIPTION
[MOB-4687]

## Context

We want to enable QA during PR reviews (see ticket).

## Approach

Lets a reviewer spin up a Firebase build of a PR branch on demand for QA.

- **New workflow** `.github/workflows/branch_firebase_build.yml`: adding the `needs-qa` label on a PR triggers the existing CircleCI `build-and-deploy-firebase` pipeline for that branch, comments the pipeline link back, and removes the label.
- Triggers CircleCI via the **new-pipelines API** (`/pipeline/run` + `definition_id`), matching this project's OAuth / new-pipelines setup.
- **SPM caching** added to the `build-and-deploy-firebase` job (`.circleci/config.yml`) plus `cloned_source_packages_path` in `fastlane/Fastfile`, so branch builds stop re-resolving packages every run.
- **Hardening:** `/qa` restricted to write-access users; all `github.*` context flows through `env` (no shell injection).

[MOB-4687]: https://ecosia.atlassian.net/browse/MOB-4687?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ