### PR TITLE
[MOB-4627] Implement Chat Modes Selection & Routing

### DIFF
--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Omnibox.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Omnibox.swift
@@ -26,11 +26,28 @@ extension BrowserViewController: NTPSearchBarDelegate {
             omniboxAttachmentCoordinator.clearAttachments()
             _ = bar.resignFirstResponder()
         }
-        submitOmniboxSearch(query: searchTerm)
+        // When a chat mode is active, every message bypasses backend
+        // autorouting and goes straight to AI Chat in that mode. The mode
+        // stays selected across submissions until the user deselects it.
+        if let mode = omniboxSheetState?.selectedChatMode {
+            submitOmniboxChatMode(mode, query: searchTerm)
+        } else {
+            submitOmniboxSearch(query: searchTerm)
+        }
         // Force the swap to the webview. Without URL bar overlay mode, the
         // standard `addressToolbar(_:didLeaveOverlayModeForReason:)` chain
         // — which is what normally calls `showEmbeddedWebview()` — never fires.
         showEmbeddedWebview()
+    }
+
+    /// Loads AI Chat seeded with the typed message and tagged with the active
+    /// chat mode's backend flags (see `OmniboxChatMode.aiChatQueryItems`).
+    private func submitOmniboxChatMode(_ mode: OmniboxChatMode, query: String) {
+        guard let tab = tabManager.selectedTab else { return }
+        let url = Environment.current.urlProvider.aiChat(origin: .omnibox,
+                                                         query: query,
+                                                         additionalQueryItems: mode.aiChatQueryItems)
+        finishEditingAndSubmit(url, visitType: .typed, forTab: tab)
     }
 
     /// Builds the search URL for an omnibox submission (direct typed submit
@@ -151,6 +168,13 @@ extension BrowserViewController: NTPSearchBarDelegate {
                                  coordinator,
                                  .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         return coordinator
+    }
+
+    /// Shared source of truth for the omnibox "AI tools" drawer, including the
+    /// active chat-mode selection. Lives on the homepage adapter, so it is only
+    /// available while the NTP is the current content.
+    fileprivate var omniboxSheetState: NTPOmniboxSheetState? {
+        (contentContainer.contentController as? HomepageViewController)?.ecosiaAdapter?.omniboxSheetState
     }
 }
 
@@ -380,16 +404,18 @@ extension BrowserViewController {
             self.omniboxUploadPickerCoordinator.presentPicker(for: option,
                                                               from: self,
                                                               sourceView: sourceView)
-        }, onSelectChatMode: { [weak self] mode in
-            self?.handleOmniboxChatModeSelection(mode)
+        }, onChatModeSelectionChanged: { [weak self] mode in
+            // The sheet state has already toggled the active mode; reflect it on
+            // the omnibox chip right away so the glyph appears while the drawer
+            // is still sliding away rather than after it disappears.
+            self?.ntpOmniboxAnchorView?.setSelectedChatMode(mode)
         })
     }
 
-    /// Handles a chat-mode selection from the "AI tools" drawer. Selecting a mode
-    /// currently just closes the drawer (dismissal is driven by the sheet state);
-    /// `mode` is delivered here so the follow-up can act on the chosen mode.
-    fileprivate func handleOmniboxChatModeSelection(_ mode: OmniboxChatMode) {
-        // TODO: MOB-4627 — add the selected chat mode as a chip on the omnibox.
+    /// Clears the active chat mode when the user taps the chip's X.
+    func ntpSearchBarDidTapChatModeChipClose() {
+        omniboxSheetState?.selectedChatMode = nil
+        ntpOmniboxAnchorView?.setSelectedChatMode(nil)
     }
 }
 

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPSearchBarView.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPSearchBarView.swift
@@ -42,12 +42,16 @@ protocol NTPSearchBarDelegate: AnyObject {
     func ntpSearchBarDidTapUpload()
     /// Called when attachments are added, removed, or finish uploading.
     func ntpSearchBarAttachmentsDidChange()
+    /// Called when the user taps the close (X) button on the active chat-mode
+    /// chip, asking to deselect the mode.
+    func ntpSearchBarDidTapChatModeChipClose()
 }
 
 extension NTPSearchBarDelegate {
     func ntpSearchBarIsSuggestionsOverlayVisible() -> Bool { false }
     func ntpSearchBarNeedsSuggestionsLayoutUpdate() {}
     func ntpSearchBarAttachmentsDidChange() {}
+    func ntpSearchBarDidTapChatModeChipClose() {}
 }
 
 /// Pill-shaped search input pinned to the bottom of the redesigned NTP. Replaces
@@ -95,6 +99,15 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable, UIGestur
         static var attachmentStripHeight: CGFloat { OmniboxAttachmentsStripView.UX.tileHeight + .ecosia.space._1s }
         static var minTextHeight: CGFloat { minHeight - textPadding - bottomRowHeight }
         static var maxTextHeight: CGFloat { maxHeight - textPadding - bottomRowHeight }
+
+        /// Active chat-mode chip shown next to the upload button. An outlined
+        /// pill holding the mode glyph plus an X to deselect.
+        static let chatModeChipHeight: CGFloat = 32
+        static let chatModeChipIconSize: CGFloat = 18
+        static let chatModeChipCloseGlyphSize: CGFloat = 9
+        static let chatModeChipLeadingInset: CGFloat = .ecosia.space._s
+        static let chatModeChipInnerSpacing: CGFloat = .ecosia.space._1s
+        static let chatModeChipTrailingInset: CGFloat = .ecosia.space._1s
     }
 
     private(set) var attachments: [OmniboxAttachment] = []
@@ -194,6 +207,38 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable, UIGestur
         glyph.isUserInteractionEnabled = false
     }
 
+    /// Active chat-mode chip in the bottom-left row, next to the upload button.
+    /// An outlined pill wrapping the selected mode's glyph and a trailing X.
+    /// Tapping anywhere on the pill (glyph or X) deselects the mode. Hidden
+    /// whenever no mode is active.
+    private lazy var chatModeChip: UIControl = .build { chip in
+        chip.layer.cornerRadius = UX.chatModeChipHeight / 2
+        chip.layer.borderWidth = 1
+        chip.isHidden = true
+        chip.accessibilityIdentifier = "NTPSearchBarChatModeChip"
+        chip.isAccessibilityElement = true
+        chip.accessibilityTraits = .button
+        chip.accessibilityHint = String.localized(.chatModeChipRemoveAccessibilityLabel)
+    }
+
+    private lazy var chatModeChipIcon: UIImageView = .build { imageView in
+        imageView.contentMode = .scaleAspectFit
+        imageView.isUserInteractionEnabled = false
+    }
+
+    /// Decorative X on the trailing edge of the chip. Not independently tappable
+    /// — the whole `chatModeChip` control handles the deselect tap.
+    private lazy var chatModeChipCloseGlyph: UIImageView = .build { glyph in
+        let symbolConfig = UIImage.SymbolConfiguration(pointSize: UX.chatModeChipCloseGlyphSize, weight: .semibold)
+        glyph.image = UIImage(systemName: "xmark", withConfiguration: symbolConfig)?
+            .withRenderingMode(.alwaysTemplate)
+        glyph.contentMode = .center
+        glyph.isUserInteractionEnabled = false
+    }
+
+    /// The mode currently reflected by the chip, if any.
+    private(set) var selectedChatMode: OmniboxChatMode?
+
     /// Fires whenever the text content changes (including programmatic clears).
     /// Use from the host to drive layout that depends on pill height changes.
     var onContentChange: ((String) -> Void)?
@@ -263,6 +308,7 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable, UIGestur
         addSubview(textView)
         addSubview(placeholderLabel)
         addSubview(uploadButton)
+        addSubview(chatModeChip)
         addSubview(submitButton)
         addSubview(counterLabel)
         addSubview(clearButton)
@@ -271,11 +317,15 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable, UIGestur
         // interaction disabled so taps fall through to the button.
         clearButton.addSubview(clearButtonCircle)
         clearButton.addSubview(clearButtonGlyph)
+        chatModeChip.addSubview(chatModeChipIcon)
+        chatModeChip.addSubview(chatModeChipCloseGlyph)
 
         textView.delegate = self
         uploadButton.addTarget(self, action: #selector(uploadTapped), for: .touchUpInside)
         submitButton.addTarget(self, action: #selector(submitTapped), for: .touchUpInside)
         clearButton.addTarget(self, action: #selector(clearTapped), for: .touchUpInside)
+        // The whole chip deselects — tapping the glyph or the X both remove the mode.
+        chatModeChip.addTarget(self, action: #selector(chatModeChipTapped), for: .touchUpInside)
 
         // Tapping anywhere on the pill (including padding around the textView)
         // focuses the field — without this, only the small intrinsic-size textView
@@ -321,12 +371,33 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable, UIGestur
             submitButton.widthAnchor.constraint(equalToConstant: UX.submitButtonSize),
             submitButton.heightAnchor.constraint(equalToConstant: UX.submitButtonSize),
 
+            // Chat-mode chip sits between the upload button and the counter in
+            // the bottom row, vertically centred on the upload button. Its
+            // width is intrinsic (glyph + X); it's simply hidden when no mode
+            // is active.
+            chatModeChip.leadingAnchor.constraint(equalTo: uploadButton.trailingAnchor,
+                                                  constant: .ecosia.space._1s),
+            chatModeChip.centerYAnchor.constraint(equalTo: uploadButton.centerYAnchor),
+            chatModeChip.heightAnchor.constraint(equalToConstant: UX.chatModeChipHeight),
+
+            chatModeChipIcon.leadingAnchor.constraint(equalTo: chatModeChip.leadingAnchor,
+                                                      constant: UX.chatModeChipLeadingInset),
+            chatModeChipIcon.centerYAnchor.constraint(equalTo: chatModeChip.centerYAnchor),
+            chatModeChipIcon.widthAnchor.constraint(equalToConstant: UX.chatModeChipIconSize),
+            chatModeChipIcon.heightAnchor.constraint(equalToConstant: UX.chatModeChipIconSize),
+
+            chatModeChipCloseGlyph.leadingAnchor.constraint(equalTo: chatModeChipIcon.trailingAnchor,
+                                                            constant: UX.chatModeChipInnerSpacing),
+            chatModeChipCloseGlyph.trailingAnchor.constraint(equalTo: chatModeChip.trailingAnchor,
+                                                             constant: -UX.chatModeChipTrailingInset),
+            chatModeChipCloseGlyph.centerYAnchor.constraint(equalTo: chatModeChip.centerYAnchor),
+
             // Character counter sits inline with the submit button on its
             // leading side — its trailing edge aligns flush with the submit
             // button's leading edge with a small gap.
             counterLabel.trailingAnchor.constraint(equalTo: submitButton.leadingAnchor, constant: -.ecosia.space._1s),
             counterLabel.centerYAnchor.constraint(equalTo: submitButton.centerYAnchor),
-            counterLabel.leadingAnchor.constraint(greaterThanOrEqualTo: uploadButton.trailingAnchor,
+            counterLabel.leadingAnchor.constraint(greaterThanOrEqualTo: chatModeChip.trailingAnchor,
                                                   constant: .ecosia.space._1s),
 
             // Clear-text button sits in the top-right of the pill — its
@@ -358,7 +429,8 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable, UIGestur
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
         var view: UIView? = touch.view
         while let current = view {
-            if current === uploadButton || current === submitButton || current === clearButton {
+            if current === uploadButton || current === submitButton || current === clearButton
+                || current === chatModeChip {
                 return false
             }
             if current === attachmentsStrip || current.isDescendant(of: attachmentsStrip) {
@@ -379,6 +451,28 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable, UIGestur
 
     @objc private func uploadTapped() {
         delegate?.ntpSearchBarDidTapUpload()
+    }
+
+    @objc private func chatModeChipTapped() {
+        delegate?.ntpSearchBarDidTapChatModeChipClose()
+    }
+
+    /// Reflects the active chat mode in the bottom-row chip. Passing `nil`
+    /// hides the chip. The chip's glyph is the mode's icon; the whole pill is
+    /// dismissible via its X. Called by the host whenever the shared selection
+    /// changes (mode picked in the drawer, or deselected).
+    func setSelectedChatMode(_ mode: OmniboxChatMode?) {
+        selectedChatMode = mode
+        if let mode {
+            chatModeChipIcon.image = UIImage.ecosia(named: mode.iconName)?
+                .withRenderingMode(.alwaysTemplate)
+            chatModeChip.accessibilityLabel = mode.title
+            chatModeChip.isHidden = false
+        } else {
+            chatModeChipIcon.image = nil
+            chatModeChip.isHidden = true
+        }
+        setNeedsLayout()
     }
 
     @objc private func submitTapped() {
@@ -596,6 +690,13 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable, UIGestur
         clearButton.backgroundColor = .clear
         clearButtonCircle.backgroundColor = colors.ecosia.textPrimary
         clearButtonGlyph.tintColor = colors.ecosia.backgroundElevation2
+
+        // Chat-mode chip: outlined pill whose border, mode glyph, and X all
+        // share one muted tint so they read as a single element (per design).
+        chatModeChip.backgroundColor = .clear
+        chatModeChip.layer.borderColor = colors.ecosia.textSecondary.cgColor
+        chatModeChipIcon.tintColor = colors.ecosia.textSecondary
+        chatModeChipCloseGlyph.tintColor = colors.ecosia.textSecondary
     }
 
     /// Swaps the pill border between the resting `borderDecorative` token and

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/NTPOmniboxSheetPresenter.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/NTPOmniboxSheetPresenter.swift
@@ -21,7 +21,8 @@ struct NTPOmniboxSheetPresenter: View {
             }) {
                 OmniboxUploadDrawerSheet(
                     windowUUID: windowUUID,
-                    onSelectUploadOption: { option in sheetState.handleUploadOptionSelected(option) },
+                    selectedChatMode: sheetState.selectedChatMode,
+                    onSelect: { option in sheetState.handleUploadOptionSelected(option) },
                     onSelectChatMode: { mode in sheetState.handleChatModeSelected(mode) }
                 )
             }

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/NTPOmniboxSheetState.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/NTPOmniboxSheetState.swift
@@ -7,51 +7,55 @@ import Ecosia
 
 @MainActor
 final class NTPOmniboxSheetState: ObservableObject {
-    /// A selection made in the "AI tools" drawer, delivered after the sheet
-    /// finishes dismissing so navigation/pickers don't fight the dismissal.
-    private enum PendingSelection {
-        case upload(OmniboxUploadOption)
-        case chatMode(OmniboxChatMode)
-    }
-
     @Published var showUploadDrawer = false
 
+    /// The currently active chat mode, or `nil` when none is selected. Drives
+    /// both the checkmark in the drawer and the mode chip on the omnibox, and
+    /// is read by the submit path to route messages to the matching AI Chat
+    /// URL. Owned here so the drawer, the chip, and routing share one source
+    /// of truth.
+    @Published var selectedChatMode: OmniboxChatMode?
+
     private var onUploadOptionSelected: ((OmniboxUploadOption) -> Void)?
-    private var onChatModeSelected: ((OmniboxChatMode) -> Void)?
-    private var pendingSelection: PendingSelection?
+    private var onChatModeSelectionChanged: ((OmniboxChatMode?) -> Void)?
+    /// An upload selection is delivered only after the sheet finishes dismissing
+    /// so the picker it presents doesn't fight the dismissal. Chat-mode changes
+    /// don't present anything, so they apply immediately (see below).
+    private var pendingUploadOption: OmniboxUploadOption?
 
     func presentUploadDrawer(onSelectUpload: @escaping (OmniboxUploadOption) -> Void,
-                             onSelectChatMode: @escaping (OmniboxChatMode) -> Void) {
-        pendingSelection = nil
+                             onChatModeSelectionChanged: @escaping (OmniboxChatMode?) -> Void) {
+        pendingUploadOption = nil
         onUploadOptionSelected = onSelectUpload
-        onChatModeSelected = onSelectChatMode
+        self.onChatModeSelectionChanged = onChatModeSelectionChanged
         showUploadDrawer = true
     }
 
     func handleUploadOptionSelected(_ option: OmniboxUploadOption) {
-        pendingSelection = .upload(option)
+        pendingUploadOption = option
         showUploadDrawer = false
     }
 
     func handleChatModeSelected(_ mode: OmniboxChatMode) {
-        pendingSelection = .chatMode(mode)
+        // Only one mode can be active; picking a mode makes it the active one.
+        // Re-picking the already-active mode is a no-op (it just closes the
+        // drawer) — deselection happens by tapping the omnibox chip, not here.
+        // Applied immediately (rather than on dismiss) so the drawer checkmark
+        // and the omnibox chip update the instant the user taps.
+        selectedChatMode = mode
+        onChatModeSelectionChanged?(selectedChatMode)
         showUploadDrawer = false
     }
 
     func handleUploadDrawerDismissed() {
-        defer {
-            pendingSelection = nil
-            onUploadOptionSelected = nil
-            onChatModeSelected = nil
-        }
+        let option = pendingUploadOption
+        let uploadCallback = onUploadOptionSelected
+        pendingUploadOption = nil
+        onUploadOptionSelected = nil
+        onChatModeSelectionChanged = nil
 
-        switch pendingSelection {
-        case .upload(let option):
-            onUploadOptionSelected?(option)
-        case .chatMode(let mode):
-            onChatModeSelected?(mode)
-        case nil:
-            break
+        if let option {
+            uploadCallback?(option)
         }
     }
 }

--- a/firefox-ios/Ecosia/Core/Environment/URLProvider.swift
+++ b/firefox-ios/Ecosia/Core/Environment/URLProvider.swift
@@ -218,13 +218,16 @@ public enum URLProvider {
     }
 
     /// Builds the AI chat URL, optionally tagged with where the user came
-    /// from (`origin`) and seeded with a `query` to start the conversation.
-    /// Centralizing both parameters here keeps callers from having to know
+    /// from (`origin`), seeded with a `query` to start the conversation,
+    /// with optional `files` for attachment routing, and extended with
+    /// `additionalQueryItems` (e.g. an omnibox chat mode's backend flags).
+    /// Centralizing the parameters here keeps callers from having to know
     /// the URL's query-item conventions.
     public func aiChat(
         origin: AIChatOrigin? = nil,
         query: String? = nil,
-        files: [AIChatFileQuery] = []
+        files: [AIChatFileQuery] = [],
+        additionalQueryItems: [URLQueryItem] = []
     ) -> URL {
         let baseURL = root.appendingPathComponent("ai-chat")
         var items: [URLQueryItem] = []
@@ -237,6 +240,7 @@ public enum URLProvider {
         if !files.isEmpty, let filesJSON = AIChatFileQuery.urlQueryValue(files) {
             items.append(URLQueryItem(name: "files", value: filesJSON))
         }
+        items.append(contentsOf: additionalQueryItems)
         guard !items.isEmpty else { return baseURL }
         return baseURL.appendingPercentEncodedQueryItems(items)
     }

--- a/firefox-ios/Ecosia/L10N/String.swift
+++ b/firefox-ios/Ecosia/L10N/String.swift
@@ -323,5 +323,6 @@ extension String {
         case uploadAttachmentFailed = "Upload failed"
         case uploadSubmitWaitingForUpload = "Waiting for the attachment to finish uploading"
         case uploadSubmitUploadFailed = "Remove the failed attachment or try uploading again"
+        case chatModeChipRemoveAccessibilityLabel = "Remove chat mode"
     }
 }

--- a/firefox-ios/Ecosia/L10N/en.lproj/Ecosia.strings
+++ b/firefox-ios/Ecosia/L10N/en.lproj/Ecosia.strings
@@ -319,6 +319,7 @@
 "Upload failed" = "Upload failed";
 "Waiting for the attachment to finish uploading" = "Waiting for the attachment to finish uploading";
 "Remove the failed attachment or try uploading again" = "Remove the failed attachment or try uploading again";
+"Remove chat mode" = "Remove chat mode";
 
 // Product Tour
 "Go back" = "Go back";

--- a/firefox-ios/Ecosia/UI/NTP/Upload/OmniboxUploadDrawerView.swift
+++ b/firefox-ios/Ecosia/UI/NTP/Upload/OmniboxUploadDrawerView.swift
@@ -28,6 +28,8 @@ private enum OmniboxUploadDrawerUX {
     static var chatModeSeparatorLeadingInset: CGFloat {
         chatModeRowHorizontalPadding + chatModeIconSize + chatModeIconSpacing
     }
+    static let newBadgeHorizontalPadding: CGFloat = .ecosia.space._1s
+    static let newBadgeVerticalPadding: CGFloat = .ecosia.space._2s
 }
 
 /// The omnibox "AI tools" drawer presented as a sheet, matching
@@ -244,9 +246,14 @@ struct OmniboxUploadDrawerView: View {
                     .frame(width: UX.chatModeIconSize, height: UX.chatModeIconSize)
 
                 VStack(alignment: .leading, spacing: .ecosia.space._2s) {
-                    Text(mode.title)
-                        .font(.system(size: .ecosia.font._m, weight: .regular))
-                        .foregroundColor(theme.titleColor)
+                    HStack(spacing: .ecosia.space._1s) {
+                        Text(mode.title)
+                            .font(.system(size: .ecosia.font._m, weight: .regular))
+                            .foregroundColor(theme.titleColor)
+                        if mode.isNew {
+                            newBadge
+                        }
+                    }
                     Text(mode.subtitle)
                         .font(.system(size: .ecosia.font._s, weight: .regular))
                         .foregroundColor(theme.subtitleColor)
@@ -272,6 +279,17 @@ struct OmniboxUploadDrawerView: View {
         .accessibilityHint(mode.accessibilityHint)
         .accessibilityAddTraits(mode == selectedChatMode ? [.isSelected] : [])
         .accessibilityIdentifier(mode.accessibilityIdentifier)
+    }
+
+    /// Grellow "New" pill shown inline after a mode's title (e.g. Think longer).
+    private var newBadge: some View {
+        Text(String.localized(.new))
+            .font(.system(size: .ecosia.font._s, weight: .semibold))
+            .foregroundColor(theme.badgeTextColor)
+            .padding(.horizontal, UX.newBadgeHorizontalPadding)
+            .padding(.vertical, UX.newBadgeVerticalPadding)
+            .background(Capsule().fill(theme.badgeBackgroundColor))
+            .accessibilityHidden(true)
     }
 
     // MARK: - Footer
@@ -313,6 +331,8 @@ struct OmniboxUploadDrawerViewTheme: EcosiaThemeable {
     var doneBackgroundColor = Color.gray.opacity(0.2)
     var listBackgroundColor = Color.white
     var selectedCheckmarkColor = Color.green
+    var badgeBackgroundColor = Color.green
+    var badgeTextColor = Color.black
 
     mutating func applyTheme(theme: Theme) {
         let colors = theme.colors.ecosia
@@ -329,6 +349,9 @@ struct OmniboxUploadDrawerViewTheme: EcosiaThemeable {
         // upload tiles and iOS inset-grouped cells).
         listBackgroundColor = Color(colors.backgroundElevation1)
         selectedCheckmarkColor = Color(colors.brandPrimary)
+        // Grellow pill + dark text in both themes, matching the design-system badge.
+        badgeBackgroundColor = Color(colors.buttonBackgroundFeatured)
+        badgeTextColor = Color(colors.textStaticDark)
     }
 }
 

--- a/firefox-ios/Ecosia/UI/NTP/Upload/OmniboxUploadDrawerView.swift
+++ b/firefox-ios/Ecosia/UI/NTP/Upload/OmniboxUploadDrawerView.swift
@@ -36,20 +36,24 @@ private enum OmniboxUploadDrawerUX {
 @available(iOS 16.0, *)
 public struct OmniboxUploadDrawerSheet: View {
     private let windowUUID: WindowUUID
-    private let onSelectUploadOption: (OmniboxUploadOption) -> Void
+    private let selectedChatMode: OmniboxChatMode?
+    private let onSelect: (OmniboxUploadOption) -> Void
     private let onSelectChatMode: (OmniboxChatMode) -> Void
 
     public init(windowUUID: WindowUUID,
-                onSelectUploadOption: @escaping (OmniboxUploadOption) -> Void,
+                selectedChatMode: OmniboxChatMode?,
+                onSelect: @escaping (OmniboxUploadOption) -> Void,
                 onSelectChatMode: @escaping (OmniboxChatMode) -> Void) {
         self.windowUUID = windowUUID
-        self.onSelectUploadOption = onSelectUploadOption
+        self.selectedChatMode = selectedChatMode
+        self.onSelect = onSelect
         self.onSelectChatMode = onSelectChatMode
     }
 
     public var body: some View {
         OmniboxUploadDrawerView(windowUUID: windowUUID,
-                                onSelectUploadOption: onSelectUploadOption,
+                                selectedChatMode: selectedChatMode,
+                                onSelect: onSelect,
                                 onSelectChatMode: onSelectChatMode)
     }
 }
@@ -68,7 +72,8 @@ struct OmniboxUploadDrawerView: View {
     private typealias UX = OmniboxUploadDrawerUX
 
     private let windowUUID: WindowUUID
-    private let onSelectUploadOption: (OmniboxUploadOption) -> Void
+    private let selectedChatMode: OmniboxChatMode?
+    private let onSelect: (OmniboxUploadOption) -> Void
     private let onSelectChatMode: (OmniboxChatMode) -> Void
 
     // `Environment` is qualified because the Ecosia framework defines its own
@@ -78,10 +83,12 @@ struct OmniboxUploadDrawerView: View {
     @State private var contentHeight = OmniboxUploadDrawerUX.fallbackHeight
 
     init(windowUUID: WindowUUID,
-         onSelectUploadOption: @escaping (OmniboxUploadOption) -> Void,
+         selectedChatMode: OmniboxChatMode?,
+         onSelect: @escaping (OmniboxUploadOption) -> Void,
          onSelectChatMode: @escaping (OmniboxChatMode) -> Void) {
         self.windowUUID = windowUUID
-        self.onSelectUploadOption = onSelectUploadOption
+        self.selectedChatMode = selectedChatMode
+        self.onSelect = onSelect
         self.onSelectChatMode = onSelectChatMode
     }
 
@@ -169,7 +176,7 @@ struct OmniboxUploadDrawerView: View {
 
     private func uploadOptionButton(for option: OmniboxUploadOption) -> some View {
         Button {
-            onSelectUploadOption(option)
+            onSelect(option)
         } label: {
             VStack(spacing: .ecosia.space._1s) {
                 Image.ecosia(option.iconName)
@@ -247,6 +254,14 @@ struct OmniboxUploadDrawerView: View {
                 }
 
                 Spacer(minLength: 0)
+
+                // The active mode is marked with a trailing checkmark; re-tapping
+                // it deselects (handled by the presenter that owns the selection).
+                if mode == selectedChatMode {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: UX.doneGlyphSize, weight: .medium))
+                        .foregroundColor(theme.selectedCheckmarkColor)
+                }
             }
             .padding(.horizontal, UX.chatModeRowHorizontalPadding)
             .padding(.vertical, UX.chatModeRowVerticalPadding)
@@ -255,6 +270,7 @@ struct OmniboxUploadDrawerView: View {
         .accessibilityElement(children: .combine)
         .accessibilityLabel(mode.accessibilityLabel)
         .accessibilityHint(mode.accessibilityHint)
+        .accessibilityAddTraits(mode == selectedChatMode ? [.isSelected] : [])
         .accessibilityIdentifier(mode.accessibilityIdentifier)
     }
 
@@ -296,6 +312,7 @@ struct OmniboxUploadDrawerViewTheme: EcosiaThemeable {
     var footerBackgroundColor = Color.white
     var doneBackgroundColor = Color.gray.opacity(0.2)
     var listBackgroundColor = Color.white
+    var selectedCheckmarkColor = Color.green
 
     mutating func applyTheme(theme: Theme) {
         let colors = theme.colors.ecosia
@@ -311,6 +328,7 @@ struct OmniboxUploadDrawerViewTheme: EcosiaThemeable {
         // Solid card behind the grouped chat-mode rows (elevation-1, like the
         // upload tiles and iOS inset-grouped cells).
         listBackgroundColor = Color(colors.backgroundElevation1)
+        selectedCheckmarkColor = Color(colors.brandPrimary)
     }
 }
 

--- a/firefox-ios/Ecosia/UI/NTP/Upload/OmniboxUploadTypes.swift
+++ b/firefox-ios/Ecosia/UI/NTP/Upload/OmniboxUploadTypes.swift
@@ -117,4 +117,17 @@ public extension OmniboxChatMode {
         case .learning: return "OmniboxChatModeLearningOption"
         }
     }
+
+    /// Extra query items appended to the AI Chat URL so the backend opens the
+    /// conversation in this mode. `standard` carries none (plain `/ai-chat`);
+    /// the others map to the agreed backend flags:
+    /// Think longer → `t=1`, Display sources → `m=2`, Learning → `m=1`.
+    var aiChatQueryItems: [URLQueryItem] {
+        switch self {
+        case .standard: return []
+        case .thinkLonger: return [URLQueryItem(name: "t", value: "1")]
+        case .displaySources: return [URLQueryItem(name: "m", value: "2")]
+        case .learning: return [URLQueryItem(name: "m", value: "1")]
+        }
+    }
 }

--- a/firefox-ios/Ecosia/UI/NTP/Upload/OmniboxUploadTypes.swift
+++ b/firefox-ios/Ecosia/UI/NTP/Upload/OmniboxUploadTypes.swift
@@ -105,6 +105,8 @@ public extension OmniboxChatMode {
         }
     }
 
+    var isNew: Bool { self == .thinkLonger }
+
     var accessibilityLabel: String { title }
 
     var accessibilityHint: String { String.localized(.aiChatAccessibilityHint) }

--- a/firefox-ios/EcosiaTests/UI/NTP/OmniboxUploadDrawerTests.swift
+++ b/firefox-ios/EcosiaTests/UI/NTP/OmniboxUploadDrawerTests.swift
@@ -70,6 +70,34 @@ final class OmniboxUploadDrawerTests: XCTestCase {
         XCTAssertNotNil(UIImage.ecosia(named: "chatmodes-display-sources"))
         XCTAssertNotNil(UIImage.ecosia(named: "chatmodes-learning"))
     }
+
+    func testChatModeAIChatQueryItemsMapToBackendFlags() {
+        XCTAssertTrue(OmniboxChatMode.standard.aiChatQueryItems.isEmpty)
+        XCTAssertEqual(OmniboxChatMode.thinkLonger.aiChatQueryItems,
+                       [URLQueryItem(name: "t", value: "1")])
+        XCTAssertEqual(OmniboxChatMode.displaySources.aiChatQueryItems,
+                       [URLQueryItem(name: "m", value: "2")])
+        XCTAssertEqual(OmniboxChatMode.learning.aiChatQueryItems,
+                       [URLQueryItem(name: "m", value: "1")])
+    }
+
+    func testAIChatURLCarriesChatModeQueryItems() {
+        let provider = URLProvider.production
+
+        let standardURL = provider.aiChat(origin: .omnibox,
+                                          query: "hello",
+                                          additionalQueryItems: OmniboxChatMode.standard.aiChatQueryItems)
+        let standardItems = URLComponents(url: standardURL, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        XCTAssertTrue(standardURL.path.hasSuffix("/ai-chat"))
+        XCTAssertFalse(standardItems.contains { $0.name == "t" || $0.name == "m" })
+
+        let learningURL = provider.aiChat(origin: .omnibox,
+                                          query: "hello",
+                                          additionalQueryItems: OmniboxChatMode.learning.aiChatQueryItems)
+        let learningItems = URLComponents(url: learningURL, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        XCTAssertTrue(learningItems.contains(URLQueryItem(name: "m", value: "1")))
+        XCTAssertTrue(learningItems.contains(URLQueryItem(name: "q", value: "hello")))
+    }
 }
 
 @MainActor
@@ -78,7 +106,7 @@ final class NTPOmniboxSheetStateTests: XCTestCase {
     func testSelectedOptionIsDeliveredAfterDrawerDismisses() {
         let state = NTPOmniboxSheetState()
         var received: OmniboxUploadOption?
-        state.presentUploadDrawer(onSelectUpload: { received = $0 }, onSelectChatMode: { _ in })
+        state.presentUploadDrawer(onSelectUpload: { received = $0 }, onChatModeSelectionChanged: { _ in })
 
         state.handleUploadOptionSelected(.files)
         XCTAssertFalse(state.showUploadDrawer)
@@ -88,32 +116,53 @@ final class NTPOmniboxSheetStateTests: XCTestCase {
         XCTAssertEqual(received, .files)
     }
 
-    func testSelectedChatModeIsDeliveredAfterDrawerDismisses() {
+    func testSelectedChatModeAppliesImmediatelyOnTap() {
         let state = NTPOmniboxSheetState()
-        var receivedMode: OmniboxChatMode?
+        var changes: [OmniboxChatMode?] = []
         var receivedUpload: OmniboxUploadOption?
         state.presentUploadDrawer(onSelectUpload: { receivedUpload = $0 },
-                                  onSelectChatMode: { receivedMode = $0 })
+                                  onChatModeSelectionChanged: { changes.append($0) })
 
         state.handleChatModeSelected(.thinkLonger)
+        // Delivered on tap — not deferred until the sheet dismisses.
+        XCTAssertEqual(state.selectedChatMode, .thinkLonger)
+        XCTAssertEqual(changes, [.thinkLonger])
         XCTAssertFalse(state.showUploadDrawer)
-        XCTAssertNil(receivedMode)
-
-        state.handleUploadDrawerDismissed()
-        XCTAssertEqual(receivedMode, .thinkLonger)
         XCTAssertNil(receivedUpload)
+    }
+
+    func testSelectingChatModeReplacesThePreviousOne() {
+        let state = NTPOmniboxSheetState()
+        state.presentUploadDrawer(onSelectUpload: { _ in }, onChatModeSelectionChanged: { _ in })
+
+        state.handleChatModeSelected(.thinkLonger)
+        state.handleChatModeSelected(.learning)
+        XCTAssertEqual(state.selectedChatMode, .learning)
+    }
+
+    func testReTappingActiveChatModeInDrawerKeepsItSelected() {
+        // Deselection happens via the omnibox chip, not the drawer — re-picking
+        // the active mode just closes the drawer with the mode still active.
+        let state = NTPOmniboxSheetState()
+        var changes: [OmniboxChatMode?] = []
+        state.presentUploadDrawer(onSelectUpload: { _ in },
+                                  onChatModeSelectionChanged: { changes.append($0) })
+
+        state.handleChatModeSelected(.learning)
+        state.handleChatModeSelected(.learning)
+        XCTAssertEqual(state.selectedChatMode, .learning)
+        XCTAssertEqual(changes, [.learning, .learning])
     }
 
     func testDismissWithoutSelectionDoesNotDeliverOption() {
         let state = NTPOmniboxSheetState()
         var received: OmniboxUploadOption?
-        var receivedMode: OmniboxChatMode?
         state.presentUploadDrawer(onSelectUpload: { received = $0 },
-                                  onSelectChatMode: { receivedMode = $0 })
+                                  onChatModeSelectionChanged: { _ in })
 
         state.handleUploadDrawerDismissed()
         XCTAssertNil(received)
-        XCTAssertNil(receivedMode)
+        XCTAssertNil(state.selectedChatMode)
     }
 }
 

--- a/firefox-ios/EcosiaTests/UI/NTP/OmniboxUploadDrawerTests.swift
+++ b/firefox-ios/EcosiaTests/UI/NTP/OmniboxUploadDrawerTests.swift
@@ -64,6 +64,13 @@ final class OmniboxUploadDrawerTests: XCTestCase {
         XCTAssertEqual(OmniboxChatMode.learning.accessibilityIdentifier, "OmniboxChatModeLearningOption")
     }
 
+    func testOnlyThinkLongerChatModeIsNew() {
+        XCTAssertTrue(OmniboxChatMode.thinkLonger.isNew)
+        XCTAssertFalse(OmniboxChatMode.standard.isNew)
+        XCTAssertFalse(OmniboxChatMode.displaySources.isNew)
+        XCTAssertFalse(OmniboxChatMode.learning.isNew)
+    }
+
     func testChatModeIconsLoadFromFrameworkBundle() {
         XCTAssertNotNil(UIImage.ecosia(named: "chatmodes-standard-ai-chat"))
         XCTAssertNotNil(UIImage.ecosia(named: "chatmodes-think-longer"))


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-4627]

## Context

This builds upon https://github.com/ecosia/ios-browser/pull/1197 which should be reviewed and merged first.

Implements (de-)selection functionality and UI as well as routing to the appropriate AI chat depending on the selected Chat Mode.

## Approach

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I wrote Unit Tests that confirm the expected behaviour
- [x] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [x] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4627]: https://ecosia.atlassian.net/browse/MOB-4627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ