### PR TITLE
[MOB-4588] File Upload - Shared error toast stack animations

### DIFF
--- a/firefox-ios/Client/Ecosia/Account/Auth/EcosiaAuth.swift
+++ b/firefox-ios/Client/Ecosia/Account/Auth/EcosiaAuth.swift
@@ -61,6 +61,9 @@ final class EcosiaAuth {
         self.authService = authService
         self.browserViewController = browserViewController
         self.browserViewController?.ecosiaAuth = self
+        if #available(iOS 16.0, *) {
+            EcosiaErrorToastPresenter.shared.delegate = browserViewController
+        }
         EcosiaLogger.auth.info("EcosiaAuth initialized")
     }
 

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+EcosiaErrorHandling.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+EcosiaErrorHandling.swift
@@ -8,7 +8,7 @@ import Common
 import Ecosia
 
 private enum EcosiaErrorToastContainerUX {
-    static let presentationAnimationDuration: TimeInterval = 0.3
+    static let presentationAnimationDuration: TimeInterval = 0.45
     static let displayDuration: TimeInterval = 4.5
 }
 
@@ -69,12 +69,16 @@ final class EcosiaErrorToastContainerView: UIView {
         installHostingIfNeeded()
 
         let wasEmpty = model.messages.isEmpty
-        model.append(messages: messages)
+        var transaction = Transaction()
+        transaction.disablesAnimations = true
+        withTransaction(transaction) {
+            model.append(messages: messages)
+        }
         scheduleFrontMessageAutoDismiss()
 
         if let announcement = messages.last?.accessibilityAnnouncement {
             let delay = wasEmpty
-                ? 0.25
+                ? EcosiaErrorToastContainerUX.presentationAnimationDuration
                 : EcosiaErrorToastContainerUX.presentationAnimationDuration + 0.05
             announceAccessibilityMessage(announcement, after: delay)
         }

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+EcosiaErrorHandling.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+EcosiaErrorHandling.swift
@@ -8,7 +8,7 @@ import Common
 import Ecosia
 
 private enum EcosiaErrorToastContainerUX {
-    static let presentationAnimationDuration: TimeInterval = 0.45
+    static let presentationAnimationDuration = EcosiaErrorToastTiming.entranceDuration
     static let displayDuration: TimeInterval = 4.5
 }
 

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+EcosiaErrorHandling.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+EcosiaErrorHandling.swift
@@ -8,108 +8,56 @@ import Common
 import Ecosia
 
 private enum EcosiaErrorToastContainerUX {
-    static let depthPeekOffset: CGFloat = .ecosia.space._s
-    static let depthScaleStep: CGFloat = 0.04
     static let presentationAnimationDuration: TimeInterval = 0.3
-    static let removalAnimationDuration: TimeInterval = 0.25
     static let displayDuration: TimeInterval = 4.5
-    static let rowMinHeight: CGFloat = 56
 }
 
 private struct EcosiaErrorToastAssociatedKeys {
     nonisolated(unsafe) static var container: UInt8 = 0
 }
 
-/// Hosts one SwiftUI error row inside the z-stacked toast container.
 @available(iOS 16.0, *)
-@MainActor
-private final class EcosiaErrorToastRowHost: UIView {
-    private var hostingController: UIHostingController<EcosiaErrorToastRowContent>?
+private struct EcosiaErrorToastStackHost: View {
+    @ObservedObject var model: EcosiaErrorToastStackModel
+    let windowUUID: WindowUUID
 
-    func install(
-        message: String,
-        windowUUID: WindowUUID,
-        parent: UIViewController,
-        onClose: @escaping () -> Void
-    ) {
-        let hostingController = UIHostingController(
-            rootView: EcosiaErrorToastRowContent(
-                message: message,
-                windowUUID: windowUUID,
-                onCloseTapped: onClose
-            )
+    var body: some View {
+        EcosiaErrorToastStack(
+            model: model,
+            windowUUID: windowUUID
         )
-        hostingController.view.backgroundColor = .clear
-        hostingController.sizingOptions = [.intrinsicContentSize]
-        self.hostingController = hostingController
-
-        parent.addChild(hostingController)
-        addSubview(hostingController.view)
-        hostingController.view.translatesAutoresizingMaskIntoConstraints = false
-
-        NSLayoutConstraint.activate([
-            hostingController.view.leadingAnchor.constraint(equalTo: leadingAnchor),
-            hostingController.view.trailingAnchor.constraint(equalTo: trailingAnchor),
-            hostingController.view.topAnchor.constraint(equalTo: topAnchor),
-            hostingController.view.bottomAnchor.constraint(equalTo: bottomAnchor)
-        ])
-
-        hostingController.didMove(toParent: parent)
-    }
-
-    func teardown() {
-        hostingController?.willMove(toParent: nil)
-        hostingController?.view.removeFromSuperview()
-        hostingController?.removeFromParent()
-        hostingController = nil
     }
 }
 
-/// Fixed top-aligned container. Toasts overlap on the z-axis: first in at the back, last in on top.
+/// Fixed top-aligned host for the overlapping SwiftUI error toast stack.
 @available(iOS 16.0, *)
 @MainActor
 final class EcosiaErrorToastContainerView: UIView {
-    private var rows: [EcosiaErrorToastRowHost] = []
-    private var heightConstraint: NSLayoutConstraint?
+    private let model = EcosiaErrorToastStackModel()
+    private var hostingController: UIHostingController<EcosiaErrorToastStackHost>?
     private var autoDismissWorkItem: DispatchWorkItem?
 
     private weak var parentViewController: UIViewController?
     private var windowUUID: WindowUUID?
-    private var lastLaidOutWidth: CGFloat = 0
 
     override init(frame: CGRect) {
         super.init(frame: frame)
         backgroundColor = .clear
         clipsToBounds = false
         isUserInteractionEnabled = true
-
-        let heightConstraint = heightAnchor.constraint(equalToConstant: 0)
-        heightConstraint.isActive = true
-        self.heightConstraint = heightConstraint
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        guard bounds.width > 0, bounds.width != lastLaidOutWidth else { return }
-        lastLaidOutWidth = bounds.width
-        updateContainerHeight()
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        guard previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory else {
-            return
-        }
-        updateContainerHeight()
-    }
-
     func configure(parent: UIViewController, windowUUID: WindowUUID) {
         parentViewController = parent
         self.windowUUID = windowUUID
+        model.onDismissCompleted = { [weak self] in
+            self?.handleMessageDismissed()
+        }
+        installHostingIfNeeded()
     }
 
     /// Appends errors in order; the first message sits at the back, the last is on top.
@@ -118,31 +66,11 @@ final class EcosiaErrorToastContainerView: UIView {
               let parentViewController,
               let windowUUID else { return }
 
-        let wasEmpty = rows.isEmpty
-        var newRows: [EcosiaErrorToastRowHost] = []
+        installHostingIfNeeded()
 
-        for message in messages {
-            let row = makeRow(message: message, windowUUID: windowUUID, parent: parentViewController)
-            rows.append(row)
-            newRows.append(row)
-        }
-
-        layoutIfNeeded()
-
-        UIView.animate(
-            withDuration: EcosiaErrorToastContainerUX.presentationAnimationDuration,
-            delay: 0,
-            options: [.curveEaseOut, .beginFromCurrentState],
-            animations: {
-                self.applyStackLayout()
-                newRows.forEach { row in
-                    row.alpha = 1
-                }
-                parentViewController.view.layoutIfNeeded()
-            }
-        )
-
-        scheduleFrontRowAutoDismiss()
+        let wasEmpty = model.messages.isEmpty
+        model.append(subtitles: messages)
+        scheduleFrontMessageAutoDismiss()
 
         if let announcement = messages.last {
             let delay = wasEmpty
@@ -150,143 +78,69 @@ final class EcosiaErrorToastContainerView: UIView {
                 : EcosiaErrorToastContainerUX.presentationAnimationDuration + 0.05
             announceAccessibilityMessage(announcement, after: delay)
         }
-    }
 
-    private func announceAccessibilityMessage(_ message: String, after delay: TimeInterval) {
-        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
-            guard let self, self.rows.last?.alpha ?? 0 > 0 else { return }
-            UIAccessibility.post(notification: .announcement, argument: message)
-        }
+        parentViewController.view.setNeedsLayout()
+        parentViewController.view.layoutIfNeeded()
     }
 
     func clear() {
         cancelAutoDismiss()
-        rows.forEach { $0.teardown() }
-        rows.forEach { $0.removeFromSuperview() }
-        rows.removeAll()
-        heightConstraint?.constant = 0
+        model.clear()
     }
 
-    private func makeRow(
-        message: String,
-        windowUUID: WindowUUID,
-        parent: UIViewController
-    ) -> EcosiaErrorToastRowHost {
-        let row = EcosiaErrorToastRowHost()
-        row.translatesAutoresizingMaskIntoConstraints = false
-        row.alpha = 0
-        addSubview(row)
+    private func installHostingIfNeeded() {
+        guard hostingController == nil,
+              let parentViewController,
+              let windowUUID else { return }
+
+        let host = EcosiaErrorToastStackHost(model: model, windowUUID: windowUUID)
+        let hostingController = UIHostingController(rootView: host)
+        hostingController.view.backgroundColor = .clear
+        hostingController.sizingOptions = [.intrinsicContentSize]
+        self.hostingController = hostingController
+
+        parentViewController.addChild(hostingController)
+        addSubview(hostingController.view)
+        hostingController.view.translatesAutoresizingMaskIntoConstraints = false
 
         NSLayoutConstraint.activate([
-            row.leadingAnchor.constraint(equalTo: leadingAnchor),
-            row.trailingAnchor.constraint(equalTo: trailingAnchor),
-            row.topAnchor.constraint(equalTo: topAnchor)
+            hostingController.view.topAnchor.constraint(equalTo: topAnchor),
+            hostingController.view.leadingAnchor.constraint(equalTo: leadingAnchor),
+            hostingController.view.trailingAnchor.constraint(equalTo: trailingAnchor),
+            hostingController.view.bottomAnchor.constraint(equalTo: bottomAnchor)
         ])
 
-        row.install(
-            message: message,
-            windowUUID: windowUUID,
-            parent: parent,
-            onClose: { [weak self, weak row] in
-                guard let self, let row else { return }
-                self.removeFrontRow(row)
-            }
-        )
-
-        return row
+        hostingController.didMove(toParent: parentViewController)
     }
 
-    /// FILO: only the front (most recently added) row can be dismissed.
-    private func removeFrontRow(_ row: EcosiaErrorToastRowHost) {
-        guard rows.last === row else { return }
-        removeRow(row)
-    }
-
-    private func removeRow(_ row: EcosiaErrorToastRowHost) {
-        guard rows.contains(where: { $0 === row }), row.alpha > 0 else { return }
-
-        cancelAutoDismiss()
-
-        UIView.animate(
-            withDuration: EcosiaErrorToastContainerUX.removalAnimationDuration,
-            delay: 0,
-            options: [.curveEaseIn, .beginFromCurrentState],
-            animations: {
-                row.alpha = 0
-                row.transform = CGAffineTransform(translationX: 0, y: -12)
-                    .scaledBy(x: 0.96, y: 0.96)
-                self.parentViewController?.view.layoutIfNeeded()
-            },
-            completion: { [weak self] _ in
-                guard let self, self.rows.contains(where: { $0 === row }) else { return }
-                row.teardown()
-                row.removeFromSuperview()
-                self.rows.removeAll { $0 === row }
-                UIView.animate(
-                    withDuration: EcosiaErrorToastContainerUX.presentationAnimationDuration,
-                    animations: {
-                        self.applyStackLayout()
-                        self.parentViewController?.view.layoutIfNeeded()
-                    },
-                    completion: { _ in
-                        self.scheduleFrontRowAutoDismiss()
-                    }
-                )
-            }
-        )
-    }
-
-    private func applyStackLayout() {
-        let count = rows.count
-
-        for (index, row) in rows.enumerated() {
-            let depthFromFront = count - 1 - index
-            let scale = max(0.88, 1 - CGFloat(depthFromFront) * EcosiaErrorToastContainerUX.depthScaleStep)
-            let yOffset = -CGFloat(depthFromFront) * EcosiaErrorToastContainerUX.depthPeekOffset
-
-            row.transform = CGAffineTransform(translationX: 0, y: yOffset)
-                .scaledBy(x: scale, y: scale)
-            row.layer.zPosition = CGFloat(index)
-            row.isUserInteractionEnabled = depthFromFront == 0
-            row.accessibilityElementsHidden = depthFromFront != 0
+    private func announceAccessibilityMessage(_ message: String, after delay: TimeInterval) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+            guard let self, self.model.messages.last?.subtitle == message else { return }
+            UIAccessibility.post(notification: .announcement, argument: message)
         }
-
-        updateContainerHeight()
     }
 
-    private func updateContainerHeight() {
-        guard let frontRow = rows.last else {
-            heightConstraint?.constant = 0
-            return
-        }
-
-        guard bounds.width > 0 else { return }
-
-        frontRow.layoutIfNeeded()
-        let fittingWidth = bounds.width
-        let frontHeight = frontRow.systemLayoutSizeFitting(
-            CGSize(width: fittingWidth, height: UIView.layoutFittingCompressedSize.height),
-            withHorizontalFittingPriority: .required,
-            verticalFittingPriority: .fittingSizeLevel
-        ).height
-
-        let peekHeight = CGFloat(max(0, rows.count - 1)) * EcosiaErrorToastContainerUX.depthPeekOffset
-        heightConstraint?.constant = max(frontHeight, EcosiaErrorToastContainerUX.rowMinHeight) + peekHeight
-    }
-
-    private func scheduleFrontRowAutoDismiss() {
+    private func scheduleFrontMessageAutoDismiss() {
         cancelAutoDismiss()
-        guard rows.last != nil else { return }
+        guard let frontID = model.messages.last?.id else { return }
 
         let workItem = DispatchWorkItem { [weak self] in
-            guard let self, let front = self.rows.last else { return }
-            self.removeRow(front)
+            guard let self, self.model.messages.last?.id == frontID else { return }
+            self.model.requestDismiss(id: frontID)
         }
         autoDismissWorkItem = workItem
         DispatchQueue.main.asyncAfter(
             deadline: .now() + EcosiaErrorToastContainerUX.displayDuration,
             execute: workItem
         )
+    }
+
+    private func handleMessageDismissed() {
+        if model.messages.isEmpty {
+            cancelAutoDismiss()
+        } else {
+            scheduleFrontMessageAutoDismiss()
+        }
     }
 
     private func cancelAutoDismiss() {

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+EcosiaErrorHandling.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+EcosiaErrorHandling.swift
@@ -78,9 +78,6 @@ final class EcosiaErrorToastContainerView: UIView {
                 : EcosiaErrorToastContainerUX.presentationAnimationDuration + 0.05
             announceAccessibilityMessage(announcement, after: delay)
         }
-
-        parentViewController.view.setNeedsLayout()
-        parentViewController.view.layoutIfNeeded()
     }
 
     /// Appends subtitle-only errors in order; the first message sits at the back, the last is on top.

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+EcosiaErrorHandling.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+EcosiaErrorHandling.swift
@@ -61,7 +61,7 @@ final class EcosiaErrorToastContainerView: UIView {
     }
 
     /// Appends errors in order; the first message sits at the back, the last is on top.
-    func present(messages: [String]) {
+    func present(messages: [EcosiaErrorToastMessage]) {
         guard !messages.isEmpty,
               let parentViewController,
               let windowUUID else { return }
@@ -69,10 +69,10 @@ final class EcosiaErrorToastContainerView: UIView {
         installHostingIfNeeded()
 
         let wasEmpty = model.messages.isEmpty
-        model.append(subtitles: messages)
+        model.append(messages: messages)
         scheduleFrontMessageAutoDismiss()
 
-        if let announcement = messages.last {
+        if let announcement = messages.last?.accessibilityAnnouncement {
             let delay = wasEmpty
                 ? 0.25
                 : EcosiaErrorToastContainerUX.presentationAnimationDuration + 0.05
@@ -81,6 +81,11 @@ final class EcosiaErrorToastContainerView: UIView {
 
         parentViewController.view.setNeedsLayout()
         parentViewController.view.layoutIfNeeded()
+    }
+
+    /// Appends subtitle-only errors in order; the first message sits at the back, the last is on top.
+    func present(subtitles: [String]) {
+        present(messages: subtitles.map { EcosiaErrorToastMessage(subtitle: $0) })
     }
 
     func clear() {
@@ -115,7 +120,8 @@ final class EcosiaErrorToastContainerView: UIView {
 
     private func announceAccessibilityMessage(_ message: String, after delay: TimeInterval) {
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
-            guard let self, self.model.messages.last?.subtitle == message else { return }
+            guard let self,
+                  self.model.messages.last?.accessibilityAnnouncement == message else { return }
             UIAccessibility.post(notification: .announcement, argument: message)
         }
     }
@@ -150,13 +156,21 @@ final class EcosiaErrorToastContainerView: UIView {
 }
 
 @available(iOS 16.0, *)
+extension BrowserViewController: EcosiaErrorToastPresenting {
+    func presentEcosiaErrorToasts(_ messages: [EcosiaErrorToastMessage]) {
+        guard !messages.isEmpty else { return }
+        let container = ensureEcosiaErrorToastContainer()
+        container.present(messages: messages)
+    }
+}
+
+@available(iOS 16.0, *)
 extension BrowserViewController {
 
     /// Shows one or more top-aligned error notifications in the fixed stack container.
     func showEcosiaErrorToasts(messages: [String]) {
         guard !messages.isEmpty else { return }
-        let container = ensureEcosiaErrorToastContainer()
-        container.present(messages: messages)
+        presentEcosiaErrorToasts(messages.map { EcosiaErrorToastMessage(subtitle: $0) })
     }
 
     /// Shows a single top-aligned error notification.
@@ -168,21 +182,23 @@ extension BrowserViewController {
     /// - Parameters:
     ///   - isLogin: Whether this was a login (true) or logout (false) error
     func showAuthFlowErrorToast(isLogin: Bool, errorMessage: String? = nil) {
-        var subtitle = isLogin
-            ? String.localized(.signInErrorMessage)
-            : String.localized(.signOutErrorMessage)
-
         #if MOZ_CHANNEL_BETA
         if let errorMessage {
+            var subtitle = isLogin
+                ? String.localized(.signInErrorMessage)
+                : String.localized(.signOutErrorMessage)
             subtitle += "Additional details: \(errorMessage)"
+            EcosiaErrorToastPresenter.shared.present(subtitle: subtitle)
+            return
         }
         #endif
 
-        showEcosiaErrorToast(message: subtitle)
+        EcosiaErrorToastPresenter.shared.presentAuthFlowError(isLogin: isLogin)
     }
 
     @discardableResult
     private func ensureEcosiaErrorToastContainer() -> EcosiaErrorToastContainerView {
+        EcosiaErrorToastPresenter.shared.delegate = self
         if let container = activeErrorToastContainer {
             if container.superview === view {
                 view.bringSubviewToFront(container)

--- a/firefox-ios/Client/Ecosia/Settings/EcosiaDebugSettings.swift
+++ b/firefox-ios/Client/Ecosia/Settings/EcosiaDebugSettings.swift
@@ -375,7 +375,9 @@ final class SimulateAuthErrorSetting: HiddenSetting {
 
         let alert = AlertController(
             title: !currentValue ? "Auth Error Enabled ✅" : "Auth Error Disabled ✅",
-            message: !currentValue ? "Next login/logout will fail with an error." : "Auth errors disabled.",
+            message: !currentValue
+                ? "Next login/logout will fail and show an error toast until you toggle this off."
+                : "Auth errors disabled.",
             preferredStyle: .alert
         )
         navigationController?.topViewController?.present(alert, animated: true) {
@@ -416,11 +418,12 @@ final class SimulateImpactAPIErrorSetting: HiddenSetting {
 
         let alert = AlertController(
             title: !currentValue ? "Impact API Error Enabled ✅" : "Impact API Error Disabled ✅",
-            message: !currentValue ? "Next impact API call will fail." : "Impact API errors disabled.",
+            message: !currentValue
+                ? "Next impact API call will fail and show the seed counter error toast."
+                : "Impact API errors disabled.",
             preferredStyle: .alert
         )
         navigationController?.topViewController?.present(alert, animated: true) {
-            // Ecosia: Task + sleep instead of DispatchQueue for strict concurrency
             Task { @MainActor in
                 try? await Task.sleep(nanoseconds: 1_500_000_000)
                 alert.dismiss(animated: true)

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadDebugSimulation.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadDebugSimulation.swift
@@ -16,6 +16,9 @@ enum OmniboxUploadDebugSimulation {
         if SimulateUploadValidationErrorSetting.isEnabled(for: .unsupportedFileType) {
             errors.insert(.unsupportedFileType)
         }
+        if shouldSimulateUploadAPIFailure {
+            errors.insert(.uploadFailed)
+        }
         return errors
     }
 

--- a/firefox-ios/Ecosia/UI/Account/EcosiaAccountImpactView.swift
+++ b/firefox-ios/Ecosia/UI/Account/EcosiaAccountImpactView.swift
@@ -75,16 +75,6 @@ public struct EcosiaAccountImpactView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .accessibilityElement(children: .combine)
 
-            // Show error view if register visit failed
-            if authStateProvider.hasRegisterVisitError {
-                EcosiaErrorView(
-                    title: String.localized(.couldNotLoadSeedCounter),
-                    subtitle: String.localized(.couldNotLoadSeedCounterMessage),
-                    windowUUID: windowUUID
-                )
-                .padding(.horizontal, .ecosia.space._m)
-            }
-
             // Conditional content based on login state
             ZStack(alignment: .top) {
                 if !viewModel.isLoggedIn {

--- a/firefox-ios/Ecosia/UI/Account/EcosiaAuthUIStateProvider.swift
+++ b/firefox-ios/Ecosia/UI/Account/EcosiaAuthUIStateProvider.swift
@@ -236,6 +236,9 @@ public class EcosiaAuthUIStateProvider: ObservableObject {
                 // Set error state
                 await MainActor.run {
                     hasRegisterVisitError = true
+                    if #available(iOS 16.0, *) {
+                        EcosiaErrorToastPresenter.shared.presentRegisterVisitError()
+                    }
                 }
             }
         }

--- a/firefox-ios/Ecosia/UI/Components/EcosiaErrorView.swift
+++ b/firefox-ios/Ecosia/UI/Components/EcosiaErrorView.swift
@@ -51,7 +51,6 @@ public struct EcosiaErrorView: View {
 
     public var body: some View {
         HStack(alignment: .center, spacing: .ecosia.space._s) {
-            // Error icon
             Image.ecosia("problem")
                 .resizable()
                 .frame(width: .ecosia.space._1l, height: .ecosia.space._1l)
@@ -59,50 +58,57 @@ public struct EcosiaErrorView: View {
                 .accessibilityLabel(String.localized(.ecosiaErrorViewAccessibilityImageLabel))
                 .accessibilityIdentifier("error_view_image")
 
-            // Text content
-            VStack(alignment: .leading, spacing: .ecosia.space._1s) {
-                if let title = title {
-                    Text(title)
-                        .font(.subheadline.bold())
-                        .foregroundColor(theme.textPrimaryColor)
-                }
-
-                Text(subtitle)
-                    .font(.subheadline)
-                    .foregroundColor(title != nil ? theme.textSecondaryColor : theme.textPrimaryColor)
-                    .multilineTextAlignment(.leading)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
+            textContent
+                .frame(maxWidth: .infinity, alignment: .leading)
 
             if showsCloseButton {
-                Button(action: {
-                    onCloseTapped?()
-                }) {
-                    Image.ecosia("close")
-                        .renderingMode(.template)
-                        .resizable()
-                        .frame(width: UX.closeButtonSize, height: UX.closeButtonSize)
-                        .foregroundColor(theme.closeButtonColor)
-                }
-                .opacity(onCloseTapped != nil ? 1 : 0)
-                .disabled(onCloseTapped == nil)
-                .accessibilityHidden(onCloseTapped == nil)
-                .accessibilityLabel(String.localized(.close))
-                .accessibilityAddTraits(.isButton)
+                closeButton
             }
         }
         .padding(.horizontal, .ecosia.space._s)
         .padding(.vertical, .ecosia.space._1s)
-        .background(
-            RoundedRectangle(cornerRadius: .ecosia.borderRadius._m)
-                .fill(theme.backgroundColor)
-                .overlay(
-                    RoundedRectangle(cornerRadius: .ecosia.borderRadius._m)
-                        .stroke(theme.borderColor, lineWidth: UX.borderWidth)
-                )
-        )
+        .background(cardBackground)
         .ecosiaThemed(windowUUID, $theme)
+    }
+
+    private var textContent: some View {
+        VStack(alignment: .leading, spacing: .ecosia.space._1s) {
+            if let title {
+                Text(title)
+                    .font(.subheadline.bold())
+                    .foregroundColor(theme.textPrimaryColor)
+            }
+
+            Text(subtitle)
+                .font(.subheadline)
+                .foregroundColor(title != nil ? theme.textSecondaryColor : theme.textPrimaryColor)
+                .multilineTextAlignment(.leading)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private var closeButton: some View {
+        Button(action: { onCloseTapped?() }) {
+            Image.ecosia("close")
+                .renderingMode(.template)
+                .resizable()
+                .frame(width: UX.closeButtonSize, height: UX.closeButtonSize)
+                .foregroundColor(theme.closeButtonColor)
+        }
+        .opacity(onCloseTapped != nil ? 1 : 0)
+        .disabled(onCloseTapped == nil)
+        .accessibilityHidden(onCloseTapped == nil)
+        .accessibilityLabel(String.localized(.close))
+        .accessibilityAddTraits(.isButton)
+    }
+
+    private var cardBackground: some View {
+        RoundedRectangle(cornerRadius: .ecosia.borderRadius._m)
+            .fill(theme.backgroundColor)
+            .overlay(
+                RoundedRectangle(cornerRadius: .ecosia.borderRadius._m)
+                    .stroke(theme.borderColor, lineWidth: UX.borderWidth)
+            )
     }
 }
 

--- a/firefox-ios/Ecosia/UI/Components/EcosiaErrorView.swift
+++ b/firefox-ios/Ecosia/UI/Components/EcosiaErrorView.swift
@@ -12,6 +12,7 @@ public struct EcosiaErrorView: View {
     private let title: String?
     private let subtitle: String
     private let windowUUID: WindowUUID
+    private let showsCloseButton: Bool
     private let onCloseTapped: (() -> Void)?
     private let onDismiss: (() -> Void)?
 
@@ -27,6 +28,7 @@ public struct EcosiaErrorView: View {
     ///   - title: Optional bold title text. If nil, only subtitle is shown
     ///   - subtitle: Main error message text
     ///   - windowUUID: Window UUID for theming
+    ///   - showsCloseButton: When true, reserves trailing space for the close button even if it is not interactive.
     ///   - onCloseTapped: Optional closure called when close button is tapped. If nil, close button is hidden.
     ///                    This closure should handle initiating dismissal (e.g., starting animations)
     ///   - onDismiss: Optional closure called when view dismissal is complete (e.g., after animations finish).
@@ -35,12 +37,14 @@ public struct EcosiaErrorView: View {
         title: String? = nil,
         subtitle: String,
         windowUUID: WindowUUID,
+        showsCloseButton: Bool = false,
         onCloseTapped: (() -> Void)? = nil,
         onDismiss: (() -> Void)? = nil
     ) {
         self.title = title
         self.subtitle = subtitle
         self.windowUUID = windowUUID
+        self.showsCloseButton = showsCloseButton || onCloseTapped != nil
         self.onCloseTapped = onCloseTapped
         self.onDismiss = onDismiss
     }
@@ -66,13 +70,14 @@ public struct EcosiaErrorView: View {
                 Text(subtitle)
                     .font(.subheadline)
                     .foregroundColor(title != nil ? theme.textSecondaryColor : theme.textPrimaryColor)
+                    .multilineTextAlignment(.leading)
+                    .fixedSize(horizontal: false, vertical: true)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
-            // Close button (conditionally shown)
-            if let onCloseTapped = onCloseTapped {
+            if showsCloseButton {
                 Button(action: {
-                    onCloseTapped()
+                    onCloseTapped?()
                 }) {
                     Image.ecosia("close")
                         .renderingMode(.template)
@@ -80,6 +85,9 @@ public struct EcosiaErrorView: View {
                         .frame(width: UX.closeButtonSize, height: UX.closeButtonSize)
                         .foregroundColor(theme.closeButtonColor)
                 }
+                .opacity(onCloseTapped != nil ? 1 : 0)
+                .disabled(onCloseTapped == nil)
+                .accessibilityHidden(onCloseTapped == nil)
                 .accessibilityLabel(String.localized(.close))
                 .accessibilityAddTraits(.isButton)
             }

--- a/firefox-ios/Ecosia/UI/Toast/EcosiaErrorToastPresenter.swift
+++ b/firefox-ios/Ecosia/UI/Toast/EcosiaErrorToastPresenter.swift
@@ -1,0 +1,63 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+@available(iOS 16.0, *)
+@MainActor
+public protocol EcosiaErrorToastPresenting: AnyObject {
+    func presentEcosiaErrorToasts(_ messages: [EcosiaErrorToastMessage])
+}
+
+/// Routes Ecosia error notifications to the active browser's top toast stack.
+@available(iOS 16.0, *)
+@MainActor
+public final class EcosiaErrorToastPresenter {
+    public static let shared = EcosiaErrorToastPresenter()
+
+    public weak var delegate: EcosiaErrorToastPresenting? {
+        didSet {
+            flushPendingMessagesIfNeeded()
+        }
+    }
+
+    private var pendingMessages: [EcosiaErrorToastMessage] = []
+
+    private init() {}
+
+    public func present(subtitle: String, title: String? = nil) {
+        present(messages: [EcosiaErrorToastMessage(title: title, subtitle: subtitle)])
+    }
+
+    public func present(messages: [EcosiaErrorToastMessage]) {
+        guard !messages.isEmpty else { return }
+
+        if let delegate {
+            delegate.presentEcosiaErrorToasts(messages)
+        } else {
+            pendingMessages.append(contentsOf: messages)
+        }
+    }
+
+    public func presentAuthFlowError(isLogin: Bool) {
+        let subtitle = isLogin
+            ? String.localized(.signInErrorMessage)
+            : String.localized(.signOutErrorMessage)
+        present(subtitle: subtitle)
+    }
+
+    public func presentRegisterVisitError() {
+        present(
+            subtitle: String.localized(.couldNotLoadSeedCounterMessage),
+            title: String.localized(.couldNotLoadSeedCounter)
+        )
+    }
+
+    private func flushPendingMessagesIfNeeded() {
+        guard let delegate, !pendingMessages.isEmpty else { return }
+        let messages = pendingMessages
+        pendingMessages.removeAll()
+        delegate.presentEcosiaErrorToasts(messages)
+    }
+}

--- a/firefox-ios/Ecosia/UI/Toast/EcosiaErrorToastPresenter.swift
+++ b/firefox-ios/Ecosia/UI/Toast/EcosiaErrorToastPresenter.swift
@@ -11,6 +11,9 @@ public protocol EcosiaErrorToastPresenting: AnyObject {
 }
 
 /// Routes Ecosia error notifications to the active browser's top toast stack.
+///
+/// Singleton is sufficient while Ecosia keeps `UIApplicationSupportsMultipleScenes`
+/// disabled. If multi-window is enabled later, route per `windowUUID` / BVC instead.
 @available(iOS 16.0, *)
 @MainActor
 public final class EcosiaErrorToastPresenter {

--- a/firefox-ios/Ecosia/UI/Toast/EcosiaErrorToastStack.swift
+++ b/firefox-ios/Ecosia/UI/Toast/EcosiaErrorToastStack.swift
@@ -30,7 +30,8 @@ public final class EcosiaErrorToastStackModel: ObservableObject {
     @Published fileprivate(set) var dismissingID: UUID?
 
     private enum UX {
-        static let fadeDuration: TimeInterval = 0.25
+        static let fadeDuration: TimeInterval = 0.28
+        static let promoteDuration: TimeInterval = 0.35
     }
 
     public var onDismissCompleted: (() -> Void)?
@@ -56,7 +57,7 @@ public final class EcosiaErrorToastStackModel: ObservableObject {
 
         DispatchQueue.main.asyncAfter(deadline: .now() + UX.fadeDuration) { [weak self] in
             guard let self else { return }
-            withAnimation(.spring(response: 0.38, dampingFraction: 0.86)) {
+            withAnimation(.easeOut(duration: UX.promoteDuration)) {
                 self.messages.removeAll { $0.id == id }
                 self.dismissingID = nil
             }
@@ -81,14 +82,18 @@ public struct EcosiaErrorToastStack: View {
 
     @State private var isVisible = false
     @State private var isExpanded = false
-    @State private var cardHeights: [UUID: CGFloat] = [:]
+    @State private var frontCardHeight: CGFloat = UX.minCardHeight
+    @State private var measuredExpandedHeight: CGFloat?
     @State private var dismissalLayoutHeight: CGFloat?
 
     private enum UX {
         static let minCardHeight: CGFloat = 56
         static let stackPeek: CGFloat = .ecosia.space._1s
         static let listSpacing: CGFloat = .ecosia.space._1s
-        static let fadeDuration: TimeInterval = 0.25
+        static let fadeDuration: TimeInterval = 0.28
+        static let entranceDuration: TimeInterval = 0.45
+        static let expandDuration: TimeInterval = 0.42
+        static let promoteDuration: TimeInterval = 0.35
         static let maxVisibleDepth = 4
     }
 
@@ -104,51 +109,59 @@ public struct EcosiaErrorToastStack: View {
         self.onExpandChange = onExpandChange
     }
 
-    private var promoteSpring: Animation {
-        .spring(response: 0.38, dampingFraction: 0.86)
+    private var entranceAnimation: Animation {
+        .timingCurve(0.16, 1, 0.3, 1, duration: UX.entranceDuration)
+    }
+
+    private var expandAnimation: Animation {
+        .spring(response: UX.expandDuration, dampingFraction: 0.92)
+    }
+
+    private var promoteAnimation: Animation {
+        .easeOut(duration: UX.promoteDuration)
     }
 
     private var layoutAnimationKey: String {
-        let messageIDs = model.messages.map(\.id.uuidString).joined(separator: "-")
+        let messageIDs = visibleMessages.map(\.id.uuidString).joined(separator: "-")
         let dismissingID = model.dismissingID?.uuidString ?? "none"
-        return "\(isExpanded)-\(messageIDs)-\(dismissingID)"
+        return "\(messageIDs)-\(dismissingID)"
     }
 
     public var body: some View {
         if !model.messages.isEmpty {
             ZStack(alignment: .top) {
-                ForEach(Array(visibleMessages.enumerated()), id: \.element.id) { index, message in
-                    let depthFromFront = visibleMessages.count - 1 - index
-                    let isFront = depthFromFront == 0
-                    let isDismissing = message.id == model.dismissingID
+                cardMeasurementStack
 
-                    toastCard(
-                        for: message,
-                        showsCloseButton: (isExpanded || isFront) && !isDismissing,
-                        onClose: { dismiss(message) }
-                    )
-                    .scaleEffect(
-                        x: isExpanded ? 1 : scaleForDepth(depthFromFront),
-                        y: 1,
-                        anchor: .top
-                    )
-                    .offset(y: yOffset(for: index))
-                    .opacity(isDismissing ? 0 : 1)
-                    .animation(.easeOut(duration: UX.fadeDuration), value: isDismissing)
-                    .allowsHitTesting(isExpanded || (isFront && !isDismissing))
-                    .zIndex(Double(index))
+                ZStack(alignment: .top) {
+                    collapsedStack
+                        .opacity(isExpanded ? 0 : 1)
+                        .allowsHitTesting(!isExpanded)
+
+                    expandedStack
+                        .opacity(isExpanded ? 1 : 0)
+                        .allowsHitTesting(isExpanded)
                 }
+                .frame(height: effectiveContainerHeight, alignment: .top)
+                .animation(expandAnimation, value: isExpanded)
             }
-            .frame(height: effectiveContainerHeight, alignment: .top)
-            .frame(maxWidth: .infinity)
+            .frame(maxWidth: .infinity, alignment: .top)
             .contentShape(Rectangle())
             .onTapGesture { toggleExpanded() }
-            .animation(promoteSpring, value: layoutAnimationKey)
-            .offset(y: isVisible ? 0 : -(referenceCardHeight + .ecosia.space._1l))
+            .offset(y: isVisible ? 0 : -entranceOffset)
             .opacity(isVisible ? 1 : 0)
-            .onPreferenceChange(ToastCardHeightPreferenceKey.self, perform: updateCardHeights)
+            .animation(entranceAnimation, value: isVisible)
+            .onPreferenceChange(ToastStackHeightPreferenceKey.self) { height in
+                guard height > 0 else { return }
+                updateMeasuredExpandedHeight(height)
+            }
+            .onPreferenceChange(ToastCardHeightPreferenceKey.self) { heights in
+                guard let frontID = visibleMessages.last?.id,
+                      let height = heights[frontID],
+                      height > 0 else { return }
+                updateFrontCardHeight(height)
+            }
             .onAppear {
-                withAnimation(.easeOut(duration: UX.fadeDuration)) {
+                withAnimation(entranceAnimation) {
                     isVisible = true
                 }
             }
@@ -156,7 +169,7 @@ public struct EcosiaErrorToastStack: View {
                 if dismissingID != nil {
                     dismissalLayoutHeight = containerHeight
                 } else if dismissalLayoutHeight != nil {
-                    withAnimation(promoteSpring) {
+                    withAnimation(promoteAnimation) {
                         dismissalLayoutHeight = nil
                     }
                 }
@@ -166,13 +179,111 @@ public struct EcosiaErrorToastStack: View {
                     dismissalLayoutHeight = nil
                 }
                 if count == 1, isExpanded {
-                    withAnimation(promoteSpring) {
+                    withAnimation(expandAnimation) {
                         isExpanded = false
                     }
                     onExpandChange(false)
                 }
             }
         }
+    }
+
+    /// Hidden sizing pass for collapsed front-card height and expanded stack height.
+    private var cardMeasurementStack: some View {
+        VStack(spacing: UX.listSpacing) {
+            ForEach(Array(visibleMessages.enumerated()), id: \.element.id) { index, message in
+                measurementRow(for: message, isFront: index == visibleMessages.count - 1)
+            }
+        }
+        .fixedSize(horizontal: false, vertical: true)
+        .frame(maxWidth: .infinity, alignment: .top)
+        .background {
+            GeometryReader { geometry in
+                Color.clear.preference(
+                    key: ToastStackHeightPreferenceKey.self,
+                    value: geometry.size.height
+                )
+            }
+        }
+        .hidden()
+        .allowsHitTesting(false)
+        .accessibilityHidden(true)
+    }
+
+    private func measurementRow(for message: EcosiaErrorToastMessage, isFront: Bool) -> some View {
+        EcosiaErrorView(
+            title: message.title,
+            subtitle: message.subtitle,
+            windowUUID: windowUUID,
+            showsCloseButton: true,
+            onCloseTapped: nil
+        )
+        .padding(.horizontal, .ecosia.space._m)
+        .overlay {
+            if isFront {
+                GeometryReader { geometry in
+                    Color.clear.preference(
+                        key: ToastCardHeightPreferenceKey.self,
+                        value: [message.id: geometry.size.height]
+                    )
+                }
+            }
+        }
+    }
+
+    private var collapsedStack: some View {
+        ZStack(alignment: .top) {
+            ForEach(Array(visibleMessages.enumerated()), id: \.element.id) { index, message in
+                let depthFromFront = visibleMessages.count - 1 - index
+                let isFront = depthFromFront == 0
+                let isDismissing = message.id == model.dismissingID
+
+                collapsedWalletCard(
+                    for: message,
+                    depthFromFront: depthFromFront,
+                    isFront: isFront,
+                    isDismissing: isDismissing
+                )
+                .offset(y: CGFloat(index) * UX.stackPeek)
+                .opacity(isDismissing ? 0 : 1)
+                .animation(.easeOut(duration: UX.fadeDuration), value: isDismissing)
+                .allowsHitTesting(isFront && !isDismissing)
+                .zIndex(Double(index))
+            }
+        }
+        .animation(promoteAnimation, value: layoutAnimationKey)
+    }
+
+    private var expandedStack: some View {
+        VStack(spacing: UX.listSpacing) {
+            ForEach(visibleMessages) { message in
+                expandedRow(for: message)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .top)
+    }
+
+    @ViewBuilder
+    private func expandedRow(for message: EcosiaErrorToastMessage) -> some View {
+        let isDismissing = message.id == model.dismissingID
+
+        EcosiaErrorView(
+            title: message.title,
+            subtitle: message.subtitle,
+            windowUUID: windowUUID,
+            showsCloseButton: true,
+            onCloseTapped: isDismissing ? nil : { dismiss(message) }
+        )
+        .padding(.horizontal, .ecosia.space._m)
+        .opacity(isDismissing ? 0 : 1)
+        .animation(.easeOut(duration: UX.fadeDuration), value: isDismissing)
+        .allowsHitTesting(!isDismissing)
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(.isStaticText)
+    }
+
+    private var entranceOffset: CGFloat {
+        referenceCardHeight + .ecosia.space._1l
     }
 
     private var visibleMessages: [EcosiaErrorToastMessage] {
@@ -183,17 +294,16 @@ public struct EcosiaErrorToastStack: View {
         visibleMessages.count > 1
     }
 
-    private var containerHeight: CGFloat {
-        isExpanded ? expandedHeight : collapsedHeight
-    }
-
     private var effectiveContainerHeight: CGFloat {
         dismissalLayoutHeight ?? containerHeight
     }
 
+    private var containerHeight: CGFloat {
+        isExpanded ? expandedHeight : collapsedHeight
+    }
+
     private var referenceCardHeight: CGFloat {
-        guard let frontID = visibleMessages.last?.id else { return UX.minCardHeight }
-        return max(cardHeights[frontID] ?? UX.minCardHeight, UX.minCardHeight)
+        max(frontCardHeight, UX.minCardHeight)
     }
 
     private var collapsedHeight: CGFloat {
@@ -201,44 +311,33 @@ public struct EcosiaErrorToastStack: View {
     }
 
     private var expandedHeight: CGFloat {
-        guard !visibleMessages.isEmpty else { return UX.minCardHeight }
+        if let measuredExpandedHeight, measuredExpandedHeight > 0 {
+            return measuredExpandedHeight
+        }
 
-        let heights = visibleMessages.map { max(cardHeights[$0.id] ?? UX.minCardHeight, UX.minCardHeight) }
+        let estimatedCards = CGFloat(visibleMessages.count) * UX.minCardHeight
         let spacing = UX.listSpacing * CGFloat(max(0, visibleMessages.count - 1))
-        return heights.reduce(0, +) + spacing
+        return estimatedCards + spacing
     }
 
-    private func updateCardHeights(_ newHeights: [UUID: CGFloat]) {
-        let activeIDs = Set(model.messages.map(\.id))
-        var updated = cardHeights.filter { activeIDs.contains($0.key) }
+    private func updateFrontCardHeight(_ height: CGFloat) {
+        guard abs(frontCardHeight - height) > 0.5 else { return }
 
-        for (id, height) in newHeights where activeIDs.contains(id) {
-            let resolved = max(height, UX.minCardHeight)
-            if let existing = updated[id] {
-                // Ignore sub-point churn from text re-measurement during animations.
-                if abs(existing - resolved) > 0.5 {
-                    updated[id] = resolved
-                }
-            } else {
-                updated[id] = resolved
-            }
+        var transaction = Transaction()
+        transaction.disablesAnimations = true
+        withTransaction(transaction) {
+            frontCardHeight = height
         }
-
-        guard updated != cardHeights else { return }
-        cardHeights = updated
     }
 
-    private func yOffset(for index: Int) -> CGFloat {
-        if isExpanded {
-            var offset: CGFloat = 0
-            for priorIndex in 0..<index {
-                let message = visibleMessages[priorIndex]
-                let height = max(cardHeights[message.id] ?? UX.minCardHeight, UX.minCardHeight)
-                offset += height + UX.listSpacing
-            }
-            return offset
+    private func updateMeasuredExpandedHeight(_ height: CGFloat) {
+        guard abs((measuredExpandedHeight ?? 0) - height) > 0.5 else { return }
+
+        var transaction = Transaction()
+        transaction.disablesAnimations = true
+        withTransaction(transaction) {
+            measuredExpandedHeight = height
         }
-        return CGFloat(index) * UX.stackPeek
     }
 
     private func scaleForDepth(_ depth: Int) -> CGFloat {
@@ -250,12 +349,40 @@ public struct EcosiaErrorToastStack: View {
     }
 
     @ViewBuilder
+    private func collapsedWalletCard(
+        for message: EcosiaErrorToastMessage,
+        depthFromFront: Int,
+        isFront: Bool,
+        isDismissing: Bool
+    ) -> some View {
+        let showsCloseButton = isFront && !isDismissing
+        let card = toastCard(
+            for: message,
+            showsCloseButton: showsCloseButton,
+            showsShadow: isFront,
+            onClose: { dismiss(message) }
+        )
+
+        Group {
+            if isFront {
+                card.scaleEffect(1, anchor: .top)
+            } else {
+                card
+                    .scaleEffect(scaleForDepth(depthFromFront), anchor: .top)
+                    .frame(height: UX.stackPeek, alignment: .top)
+                    .clipped()
+            }
+        }
+    }
+
+    @ViewBuilder
     private func toastCard(
         for message: EcosiaErrorToastMessage,
         showsCloseButton: Bool,
+        showsShadow: Bool,
         onClose: @escaping () -> Void
     ) -> some View {
-        EcosiaErrorView(
+        let content = EcosiaErrorView(
             title: message.title,
             subtitle: message.subtitle,
             windowUUID: windowUUID,
@@ -264,16 +391,15 @@ public struct EcosiaErrorToastStack: View {
         )
         .frame(minHeight: UX.minCardHeight, alignment: .center)
         .fixedSize(horizontal: false, vertical: true)
-        .background {
-            GeometryReader { geometry in
-                Color.clear.preference(
-                    key: ToastCardHeightPreferenceKey.self,
-                    value: [message.id: geometry.size.height]
-                )
+        .padding(.horizontal, .ecosia.space._m)
+
+        Group {
+            if showsShadow {
+                content.shadow(color: Color.black.opacity(0.12), radius: 8, x: 0, y: 4)
+            } else {
+                content
             }
         }
-        .padding(.horizontal, .ecosia.space._m)
-        .shadow(color: Color.black.opacity(0.12), radius: 8, x: 0, y: 4)
         .accessibilityElement(children: .combine)
         .accessibilityAddTraits(.isStaticText)
     }
@@ -282,7 +408,7 @@ public struct EcosiaErrorToastStack: View {
         guard canExpand else { return }
 
         let willExpand = !isExpanded
-        withAnimation(promoteSpring) {
+        withAnimation(expandAnimation) {
             isExpanded = willExpand
         }
         onExpandChange(willExpand)
@@ -300,6 +426,15 @@ private struct ToastCardHeightPreferenceKey: PreferenceKey {
 
     static func reduce(value: inout [UUID: CGFloat], nextValue: () -> [UUID: CGFloat]) {
         value.merge(nextValue()) { _, new in new }
+    }
+}
+
+@available(iOS 16.0, *)
+private struct ToastStackHeightPreferenceKey: PreferenceKey {
+    nonisolated(unsafe) static var defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
     }
 }
 

--- a/firefox-ios/Ecosia/UI/Toast/EcosiaErrorToastStack.swift
+++ b/firefox-ios/Ecosia/UI/Toast/EcosiaErrorToastStack.swift
@@ -15,6 +15,13 @@ public struct EcosiaErrorToastMessage: Identifiable, Equatable, Sendable {
         self.title = title
         self.subtitle = subtitle
     }
+
+    public var accessibilityAnnouncement: String {
+        if let title, !title.isEmpty {
+            return "\(title). \(subtitle)"
+        }
+        return subtitle
+    }
 }
 
 @MainActor
@@ -31,7 +38,11 @@ public final class EcosiaErrorToastStackModel: ObservableObject {
     public init() {}
 
     public func append(subtitles: [String]) {
-        let newMessages = subtitles.map { EcosiaErrorToastMessage(subtitle: $0) }
+        append(messages: subtitles.map { EcosiaErrorToastMessage(subtitle: $0) })
+    }
+
+    public func append(messages newMessages: [EcosiaErrorToastMessage]) {
+        guard !newMessages.isEmpty else { return }
         messages.append(contentsOf: newMessages)
     }
 

--- a/firefox-ios/Ecosia/UI/Toast/EcosiaErrorToastStack.swift
+++ b/firefox-ios/Ecosia/UI/Toast/EcosiaErrorToastStack.swift
@@ -135,6 +135,7 @@ public struct EcosiaErrorToastStack: View {
             .frame(maxWidth: .infinity, alignment: .top)
             .contentShape(Rectangle())
             .onTapGesture(perform: toggleExpanded)
+            .accessibilityAddTraits(.isButton)
             .offset(y: isVisible ? 0 : -(frontCardHeight + .ecosia.space._1l))
             .opacity(isVisible ? 1 : 0)
             .animation(entranceAnimation, value: isVisible)

--- a/firefox-ios/Ecosia/UI/Toast/EcosiaErrorToastStack.swift
+++ b/firefox-ios/Ecosia/UI/Toast/EcosiaErrorToastStack.swift
@@ -71,8 +71,8 @@ public final class EcosiaErrorToastStackModel: ObservableObject {
     }
 }
 
-/// Overlapping top toast stack from Global Components (Figma 19211:4961).
-/// Tap the stack to expand into a vertical list; tap again to collapse.
+/// Wallet-style top toast stack (Figma 19211:4961).
+/// Collapsed: overlapping peeks. Expanded: even vertical list. Tap to toggle.
 @available(iOS 16.0, *)
 public struct EcosiaErrorToastStack: View {
     @ObservedObject private var model: EcosiaErrorToastStackModel
@@ -82,7 +82,7 @@ public struct EcosiaErrorToastStack: View {
 
     @State private var isVisible = false
     @State private var isExpanded = false
-    @State private var frontCardHeight: CGFloat = UX.minCardHeight
+    @State private var frontCardHeight = UX.minCardHeight
     @State private var measuredExpandedHeight: CGFloat?
     @State private var dismissalLayoutHeight: CGFloat?
 
@@ -95,6 +95,8 @@ public struct EcosiaErrorToastStack: View {
         static let expandDuration: TimeInterval = 0.42
         static let promoteDuration: TimeInterval = 0.35
         static let maxVisibleDepth = 4
+        static let depth1Scale: CGFloat = 327.0 / 343.0
+        static let depth2Scale: CGFloat = 311.0 / 343.0
     }
 
     public init(
@@ -109,6 +111,261 @@ public struct EcosiaErrorToastStack: View {
         self.onExpandChange = onExpandChange
     }
 
+    // MARK: - Body
+
+    public var body: some View {
+        if !model.messages.isEmpty {
+            ZStack(alignment: .top) {
+                // Hidden sizing pass keeps GeometryReader off the visible list
+                // (per-row readers inflate the first expanded gap).
+                sizingPass
+
+                ZStack(alignment: .top) {
+                    collapsedStack
+                        .opacity(isExpanded ? 0 : 1)
+                        .allowsHitTesting(!isExpanded)
+
+                    expandedStack
+                        .opacity(isExpanded ? 1 : 0)
+                        .allowsHitTesting(isExpanded)
+                }
+                .frame(height: containerHeight, alignment: .top)
+                .animation(expandAnimation, value: isExpanded)
+            }
+            .frame(maxWidth: .infinity, alignment: .top)
+            .contentShape(Rectangle())
+            .onTapGesture(perform: toggleExpanded)
+            .offset(y: isVisible ? 0 : -(frontCardHeight + .ecosia.space._1l))
+            .opacity(isVisible ? 1 : 0)
+            .animation(entranceAnimation, value: isVisible)
+            .onPreferenceChange(ToastLayoutMetricsKey.self, perform: applyLayoutMetrics)
+            .onAppear {
+                withAnimation(entranceAnimation) { isVisible = true }
+            }
+            .onChange(of: model.dismissingID, perform: handleDismissingIDChange)
+            .onChange(of: model.messages.count, perform: handleMessageCountChange)
+        }
+    }
+
+    // MARK: - Stacks
+
+    private var collapsedStack: some View {
+        ZStack(alignment: .top) {
+            ForEach(Array(visibleMessages.enumerated()), id: \.element.id) { index, message in
+                let depthFromFront = visibleMessages.count - 1 - index
+                let isFront = depthFromFront == 0
+                let isDismissing = message.id == model.dismissingID
+
+                walletCard(
+                    for: message,
+                    depthFromFront: depthFromFront,
+                    isFront: isFront,
+                    isDismissing: isDismissing
+                )
+                .offset(y: CGFloat(index) * UX.stackPeek)
+                .dismissChrome(isDismissing: isDismissing, duration: UX.fadeDuration)
+                .allowsHitTesting(isFront && !isDismissing)
+                .zIndex(Double(index))
+            }
+        }
+        .animation(promoteAnimation, value: layoutAnimationKey)
+    }
+
+    private var expandedStack: some View {
+        VStack(spacing: UX.listSpacing) {
+            ForEach(visibleMessages) { message in
+                let isDismissing = message.id == model.dismissingID
+                // Natural height only — minHeight leaves empty space below short cards
+                // and makes the first gap look larger than the rest.
+                errorCard(for: message, showsCloseButton: !isDismissing)
+                    .dismissChrome(isDismissing: isDismissing, duration: UX.fadeDuration)
+                    .allowsHitTesting(!isDismissing)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .top)
+    }
+
+    /// Sibling pass that reports natural front-card and expanded-stack heights.
+    /// GeometryReaders stay here (not on the visible VStack) so they cannot inflate row spacing.
+    private var sizingPass: some View {
+        VStack(spacing: UX.listSpacing) {
+            ForEach(Array(visibleMessages.enumerated()), id: \.element.id) { index, message in
+                let isFront = index == visibleMessages.count - 1
+                errorCard(for: message, showsCloseButton: true)
+                    .overlay {
+                        if isFront {
+                            GeometryReader { geometry in
+                                Color.clear.preference(
+                                    key: ToastLayoutMetricsKey.self,
+                                    value: ToastLayoutMetrics(frontCardHeight: geometry.size.height)
+                                )
+                            }
+                        }
+                    }
+            }
+        }
+        .fixedSize(horizontal: false, vertical: true)
+        .frame(maxWidth: .infinity, alignment: .top)
+        .background {
+            GeometryReader { geometry in
+                Color.clear.preference(
+                    key: ToastLayoutMetricsKey.self,
+                    value: ToastLayoutMetrics(expandedHeight: geometry.size.height)
+                )
+            }
+        }
+        .hidden()
+        .allowsHitTesting(false)
+        .accessibilityHidden(true)
+    }
+
+    // MARK: - Cards
+
+    @ViewBuilder
+    private func walletCard(
+        for message: EcosiaErrorToastMessage,
+        depthFromFront: Int,
+        isFront: Bool,
+        isDismissing: Bool
+    ) -> some View {
+        let card = errorCard(
+            for: message,
+            showsCloseButton: isFront && !isDismissing,
+            fillsMinHeight: true,
+            showsShadow: isFront
+        )
+
+        if isFront {
+            card.scaleEffect(1, anchor: .top)
+        } else {
+            card
+                .scaleEffect(scaleForDepth(depthFromFront), anchor: .top)
+                .frame(height: UX.stackPeek, alignment: .top)
+                .clipped()
+        }
+    }
+
+    @ViewBuilder
+    private func errorCard(
+        for message: EcosiaErrorToastMessage,
+        showsCloseButton: Bool,
+        fillsMinHeight: Bool = false,
+        showsShadow: Bool = false
+    ) -> some View {
+        let content = EcosiaErrorView(
+            title: message.title,
+            subtitle: message.subtitle,
+            windowUUID: windowUUID,
+            showsCloseButton: true,
+            onCloseTapped: showsCloseButton ? { dismiss(message) } : nil
+        )
+        .padding(.horizontal, .ecosia.space._m)
+
+        Group {
+            if fillsMinHeight {
+                content
+                    .frame(minHeight: UX.minCardHeight, alignment: .top)
+                    .fixedSize(horizontal: false, vertical: true)
+            } else {
+                content
+            }
+        }
+        .shadow(
+            color: showsShadow ? Color.black.opacity(0.12) : .clear,
+            radius: showsShadow ? 8 : 0,
+            x: 0,
+            y: showsShadow ? 4 : 0
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(.isStaticText)
+    }
+
+    // MARK: - Layout
+
+    private var visibleMessages: [EcosiaErrorToastMessage] {
+        Array(model.messages.suffix(UX.maxVisibleDepth))
+    }
+
+    private var containerHeight: CGFloat {
+        dismissalLayoutHeight ?? (isExpanded ? expandedHeight : collapsedHeight)
+    }
+
+    private var collapsedHeight: CGFloat {
+        frontCardHeight + CGFloat(max(0, visibleMessages.count - 1)) * UX.stackPeek
+    }
+
+    private var expandedHeight: CGFloat {
+        if let measuredExpandedHeight, measuredExpandedHeight > 0 {
+            return measuredExpandedHeight
+        }
+        let cards = CGFloat(visibleMessages.count) * UX.minCardHeight
+        let spacing = UX.listSpacing * CGFloat(max(0, visibleMessages.count - 1))
+        return cards + spacing
+    }
+
+    private var layoutAnimationKey: String {
+        let ids = visibleMessages.map(\.id.uuidString).joined(separator: "-")
+        return "\(ids)-\(model.dismissingID?.uuidString ?? "none")"
+    }
+
+    private func scaleForDepth(_ depth: Int) -> CGFloat {
+        switch depth {
+        case 0: return 1
+        case 1: return UX.depth1Scale
+        default: return UX.depth2Scale
+        }
+    }
+
+    private func applyLayoutMetrics(_ metrics: ToastLayoutMetrics) {
+        updateWithoutAnimation {
+            if let height = metrics.frontCardHeight, abs(frontCardHeight - height) > 0.5 {
+                frontCardHeight = max(height, UX.minCardHeight)
+            }
+            if let height = metrics.expandedHeight, abs((measuredExpandedHeight ?? 0) - height) > 0.5 {
+                measuredExpandedHeight = height
+            }
+        }
+    }
+
+    // MARK: - Actions
+
+    private func toggleExpanded() {
+        guard visibleMessages.count > 1 else { return }
+        let willExpand = !isExpanded
+        withAnimation(expandAnimation) { isExpanded = willExpand }
+        onExpandChange(willExpand)
+    }
+
+    private func dismiss(_ message: EcosiaErrorToastMessage) {
+        guard model.dismissingID == nil else { return }
+        onDismiss(message)
+        model.requestDismiss(id: message.id)
+    }
+
+    private func handleDismissingIDChange(_ dismissingID: UUID?) {
+        if dismissingID != nil {
+            dismissalLayoutHeight = containerHeight
+        } else if dismissalLayoutHeight != nil {
+            withAnimation(promoteAnimation) { dismissalLayoutHeight = nil }
+        }
+    }
+
+    private func handleMessageCountChange(_ count: Int) {
+        if count == 0 { dismissalLayoutHeight = nil }
+        if count == 1, isExpanded {
+            withAnimation(expandAnimation) { isExpanded = false }
+            onExpandChange(false)
+        }
+    }
+
+    private func updateWithoutAnimation(_ updates: () -> Void) {
+        var transaction = Transaction()
+        transaction.disablesAnimations = true
+        withTransaction(transaction, updates)
+    }
+
+    // MARK: - Animations
+
     private var entranceAnimation: Animation {
         .timingCurve(0.16, 1, 0.3, 1, duration: UX.entranceDuration)
     }
@@ -120,321 +377,38 @@ public struct EcosiaErrorToastStack: View {
     private var promoteAnimation: Animation {
         .easeOut(duration: UX.promoteDuration)
     }
+}
 
-    private var layoutAnimationKey: String {
-        let messageIDs = visibleMessages.map(\.id.uuidString).joined(separator: "-")
-        let dismissingID = model.dismissingID?.uuidString ?? "none"
-        return "\(messageIDs)-\(dismissingID)"
-    }
+// MARK: - Layout metrics
 
-    public var body: some View {
-        if !model.messages.isEmpty {
-            ZStack(alignment: .top) {
-                cardMeasurementStack
+@available(iOS 16.0, *)
+private struct ToastLayoutMetrics: Equatable {
+    var frontCardHeight: CGFloat?
+    var expandedHeight: CGFloat?
 
-                ZStack(alignment: .top) {
-                    collapsedStack
-                        .opacity(isExpanded ? 0 : 1)
-                        .allowsHitTesting(!isExpanded)
-
-                    expandedStack
-                        .opacity(isExpanded ? 1 : 0)
-                        .allowsHitTesting(isExpanded)
-                }
-                .frame(height: effectiveContainerHeight, alignment: .top)
-                .animation(expandAnimation, value: isExpanded)
-            }
-            .frame(maxWidth: .infinity, alignment: .top)
-            .contentShape(Rectangle())
-            .onTapGesture { toggleExpanded() }
-            .offset(y: isVisible ? 0 : -entranceOffset)
-            .opacity(isVisible ? 1 : 0)
-            .animation(entranceAnimation, value: isVisible)
-            .onPreferenceChange(ToastStackHeightPreferenceKey.self) { height in
-                guard height > 0 else { return }
-                updateMeasuredExpandedHeight(height)
-            }
-            .onPreferenceChange(ToastCardHeightPreferenceKey.self) { heights in
-                guard let frontID = visibleMessages.last?.id,
-                      let height = heights[frontID],
-                      height > 0 else { return }
-                updateFrontCardHeight(height)
-            }
-            .onAppear {
-                withAnimation(entranceAnimation) {
-                    isVisible = true
-                }
-            }
-            .onChange(of: model.dismissingID) { dismissingID in
-                if dismissingID != nil {
-                    dismissalLayoutHeight = containerHeight
-                } else if dismissalLayoutHeight != nil {
-                    withAnimation(promoteAnimation) {
-                        dismissalLayoutHeight = nil
-                    }
-                }
-            }
-            .onChange(of: model.messages.count) { count in
-                if count == 0 {
-                    dismissalLayoutHeight = nil
-                }
-                if count == 1, isExpanded {
-                    withAnimation(expandAnimation) {
-                        isExpanded = false
-                    }
-                    onExpandChange(false)
-                }
-            }
-        }
-    }
-
-    /// Hidden sizing pass for collapsed front-card height and expanded stack height.
-    private var cardMeasurementStack: some View {
-        VStack(spacing: UX.listSpacing) {
-            ForEach(Array(visibleMessages.enumerated()), id: \.element.id) { index, message in
-                measurementRow(for: message, isFront: index == visibleMessages.count - 1)
-            }
-        }
-        .fixedSize(horizontal: false, vertical: true)
-        .frame(maxWidth: .infinity, alignment: .top)
-        .background {
-            GeometryReader { geometry in
-                Color.clear.preference(
-                    key: ToastStackHeightPreferenceKey.self,
-                    value: geometry.size.height
-                )
-            }
-        }
-        .hidden()
-        .allowsHitTesting(false)
-        .accessibilityHidden(true)
-    }
-
-    private func measurementRow(for message: EcosiaErrorToastMessage, isFront: Bool) -> some View {
-        EcosiaErrorView(
-            title: message.title,
-            subtitle: message.subtitle,
-            windowUUID: windowUUID,
-            showsCloseButton: true,
-            onCloseTapped: nil
-        )
-        .padding(.horizontal, .ecosia.space._m)
-        .overlay {
-            if isFront {
-                GeometryReader { geometry in
-                    Color.clear.preference(
-                        key: ToastCardHeightPreferenceKey.self,
-                        value: [message.id: geometry.size.height]
-                    )
-                }
-            }
-        }
-    }
-
-    private var collapsedStack: some View {
-        ZStack(alignment: .top) {
-            ForEach(Array(visibleMessages.enumerated()), id: \.element.id) { index, message in
-                let depthFromFront = visibleMessages.count - 1 - index
-                let isFront = depthFromFront == 0
-                let isDismissing = message.id == model.dismissingID
-
-                collapsedWalletCard(
-                    for: message,
-                    depthFromFront: depthFromFront,
-                    isFront: isFront,
-                    isDismissing: isDismissing
-                )
-                .offset(y: CGFloat(index) * UX.stackPeek)
-                .opacity(isDismissing ? 0 : 1)
-                .animation(.easeOut(duration: UX.fadeDuration), value: isDismissing)
-                .allowsHitTesting(isFront && !isDismissing)
-                .zIndex(Double(index))
-            }
-        }
-        .animation(promoteAnimation, value: layoutAnimationKey)
-    }
-
-    private var expandedStack: some View {
-        VStack(spacing: UX.listSpacing) {
-            ForEach(visibleMessages) { message in
-                expandedRow(for: message)
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .top)
-    }
-
-    @ViewBuilder
-    private func expandedRow(for message: EcosiaErrorToastMessage) -> some View {
-        let isDismissing = message.id == model.dismissingID
-
-        EcosiaErrorView(
-            title: message.title,
-            subtitle: message.subtitle,
-            windowUUID: windowUUID,
-            showsCloseButton: true,
-            onCloseTapped: isDismissing ? nil : { dismiss(message) }
-        )
-        .padding(.horizontal, .ecosia.space._m)
-        .opacity(isDismissing ? 0 : 1)
-        .animation(.easeOut(duration: UX.fadeDuration), value: isDismissing)
-        .allowsHitTesting(!isDismissing)
-        .accessibilityElement(children: .combine)
-        .accessibilityAddTraits(.isStaticText)
-    }
-
-    private var entranceOffset: CGFloat {
-        referenceCardHeight + .ecosia.space._1l
-    }
-
-    private var visibleMessages: [EcosiaErrorToastMessage] {
-        Array(model.messages.suffix(UX.maxVisibleDepth))
-    }
-
-    private var canExpand: Bool {
-        visibleMessages.count > 1
-    }
-
-    private var effectiveContainerHeight: CGFloat {
-        dismissalLayoutHeight ?? containerHeight
-    }
-
-    private var containerHeight: CGFloat {
-        isExpanded ? expandedHeight : collapsedHeight
-    }
-
-    private var referenceCardHeight: CGFloat {
-        max(frontCardHeight, UX.minCardHeight)
-    }
-
-    private var collapsedHeight: CGFloat {
-        referenceCardHeight + CGFloat(max(0, visibleMessages.count - 1)) * UX.stackPeek
-    }
-
-    private var expandedHeight: CGFloat {
-        if let measuredExpandedHeight, measuredExpandedHeight > 0 {
-            return measuredExpandedHeight
-        }
-
-        let estimatedCards = CGFloat(visibleMessages.count) * UX.minCardHeight
-        let spacing = UX.listSpacing * CGFloat(max(0, visibleMessages.count - 1))
-        return estimatedCards + spacing
-    }
-
-    private func updateFrontCardHeight(_ height: CGFloat) {
-        guard abs(frontCardHeight - height) > 0.5 else { return }
-
-        var transaction = Transaction()
-        transaction.disablesAnimations = true
-        withTransaction(transaction) {
-            frontCardHeight = height
-        }
-    }
-
-    private func updateMeasuredExpandedHeight(_ height: CGFloat) {
-        guard abs((measuredExpandedHeight ?? 0) - height) > 0.5 else { return }
-
-        var transaction = Transaction()
-        transaction.disablesAnimations = true
-        withTransaction(transaction) {
-            measuredExpandedHeight = height
-        }
-    }
-
-    private func scaleForDepth(_ depth: Int) -> CGFloat {
-        switch depth {
-        case 0: return 1
-        case 1: return 327.0 / 343.0
-        default: return 311.0 / 343.0
-        }
-    }
-
-    @ViewBuilder
-    private func collapsedWalletCard(
-        for message: EcosiaErrorToastMessage,
-        depthFromFront: Int,
-        isFront: Bool,
-        isDismissing: Bool
-    ) -> some View {
-        let showsCloseButton = isFront && !isDismissing
-        let card = toastCard(
-            for: message,
-            showsCloseButton: showsCloseButton,
-            showsShadow: isFront,
-            onClose: { dismiss(message) }
-        )
-
-        Group {
-            if isFront {
-                card.scaleEffect(1, anchor: .top)
-            } else {
-                card
-                    .scaleEffect(scaleForDepth(depthFromFront), anchor: .top)
-                    .frame(height: UX.stackPeek, alignment: .top)
-                    .clipped()
-            }
-        }
-    }
-
-    @ViewBuilder
-    private func toastCard(
-        for message: EcosiaErrorToastMessage,
-        showsCloseButton: Bool,
-        showsShadow: Bool,
-        onClose: @escaping () -> Void
-    ) -> some View {
-        let content = EcosiaErrorView(
-            title: message.title,
-            subtitle: message.subtitle,
-            windowUUID: windowUUID,
-            showsCloseButton: true,
-            onCloseTapped: showsCloseButton ? onClose : nil
-        )
-        .frame(minHeight: UX.minCardHeight, alignment: .center)
-        .fixedSize(horizontal: false, vertical: true)
-        .padding(.horizontal, .ecosia.space._m)
-
-        Group {
-            if showsShadow {
-                content.shadow(color: Color.black.opacity(0.12), radius: 8, x: 0, y: 4)
-            } else {
-                content
-            }
-        }
-        .accessibilityElement(children: .combine)
-        .accessibilityAddTraits(.isStaticText)
-    }
-
-    private func toggleExpanded() {
-        guard canExpand else { return }
-
-        let willExpand = !isExpanded
-        withAnimation(expandAnimation) {
-            isExpanded = willExpand
-        }
-        onExpandChange(willExpand)
-    }
-
-    private func dismiss(_ message: EcosiaErrorToastMessage) {
-        guard model.dismissingID == nil else { return }
-        model.requestDismiss(id: message.id)
+    init(frontCardHeight: CGFloat? = nil, expandedHeight: CGFloat? = nil) {
+        self.frontCardHeight = frontCardHeight
+        self.expandedHeight = expandedHeight
     }
 }
 
 @available(iOS 16.0, *)
-private struct ToastCardHeightPreferenceKey: PreferenceKey {
-    nonisolated(unsafe) static var defaultValue: [UUID: CGFloat] = [:]
+private struct ToastLayoutMetricsKey: PreferenceKey {
+    nonisolated(unsafe) static var defaultValue = ToastLayoutMetrics()
 
-    static func reduce(value: inout [UUID: CGFloat], nextValue: () -> [UUID: CGFloat]) {
-        value.merge(nextValue()) { _, new in new }
+    static func reduce(value: inout ToastLayoutMetrics, nextValue: () -> ToastLayoutMetrics) {
+        let next = nextValue()
+        if let height = next.frontCardHeight { value.frontCardHeight = height }
+        if let height = next.expandedHeight { value.expandedHeight = height }
     }
 }
 
 @available(iOS 16.0, *)
-private struct ToastStackHeightPreferenceKey: PreferenceKey {
-    nonisolated(unsafe) static var defaultValue: CGFloat = 0
-
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = max(value, nextValue())
+private extension View {
+    func dismissChrome(isDismissing: Bool, duration: TimeInterval) -> some View {
+        self
+            .opacity(isDismissing ? 0 : 1)
+            .animation(.easeOut(duration: duration), value: isDismissing)
     }
 }
 

--- a/firefox-ios/Ecosia/UI/Toast/EcosiaErrorToastStack.swift
+++ b/firefox-ios/Ecosia/UI/Toast/EcosiaErrorToastStack.swift
@@ -82,13 +82,14 @@ public struct EcosiaErrorToastStack: View {
     @State private var isVisible = false
     @State private var isExpanded = false
     @State private var cardHeights: [UUID: CGFloat] = [:]
+    @State private var dismissalLayoutHeight: CGFloat?
 
     private enum UX {
         static let minCardHeight: CGFloat = 56
-        static let stackPeek: CGFloat = .ecosia.space._s
-        static let listSpacing: CGFloat = .ecosia.space._s
+        static let stackPeek: CGFloat = .ecosia.space._1s
+        static let listSpacing: CGFloat = .ecosia.space._1s
         static let fadeDuration: TimeInterval = 0.25
-        static let maxVisibleDepth = 3
+        static let maxVisibleDepth = 4
     }
 
     public init(
@@ -105,6 +106,12 @@ public struct EcosiaErrorToastStack: View {
 
     private var promoteSpring: Animation {
         .spring(response: 0.38, dampingFraction: 0.86)
+    }
+
+    private var layoutAnimationKey: String {
+        let messageIDs = model.messages.map(\.id.uuidString).joined(separator: "-")
+        let dismissingID = model.dismissingID?.uuidString ?? "none"
+        return "\(isExpanded)-\(messageIDs)-\(dismissingID)"
     }
 
     public var body: some View {
@@ -132,25 +139,36 @@ public struct EcosiaErrorToastStack: View {
                     .zIndex(Double(index))
                 }
             }
-            .frame(height: containerHeight, alignment: .top)
+            .frame(height: effectiveContainerHeight, alignment: .top)
             .frame(maxWidth: .infinity)
             .contentShape(Rectangle())
             .onTapGesture { toggleExpanded() }
-            .animation(promoteSpring, value: isExpanded)
-            .animation(promoteSpring, value: model.messages.map(\.id))
-            .animation(promoteSpring, value: cardHeights)
-            .animation(promoteSpring, value: model.dismissingID)
+            .animation(promoteSpring, value: layoutAnimationKey)
             .offset(y: isVisible ? 0 : -(referenceCardHeight + .ecosia.space._1l))
             .opacity(isVisible ? 1 : 0)
-            .onPreferenceChange(ToastCardHeightPreferenceKey.self) { cardHeights = $0 }
+            .onPreferenceChange(ToastCardHeightPreferenceKey.self, perform: updateCardHeights)
             .onAppear {
                 withAnimation(.easeOut(duration: UX.fadeDuration)) {
                     isVisible = true
                 }
             }
+            .onChange(of: model.dismissingID) { dismissingID in
+                if dismissingID != nil {
+                    dismissalLayoutHeight = containerHeight
+                } else if dismissalLayoutHeight != nil {
+                    withAnimation(promoteSpring) {
+                        dismissalLayoutHeight = nil
+                    }
+                }
+            }
             .onChange(of: model.messages.count) { count in
-                if count <= 1, isExpanded {
-                    isExpanded = false
+                if count == 0 {
+                    dismissalLayoutHeight = nil
+                }
+                if count == 1, isExpanded {
+                    withAnimation(promoteSpring) {
+                        isExpanded = false
+                    }
                     onExpandChange(false)
                 }
             }
@@ -163,6 +181,14 @@ public struct EcosiaErrorToastStack: View {
 
     private var canExpand: Bool {
         visibleMessages.count > 1
+    }
+
+    private var containerHeight: CGFloat {
+        isExpanded ? expandedHeight : collapsedHeight
+    }
+
+    private var effectiveContainerHeight: CGFloat {
+        dismissalLayoutHeight ?? containerHeight
     }
 
     private var referenceCardHeight: CGFloat {
@@ -182,8 +208,24 @@ public struct EcosiaErrorToastStack: View {
         return heights.reduce(0, +) + spacing
     }
 
-    private var containerHeight: CGFloat {
-        isExpanded ? expandedHeight : collapsedHeight
+    private func updateCardHeights(_ newHeights: [UUID: CGFloat]) {
+        let activeIDs = Set(model.messages.map(\.id))
+        var updated = cardHeights.filter { activeIDs.contains($0.key) }
+
+        for (id, height) in newHeights where activeIDs.contains(id) {
+            let resolved = max(height, UX.minCardHeight)
+            if let existing = updated[id] {
+                // Ignore sub-point churn from text re-measurement during animations.
+                if abs(existing - resolved) > 0.5 {
+                    updated[id] = resolved
+                }
+            } else {
+                updated[id] = resolved
+            }
+        }
+
+        guard updated != cardHeights else { return }
+        cardHeights = updated
     }
 
     private func yOffset(for index: Int) -> CGFloat {
@@ -217,11 +259,11 @@ public struct EcosiaErrorToastStack: View {
             title: message.title,
             subtitle: message.subtitle,
             windowUUID: windowUUID,
+            showsCloseButton: true,
             onCloseTapped: showsCloseButton ? onClose : nil
         )
         .frame(minHeight: UX.minCardHeight, alignment: .center)
-        .padding(.horizontal, .ecosia.space._m)
-        .shadow(color: Color.black.opacity(0.12), radius: 8, x: 0, y: 4)
+        .fixedSize(horizontal: false, vertical: true)
         .background {
             GeometryReader { geometry in
                 Color.clear.preference(
@@ -230,6 +272,8 @@ public struct EcosiaErrorToastStack: View {
                 )
             }
         }
+        .padding(.horizontal, .ecosia.space._m)
+        .shadow(color: Color.black.opacity(0.12), radius: 8, x: 0, y: 4)
         .accessibilityElement(children: .combine)
         .accessibilityAddTraits(.isStaticText)
     }

--- a/firefox-ios/Ecosia/UI/Toast/EcosiaErrorToastStack.swift
+++ b/firefox-ios/Ecosia/UI/Toast/EcosiaErrorToastStack.swift
@@ -1,0 +1,278 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import SwiftUI
+import Common
+
+public struct EcosiaErrorToastMessage: Identifiable, Equatable, Sendable {
+    public let id: UUID
+    public let subtitle: String
+    public let title: String?
+
+    public init(id: UUID = UUID(), title: String? = nil, subtitle: String) {
+        self.id = id
+        self.title = title
+        self.subtitle = subtitle
+    }
+}
+
+@MainActor
+public final class EcosiaErrorToastStackModel: ObservableObject {
+    @Published public var messages: [EcosiaErrorToastMessage] = []
+    @Published fileprivate(set) var dismissingID: UUID?
+
+    private enum UX {
+        static let fadeDuration: TimeInterval = 0.25
+    }
+
+    public var onDismissCompleted: (() -> Void)?
+
+    public init() {}
+
+    public func append(subtitles: [String]) {
+        let newMessages = subtitles.map { EcosiaErrorToastMessage(subtitle: $0) }
+        messages.append(contentsOf: newMessages)
+    }
+
+    public func requestDismiss(id: UUID) {
+        guard dismissingID == nil,
+              messages.contains(where: { $0.id == id }) else { return }
+
+        withAnimation(.easeOut(duration: UX.fadeDuration)) {
+            dismissingID = id
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + UX.fadeDuration) { [weak self] in
+            guard let self else { return }
+            withAnimation(.spring(response: 0.38, dampingFraction: 0.86)) {
+                self.messages.removeAll { $0.id == id }
+                self.dismissingID = nil
+            }
+            self.onDismissCompleted?()
+        }
+    }
+
+    public func clear() {
+        dismissingID = nil
+        messages.removeAll()
+    }
+}
+
+/// Overlapping top toast stack from Global Components (Figma 19211:4961).
+/// Tap the stack to expand into a vertical list; tap again to collapse.
+@available(iOS 16.0, *)
+public struct EcosiaErrorToastStack: View {
+    @ObservedObject private var model: EcosiaErrorToastStackModel
+    private let windowUUID: WindowUUID
+    private let onDismiss: (EcosiaErrorToastMessage) -> Void
+    private let onExpandChange: (Bool) -> Void
+
+    @State private var isVisible = false
+    @State private var isExpanded = false
+    @State private var cardHeights: [UUID: CGFloat] = [:]
+
+    private enum UX {
+        static let minCardHeight: CGFloat = 56
+        static let stackPeek: CGFloat = .ecosia.space._s
+        static let listSpacing: CGFloat = .ecosia.space._s
+        static let fadeDuration: TimeInterval = 0.25
+        static let maxVisibleDepth = 3
+    }
+
+    public init(
+        model: EcosiaErrorToastStackModel,
+        windowUUID: WindowUUID,
+        onDismiss: @escaping (EcosiaErrorToastMessage) -> Void = { _ in },
+        onExpandChange: @escaping (Bool) -> Void = { _ in }
+    ) {
+        self.model = model
+        self.windowUUID = windowUUID
+        self.onDismiss = onDismiss
+        self.onExpandChange = onExpandChange
+    }
+
+    private var promoteSpring: Animation {
+        .spring(response: 0.38, dampingFraction: 0.86)
+    }
+
+    public var body: some View {
+        if !model.messages.isEmpty {
+            ZStack(alignment: .top) {
+                ForEach(Array(visibleMessages.enumerated()), id: \.element.id) { index, message in
+                    let depthFromFront = visibleMessages.count - 1 - index
+                    let isFront = depthFromFront == 0
+                    let isDismissing = message.id == model.dismissingID
+
+                    toastCard(
+                        for: message,
+                        showsCloseButton: (isExpanded || isFront) && !isDismissing,
+                        onClose: { dismiss(message) }
+                    )
+                    .scaleEffect(
+                        x: isExpanded ? 1 : scaleForDepth(depthFromFront),
+                        y: 1,
+                        anchor: .top
+                    )
+                    .offset(y: yOffset(for: index))
+                    .opacity(isDismissing ? 0 : 1)
+                    .animation(.easeOut(duration: UX.fadeDuration), value: isDismissing)
+                    .allowsHitTesting(isExpanded || (isFront && !isDismissing))
+                    .zIndex(Double(index))
+                }
+            }
+            .frame(height: containerHeight, alignment: .top)
+            .frame(maxWidth: .infinity)
+            .contentShape(Rectangle())
+            .onTapGesture { toggleExpanded() }
+            .animation(promoteSpring, value: isExpanded)
+            .animation(promoteSpring, value: model.messages.map(\.id))
+            .animation(promoteSpring, value: cardHeights)
+            .animation(promoteSpring, value: model.dismissingID)
+            .offset(y: isVisible ? 0 : -(referenceCardHeight + .ecosia.space._1l))
+            .opacity(isVisible ? 1 : 0)
+            .onPreferenceChange(ToastCardHeightPreferenceKey.self) { cardHeights = $0 }
+            .onAppear {
+                withAnimation(.easeOut(duration: UX.fadeDuration)) {
+                    isVisible = true
+                }
+            }
+            .onChange(of: model.messages.count) { count in
+                if count <= 1, isExpanded {
+                    isExpanded = false
+                    onExpandChange(false)
+                }
+            }
+        }
+    }
+
+    private var visibleMessages: [EcosiaErrorToastMessage] {
+        Array(model.messages.suffix(UX.maxVisibleDepth))
+    }
+
+    private var canExpand: Bool {
+        visibleMessages.count > 1
+    }
+
+    private var referenceCardHeight: CGFloat {
+        guard let frontID = visibleMessages.last?.id else { return UX.minCardHeight }
+        return max(cardHeights[frontID] ?? UX.minCardHeight, UX.minCardHeight)
+    }
+
+    private var collapsedHeight: CGFloat {
+        referenceCardHeight + CGFloat(max(0, visibleMessages.count - 1)) * UX.stackPeek
+    }
+
+    private var expandedHeight: CGFloat {
+        guard !visibleMessages.isEmpty else { return UX.minCardHeight }
+
+        let heights = visibleMessages.map { max(cardHeights[$0.id] ?? UX.minCardHeight, UX.minCardHeight) }
+        let spacing = UX.listSpacing * CGFloat(max(0, visibleMessages.count - 1))
+        return heights.reduce(0, +) + spacing
+    }
+
+    private var containerHeight: CGFloat {
+        isExpanded ? expandedHeight : collapsedHeight
+    }
+
+    private func yOffset(for index: Int) -> CGFloat {
+        if isExpanded {
+            var offset: CGFloat = 0
+            for priorIndex in 0..<index {
+                let message = visibleMessages[priorIndex]
+                let height = max(cardHeights[message.id] ?? UX.minCardHeight, UX.minCardHeight)
+                offset += height + UX.listSpacing
+            }
+            return offset
+        }
+        return CGFloat(index) * UX.stackPeek
+    }
+
+    private func scaleForDepth(_ depth: Int) -> CGFloat {
+        switch depth {
+        case 0: return 1
+        case 1: return 327.0 / 343.0
+        default: return 311.0 / 343.0
+        }
+    }
+
+    @ViewBuilder
+    private func toastCard(
+        for message: EcosiaErrorToastMessage,
+        showsCloseButton: Bool,
+        onClose: @escaping () -> Void
+    ) -> some View {
+        EcosiaErrorView(
+            title: message.title,
+            subtitle: message.subtitle,
+            windowUUID: windowUUID,
+            onCloseTapped: showsCloseButton ? onClose : nil
+        )
+        .frame(minHeight: UX.minCardHeight, alignment: .center)
+        .padding(.horizontal, .ecosia.space._m)
+        .shadow(color: Color.black.opacity(0.12), radius: 8, x: 0, y: 4)
+        .background {
+            GeometryReader { geometry in
+                Color.clear.preference(
+                    key: ToastCardHeightPreferenceKey.self,
+                    value: [message.id: geometry.size.height]
+                )
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(.isStaticText)
+    }
+
+    private func toggleExpanded() {
+        guard canExpand else { return }
+
+        let willExpand = !isExpanded
+        withAnimation(promoteSpring) {
+            isExpanded = willExpand
+        }
+        onExpandChange(willExpand)
+    }
+
+    private func dismiss(_ message: EcosiaErrorToastMessage) {
+        guard model.dismissingID == nil else { return }
+        model.requestDismiss(id: message.id)
+    }
+}
+
+@available(iOS 16.0, *)
+private struct ToastCardHeightPreferenceKey: PreferenceKey {
+    nonisolated(unsafe) static var defaultValue: [UUID: CGFloat] = [:]
+
+    static func reduce(value: inout [UUID: CGFloat], nextValue: () -> [UUID: CGFloat]) {
+        value.merge(nextValue()) { _, new in new }
+    }
+}
+
+#if DEBUG
+@available(iOS 16.0, *)
+struct EcosiaErrorToastStack_Previews: PreviewProvider {
+    struct PreviewHost: View {
+        @StateObject private var model = EcosiaErrorToastStackModel()
+
+        var body: some View {
+            EcosiaErrorToastStack(
+                model: model,
+                windowUUID: .XCTestDefaultUUID
+            )
+            .padding()
+            .onAppear {
+                model.append(subtitles: [
+                    "You can upload up to 5 files per chat.",
+                    "The file is too large, the maximum file size is 5MB.",
+                    "The file type is not supported. Please upload a JPG, PNG, PDF or text file."
+                ])
+            }
+        }
+    }
+
+    static var previews: some View {
+        PreviewHost()
+            .previewLayout(.sizeThatFits)
+    }
+}
+#endif

--- a/firefox-ios/Ecosia/UI/Toast/EcosiaErrorToastStack.swift
+++ b/firefox-ios/Ecosia/UI/Toast/EcosiaErrorToastStack.swift
@@ -24,6 +24,11 @@ public struct EcosiaErrorToastMessage: Identifiable, Equatable, Sendable {
     }
 }
 
+/// Shared timing used by the toast stack and its UIKit host (e.g. VoiceOver delay).
+public enum EcosiaErrorToastTiming {
+    public static let entranceDuration: TimeInterval = 0.45
+}
+
 @MainActor
 public final class EcosiaErrorToastStackModel: ObservableObject {
     @Published public var messages: [EcosiaErrorToastMessage] = []
@@ -91,7 +96,7 @@ public struct EcosiaErrorToastStack: View {
         static let stackPeek: CGFloat = .ecosia.space._1s
         static let listSpacing: CGFloat = .ecosia.space._1s
         static let fadeDuration: TimeInterval = 0.28
-        static let entranceDuration: TimeInterval = 0.45
+        static let entranceDuration = EcosiaErrorToastTiming.entranceDuration
         static let expandDuration: TimeInterval = 0.42
         static let promoteDuration: TimeInterval = 0.35
         static let maxVisibleDepth = 4
@@ -277,8 +282,6 @@ public struct EcosiaErrorToastStack: View {
             x: 0,
             y: showsShadow ? 4 : 0
         )
-        .accessibilityElement(children: .combine)
-        .accessibilityAddTraits(.isStaticText)
     }
 
     // MARK: - Layout
@@ -395,7 +398,7 @@ private struct ToastLayoutMetrics: Equatable {
 
 @available(iOS 16.0, *)
 private struct ToastLayoutMetricsKey: PreferenceKey {
-    nonisolated(unsafe) static var defaultValue = ToastLayoutMetrics()
+    static let defaultValue = ToastLayoutMetrics()
 
     static func reduce(value: inout ToastLayoutMetrics, nextValue: () -> ToastLayoutMetrics) {
         let next = nextValue()

--- a/firefox-ios/EcosiaTests/UI/NTP/OmniboxUploadDebugSimulationTests.swift
+++ b/firefox-ios/EcosiaTests/UI/NTP/OmniboxUploadDebugSimulationTests.swift
@@ -25,6 +25,16 @@ final class OmniboxUploadDebugSimulationTests: XCTestCase {
         )
     }
 
+    func testSimulatedValidationErrorsIncludeUploadAPIFailureWhenEnabled() {
+        UserDefaults.standard.set(true, forKey: SimulateUploadValidationErrorSetting.debugKey(for: .tooManyFiles))
+        UserDefaults.standard.set(true, forKey: SimulateFileUploadAPIErrorSetting.debugKey)
+
+        XCTAssertEqual(
+            OmniboxUploadDebugSimulation.simulatedValidationErrors(),
+            [.tooManyFiles, .uploadFailed]
+        )
+    }
+
     func testUploadAPIFailureToggle() {
         XCTAssertFalse(OmniboxUploadDebugSimulation.shouldSimulateUploadAPIFailure)
 


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-4588]

## Context

We want to improve the way we show the Ecosia-owned errors.
We took the opportunity to improve the error handling for all errors, including the Accounts ones.

## Approach

| Outcome |
| --------- |
| <img width="295" height="640" alt="Simulator Screen Recording - iPhone 17 Pro - 2026-07-16 at 11 14 26" src="https://github.com/user-attachments/assets/8efe7a56-453b-49b6-801b-77317c537ed8" /> |

- Introduce `EcosiaErrorToastStack` / `EcosiaErrorToastStackModel` as a wallet-style top stack: collapsed overlapping peeks, tap to expand into a vertical list.
- Host the stack from `BrowserViewController+EcosiaErrorHandling` with intrinsic `UIHostingController` sizing, top-aligned under the NTP search bar.
- Route account and upload errors through `EcosiaErrorToastPresenter` so multiple messages share one container and pending queue.
- Keep expanded layout on a native `VStack` for even `_1s` spacing; measure heights in a hidden sizing pass so `GeometryReader` never inflates the first visible row.
- Drop `minHeight` from expanded rows so short single-line cards do not leave empty space under the pink background.
- Slow entrance and expand animations (ease-out slide-in, spring expand) and keep dismiss as fade-then-promote.

## Other

- Debug upload simulation can surface the full validation set, including `uploadFailed`.
- Success toasts (`SimpleToast`) and referral `UIAlertController` retry flows are intentionally unchanged.
- `NSPhotoLibraryUsageDescription` / picker compliance is out of scope here (handled in #1203).

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [x] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [ ] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4588]: https://ecosia.atlassian.net/browse/MOB-4588

Made with [Cursor](https://cursor.com)