### PR TITLE
[MOB-4519] Fix padding of X-button after files are added

### DIFF
--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPSearchBarView.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/NTPSearchBarView.swift
@@ -253,9 +253,12 @@ final class NTPSearchBarView: UIView, ThemeApplicable, Autocompletable, UIGestur
     /// Resting position: top-right of the pill (no attachments).
     private lazy var clearButtonTopToPillConstraint: NSLayoutConstraint =
         clearButton.topAnchor.constraint(equalTo: topAnchor, constant: .ecosia.space._1s)
-    /// With attachments: trail the textView so the control isn't buried under the strip.
+    /// With attachments: trail the textView so the control isn't buried under the
+    /// strip. The `-_1s` keeps the same button-top-to-text-top offset as the resting
+    /// constraint (pill+_1s vs text+textPadding), so the disc stays centered on the
+    /// first text line instead of dropping ~8pt below it.
     private lazy var clearButtonTopToTextConstraint: NSLayoutConstraint =
-        clearButton.topAnchor.constraint(equalTo: textView.topAnchor)
+        clearButton.topAnchor.constraint(equalTo: textView.topAnchor, constant: -.ecosia.space._1s)
 
     /// Current text content. Mirrors `textView.text` but lets callers drive
     /// programmatic changes (e.g. accepting a tapped suggestion).


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-4519]

## Context

Fixes padding of X-buton when files are added

## Approach

| Only text | With files |
|---|---|
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-24 at 09 05 34" src="https://github.com/user-attachments/assets/7f7cd119-77d4-4390-b74a-8ee01a0a6e5c" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-24 at 09 05 43" src="https://github.com/user-attachments/assets/9b5f95ba-32ea-4872-814c-1288ab3cc6a9" /> |


## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [ ] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4519]: https://ecosia.atlassian.net/browse/MOB-4519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ