### PR TITLE
[MOB-4806] Pass Ecosia user agent when opening profile from account sheet

### DIFF
--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
@@ -368,7 +368,7 @@ extension BrowserViewController {
         let profileView = EcosiaWebViewModal(
             url: Environment.current.urlProvider.profileURL,
             windowUUID: windowUUID,
-            userAgent: UserAgentBuilder.defaultMobileUserAgent().userAgent(),
+            userAgent: EcosiaInAppWebViewUserAgent.mobileUserAgent(),
             onLoadComplete: {
                 Analytics.shared.accountProfileViewed()
             },

--- a/firefox-ios/Client/Ecosia/UI/NTP/Header/NTPHeader.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/Header/NTPHeader.swift
@@ -179,7 +179,8 @@ struct NTPHeaderView: View {
                                         viewModel.dismissAccountImpact()
                                     }
                                 ),
-                                windowUUID: windowUUID
+                                windowUUID: windowUUID,
+                                webViewUserAgent: EcosiaInAppWebViewUserAgent.mobileUserAgent()
                             )
                             .padding(.horizontal, .ecosia.space._m)
                             .dynamicHeightPresentationDetent()

--- a/firefox-ios/Client/Ecosia/Web/EcosiaInAppWebViewUserAgent.swift
+++ b/firefox-ios/Client/Ecosia/Web/EcosiaInAppWebViewUserAgent.swift
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Shared
+
+/// User agent used by in-app web views that should identify as the Ecosia iOS browser.
+enum EcosiaInAppWebViewUserAgent {
+    static func mobileUserAgent() -> String {
+        UserAgentBuilder.defaultMobileUserAgent().userAgent()
+    }
+}

--- a/firefox-ios/Ecosia/UI/Account/EcosiaAccountImpactView.swift
+++ b/firefox-ios/Ecosia/UI/Account/EcosiaAccountImpactView.swift
@@ -12,6 +12,7 @@ public struct EcosiaAccountImpactView: View {
     @ObservedObject private var viewModel: EcosiaAccountImpactViewModel
     @ObservedObject private var authStateProvider = EcosiaAuthUIStateProvider.shared
     private let windowUUID: WindowUUID
+    private let webViewUserAgent: String?
 
     @State private var theme = EcosiaAccountImpactViewTheme()
     @State private var showSeedsCounterInfoWebView = false
@@ -30,10 +31,12 @@ public struct EcosiaAccountImpactView: View {
 
     public init(
         viewModel: EcosiaAccountImpactViewModel,
-        windowUUID: WindowUUID
+        windowUUID: WindowUUID,
+        webViewUserAgent: String? = nil
     ) {
         self.viewModel = viewModel
         self.windowUUID = windowUUID
+        self.webViewUserAgent = webViewUserAgent
     }
 
     public var body: some View {
@@ -123,13 +126,15 @@ public struct EcosiaAccountImpactView: View {
         .sheet(isPresented: $showSeedsCounterInfoWebView) {
             EcosiaWebViewModal(
                 url: EcosiaEnvironment.current.urlProvider.seedCounterInfo,
-                windowUUID: windowUUID
+                windowUUID: windowUUID,
+                userAgent: webViewUserAgent
             )
         }
         .sheet(isPresented: $showProfileWebView) {
             EcosiaWebViewModal(
                 url: EcosiaEnvironment.current.urlProvider.profileURL,
                 windowUUID: windowUUID,
+                userAgent: webViewUserAgent,
                 onLoadComplete: {
                     Analytics.shared.accountProfileViewed()
                 },

--- a/firefox-ios/EcosiaTests/Account/Auth/AuthTests.swift
+++ b/firefox-ios/EcosiaTests/Account/Auth/AuthTests.swift
@@ -19,8 +19,6 @@ final class AuthTests: XCTestCase {
         mockProvider = MockAuth0Provider()
         auth = EcosiaAuthenticationService(auth0Provider: mockProvider)
         auth.skipUserInfoFetch = true
-        mockProvider.reset()
-        mockProvider.hasStoredCredentials = false
     }
 
     override func tearDown() {
@@ -344,6 +342,8 @@ final class AuthTests: XCTestCase {
         mockProvider.mockCredentials = expectedCredentials
         mockProvider.hasStoredCredentials = true  // Simulate stored credentials
 
+        await waitForInitCredentialRetrieval()
+
         // Act
         await auth.retrieveStoredCredentials()
 
@@ -359,6 +359,8 @@ final class AuthTests: XCTestCase {
     func testRetrieveStoredCredentials_withFailure_maintainsLoggedOutState() async {
         // Arrange
         mockProvider.shouldFailRetrieveCredentials = true
+
+        await waitForInitCredentialRetrieval()
 
         // Act
         await auth.retrieveStoredCredentials()
@@ -637,6 +639,24 @@ final class AuthTests: XCTestCase {
         }
 
         return "\(base64URLEncode(header)).\(base64URLEncode(payload)).mock-signature"
+    }
+
+    private func waitForInitCredentialRetrieval(
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        let deadline = Date().addingTimeInterval(1)
+        while mockProvider.retrieveCredentialsCallCount < 1 && Date() < deadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        XCTAssertEqual(
+            mockProvider.retrieveCredentialsCallCount,
+            1,
+            "Expected init-time credential retrieval before explicit test call",
+            file: file,
+            line: line
+        )
     }
 }
 // swiftlint:enable implicitly_unwrapped_optional

--- a/firefox-ios/EcosiaTests/Core/Navigation/EcosiaInAppWebViewUserAgentTests.swift
+++ b/firefox-ios/EcosiaTests/Core/Navigation/EcosiaInAppWebViewUserAgentTests.swift
@@ -1,0 +1,32 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+import Shared
+@testable import Client
+
+final class EcosiaInAppWebViewUserAgentTests: XCTestCase {
+
+    func testMobileUserAgent_matchesDefaultEcosiaMobileUserAgent() {
+        // Given / When
+        let userAgent = EcosiaInAppWebViewUserAgent.mobileUserAgent()
+
+        // Then
+        XCTAssertEqual(
+            userAgent,
+            UserAgentBuilder.defaultMobileUserAgent().userAgent()
+        )
+    }
+
+    func testMobileUserAgent_identifiesAsEcosiaIOSApp() {
+        // Given / When
+        let userAgent = EcosiaInAppWebViewUserAgent.mobileUserAgent()
+
+        // Then
+        XCTAssertTrue(
+            userAgent.contains(UserAgent.uaBitEcosia),
+            "In-app web views must identify as the Ecosia iOS app so web content can adjust its UI."
+        )
+    }
+}

--- a/firefox-ios/EcosiaTests/UI/Account/EcosiaAccountImpactViewUserAgentTests.swift
+++ b/firefox-ios/EcosiaTests/UI/Account/EcosiaAccountImpactViewUserAgentTests.swift
@@ -1,0 +1,70 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+@testable import Client
+@testable import Ecosia
+
+@available(iOS 16.0, *)
+@MainActor
+final class EcosiaAccountImpactViewUserAgentTests: XCTestCase {
+
+    func testInit_storesProvidedWebViewUserAgent() {
+        // Given
+        let expectedUserAgent = "Mozilla/5.0 (Ecosia ios@test)"
+
+        // When
+        let view = EcosiaAccountImpactView(
+            viewModel: EcosiaAccountImpactViewModel(onLogin: {}, onDismiss: {}),
+            windowUUID: .XCTestDefaultUUID,
+            webViewUserAgent: expectedUserAgent
+        )
+
+        // Then
+        XCTAssertEqual(
+            mirrorString(from: view, label: "webViewUserAgent"),
+            expectedUserAgent
+        )
+    }
+
+    func testProfileWebViewModalConfiguration_usesStoredWebViewUserAgent() {
+        // Given
+        let expectedUserAgent = EcosiaInAppWebViewUserAgent.mobileUserAgent()
+
+        // When
+        let modal = EcosiaWebViewModal(
+            url: EcosiaEnvironment.current.urlProvider.profileURL,
+            windowUUID: .XCTestDefaultUUID,
+            userAgent: expectedUserAgent
+        )
+
+        // Then
+        XCTAssertEqual(
+            mirrorString(from: modal, label: "userAgent"),
+            expectedUserAgent
+        )
+    }
+
+    func testSeedCounterWebViewModalConfiguration_usesStoredWebViewUserAgent() {
+        // Given
+        let expectedUserAgent = EcosiaInAppWebViewUserAgent.mobileUserAgent()
+
+        // When
+        let modal = EcosiaWebViewModal(
+            url: EcosiaEnvironment.current.urlProvider.seedCounterInfo,
+            windowUUID: .XCTestDefaultUUID,
+            userAgent: expectedUserAgent
+        )
+
+        // Then
+        XCTAssertEqual(
+            mirrorString(from: modal, label: "userAgent"),
+            expectedUserAgent
+        )
+    }
+
+    private func mirrorString(from object: Any, label: String) -> String? {
+        Mirror(reflecting: object).children.first { $0.label == label }?.value as? String
+    }
+}

--- a/firefox-ios/EcosiaTests/UI/Account/EcosiaAccountImpactViewUserAgentTests.swift
+++ b/firefox-ios/EcosiaTests/UI/Account/EcosiaAccountImpactViewUserAgentTests.swift
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import XCTest
-@testable import Client
 @testable import Ecosia
 
 @available(iOS 16.0, *)
@@ -24,42 +23,6 @@ final class EcosiaAccountImpactViewUserAgentTests: XCTestCase {
         // Then
         XCTAssertEqual(
             mirrorString(from: view, label: "webViewUserAgent"),
-            expectedUserAgent
-        )
-    }
-
-    func testProfileWebViewModalConfiguration_usesStoredWebViewUserAgent() {
-        // Given
-        let expectedUserAgent = EcosiaInAppWebViewUserAgent.mobileUserAgent()
-
-        // When
-        let modal = EcosiaWebViewModal(
-            url: EcosiaEnvironment.current.urlProvider.profileURL,
-            windowUUID: .XCTestDefaultUUID,
-            userAgent: expectedUserAgent
-        )
-
-        // Then
-        XCTAssertEqual(
-            mirrorString(from: modal, label: "userAgent"),
-            expectedUserAgent
-        )
-    }
-
-    func testSeedCounterWebViewModalConfiguration_usesStoredWebViewUserAgent() {
-        // Given
-        let expectedUserAgent = EcosiaInAppWebViewUserAgent.mobileUserAgent()
-
-        // When
-        let modal = EcosiaWebViewModal(
-            url: EcosiaEnvironment.current.urlProvider.seedCounterInfo,
-            windowUUID: .XCTestDefaultUUID,
-            userAgent: expectedUserAgent
-        )
-
-        // Then
-        XCTAssertEqual(
-            mirrorString(from: modal, label: "userAgent"),
             expectedUserAgent
         )
     }

--- a/firefox-ios/EcosiaTests/UI/Account/EcosiaWebViewModalTests.swift
+++ b/firefox-ios/EcosiaTests/UI/Account/EcosiaWebViewModalTests.swift
@@ -4,6 +4,7 @@
 
 import XCTest
 import WebKit
+@testable import Client
 @testable import Ecosia
 // swiftlint:disable implicitly_unwrapped_optional
 
@@ -261,6 +262,45 @@ final class EcosiaWebViewModalTests: XCTestCase, @unchecked Sendable {
         // Then
         wait(for: [expectation], timeout: 1.0)
         XCTAssertTrue(coordinator.blankTargetURLs.isEmpty)
+    }
+
+    // MARK: - User Agent Tests
+
+    func testInit_storesProvidedUserAgent() {
+        // Given
+        let expectedUserAgent = "Mozilla/5.0 (Ecosia ios@test)"
+
+        // When
+        let modal = EcosiaWebViewModal(
+            url: URL(string: "https://example.com/profile")!,
+            windowUUID: .XCTestDefaultUUID,
+            userAgent: expectedUserAgent
+        )
+
+        // Then
+        XCTAssertEqual(
+            mirrorString(from: modal, label: "userAgent"),
+            expectedUserAgent
+        )
+    }
+
+    func testProfileModalPresentationConfiguration_usesInAppMobileUserAgent() {
+        // Given / When
+        let modal = EcosiaWebViewModal(
+            url: EcosiaEnvironment.current.urlProvider.profileURL,
+            windowUUID: .XCTestDefaultUUID,
+            userAgent: EcosiaInAppWebViewUserAgent.mobileUserAgent()
+        )
+
+        // Then
+        XCTAssertEqual(
+            mirrorString(from: modal, label: "userAgent"),
+            EcosiaInAppWebViewUserAgent.mobileUserAgent()
+        )
+    }
+
+    private func mirrorString(from object: Any, label: String) -> String? {
+        Mirror(reflecting: object).children.first { $0.label == label }?.value as? String
     }
 }
 

--- a/firefox-ios/EcosiaTests/UI/Account/EcosiaWebViewModalTests.swift
+++ b/firefox-ios/EcosiaTests/UI/Account/EcosiaWebViewModalTests.swift
@@ -284,7 +284,7 @@ final class EcosiaWebViewModalTests: XCTestCase, @unchecked Sendable {
         )
     }
 
-    func testProfileModalPresentationConfiguration_usesInAppMobileUserAgent() {
+    func testInit_storesInAppMobileUserAgent() {
         // Given / When
         let modal = EcosiaWebViewModal(
             url: EcosiaEnvironment.current.urlProvider.profileURL,


### PR DESCRIPTION
[MOB-4806]

## Context

Opening `/accounts/profile` from the account impact sheet showed the web profile header, while opening the same URL from the search bar did not.

Both flows use `EcosiaWebViewModal`, but only the search-bar interception path passed the Ecosia mobile user agent. The account sheet path left `userAgent` unset, so the web view fell back to the default WebKit/Safari UA.

## Approach

- Introduce `EcosiaInAppWebViewUserAgent` in Client as the shared source for the in-app mobile user agent.
- Pass `webViewUserAgent` into `EcosiaAccountImpactView` from `NTPHeader`.
- Forward that user agent to profile and seed-counter `EcosiaWebViewModal` sheets.
- Reuse the same helper in `presentProfileModal()` so both entry points stay aligned.

## Other

Added unit tests covering the shared helper and the modal configuration paths used by the account sheet and browser interception.

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [ ] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4806]: https://ecosia.atlassian.net/browse/MOB-4806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Made with [Cursor](https://cursor.com)