### PR TITLE
[MOB-4662] Fix accessibility crash on Omnibox search automated tests

### DIFF
--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPLocationTextView.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPLocationTextView.swift
@@ -39,6 +39,14 @@ final class NTPLocationTextView: UITextView {
     }
 
     private func commonInit() {
+        // Opt into TextKit 1 (legacy) layout. A default UITextView uses TextKit 2, whose
+        // `_UITextKit2LayoutController` crashes in `-[UITextView firstRectForRange:]` /
+        // `NSTextRange` when the accessibility system queries the field's geometry — e.g. XCUITest
+        // computing an activation point — aborting the app (seen on iOS 17.3, MOB-4662). Reading
+        // `layoutManager` migrates the view to TextKit 1 compatibility mode, avoiding that code
+        // path; it must happen before the view lays out any text.
+        _ = layoutManager
+
         font = .preferredFont(forTextStyle: .body)
         adjustsFontForContentSizeCategory = true
         backgroundColor = .clear


### PR DESCRIPTION
[MOB-4662]

## Context

A crash was happening when runnning https://github.com/ecosia/mobile-acceptance-testing/pull/207 on iOS 17.3.

## Approach

Add support to TextKit 1 on Omnibox's UITextView.

## Other

## Before merging

### Checklist

- [ ] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [ ] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4662]: https://ecosia.atlassian.net/browse/MOB-4662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ