### PR TITLE
[MOB-4700] Add Auth0 conversation scopes

### DIFF
--- a/firefox-ios/Ecosia/Account/Auth/EcosiaAuthScopes.swift
+++ b/firefox-ios/Ecosia/Account/Auth/EcosiaAuthScopes.swift
@@ -7,7 +7,8 @@ import Foundation
 /// OAuth scopes requested during native Auth0 authentication.
 public enum EcosiaAuthScopes {
     public static let oauthScope =
-        "openid profile email offline_access read:impact write:impact read:conversations write:conversations"
+        "openid profile email offline_access read:impact write:impact " +
+        "read:conversations write:conversations update:conversations delete:conversations"
 
     public static let conversationScopes: Set<String> = [
         "read:conversations",

--- a/firefox-ios/Ecosia/Account/Auth/EcosiaAuthenticationService.swift
+++ b/firefox-ios/Ecosia/Account/Auth/EcosiaAuthenticationService.swift
@@ -132,7 +132,7 @@ public final class EcosiaAuthenticationService: @unchecked Sendable {
         do {
             let didStore = try auth0Provider.storeCredentials(credentials)
             if didStore {
-                setupTokensWithCredentials(credentials, settingLoggedInStateTo: true, accountOrigin: accountOrigin, context: "login")
+                setupTokensWithCredentials(credentials, settingLoggedInStateTo: true, accountOrigin: accountOrigin)
                 if !skipUserInfoFetch {
                     await fetchUserInfoFromAuth0(accessToken: credentials.accessToken)
                 }
@@ -184,7 +184,7 @@ public final class EcosiaAuthenticationService: @unchecked Sendable {
         let credentialsCleared = auth0Provider.clearCredentials()
 
         if credentialsCleared {
-            setupTokensWithCredentials(nil, context: "logout")
+            setupTokensWithCredentials(nil)
             // Clear user profile on logout
             try await ImageCacheLoader.clearCache(for: userProfile?.pictureURL)
             userProfile = nil
@@ -224,7 +224,7 @@ public final class EcosiaAuthenticationService: @unchecked Sendable {
     public func retrieveStoredCredentials() async {
         do {
             let credentials = try await auth0Provider.retrieveCredentials()
-            setupTokensWithCredentials(credentials, settingLoggedInStateTo: true, context: "initial cached retrieval")
+            setupTokensWithCredentials(credentials, settingLoggedInStateTo: true)
             if !skipUserInfoFetch {
                 await fetchUserInfoFromAuth0(accessToken: credentials.accessToken)
             }
@@ -257,7 +257,7 @@ public final class EcosiaAuthenticationService: @unchecked Sendable {
 
         do {
             let credentials = try await auth0Provider.renewCredentials()
-            setupTokensWithCredentials(credentials, settingLoggedInStateTo: true, context: "forced renewal")
+            setupTokensWithCredentials(credentials, settingLoggedInStateTo: true)
             EcosiaLogger.auth.info("Renewed credentials successfully")
         } catch {
             EcosiaLogger.auth.error("Failed to renew credentials: \(error)")
@@ -268,16 +268,13 @@ public final class EcosiaAuthenticationService: @unchecked Sendable {
     /// Helper method to setup tokens and login flag
     private func setupTokensWithCredentials(_ credentials: Credentials?,
                                             settingLoggedInStateTo isLoggedIn: Bool = false,
-                                            accountOrigin: AccountOrigin? = nil,
-                                            context: String) {
+                                            accountOrigin: AccountOrigin? = nil) {
         self.idToken = credentials?.idToken
         self.accessToken = credentials?.accessToken
         self.grantedScope = credentials?.scope
         self.refreshToken = credentials?.refreshToken
         let wasLoggedIn = self.isLoggedIn
         self.isLoggedIn = isLoggedIn
-
-        EcosiaLogger.auth.info("Tokens updated (\(context)) — grantedScope: \(self.grantedScope ?? "nil"), hasConversationScopes: \(self.hasConversationScopes)")
 
         // Only dispatch the auth state change when the login state actually transitions,
         // to avoid triggering observers (e.g. EcosiaAuthUIStateProvider.registerVisitIfNeeded)

--- a/firefox-ios/Ecosia/Account/Auth/EcosiaAuthenticationService.swift
+++ b/firefox-ios/Ecosia/Account/Auth/EcosiaAuthenticationService.swift
@@ -132,7 +132,7 @@ public final class EcosiaAuthenticationService: @unchecked Sendable {
         do {
             let didStore = try auth0Provider.storeCredentials(credentials)
             if didStore {
-                setupTokensWithCredentials(credentials, settingLoggedInStateTo: true, accountOrigin: accountOrigin)
+                setupTokensWithCredentials(credentials, settingLoggedInStateTo: true, accountOrigin: accountOrigin, context: "login")
                 if !skipUserInfoFetch {
                     await fetchUserInfoFromAuth0(accessToken: credentials.accessToken)
                 }
@@ -184,7 +184,7 @@ public final class EcosiaAuthenticationService: @unchecked Sendable {
         let credentialsCleared = auth0Provider.clearCredentials()
 
         if credentialsCleared {
-            setupTokensWithCredentials(nil)
+            setupTokensWithCredentials(nil, context: "logout")
             // Clear user profile on logout
             try await ImageCacheLoader.clearCache(for: userProfile?.pictureURL)
             userProfile = nil
@@ -224,7 +224,7 @@ public final class EcosiaAuthenticationService: @unchecked Sendable {
     public func retrieveStoredCredentials() async {
         do {
             let credentials = try await auth0Provider.retrieveCredentials()
-            setupTokensWithCredentials(credentials, settingLoggedInStateTo: true)
+            setupTokensWithCredentials(credentials, settingLoggedInStateTo: true, context: "initial cached retrieval")
             if !skipUserInfoFetch {
                 await fetchUserInfoFromAuth0(accessToken: credentials.accessToken)
             }
@@ -257,7 +257,7 @@ public final class EcosiaAuthenticationService: @unchecked Sendable {
 
         do {
             let credentials = try await auth0Provider.renewCredentials()
-            setupTokensWithCredentials(credentials, settingLoggedInStateTo: true)
+            setupTokensWithCredentials(credentials, settingLoggedInStateTo: true, context: "forced renewal")
             EcosiaLogger.auth.info("Renewed credentials successfully")
         } catch {
             EcosiaLogger.auth.error("Failed to renew credentials: \(error)")
@@ -268,13 +268,16 @@ public final class EcosiaAuthenticationService: @unchecked Sendable {
     /// Helper method to setup tokens and login flag
     private func setupTokensWithCredentials(_ credentials: Credentials?,
                                             settingLoggedInStateTo isLoggedIn: Bool = false,
-                                            accountOrigin: AccountOrigin? = nil) {
+                                            accountOrigin: AccountOrigin? = nil,
+                                            context: String) {
         self.idToken = credentials?.idToken
         self.accessToken = credentials?.accessToken
         self.grantedScope = credentials?.scope
         self.refreshToken = credentials?.refreshToken
         let wasLoggedIn = self.isLoggedIn
         self.isLoggedIn = isLoggedIn
+
+        EcosiaLogger.auth.info("Tokens updated (\(context)) — grantedScope: \(self.grantedScope ?? "nil"), hasConversationScopes: \(self.hasConversationScopes)")
 
         // Only dispatch the auth state change when the login state actually transitions,
         // to avoid triggering observers (e.g. EcosiaAuthUIStateProvider.registerVisitIfNeeded)


### PR DESCRIPTION
[MOB-4700]

## Context

See ticket.

## Approach

Including the additional conversation scopes like discussed on https://github.com/ecosia/platform/pull/7306.

## Other

Used some temporary logs on this branch to test the scope refresh: see report on [this ticket comment](https://ecosia.atlassian.net/browse/MOB-4700?focusedCommentId=135598).

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [ ] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4700]: https://ecosia.atlassian.net/browse/MOB-4700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ