### PR TITLE
Remove `NSPhotoLibraryUsageDescription` to unblock release

### DIFF
--- a/firefox-ios/Client/Info.plist
+++ b/firefox-ios/Client/Info.plist
@@ -110,8 +110,6 @@
 	<string>Firefox uses your microphone to record and upload audio.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>This lets you save photos.</string>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>Ecosia needs photo library access so you can attach images from your camera roll.</string>
 	<key>NSUserActivityTypes</key>
 	<array>
 		<string>QuickActionIntent</string>


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

## Context

Removes the permission to unblock release, as this permission is needed for an upcoming feature.