### PR TITLE
[MOB-4519] Improve file upload drawer top padding

### DIFF
--- a/firefox-ios/Ecosia/UI/NTP/Upload/OmniboxUploadDrawerView.swift
+++ b/firefox-ios/Ecosia/UI/NTP/Upload/OmniboxUploadDrawerView.swift
@@ -138,8 +138,8 @@ struct OmniboxUploadDrawerView: View {
             }
         }
         .padding(.horizontal, .ecosia.space._m)
-        .padding(.top, .ecosia.space._m)
-        .padding(.bottom, .ecosia.space._l)
+        .padding(.top, .ecosia.space._2l)
+        .padding(.bottom, .ecosia.space._2l)
         .frame(maxWidth: .infinity)
         // Measure the intrinsic content height so the sheet detent fits exactly,
         // keeping the banner at the bottom without a floating gap.


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-4519] PR SHORT DESCRIPTION
-->

[MOB-4519]

## Context

Increases padding on top of buttons in file drawer

| Before | After |
|---|---|
| <img width="1206" height="2622" alt="simulator_screenshot_9934E2F7-5846-4E60-9CD4-8C18C16239D7" src="https://github.com/user-attachments/assets/385ab7ba-d86b-48b7-8828-15f0267ec2f2" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-22 at 12 38 12" src="https://github.com/user-attachments/assets/a84bdea5-9006-4b89-9b21-fb3c4b6d772a" /> |

## Approach

## Other

## Before merging

### Checklist

- [ ] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [ ] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4519]: https://ecosia.atlassian.net/browse/MOB-4519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MOB-4519]: https://ecosia.atlassian.net/browse/MOB-4519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ