### PR TITLE
[MOB-4628] Implement Chat Modes Drawer logged out state

### DIFF
--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Omnibox.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Omnibox.swift
@@ -5,6 +5,7 @@
 import UIKit
 import Shared
 import Ecosia
+import Common
 
 // MARK: NTPSearchBarDelegate
 // Ecosia: Routes the embedded NTP omnibox into the existing browser navigation
@@ -377,6 +378,7 @@ private struct OmniboxUploadAssociatedKeys {
     /// Used only as opaque key for objc_getAssociatedObject; no shared mutable state.
     nonisolated(unsafe) static var pickerCoordinator: UInt8 = 0
     nonisolated(unsafe) static var attachmentCoordinator: UInt8 = 0
+    nonisolated(unsafe) static var authLogoutObserver: UInt8 = 0
 }
 
 @MainActor
@@ -401,6 +403,7 @@ extension BrowserViewController {
         guard let homepage = contentContainer.contentController as? HomepageViewController,
               let sheetState = homepage.ecosiaAdapter?.omniboxSheetState else { return }
 
+        registerOmniboxLogoutObserverIfNeeded()
         let sourceView = ntpOmniboxAnchorView ?? view
         homepage.presentOmniboxUploadSheetIfNeeded()
         sheetState.presentUploadDrawer(isAuthenticated: ecosiaAuth?.isLoggedIn == true,
@@ -434,6 +437,48 @@ extension BrowserViewController {
     func ntpSearchBarDidTapChatModeChipClose() {
         omniboxSheetState?.selectedChatMode = nil
         ntpOmniboxAnchorView?.setSelectedChatMode(nil)
+    }
+
+    /// Registers a one-shot observer that clears pending omnibox selections on
+    /// logout. Advanced chat modes and uploads are only valid while signed in,
+    /// so logging out (without first submitting a search) must not leave a stale
+    /// chat-mode chip or media attachment behind. The block observer is retained
+    /// as an associated object and torn down automatically when the BVC dies.
+    fileprivate func registerOmniboxLogoutObserverIfNeeded() {
+        guard objc_getAssociatedObject(self, &OmniboxUploadAssociatedKeys.authLogoutObserver) == nil else { return }
+        let observer = NotificationCenter.default.addObserver(
+            forName: .EcosiaAuthStateChanged,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            // Parse on the delivering (main) queue so only Sendable state crosses
+            // the MainActor hop — `Notification` itself isn't Sendable. `windowUUID`
+            // is a `nonisolated let`, so it's safe to read here.
+            guard let expectedWindow = self?.windowUUID,
+                  notification.userInfo?["windowUUID"] as? WindowUUID == expectedWindow,
+                  notification.userInfo?["actionType"] as? EcosiaAuthActionType == .userLoggedOut
+            else { return }
+            Task { @MainActor in
+                self?.resetOmniboxSelectionsAfterLogout()
+            }
+        }
+        objc_setAssociatedObject(self,
+                                 &OmniboxUploadAssociatedKeys.authLogoutObserver,
+                                 observer,
+                                 .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+    }
+
+    /// Clears any active chat mode (and its omnibox chip) and cancels/clears any
+    /// media attachments. Idempotent — a no-op when nothing is selected.
+    private func resetOmniboxSelectionsAfterLogout() {
+        omniboxSheetState?.selectedChatMode = nil
+        ntpOmniboxAnchorView?.setSelectedChatMode(nil)
+        // Only touch the attachment coordinator if it was actually created (the
+        // user picked media); don't spin one up just to clear nothing.
+        if let coordinator = objc_getAssociatedObject(self, &OmniboxUploadAssociatedKeys.attachmentCoordinator)
+            as? OmniboxAttachmentUploadCoordinator {
+            coordinator.clearAttachments()
+        }
     }
 }
 

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Omnibox.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Omnibox.swift
@@ -130,7 +130,11 @@ extension BrowserViewController: NTPSearchBarDelegate {
     func ntpSearchBarDidTapUpload() {
         guard FileUploadFeatureFlag.isEnabled else { return }
         _ = ntpOmniboxAnchorView?.resignFirstResponder()
-        if ecosiaAuth?.isLoggedIn == false {
+        // With Chat Modes on, the drawer handles the signed-out state itself
+        // (Standard AI Chat selectable, other modes disabled, sign-in CTA), so
+        // always open it. Without Chat Modes the drawer is upload-only, which
+        // still requires an account, so keep the existing signed-out gate.
+        if !ChatModesFeatureFlag.isEnabled, ecosiaAuth?.isLoggedIn == false {
             if #available(iOS 16.0, *), !AccountsDisabled.isActive {
                 presentAccountImpactFromNTPHeader()
             } else {
@@ -399,7 +403,8 @@ extension BrowserViewController {
 
         let sourceView = ntpOmniboxAnchorView ?? view
         homepage.presentOmniboxUploadSheetIfNeeded()
-        sheetState.presentUploadDrawer(onSelectUpload: { [weak self] option in
+        sheetState.presentUploadDrawer(isAuthenticated: ecosiaAuth?.isLoggedIn == true,
+                                       onSelectUpload: { [weak self] option in
             guard let self else { return }
             self.omniboxUploadPickerCoordinator.presentPicker(for: option,
                                                               from: self,
@@ -409,7 +414,20 @@ extension BrowserViewController {
             // the omnibox chip right away so the glyph appears while the drawer
             // is still sliding away rather than after it disappears.
             self?.ntpOmniboxAnchorView?.setSelectedChatMode(mode)
+        }, onLogin: { [weak self] in
+            self?.handleOmniboxLoginRequested()
         })
+    }
+
+    /// Starts the sign-in flow from the drawer's CTA and, on success, re-opens
+    /// the drawer so the user lands back on the omnibox with the advanced modes
+    /// now unlocked.
+    private func handleOmniboxLoginRequested() {
+        let auth = ecosiaAuth ?? EcosiaAuth(browserViewController: self)
+        auth.onAuthFlowCompleted { [weak self] success in
+            guard success else { return }
+            self?.presentOmniboxUploadDrawer()
+        }.login()
     }
 
     /// Clears the active chat mode when the user taps the chip's X.

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/NTPOmniboxSheetPresenter.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/NTPOmniboxSheetPresenter.swift
@@ -22,8 +22,10 @@ struct NTPOmniboxSheetPresenter: View {
                 OmniboxUploadDrawerSheet(
                     windowUUID: windowUUID,
                     selectedChatMode: sheetState.selectedChatMode,
+                    isAuthenticated: sheetState.isAuthenticated,
                     onSelect: { option in sheetState.handleUploadOptionSelected(option) },
-                    onSelectChatMode: { mode in sheetState.handleChatModeSelected(mode) }
+                    onSelectChatMode: { mode in sheetState.handleChatModeSelected(mode) },
+                    onLogin: { sheetState.handleLoginRequested() }
                 )
             }
     }

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/NTPOmniboxSheetState.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/NTPOmniboxSheetState.swift
@@ -16,18 +16,30 @@ final class NTPOmniboxSheetState: ObservableObject {
     /// of truth.
     @Published var selectedChatMode: OmniboxChatMode?
 
+    /// Whether the current user is signed in. Drives the drawer's signed-out
+    /// state (only Standard AI Chat selectable, others disabled, sign-in CTA).
+    @Published var isAuthenticated = false
+
     private var onUploadOptionSelected: ((OmniboxUploadOption) -> Void)?
     private var onChatModeSelectionChanged: ((OmniboxChatMode?) -> Void)?
-    /// An upload selection is delivered only after the sheet finishes dismissing
-    /// so the picker it presents doesn't fight the dismissal. Chat-mode changes
-    /// don't present anything, so they apply immediately (see below).
+    private var onLoginRequested: (() -> Void)?
+    /// An upload selection (or a sign-in tap) is delivered only after the sheet
+    /// finishes dismissing so the picker / auth flow it presents doesn't fight
+    /// the dismissal. Chat-mode changes don't present anything, so they apply
+    /// immediately (see below).
     private var pendingUploadOption: OmniboxUploadOption?
+    private var pendingLogin = false
 
-    func presentUploadDrawer(onSelectUpload: @escaping (OmniboxUploadOption) -> Void,
-                             onChatModeSelectionChanged: @escaping (OmniboxChatMode?) -> Void) {
+    func presentUploadDrawer(isAuthenticated: Bool,
+                             onSelectUpload: @escaping (OmniboxUploadOption) -> Void,
+                             onChatModeSelectionChanged: @escaping (OmniboxChatMode?) -> Void,
+                             onLogin: @escaping () -> Void) {
         pendingUploadOption = nil
+        pendingLogin = false
+        self.isAuthenticated = isAuthenticated
         onUploadOptionSelected = onSelectUpload
         self.onChatModeSelectionChanged = onChatModeSelectionChanged
+        onLoginRequested = onLogin
         showUploadDrawer = true
     }
 
@@ -47,15 +59,28 @@ final class NTPOmniboxSheetState: ObservableObject {
         showUploadDrawer = false
     }
 
+    /// Requests the sign-in flow from the drawer's CTA. Deferred until the sheet
+    /// dismisses so the auth UI doesn't fight the dismissal.
+    func handleLoginRequested() {
+        pendingLogin = true
+        showUploadDrawer = false
+    }
+
     func handleUploadDrawerDismissed() {
         let option = pendingUploadOption
         let uploadCallback = onUploadOptionSelected
+        let login = pendingLogin
+        let loginCallback = onLoginRequested
         pendingUploadOption = nil
+        pendingLogin = false
         onUploadOptionSelected = nil
         onChatModeSelectionChanged = nil
+        onLoginRequested = nil
 
         if let option {
             uploadCallback?(option)
+        } else if login {
+            loginCallback?()
         }
     }
 }

--- a/firefox-ios/Ecosia/L10N/String.swift
+++ b/firefox-ios/Ecosia/L10N/String.swift
@@ -324,5 +324,6 @@ extension String {
         case uploadSubmitWaitingForUpload = "Waiting for the attachment to finish uploading"
         case uploadSubmitUploadFailed = "Remove the failed attachment or try uploading again"
         case chatModeChipRemoveAccessibilityLabel = "Remove chat mode"
+        case chatModesSignInDisclaimer = "Sign in to use advanced AI features."
     }
 }

--- a/firefox-ios/Ecosia/L10N/en.lproj/Ecosia.strings
+++ b/firefox-ios/Ecosia/L10N/en.lproj/Ecosia.strings
@@ -320,6 +320,7 @@
 "Waiting for the attachment to finish uploading" = "Waiting for the attachment to finish uploading";
 "Remove the failed attachment or try uploading again" = "Remove the failed attachment or try uploading again";
 "Remove chat mode" = "Remove chat mode";
+"Sign in to use advanced AI features." = "Sign in to use advanced AI features.";
 
 // Product Tour
 "Go back" = "Go back";

--- a/firefox-ios/Ecosia/UI/NTP/Upload/OmniboxUploadDrawerView.swift
+++ b/firefox-ios/Ecosia/UI/NTP/Upload/OmniboxUploadDrawerView.swift
@@ -30,6 +30,8 @@ private enum OmniboxUploadDrawerUX {
     }
     static let newBadgeHorizontalPadding: CGFloat = .ecosia.space._1s
     static let newBadgeVerticalPadding: CGFloat = .ecosia.space._2s
+    /// Opacity of chat-mode rows that are disabled for signed-out users.
+    static let disabledRowOpacity: CGFloat = 0.4
 }
 
 /// The omnibox "AI tools" drawer presented as a sheet, matching
@@ -39,24 +41,32 @@ private enum OmniboxUploadDrawerUX {
 public struct OmniboxUploadDrawerSheet: View {
     private let windowUUID: WindowUUID
     private let selectedChatMode: OmniboxChatMode?
+    private let isAuthenticated: Bool
     private let onSelect: (OmniboxUploadOption) -> Void
     private let onSelectChatMode: (OmniboxChatMode) -> Void
+    private let onLogin: () -> Void
 
     public init(windowUUID: WindowUUID,
                 selectedChatMode: OmniboxChatMode?,
+                isAuthenticated: Bool,
                 onSelect: @escaping (OmniboxUploadOption) -> Void,
-                onSelectChatMode: @escaping (OmniboxChatMode) -> Void) {
+                onSelectChatMode: @escaping (OmniboxChatMode) -> Void,
+                onLogin: @escaping () -> Void) {
         self.windowUUID = windowUUID
         self.selectedChatMode = selectedChatMode
+        self.isAuthenticated = isAuthenticated
         self.onSelect = onSelect
         self.onSelectChatMode = onSelectChatMode
+        self.onLogin = onLogin
     }
 
     public var body: some View {
         OmniboxUploadDrawerView(windowUUID: windowUUID,
                                 selectedChatMode: selectedChatMode,
+                                isAuthenticated: isAuthenticated,
                                 onSelect: onSelect,
-                                onSelectChatMode: onSelectChatMode)
+                                onSelectChatMode: onSelectChatMode,
+                                onLogin: onLogin)
     }
 }
 
@@ -75,8 +85,10 @@ struct OmniboxUploadDrawerView: View {
 
     private let windowUUID: WindowUUID
     private let selectedChatMode: OmniboxChatMode?
+    private let isAuthenticated: Bool
     private let onSelect: (OmniboxUploadOption) -> Void
     private let onSelectChatMode: (OmniboxChatMode) -> Void
+    private let onLogin: () -> Void
 
     // `Environment` is qualified because the Ecosia framework defines its own
     // `Environment` type, which otherwise shadows the SwiftUI property wrapper.
@@ -86,12 +98,23 @@ struct OmniboxUploadDrawerView: View {
 
     init(windowUUID: WindowUUID,
          selectedChatMode: OmniboxChatMode?,
+         isAuthenticated: Bool,
          onSelect: @escaping (OmniboxUploadOption) -> Void,
-         onSelectChatMode: @escaping (OmniboxChatMode) -> Void) {
+         onSelectChatMode: @escaping (OmniboxChatMode) -> Void,
+         onLogin: @escaping () -> Void) {
         self.windowUUID = windowUUID
         self.selectedChatMode = selectedChatMode
+        self.isAuthenticated = isAuthenticated
         self.onSelect = onSelect
         self.onSelectChatMode = onSelectChatMode
+        self.onLogin = onLogin
+    }
+
+    /// A chat mode is selectable only when the user is signed in; signed-out
+    /// users may pick Standard AI Chat (no advanced features) but every other
+    /// mode is shown disabled.
+    private func isModeEnabled(_ mode: OmniboxChatMode) -> Bool {
+        isAuthenticated || mode == .standard
     }
 
     var body: some View {
@@ -234,7 +257,8 @@ struct OmniboxUploadDrawerView: View {
     }
 
     private func chatModeRow(for mode: OmniboxChatMode) -> some View {
-        Button {
+        let isEnabled = isModeEnabled(mode)
+        return Button {
             onSelectChatMode(mode)
         } label: {
             HStack(spacing: UX.chatModeIconSpacing) {
@@ -274,6 +298,10 @@ struct OmniboxUploadDrawerView: View {
             .padding(.vertical, UX.chatModeRowVerticalPadding)
             .contentShape(Rectangle())
         }
+        // Signed-out users can only pick Standard; other modes are visible but
+        // non-interactive and dimmed until they sign in.
+        .disabled(!isEnabled)
+        .opacity(isEnabled ? 1 : UX.disabledRowOpacity)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(mode.accessibilityLabel)
         .accessibilityHint(mode.accessibilityHint)
@@ -294,7 +322,18 @@ struct OmniboxUploadDrawerView: View {
 
     // MARK: - Footer
 
+    /// Signed-in users get the "redirect to AI Chat" notice; signed-out users
+    /// get a sign-in disclaimer with a CTA that unlocks the advanced modes.
+    @ViewBuilder
     private var footer: some View {
+        if isAuthenticated {
+            redirectNoticeFooter
+        } else {
+            signInFooter
+        }
+    }
+
+    private var redirectNoticeFooter: some View {
         HStack(spacing: .ecosia.space._1s) {
             Text(String.localized(.aiToolsRedirectNotice))
                 .font(.system(size: .ecosia.font._s, weight: .regular))
@@ -316,6 +355,39 @@ struct OmniboxUploadDrawerView: View {
         )
         .accessibilityElement(children: .combine)
     }
+
+    private var signInFooter: some View {
+        HStack(alignment: .center, spacing: .ecosia.space._m) {
+            Text(String.localized(.chatModesSignInDisclaimer))
+                .font(.system(size: .ecosia.font._s, weight: .regular))
+                .foregroundColor(theme.subtitleColor)
+                .multilineTextAlignment(.leading)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.leading, .ecosia.space._1s)
+            Spacer(minLength: 0)
+            signInButton
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var signInButton: some View {
+        Button {
+            onLogin()
+        } label: {
+            HStack(spacing: .ecosia.space._1s) {
+                Image(systemName: "rectangle.portrait.and.arrow.right")
+                    .font(.system(size: .ecosia.font._m, weight: .semibold))
+                Text(String.localized(.signIn))
+                    .font(.system(size: .ecosia.font._m, weight: .semibold))
+            }
+            .foregroundColor(theme.signInButtonTextColor)
+            .padding(.horizontal, .ecosia.space._m)
+            .frame(height: UX.footerHeight)
+            .background(Capsule().fill(theme.signInButtonBackgroundColor))
+        }
+        .accessibilityLabel(String.localized(.signIn))
+        .accessibilityIdentifier("OmniboxAIToolsSignInButton")
+    }
 }
 
 @available(iOS 16.0, *)
@@ -333,6 +405,8 @@ struct OmniboxUploadDrawerViewTheme: EcosiaThemeable {
     var selectedCheckmarkColor = Color.green
     var badgeBackgroundColor = Color.green
     var badgeTextColor = Color.black
+    var signInButtonBackgroundColor = Color.green
+    var signInButtonTextColor = Color.black
 
     mutating func applyTheme(theme: Theme) {
         let colors = theme.colors.ecosia
@@ -352,6 +426,9 @@ struct OmniboxUploadDrawerViewTheme: EcosiaThemeable {
         // Grellow pill + dark text in both themes, matching the design-system badge.
         badgeBackgroundColor = Color(colors.buttonBackgroundFeatured)
         badgeTextColor = Color(colors.textStaticDark)
+        // Sign-in CTA uses the same featured grellow pill as the design-system primary button.
+        signInButtonBackgroundColor = Color(colors.buttonBackgroundFeatured)
+        signInButtonTextColor = Color(colors.textStaticDark)
     }
 }
 

--- a/firefox-ios/Ecosia/UI/NTP/Upload/OmniboxUploadDrawerView.swift
+++ b/firefox-ios/Ecosia/UI/NTP/Upload/OmniboxUploadDrawerView.swift
@@ -32,6 +32,7 @@ private enum OmniboxUploadDrawerUX {
     static let newBadgeVerticalPadding: CGFloat = .ecosia.space._2s
     /// Opacity of chat-mode rows that are disabled for signed-out users.
     static let disabledRowOpacity: CGFloat = 0.4
+    static let signInIconWidth: CGFloat = 18
 }
 
 /// The omnibox "AI tools" drawer presented as a sheet, matching
@@ -379,8 +380,11 @@ struct OmniboxUploadDrawerView: View {
             onLogin()
         } label: {
             HStack(spacing: .ecosia.space._1s) {
-                Image(systemName: "rectangle.portrait.and.arrow.right")
-                    .font(.system(size: .ecosia.font._m, weight: .semibold))
+                Image.ecosia("sign-in")
+                    .renderingMode(.template)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: UX.signInIconWidth)
                 Text(String.localized(.signIn))
                     .font(.system(size: .ecosia.font._m, weight: .semibold))
             }

--- a/firefox-ios/Ecosia/UI/NTP/Upload/OmniboxUploadDrawerView.swift
+++ b/firefox-ios/Ecosia/UI/NTP/Upload/OmniboxUploadDrawerView.swift
@@ -223,6 +223,10 @@ struct OmniboxUploadDrawerView: View {
                     .multilineTextAlignment(.center)
             }
         }
+        // Uploads require an account, so the media pickers are disabled and
+        // dimmed for signed-out users (same treatment as the advanced modes).
+        .disabled(!isAuthenticated)
+        .opacity(isAuthenticated ? 1 : UX.disabledRowOpacity)
         .accessibilityLabel(option.accessibilityLabel)
         .accessibilityHint(option.accessibilityHint)
         .accessibilityIdentifier(option.accessibilityIdentifier)

--- a/firefox-ios/Ecosia/UI/NTP/Upload/OmniboxUploadDrawerView.swift
+++ b/firefox-ios/Ecosia/UI/NTP/Upload/OmniboxUploadDrawerView.swift
@@ -297,6 +297,7 @@ struct OmniboxUploadDrawerView: View {
                     Image(systemName: "checkmark")
                         .font(.system(size: UX.doneGlyphSize, weight: .medium))
                         .foregroundColor(theme.selectedCheckmarkColor)
+                        .accessibilityHidden(true)
                 }
             }
             .padding(.horizontal, UX.chatModeRowHorizontalPadding)

--- a/firefox-ios/EcosiaTests/UI/NTP/OmniboxUploadDrawerTests.swift
+++ b/firefox-ios/EcosiaTests/UI/NTP/OmniboxUploadDrawerTests.swift
@@ -110,10 +110,21 @@ final class OmniboxUploadDrawerTests: XCTestCase {
 @MainActor
 final class NTPOmniboxSheetStateTests: XCTestCase {
 
+    private func present(_ state: NTPOmniboxSheetState,
+                         isAuthenticated: Bool = true,
+                         onSelectUpload: @escaping (OmniboxUploadOption) -> Void = { _ in },
+                         onChatModeSelectionChanged: @escaping (OmniboxChatMode?) -> Void = { _ in },
+                         onLogin: @escaping () -> Void = {}) {
+        state.presentUploadDrawer(isAuthenticated: isAuthenticated,
+                                  onSelectUpload: onSelectUpload,
+                                  onChatModeSelectionChanged: onChatModeSelectionChanged,
+                                  onLogin: onLogin)
+    }
+
     func testSelectedOptionIsDeliveredAfterDrawerDismisses() {
         let state = NTPOmniboxSheetState()
         var received: OmniboxUploadOption?
-        state.presentUploadDrawer(onSelectUpload: { received = $0 }, onChatModeSelectionChanged: { _ in })
+        present(state, onSelectUpload: { received = $0 })
 
         state.handleUploadOptionSelected(.files)
         XCTAssertFalse(state.showUploadDrawer)
@@ -127,8 +138,8 @@ final class NTPOmniboxSheetStateTests: XCTestCase {
         let state = NTPOmniboxSheetState()
         var changes: [OmniboxChatMode?] = []
         var receivedUpload: OmniboxUploadOption?
-        state.presentUploadDrawer(onSelectUpload: { receivedUpload = $0 },
-                                  onChatModeSelectionChanged: { changes.append($0) })
+        present(state, onSelectUpload: { receivedUpload = $0 },
+                onChatModeSelectionChanged: { changes.append($0) })
 
         state.handleChatModeSelected(.thinkLonger)
         // Delivered on tap — not deferred until the sheet dismisses.
@@ -140,7 +151,7 @@ final class NTPOmniboxSheetStateTests: XCTestCase {
 
     func testSelectingChatModeReplacesThePreviousOne() {
         let state = NTPOmniboxSheetState()
-        state.presentUploadDrawer(onSelectUpload: { _ in }, onChatModeSelectionChanged: { _ in })
+        present(state)
 
         state.handleChatModeSelected(.thinkLonger)
         state.handleChatModeSelected(.learning)
@@ -152,8 +163,7 @@ final class NTPOmniboxSheetStateTests: XCTestCase {
         // the active mode just closes the drawer with the mode still active.
         let state = NTPOmniboxSheetState()
         var changes: [OmniboxChatMode?] = []
-        state.presentUploadDrawer(onSelectUpload: { _ in },
-                                  onChatModeSelectionChanged: { changes.append($0) })
+        present(state, onChatModeSelectionChanged: { changes.append($0) })
 
         state.handleChatModeSelected(.learning)
         state.handleChatModeSelected(.learning)
@@ -164,12 +174,46 @@ final class NTPOmniboxSheetStateTests: XCTestCase {
     func testDismissWithoutSelectionDoesNotDeliverOption() {
         let state = NTPOmniboxSheetState()
         var received: OmniboxUploadOption?
-        state.presentUploadDrawer(onSelectUpload: { received = $0 },
-                                  onChatModeSelectionChanged: { _ in })
+        present(state, onSelectUpload: { received = $0 })
 
         state.handleUploadDrawerDismissed()
         XCTAssertNil(received)
         XCTAssertNil(state.selectedChatMode)
+    }
+
+    func testPresentPublishesAuthenticationState() {
+        let state = NTPOmniboxSheetState()
+        present(state, isAuthenticated: false)
+        XCTAssertFalse(state.isAuthenticated)
+
+        present(state, isAuthenticated: true)
+        XCTAssertTrue(state.isAuthenticated)
+    }
+
+    func testLoginRequestIsDeliveredAfterDrawerDismisses() {
+        let state = NTPOmniboxSheetState()
+        var didLogin = false
+        present(state, isAuthenticated: false, onLogin: { didLogin = true })
+
+        state.handleLoginRequested()
+        // Deferred until the sheet dismisses so the auth flow doesn't fight it.
+        XCTAssertFalse(state.showUploadDrawer)
+        XCTAssertFalse(didLogin)
+
+        state.handleUploadDrawerDismissed()
+        XCTAssertTrue(didLogin)
+    }
+
+    func testUploadSelectionTakesPrecedenceOverPendingLogin() {
+        let state = NTPOmniboxSheetState()
+        var didLogin = false
+        var received: OmniboxUploadOption?
+        present(state, onSelectUpload: { received = $0 }, onLogin: { didLogin = true })
+
+        state.handleUploadOptionSelected(.files)
+        state.handleUploadDrawerDismissed()
+        XCTAssertEqual(received, .files)
+        XCTAssertFalse(didLogin)
     }
 }
 

--- a/firefox-ios/EcosiaTests/UI/NTP/OmniboxUploadDrawerTests.swift
+++ b/firefox-ios/EcosiaTests/UI/NTP/OmniboxUploadDrawerTests.swift
@@ -138,8 +138,11 @@ final class NTPOmniboxSheetStateTests: XCTestCase {
         let state = NTPOmniboxSheetState()
         var changes: [OmniboxChatMode?] = []
         var receivedUpload: OmniboxUploadOption?
-        present(state, onSelectUpload: { receivedUpload = $0 },
-                onChatModeSelectionChanged: { changes.append($0) })
+        present(
+            state,
+            onSelectUpload: { receivedUpload = $0 },
+            onChatModeSelectionChanged: { changes.append($0) }
+        )
 
         state.handleChatModeSelected(.thinkLonger)
         // Delivered on tap — not deferred until the sheet dismisses.


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-4628]

## Context

Implements logged-out state for Chat Modes Drawer

## Approach

### iPhone
|||
|---|---|
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-07 at 14 57 00" src="https://github.com/user-attachments/assets/ca89b9aa-cbc1-431c-be23-3bbf04023d28" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-07 at 14 56 55" src="https://github.com/user-attachments/assets/5d29fc79-5e43-46a9-92aa-bd8244c5c4de" />|


## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I wrote Unit Tests that confirm the expected behaviour
- [x] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [x] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4628]: https://ecosia.atlassian.net/browse/MOB-4628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ