### PR TITLE
Adjust release workflow requirements

### DIFF
--- a/.circleci/release-config.yml
+++ b/.circleci/release-config.yml
@@ -108,10 +108,7 @@ jobs:
               echo "🚀 PRODUCTION: Running iOS tests on BrowserStack"
               echo "Using App URL: $BROWSERSTACK_URL"
               cd mobile-acceptance-testing
-              mvn test -PiOSCHCTests -DBStackIOSAppUrl="$BROWSERSTACK_URL" || {
-                echo "Health checks failed, but continuing with deployment..."
-                exit 0
-              }
+              mvn test -PiOSCHCTests -DBStackIOSAppUrl="$BROWSERSTACK_URL"
             fi
       - jira/notify:
           issue_regexp: "([A-Za-z]{2,30}-[0-9]+)"

--- a/.circleci/release-config.yml
+++ b/.circleci/release-config.yml
@@ -181,7 +181,4 @@ workflows:
           context: napps
       - build-testflight-deploy:
           name: Auto Deploy release version to TestFlight
-          requires:
-            - L10N Translation Completeness Check
-            - Critical Health Checks (release cut pipeline)
-          context: napps 
+          context: napps


### PR DESCRIPTION
## Context

Last https://github.com/ecosia/ios-browser/pull/1199 [release workflow](https://app.circleci.com/pipelines/github/ecosia/ios-browser/6883/workflows/4369665c-9367-4555-9224-197f30b9945d) failed on the "L10N Translation Completeness Check". This turned out to be a bit of a false negative given the missing string are for a WIP feature that is behind a feature flag (file upload).

Additionally, for a while our Critical Health Checks step swallowed failures, continuing to deployment regardless. This was a conscious decision due to flakiness and the release captain always checks the result of the tests.

## Approach

Since neither check should block the release, but their results are still valuable signal for the release captain, I made the three jobs in the release-pipeline workflow run in parallel instead of gating the TestFlight deploy behind them:

* Removed the requires on `build-testflight-deploy`, so it now runs alongside the translation check and health checks rather than waiting for them. The deploy happens regardless of their outcome.
* Removed the `|| exit 0` swallow in the Critical Health Checks step so a failing check now surfaces as a red X instead of a green pass. The Jira orb still reports status correctly on failure (its notify runs when: always).
* Kept the translation check failing loudly for the same reason.

Net effect: the deploy is no longer blocked by either check, but a real failure is now clearly visible in the workflow rather than hidden, so the release captain gets a proper signal to investigate