### PR TITLE
[MOB-4769] Implement omnibox file upload analytics

### DIFF
--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxAttachmentUploadCoordinator.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxAttachmentUploadCoordinator.swift
@@ -55,6 +55,9 @@ final class OmniboxAttachmentUploadCoordinator {
                 state: .loading
             )
             searchBar.addAttachment(attachment)
+            Analytics.shared.fileUploadInitiated(
+                fileType: Analytics.fileUploadFileType(fromFileName: item.fileName)
+            )
 
             let attachmentID = attachment.id
             tasks[attachmentID] = Task { @MainActor [weak self] in
@@ -121,10 +124,15 @@ final class OmniboxAttachmentUploadCoordinator {
                 state: .ready(byteCount: payload.data.count, fileId: fileId, mimeType: payload.mimeType),
                 previewImages: previewImages
             )
+            Analytics.shared.fileUploadCompleted(
+                fileType: Analytics.fileUploadFileType(fromFileName: payload.fileName),
+                fileSizeKb: Analytics.fileUploadSizeKb(byteCount: payload.data.count)
+            )
             EcosiaLogger.network.info("[FileUpload] Attachment \(attachmentID) ready fileId=\(fileId)")
             delegate?.omniboxAttachmentsDidChange()
         } catch let error as OmniboxUploadPayloadError where error == .fileTooLarge {
             guard !Task.isCancelled else { return }
+            trackUploadFailure(errorType: .tooLarge, fileName: displayFileName)
             searchBar.removeAttachment(id: attachmentID)
             previewImages.removeValue(forKey: attachmentID)
             delegate?.omniboxUploadDidEncounterValidationErrors([.fileTooLarge])
@@ -134,6 +142,7 @@ final class OmniboxAttachmentUploadCoordinator {
             EcosiaLogger.network.error(
                 "[FileUpload] Attachment \(attachmentID) failed: \(error.localizedDescription)"
             )
+            trackUploadFailure(for: error, fileName: displayFileName)
             if error is OmniboxUploadPayloadError {
                 searchBar.removeAttachment(id: attachmentID)
                 previewImages.removeValue(forKey: attachmentID)
@@ -150,6 +159,26 @@ final class OmniboxAttachmentUploadCoordinator {
             }
             delegate?.omniboxAttachmentsDidChange()
         }
+    }
+
+    private func trackUploadFailure(for error: Error, fileName: String) {
+        if let serviceError = error as? FileUploadService.Error {
+            // Only `timeout` is in the tracking-plan `error_type` enum for
+            // service failures; other network/auth/API errors are omitted.
+            guard serviceError == .timedOut else { return }
+            trackUploadFailure(errorType: .timeout, fileName: fileName)
+            return
+        }
+        if error is OmniboxUploadPayloadError {
+            trackUploadFailure(errorType: .parseFailed, fileName: fileName)
+        }
+    }
+
+    private func trackUploadFailure(errorType: Analytics.Property.FileUploadErrorType, fileName: String) {
+        Analytics.shared.fileUploadFailed(
+            errorType: errorType,
+            fileType: Analytics.fileUploadFileType(fromFileName: fileName)
+        )
     }
 
     private func uploadWithRetry(payload: OmniboxUploadLocalPayload,

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxAttachmentUploadCoordinator.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxAttachmentUploadCoordinator.swift
@@ -90,6 +90,7 @@ final class OmniboxAttachmentUploadCoordinator {
 
         var displayFileName = item.fileName
         var displayLayout = item.layout
+        var displayMimeType: String?
 
         do {
             let payload = try await item.loadPayload()
@@ -97,6 +98,7 @@ final class OmniboxAttachmentUploadCoordinator {
 
             displayFileName = payload.fileName
             displayLayout = payload.layout
+            displayMimeType = payload.mimeType
 
             if let previewImage = payload.previewImage {
                 previewImages[attachmentID] = previewImage
@@ -125,14 +127,17 @@ final class OmniboxAttachmentUploadCoordinator {
                 previewImages: previewImages
             )
             Analytics.shared.fileUploadCompleted(
-                fileType: Analytics.fileUploadFileType(fromFileName: payload.fileName),
+                fileType: Analytics.fileUploadFileType(
+                    fromFileName: payload.fileName,
+                    mimeType: payload.mimeType
+                ),
                 fileSizeKb: Analytics.fileUploadSizeKb(byteCount: payload.data.count)
             )
             EcosiaLogger.network.info("[FileUpload] Attachment \(attachmentID) ready fileId=\(fileId)")
             delegate?.omniboxAttachmentsDidChange()
         } catch let error as OmniboxUploadPayloadError where error == .fileTooLarge {
             guard !Task.isCancelled else { return }
-            trackUploadFailure(errorType: .tooLarge, fileName: displayFileName)
+            trackUploadFailure(errorType: .tooLarge, fileName: displayFileName, mimeType: displayMimeType)
             searchBar.removeAttachment(id: attachmentID)
             previewImages.removeValue(forKey: attachmentID)
             delegate?.omniboxUploadDidEncounterValidationErrors([.fileTooLarge])
@@ -142,7 +147,7 @@ final class OmniboxAttachmentUploadCoordinator {
             EcosiaLogger.network.error(
                 "[FileUpload] Attachment \(attachmentID) failed: \(error.localizedDescription)"
             )
-            trackUploadFailure(for: error, fileName: displayFileName)
+            trackUploadFailure(for: error, fileName: displayFileName, mimeType: displayMimeType)
             if error is OmniboxUploadPayloadError {
                 searchBar.removeAttachment(id: attachmentID)
                 previewImages.removeValue(forKey: attachmentID)
@@ -161,23 +166,25 @@ final class OmniboxAttachmentUploadCoordinator {
         }
     }
 
-    private func trackUploadFailure(for error: Error, fileName: String) {
+    private func trackUploadFailure(for error: Error, fileName: String, mimeType: String?) {
         if let serviceError = error as? FileUploadService.Error {
             // Only `timeout` is in the tracking-plan `error_type` enum for
             // service failures; other network/auth/API errors are omitted.
             guard serviceError == .timedOut else { return }
-            trackUploadFailure(errorType: .timeout, fileName: fileName)
+            trackUploadFailure(errorType: .timeout, fileName: fileName, mimeType: mimeType)
             return
         }
         if error is OmniboxUploadPayloadError {
-            trackUploadFailure(errorType: .parseFailed, fileName: fileName)
+            trackUploadFailure(errorType: .parseFailed, fileName: fileName, mimeType: mimeType)
         }
     }
 
-    private func trackUploadFailure(errorType: Analytics.Property.FileUploadErrorType, fileName: String) {
+    private func trackUploadFailure(errorType: Analytics.Property.FileUploadErrorType,
+                                    fileName: String,
+                                    mimeType: String?) {
         Analytics.shared.fileUploadFailed(
             errorType: errorType,
-            fileType: Analytics.fileUploadFileType(fromFileName: fileName)
+            fileType: Analytics.fileUploadFileType(fromFileName: fileName, mimeType: mimeType)
         )
     }
 

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadFilePicker.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadFilePicker.swift
@@ -32,6 +32,8 @@ extension OmniboxUploadPickerCoordinator: UIDocumentPickerDelegate {
             existingAttachmentCount: delegate?.omniboxUploadExistingAttachmentCount ?? 0
         )
 
+        trackFilePickerValidationFailures(for: urls, acceptedURLs: validationResult.acceptedURLs)
+
         let pendingItems = validationResult.acceptedURLs.map { url in
             let ext = url.pathExtension.lowercased()
             let layout: OmniboxAttachment.Layout = OmniboxUploadFileSelectionValidator.imageExtensions.contains(ext)
@@ -46,5 +48,21 @@ extension OmniboxUploadPickerCoordinator: UIDocumentPickerDelegate {
             items: pendingItems,
             validationErrors: validationResult.validationErrors
         )
+    }
+
+    /// Fires `file_upload_failed` per rejected URL for the two mapped picker
+    /// errors (`unsupported_format`, `too_large`). Excess-count rejections are
+    /// intentionally omitted — `tooManyFiles` is not in the tracking-plan
+    /// `error_type` enum.
+    private func trackFilePickerValidationFailures(for urls: [URL], acceptedURLs: [URL]) {
+        let acceptedPaths = Set(acceptedURLs.map(\.path))
+        for url in urls where !acceptedPaths.contains(url.path) {
+            let fileType = Analytics.fileUploadFileType(fromFileName: url.lastPathComponent)
+            if !OmniboxUploadFileSelectionValidator.isAllowed(url) {
+                Analytics.shared.fileUploadFailed(errorType: .unsupportedFormat, fileType: fileType)
+            } else if OmniboxUploadFileSelectionValidator.isOversized(url) {
+                Analytics.shared.fileUploadFailed(errorType: .tooLarge, fileType: fileType)
+            }
+        }
     }
 }

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadFileSelectionValidator.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadFileSelectionValidator.swift
@@ -97,7 +97,7 @@ enum OmniboxUploadFileSelectionValidator {
         return supportedExtensions.contains(ext)
     }
 
-    private static func isOversized(_ url: URL) -> Bool {
+    static func isOversized(_ url: URL) -> Bool {
         guard let fileSize = fileSize(for: url) else { return false }
         return fileSize > OmniboxUploadPayloadLoader.maxFileSizeBytes
     }

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadPayload.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxUploadPayload.swift
@@ -76,7 +76,7 @@ enum OmniboxUploadPayloadLoader {
         let layout: OmniboxAttachment.Layout = mimeType.hasPrefix("image/") ? .image : .file
         let previewImage = layout == .image ? UIImage(data: data) : nil
         return OmniboxUploadLocalPayload(
-            fileName: url.lastPathComponent,
+            fileName: fileNameWithExtension(url.lastPathComponent, mimeType: mimeType),
             mimeType: mimeType,
             data: data,
             layout: layout,
@@ -99,12 +99,29 @@ enum OmniboxUploadPayloadLoader {
     static func loadImage(data: Data, fileName: String, mimeType: String) throws -> OmniboxUploadLocalPayload {
         try validateSize(data)
         return OmniboxUploadLocalPayload(
-            fileName: fileName,
+            fileName: fileNameWithExtension(fileName, mimeType: mimeType),
             mimeType: mimeType,
             data: data,
             layout: .image,
             previewImage: UIImage(data: data)
         )
+    }
+
+    /// PHPicker `suggestedName` often omits an extension (`IMG_1234`). Append one
+    /// derived from the MIME type so analytics `file_type` and UI labels stay useful.
+    static func fileNameWithExtension(_ fileName: String, mimeType: String) -> String {
+        let nsName = fileName as NSString
+        guard nsName.pathExtension.isEmpty else { return fileName }
+        let stem = fileName.isEmpty ? "file" : fileName
+        let ext = preferredExtension(forMimeType: mimeType) ?? "bin"
+        return "\(stem).\(ext)"
+    }
+
+    private static func preferredExtension(forMimeType mimeType: String) -> String? {
+        if let ext = UTType(mimeType: mimeType)?.preferredFilenameExtension {
+            return ext == "jpeg" ? "jpg" : ext
+        }
+        return Analytics.fileUploadFileType(fromMimeType: mimeType)
     }
 
     static func validateSize(_ data: Data) throws {

--- a/firefox-ios/Ecosia/Analytics/Analytics.Values.swift
+++ b/firefox-ios/Ecosia/Analytics/Analytics.Values.swift
@@ -38,6 +38,9 @@ extension Analytics {
         close,
         market,
         modeSelection = "mode_selection",
+        fileUploadInitiated = "file_upload_initiated",
+        fileUploadCompleted = "file_upload_completed",
+        fileUploadFailed = "file_upload_failed",
         profile,
         signIn = "sign_in",
         signUp = "sign_up",
@@ -259,6 +262,21 @@ extension Analytics {
             case
             select,
             deselect
+        }
+
+        /// `source` field of the `file_upload_initiated` payload. Native iOS
+        /// only has picker selection — there is no drag-and-drop path.
+        public enum FileUploadSource: String {
+            case buttonClick = "button_click"
+        }
+
+        /// `error_type` field of the `file_upload_failed` payload.
+        public enum FileUploadErrorType: String {
+            case
+            unsupportedFormat = "unsupported_format",
+            tooLarge = "too_large",
+            parseFailed = "parse_failed",
+            timeout
         }
 
         public enum APNConsent: String {

--- a/firefox-ios/Ecosia/Analytics/Analytics.swift
+++ b/firefox-ios/Ecosia/Analytics/Analytics.swift
@@ -479,10 +479,39 @@ open class Analytics {
             .property(json))
     }
 
-    /// Lowercased path extension used as `file_type`, or `"unknown"` when absent.
-    public static func fileUploadFileType(fromFileName fileName: String) -> String {
+    /// Prefer the lowercased path extension; fall back to a MIME-derived type
+    /// (PHPicker `suggestedName` often has no extension). `"unknown"` only when
+    /// neither source yields a usable type.
+    public static func fileUploadFileType(fromFileName fileName: String,
+                                          mimeType: String? = nil) -> String {
         let ext = (fileName as NSString).pathExtension.lowercased()
-        return ext.isEmpty ? "unknown" : ext
+        if !ext.isEmpty {
+            return ext == "jpeg" ? "jpg" : ext
+        }
+        return fileUploadFileType(fromMimeType: mimeType) ?? "unknown"
+    }
+
+    /// Maps a MIME type to the `file_type` vocabulary (`jpg`, `png`, `pdf`, …).
+    public static func fileUploadFileType(fromMimeType mimeType: String?) -> String? {
+        guard let mimeType, !mimeType.isEmpty else { return nil }
+        switch mimeType.lowercased() {
+        case "image/jpeg":
+            return "jpg"
+        case "image/png":
+            return "png"
+        case "application/pdf":
+            return "pdf"
+        case "text/plain":
+            return "txt"
+        case "application/msword":
+            return "doc"
+        default:
+            guard let subtype = mimeType.split(separator: "/").last, !subtype.isEmpty else {
+                return nil
+            }
+            let value = String(subtype).lowercased()
+            return value == "jpeg" ? "jpg" : value
+        }
     }
 
     /// Rounded kibibyte size for `file_size_kb`.

--- a/firefox-ios/Ecosia/Analytics/Analytics.swift
+++ b/firefox-ios/Ecosia/Analytics/Analytics.swift
@@ -422,16 +422,82 @@ open class Analytics {
             "action": action.rawValue,
             "logged_in": isLoggedIn
         ]
-        // `sortedKeys` only to make the emitted string deterministic — a JSON
-        // object has no meaningful key order, and consumers parse it.
-        guard let data = try? JSONSerialization.data(withJSONObject: payload,
-                                                     options: [.sortedKeys]),
-              let json = String(data: data, encoding: .utf8) else { return }
+        guard let json = Self.jsonProperty(payload) else { return }
 
         track(Structured(category: Category.newTab.rawValue,
                          action: Action.click.rawValue)
             .label(Label.modeSelection.rawValue)
             .property(json))
+    }
+
+    // MARK: File Upload
+
+    /// User selected a file for omnibox upload (picker confirmation).
+    ///
+    /// `file_type` and `source` travel as JSON in `se_property` — a structured
+    /// event has only one string property.
+    public func fileUploadInitiated(fileType: String,
+                                    source: Property.FileUploadSource = .buttonClick) {
+        let payload: [String: Any] = [
+            "file_type": fileType,
+            "source": source.rawValue
+        ]
+        guard let json = Self.jsonProperty(payload) else { return }
+
+        track(Structured(category: Category.newTab.rawValue,
+                         action: Action.click.rawValue)
+            .label(Label.fileUploadInitiated.rawValue)
+            .property(json))
+    }
+
+    /// File finished loading and uploading and is attached to the omnibox.
+    public func fileUploadCompleted(fileType: String, fileSizeKb: Int) {
+        let payload: [String: Any] = [
+            "file_type": fileType,
+            "file_size_kb": fileSizeKb
+        ]
+        guard let json = Self.jsonProperty(payload) else { return }
+
+        track(Structured(category: Category.newTab.rawValue,
+                         action: Action.success.rawValue)
+            .label(Label.fileUploadCompleted.rawValue)
+            .property(json))
+    }
+
+    /// Upload failed for a mapped error (`unsupported_format`, `too_large`,
+    /// `parse_failed`, or `timeout`).
+    public func fileUploadFailed(errorType: Property.FileUploadErrorType, fileType: String) {
+        let payload: [String: Any] = [
+            "error_type": errorType.rawValue,
+            "file_type": fileType
+        ]
+        guard let json = Self.jsonProperty(payload) else { return }
+
+        track(Structured(category: Category.newTab.rawValue,
+                         action: Action.error.rawValue)
+            .label(Label.fileUploadFailed.rawValue)
+            .property(json))
+    }
+
+    /// Lowercased path extension used as `file_type`, or `"unknown"` when absent.
+    public static func fileUploadFileType(fromFileName fileName: String) -> String {
+        let ext = (fileName as NSString).pathExtension.lowercased()
+        return ext.isEmpty ? "unknown" : ext
+    }
+
+    /// Rounded kibibyte size for `file_size_kb`.
+    public static func fileUploadSizeKb(byteCount: Int) -> Int {
+        (byteCount + 512) / 1024
+    }
+
+    /// Encodes a multi-field tracking-plan payload for `se_property`.
+    /// `sortedKeys` keeps the emitted string deterministic for tests.
+    private static func jsonProperty(_ payload: [String: Any]) -> String? {
+        guard let data = try? JSONSerialization.data(withJSONObject: payload,
+                                                     options: [.sortedKeys]) else {
+            return nil
+        }
+        return String(data: data, encoding: .utf8)
     }
 
     // MARK: Account Authentication

--- a/firefox-ios/Ecosia/Core/FileUpload/FileUploadService.swift
+++ b/firefox-ios/Ecosia/Core/FileUpload/FileUploadService.swift
@@ -44,7 +44,7 @@ private struct PresignResponse: Decodable {
 /// There is no separate confirm step; `file_id` from the presign response is the upload handle.
 public final class FileUploadService: Sendable {
 
-    enum Error: Swift.Error, LocalizedError {
+    public enum Error: Swift.Error, LocalizedError, Equatable {
         case network(statusCode: Int, body: String?)
         case eaistRefreshFailed(statusCode: Int)
         case invalidPresignResponse(body: String?)
@@ -52,7 +52,7 @@ public final class FileUploadService: Sendable {
         case authenticationRequired
         case timedOut
 
-        var errorDescription: String? {
+        public var errorDescription: String? {
             switch self {
             case .network(let statusCode, _):
                 return "Network error (status \(statusCode))"

--- a/firefox-ios/EcosiaTests/Analytics/AnalyticsSpyTests.swift
+++ b/firefox-ios/EcosiaTests/Analytics/AnalyticsSpyTests.swift
@@ -944,9 +944,61 @@ final class AnalyticsSpyTests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(payload["logged_in"] as? Bool, false)
     }
 
-    /// The `mode_selection` payload rides in `se_property` as a JSON string; parse it back for assertions.
+    func testFileUploadInitiatedTracksJSONPayload() throws {
+        User.shared.sendAnonymousUsageData = true
+
+        analyticsSpy.fileUploadInitiated(fileType: "pdf", source: .buttonClick)
+
+        let event = try lastStructuredEvent()
+        XCTAssertEqual(event.category, Analytics.Category.newTab.rawValue)
+        XCTAssertEqual(event.action, Analytics.Action.click.rawValue)
+        XCTAssertEqual(event.label, Analytics.Label.fileUploadInitiated.rawValue)
+
+        let payload = try decodeProperty(event)
+        XCTAssertEqual(payload["file_type"] as? String, "pdf")
+        XCTAssertEqual(payload["source"] as? String, "button_click")
+    }
+
+    func testFileUploadCompletedTracksJSONPayload() throws {
+        User.shared.sendAnonymousUsageData = true
+
+        analyticsSpy.fileUploadCompleted(fileType: "jpg", fileSizeKb: 240)
+
+        let event = try lastStructuredEvent()
+        XCTAssertEqual(event.category, Analytics.Category.newTab.rawValue)
+        XCTAssertEqual(event.action, Analytics.Action.success.rawValue)
+        XCTAssertEqual(event.label, Analytics.Label.fileUploadCompleted.rawValue)
+
+        let payload = try decodeProperty(event)
+        XCTAssertEqual(payload["file_type"] as? String, "jpg")
+        XCTAssertEqual((payload["file_size_kb"] as? NSNumber)?.intValue, 240)
+    }
+
+    func testFileUploadFailedTracksJSONPayload() throws {
+        User.shared.sendAnonymousUsageData = true
+
+        analyticsSpy.fileUploadFailed(errorType: .tooLarge, fileType: "png")
+
+        let event = try lastStructuredEvent()
+        XCTAssertEqual(event.category, Analytics.Category.newTab.rawValue)
+        XCTAssertEqual(event.action, Analytics.Action.error.rawValue)
+        XCTAssertEqual(event.label, Analytics.Label.fileUploadFailed.rawValue)
+
+        let payload = try decodeProperty(event)
+        XCTAssertEqual(payload["error_type"] as? String, "too_large")
+        XCTAssertEqual(payload["file_type"] as? String, "png")
+    }
+
+    func testFileUploadFileTypeAndSizeHelpers() {
+        XCTAssertEqual(Analytics.fileUploadFileType(fromFileName: "report.PDF"), "pdf")
+        XCTAssertEqual(Analytics.fileUploadFileType(fromFileName: "no-extension"), "unknown")
+        XCTAssertEqual(Analytics.fileUploadSizeKb(byteCount: 1024), 1)
+        XCTAssertEqual(Analytics.fileUploadSizeKb(byteCount: 1536), 2)
+    }
+
+    /// Multi-field payloads ride in `se_property` as a JSON string; parse it back for assertions.
     private func decodeProperty(_ event: Structured, file: StaticString = #filePath, line: UInt = #line) throws -> [String: Any] {
-        let property = try XCTUnwrap(event.property, "mode_selection must carry a property payload", file: file, line: line)
+        let property = try XCTUnwrap(event.property, "event must carry a property payload", file: file, line: line)
         let data = try XCTUnwrap(property.data(using: .utf8), file: file, line: line)
         let object = try JSONSerialization.jsonObject(with: data)
         return try XCTUnwrap(object as? [String: Any], "property must be a JSON object", file: file, line: line)

--- a/firefox-ios/EcosiaTests/Analytics/AnalyticsSpyTests.swift
+++ b/firefox-ios/EcosiaTests/Analytics/AnalyticsSpyTests.swift
@@ -992,6 +992,12 @@ final class AnalyticsSpyTests: XCTestCase, @unchecked Sendable {
     func testFileUploadFileTypeAndSizeHelpers() {
         XCTAssertEqual(Analytics.fileUploadFileType(fromFileName: "report.PDF"), "pdf")
         XCTAssertEqual(Analytics.fileUploadFileType(fromFileName: "no-extension"), "unknown")
+        // PHPicker suggested names often omit an extension — fall back to MIME.
+        XCTAssertEqual(
+            Analytics.fileUploadFileType(fromFileName: "IMG_1234", mimeType: "image/jpeg"),
+            "jpg"
+        )
+        XCTAssertEqual(Analytics.fileUploadFileType(fromMimeType: "application/pdf"), "pdf")
         XCTAssertEqual(Analytics.fileUploadSizeKb(byteCount: 1024), 1)
         XCTAssertEqual(Analytics.fileUploadSizeKb(byteCount: 1536), 2)
     }

--- a/firefox-ios/EcosiaTests/UI/NTP/OmniboxUploadPayloadLoaderTests.swift
+++ b/firefox-ios/EcosiaTests/UI/NTP/OmniboxUploadPayloadLoaderTests.swift
@@ -27,4 +27,15 @@ final class OmniboxUploadPayloadLoaderTests: XCTestCase {
         XCTAssertEqual(payload.fileName, "small.txt")
         XCTAssertEqual(payload.data, Data("hello".utf8))
     }
+
+    func testFileNameWithExtensionAppendsMIMEDerivedExtensionWhenMissing() {
+        XCTAssertEqual(
+            OmniboxUploadPayloadLoader.fileNameWithExtension("IMG_1234", mimeType: "image/jpeg"),
+            "IMG_1234.jpg"
+        )
+        XCTAssertEqual(
+            OmniboxUploadPayloadLoader.fileNameWithExtension("report.pdf", mimeType: "application/pdf"),
+            "report.pdf"
+        )
+    }
 }


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-4769]

## Context

We need analytics for the omnibox file-upload funnel so we can measure when users start an upload, when a file is successfully attached, and when a mapped failure occurs. Based it on inputs from the Chat Modes and AIC / AIS structures.

## Approach

- Add Structured Snowplow events under `new_tab`, following the Chat Modes pattern: event name in `se_la`, multi-field payload as JSON in `se_property`.
- Track `file_upload_initiated` when a selection is accepted into the upload pipeline (`file_type`, `source=button_click` — iOS has no drag-and-drop path).
- Track `file_upload_completed` when an attachment reaches `.ready` (`file_type`, `file_size_kb`).
- Track `file_upload_failed` for mapped errors only: `unsupported_format`, `too_large`, `parse_failed`, `timeout`.
- Wire call sites in `OmniboxAttachmentUploadCoordinator` and Files-picker validation; expose `FileUploadService.Error` so Client can detect timeouts.
- Cover payload shape with `AnalyticsSpy` unit tests.

## Before merging

### Checklist

- [ ] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [ ] I added the `// Ecosia:` helper comments where needed
- [x] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4769]: https://ecosia.atlassian.net/browse/MOB-4769