### PR TITLE
[MOB-4813] Send X-Ecosia-App header on the AI Search token refresh request

### DIFF
--- a/firefox-ios/Ecosia/Core/FileUpload/FileUploadService.swift
+++ b/firefox-ios/Ecosia/Core/FileUpload/FileUploadService.swift
@@ -178,6 +178,9 @@ public final class FileUploadService: Sendable {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        // Ecosia: identifies this native app call to the Cloudflare WAF rule guarding this
+        // endpoint, which otherwise only allows browser-style requests with a matching Origin.
+        request.setValue("ios", forHTTPHeaderField: "X-Ecosia-App")
         request.cachePolicy = .reloadIgnoringLocalCacheData
         request.httpBody = Data("{}".utf8)
 


### PR DESCRIPTION
[MOB-4813]

## Context

See ticket.

## Approach

`refreshEAIST()` now sends `X-Ecosia-App: ios` so it matches the new WAF allowlist, since native requests never send a browser-style Origin header.

## Before merging

Depends on https://github.com/ecosia/platform/pull/7380.

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [x] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4813]: https://ecosia.atlassian.net/browse/MOB-4813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ