### PR TITLE
[MOB-3548] Fixed default browser promo layout on iPad

### DIFF
--- a/firefox-ios/Client/Ecosia/UI/NTP/DefaultBrowserViewController.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/DefaultBrowserViewController.swift
@@ -230,7 +230,7 @@ final class DefaultBrowserViewController: UIViewController, Themeable {
             afterView.centerXAnchor.constraint(equalTo: imageView.centerXAnchor, constant: screenWidth/4)
         ])
     }
-    
+
     private func createTopConstraint() -> NSLayoutConstraint {
         if traitCollection.userInterfaceIdiom == .pad {
             return contentView.topAnchor.constraint(equalTo: view.topAnchor)

--- a/firefox-ios/Client/Ecosia/UI/NTP/DefaultBrowserViewController.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/DefaultBrowserViewController.swift
@@ -126,7 +126,6 @@ final class DefaultBrowserViewController: UIViewController, Themeable {
         self.delegate = delegate
         if traitCollection.userInterfaceIdiom == .pad {
             modalPresentationStyle = .formSheet
-            preferredContentSize = .init(width: 544, height: 600)
         } else {
             modalPresentationCapturesStatusBarAppearance = true
         }
@@ -170,16 +169,20 @@ final class DefaultBrowserViewController: UIViewController, Themeable {
         contentView.addSubview(actionButton)
         contentView.addSubview(skipButton)
         view.addSubview(triviaView)
-
+        
         triviaView.addSubview(triviaTitleLabel)
         triviaView.addSubview(triviaDecriptionLabel)
         contentView.addSubview(beforeView)
         contentView.addSubview(afterView)
+        
+        if(traitCollection.userInterfaceIdiom == .pad) {
+            waves.contentMode = .scaleToFill
+        }
     }
 
     private func setupConstraints() {
         NSLayoutConstraint.activate([
-            contentView.topAnchor.constraint(greaterThanOrEqualTo: view.topAnchor),
+            createTopConstraint(),
             contentView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             contentView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             contentView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
@@ -226,6 +229,14 @@ final class DefaultBrowserViewController: UIViewController, Themeable {
             beforeView.centerXAnchor.constraint(equalTo: imageView.centerXAnchor, constant: -screenWidth/4),
             afterView.centerXAnchor.constraint(equalTo: imageView.centerXAnchor, constant: screenWidth/4)
         ])
+    }
+    
+    private func createTopConstraint() -> NSLayoutConstraint {
+        if traitCollection.userInterfaceIdiom == .pad {
+            return contentView.topAnchor.constraint(equalTo: view.topAnchor)
+        } else {
+            return contentView.topAnchor.constraint(greaterThanOrEqualTo: view.topAnchor)
+        }
     }
 
     @objc func applyTheme() {

--- a/firefox-ios/Client/Ecosia/UI/NTP/DefaultBrowserViewController.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/DefaultBrowserViewController.swift
@@ -169,13 +169,13 @@ final class DefaultBrowserViewController: UIViewController, Themeable {
         contentView.addSubview(actionButton)
         contentView.addSubview(skipButton)
         view.addSubview(triviaView)
-        
+
         triviaView.addSubview(triviaTitleLabel)
         triviaView.addSubview(triviaDecriptionLabel)
         contentView.addSubview(beforeView)
         contentView.addSubview(afterView)
-        
-        if(traitCollection.userInterfaceIdiom == .pad) {
+
+        if traitCollection.userInterfaceIdiom == .pad {
             waves.contentMode = .scaleToFill
         }
     }

--- a/firefox-ios/Client/Ecosia/UI/NTP/DefaultBrowserViewController.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/DefaultBrowserViewController.swift
@@ -182,7 +182,7 @@ final class DefaultBrowserViewController: UIViewController, Themeable {
 
     private func setupConstraints() {
         NSLayoutConstraint.activate([
-            createTopConstraint(),
+            contentView.topAnchor.constraint(equalTo: view.topAnchor),
             contentView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             contentView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             contentView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
@@ -229,14 +229,6 @@ final class DefaultBrowserViewController: UIViewController, Themeable {
             beforeView.centerXAnchor.constraint(equalTo: imageView.centerXAnchor, constant: -screenWidth/4),
             afterView.centerXAnchor.constraint(equalTo: imageView.centerXAnchor, constant: screenWidth/4)
         ])
-    }
-
-    private func createTopConstraint() -> NSLayoutConstraint {
-        if traitCollection.userInterfaceIdiom == .pad {
-            return contentView.topAnchor.constraint(equalTo: view.topAnchor)
-        } else {
-            return contentView.topAnchor.constraint(greaterThanOrEqualTo: view.topAnchor)
-        }
     }
 
     @objc func applyTheme() {


### PR DESCRIPTION
[MOB-3548]

Fix spacing for default browser promo on ipad, see:
https://ecosia.atlassian.net/browse/MOB-3548

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [ ] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

Sceen for **iPad**
<img width="1640" height="2360" alt="Simulator Screenshot - iPad (A16) - 2026-07-16 at 13 17 45" src="https://github.com/user-attachments/assets/4ca1c01f-4108-4cce-8f75-b624df748c50" />

Screen for **iPhone**
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-16 at 13 10 31" src="https://github.com/user-attachments/assets/2032d9d0-206d-4617-8ee5-9f8ea0a7bd02" />


[MOB-3548]: https://ecosia.atlassian.net/browse/MOB-3548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ