### PR TITLE
[MOB-4813] Refactor http client to support different base urls

### DIFF
--- a/firefox-ios/Ecosia/Core/Accounts/Service/AccountVisitRequest.swift
+++ b/firefox-ios/Ecosia/Core/Accounts/Service/AccountVisitRequest.swift
@@ -20,8 +20,8 @@ struct AccountVisitRequest: BaseRequest {
 
     var body: Data?
 
-    var baseURL: URL {
-        environment.urlProvider.root
+    var baseURL: BaseURL {
+        .web
     }
 
     init(accessToken: String) {

--- a/firefox-ios/Ecosia/Core/Accounts/Service/AccountsService.swift
+++ b/firefox-ios/Ecosia/Core/Accounts/Service/AccountsService.swift
@@ -51,7 +51,7 @@ public final class AccountsService: AccountsServiceProtocol {
     private func performVisitRequest(accessToken: String) async throws -> AccountVisitResponse {
         let request = AccountVisitRequest(accessToken: accessToken)
 
-        EcosiaLogger.network.info("Making accounts visit request to: \(request.baseURL.absoluteString)\(request.path)")
+        EcosiaLogger.network.info("Making accounts visit request to: \(request.resolvedBaseURL.absoluteString)\(request.path)")
 
         let (data, response) = try await client.perform(request)
 

--- a/firefox-ios/Ecosia/Core/Environment/URLProvider.swift
+++ b/firefox-ios/Ecosia/Core/Environment/URLProvider.swift
@@ -34,12 +34,6 @@ public enum URLProvider {
         URL(string: "https://ac.ecosia.org/autocomplete")!
     }
 
-    /// Endpoint that issues the EAIST Cloudflare WAF protection cookie.
-    /// Must be called before requests to AI Worker endpoints — matches web `refreshToken()`.
-    public var aiChatRefresh: URL {
-        root.appendingPathComponent("ai-chat/refresh")
-    }
-
     public var snowplowMicro: String? {
         switch self {
         case .staging:

--- a/firefox-ios/Ecosia/Core/FileUpload/AIChatRefreshRequest.swift
+++ b/firefox-ios/Ecosia/Core/FileUpload/AIChatRefreshRequest.swift
@@ -1,0 +1,22 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// POST to refresh the Cloudflare WAF `EAIST` protection cookie ahead of AI Worker calls.
+/// Lives on the `www` host rather than `api`, unlike most other `BaseRequest`s.
+struct AIChatRefreshRequest: BaseRequest {
+
+    var baseURL: BaseURL { .web }
+
+    var method: HTTPMethod { .post }
+
+    var path: String { "/ai-chat/refresh" }
+
+    var queryParameters: [String: String]?
+
+    var additionalHeaders: [String: String]? { nil }
+
+    var body: Data? { Data("{}".utf8) }
+}

--- a/firefox-ios/Ecosia/Core/FileUpload/FileUploadService.swift
+++ b/firefox-ios/Ecosia/Core/FileUpload/FileUploadService.swift
@@ -172,9 +172,10 @@ public final class FileUploadService: Sendable {
 
     private func refreshEAIST() async throws {
         await ensureCloudflareAccessCookieForStagingAPI()
-        log(.info, "Refreshing EAIST cookie url=\(Environment.current.urlProvider.aiChatRefresh.absoluteString)")
+        let request = AIChatRefreshRequest()
+        log(.info, "Refreshing EAIST cookie url=\(request.resolvedBaseURL.absoluteString)\(request.path)")
 
-        let (_, response) = try await client.perform(AIChatRefreshRequest())
+        let (_, response) = try await client.perform(request)
         let statusCode = response?.statusCode ?? -1
         guard let http = response, (200..<300).contains(http.statusCode) else {
             log(.error, "EAIST refresh failed status=\(statusCode)")

--- a/firefox-ios/Ecosia/Core/FileUpload/FileUploadService.swift
+++ b/firefox-ios/Ecosia/Core/FileUpload/FileUploadService.swift
@@ -172,18 +172,11 @@ public final class FileUploadService: Sendable {
 
     private func refreshEAIST() async throws {
         await ensureCloudflareAccessCookieForStagingAPI()
-        let url = Environment.current.urlProvider.aiChatRefresh
-        log(.info, "Refreshing EAIST cookie url=\(url.absoluteString)")
+        log(.info, "Refreshing EAIST cookie url=\(Environment.current.urlProvider.aiChatRefresh.absoluteString)")
 
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.cachePolicy = .reloadIgnoringLocalCacheData
-        request.httpBody = Data("{}".utf8)
-
-        let (_, response) = try await URLSession.shared.data(for: request)
-        let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
-        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+        let (_, response) = try await client.perform(AIChatRefreshRequest())
+        let statusCode = response?.statusCode ?? -1
+        guard let http = response, (200..<300).contains(http.statusCode) else {
             log(.error, "EAIST refresh failed status=\(statusCode)")
             throw Error.eaistRefreshFailed(statusCode: statusCode)
         }

--- a/firefox-ios/Ecosia/Core/HTTPClient/Requestable/BaseRequest.swift
+++ b/firefox-ios/Ecosia/Core/HTTPClient/Requestable/BaseRequest.swift
@@ -36,15 +36,24 @@ public extension BaseRequest {
     }
 
     func makeURLRequest() throws -> URLRequest {
-        guard var urlComponents = URLComponents(url: resolvedBaseURL, resolvingAgainstBaseURL: false) else {
-            throw RequestError.invalidBaseURL
-        }
-        urlComponents.path = path
-        if let queryParameters {
-            urlComponents.queryItems = queryParameters.map({ .init(name: $0.key, value: $0.value ) })
-        }
-        guard let url = urlComponents.url else {
-            throw RequestError.invalidURLComponents
+        let url: URL
+        switch baseURL {
+        case .custom:
+            // Ecosia: a caller-supplied URL (e.g. a presigned upload URL) already carries its
+            // own path/query, often signed — used exactly as given, not merged with `path`.
+            url = resolvedBaseURL
+        case .api, .web:
+            guard var urlComponents = URLComponents(url: resolvedBaseURL, resolvingAgainstBaseURL: false) else {
+                throw RequestError.invalidBaseURL
+            }
+            urlComponents.path = path
+            if let queryParameters {
+                urlComponents.queryItems = queryParameters.map({ .init(name: $0.key, value: $0.value ) })
+            }
+            guard let resolvedURL = urlComponents.url else {
+                throw RequestError.invalidURLComponents
+            }
+            url = resolvedURL
         }
 
         var request = URLRequest(url: url)

--- a/firefox-ios/Ecosia/Core/HTTPClient/Requestable/BaseRequest.swift
+++ b/firefox-ios/Ecosia/Core/HTTPClient/Requestable/BaseRequest.swift
@@ -13,16 +13,30 @@ enum RequestError: Error {
 
 public extension BaseRequest {
 
-    var baseURL: URL {
-        environment.urlProvider.apiRoot
+    var baseURL: BaseURL {
+        .api
     }
 
     var environment: Environment {
         .current
     }
 
+    /// Resolves `baseURL` to an actual host. Only `.api`/`.web` are guaranteed Ecosia
+    /// domains — see `makeURLRequest()`, which uses that guarantee to decide which
+    /// Ecosia-internal headers are safe to attach.
+    var resolvedBaseURL: URL {
+        switch baseURL {
+        case .api:
+            return environment.urlProvider.apiRoot
+        case .web:
+            return environment.urlProvider.root
+        case .custom(let url):
+            return url
+        }
+    }
+
     func makeURLRequest() throws -> URLRequest {
-        guard var urlComponents = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
+        guard var urlComponents = URLComponents(url: resolvedBaseURL, resolvingAgainstBaseURL: false) else {
             throw RequestError.invalidBaseURL
         }
         urlComponents.path = path
@@ -43,6 +57,12 @@ public extension BaseRequest {
             additionalHeaders.forEach({ request.setValue($0.value, forHTTPHeaderField: $0.key) })
         }
 
-        return request.withCloudFlareAuthParameters()
+        // Ecosia: only attach app-identifying/Cloudflare Access headers when the host is
+        // guaranteed to be ours — a `.custom` URL (CDN, presigned upload URL, ...) isn't.
+        guard case .custom = baseURL else {
+            request.setValue("ios", forHTTPHeaderField: "X-Ecosia-App")
+            return request.withCloudFlareAuthParameters()
+        }
+        return request
     }
 }

--- a/firefox-ios/Ecosia/Core/HTTPClient/Requestable/BaseURL.swift
+++ b/firefox-ios/Ecosia/Core/HTTPClient/Requestable/BaseURL.swift
@@ -1,0 +1,18 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// Selects the host a `Requestable` resolves against, and controls which Ecosia-internal
+/// headers `BaseRequest.makeURLRequest()` attaches automatically. Mirrors the Android
+/// `BaseUrl` sealed class in `NetworkRequest.kt`.
+public enum BaseURL: Sendable {
+    /// `https://api.<domain>` — `X-Ecosia-App` and Cloudflare Access headers are attached.
+    case api
+    /// `https://www.<domain>` — same automatic headers as `.api`.
+    case web
+    /// Caller-supplied URL (e.g. a CDN, or a server-issued presigned upload URL). No
+    /// Ecosia-internal headers are attached, since the host isn't guaranteed to be ours.
+    case custom(URL)
+}

--- a/firefox-ios/Ecosia/Core/HTTPClient/Requestable/BaseURL.swift
+++ b/firefox-ios/Ecosia/Core/HTTPClient/Requestable/BaseURL.swift
@@ -14,5 +14,10 @@ public enum BaseURL: Sendable {
     case web
     /// Caller-supplied URL (e.g. a CDN, or a server-issued presigned upload URL). No
     /// Ecosia-internal headers are attached, since the host isn't guaranteed to be ours.
+    ///
+    /// This is NOT a host override: `BaseRequest.makeURLRequest()` uses this URL exactly as
+    /// given, including its own path and query, ignoring `path`/`queryParameters` entirely.
+    /// That matters for e.g. a presigned upload URL, whose path and signed query string must
+    /// survive untouched.
     case custom(URL)
 }

--- a/firefox-ios/Ecosia/Core/HTTPClient/Requestable/Requestable.swift
+++ b/firefox-ios/Ecosia/Core/HTTPClient/Requestable/Requestable.swift
@@ -8,7 +8,7 @@ public protocol Requestable: Sendable {
 
     var method: HTTPMethod { get }
 
-    var baseURL: URL { get }
+    var baseURL: BaseURL { get }
 
     var path: String { get }
 

--- a/firefox-ios/EcosiaTests/Core/BaseRequestTests.swift
+++ b/firefox-ios/EcosiaTests/Core/BaseRequestTests.swift
@@ -1,0 +1,80 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+@testable import Ecosia
+import XCTest
+
+final class BaseRequestTests: XCTestCase {
+
+    private struct TestRequest: BaseRequest {
+        var baseURL: BaseURL = .api
+        var path: String = "/test"
+        var queryParameters: [String: String]?
+        var additionalHeaders: [String: String]?
+        var body: Data?
+
+        var method: HTTPMethod { .get }
+    }
+
+    // MARK: - resolvedBaseURL
+
+    func testResolvedBaseURLForAPI() {
+        let request = TestRequest(baseURL: .api)
+        XCTAssertEqual(request.resolvedBaseURL, Environment.current.urlProvider.apiRoot)
+    }
+
+    func testResolvedBaseURLForWeb() {
+        let request = TestRequest(baseURL: .web)
+        XCTAssertEqual(request.resolvedBaseURL, Environment.current.urlProvider.root)
+    }
+
+    func testResolvedBaseURLForCustom() {
+        let customURL = URL(string: "https://example.com/asset.json")!
+        let request = TestRequest(baseURL: .custom(customURL))
+        XCTAssertEqual(request.resolvedBaseURL, customURL)
+    }
+
+    // MARK: - X-Ecosia-App header
+
+    func testAPIRequestAttachesEcosiaAppHeader() throws {
+        let request = try TestRequest(baseURL: .api).makeURLRequest()
+        XCTAssertEqual(request.value(forHTTPHeaderField: "X-Ecosia-App"), "ios")
+    }
+
+    func testWebRequestAttachesEcosiaAppHeader() throws {
+        let request = try TestRequest(baseURL: .web).makeURLRequest()
+        XCTAssertEqual(request.value(forHTTPHeaderField: "X-Ecosia-App"), "ios")
+    }
+
+    func testCustomRequestDoesNotAttachEcosiaAppHeader() throws {
+        let customURL = URL(string: "https://example.com/asset.json")!
+        let request = try TestRequest(baseURL: .custom(customURL)).makeURLRequest()
+        XCTAssertNil(request.value(forHTTPHeaderField: "X-Ecosia-App"))
+    }
+
+    // MARK: - Cloudflare Access headers
+    //
+    // Only the `.custom` case is asserted here: the real presence of these headers for
+    // `.api`/`.web` depends on `Environment.current` (derived from `Bundle.main.bundleIdentifier`,
+    // see `withCloudFlareAuthParameters()`), which always resolves to `.debug` in this test
+    // target and so can't be flipped to `.staging` per-test. The security property that
+    // matters here doesn't need that: a `.custom` host must never get these headers, full stop.
+
+    func testCustomRequestDoesNotAttachCloudflareAccessHeaders() throws {
+        let customURL = URL(string: "https://example.com/asset.json")!
+        let request = try TestRequest(baseURL: .custom(customURL)).makeURLRequest()
+        XCTAssertNil(request.value(forHTTPHeaderField: CloudflareKeyProvider.clientId))
+        XCTAssertNil(request.value(forHTTPHeaderField: CloudflareKeyProvider.clientSecret))
+    }
+
+    // MARK: - Custom URL is used as-is
+
+    /// A `.custom` URL (e.g. a presigned upload URL) already carries its own path/query,
+    /// often signed, and must survive untouched — even though `path` here is non-empty.
+    func testCustomRequestUsesExactURLIgnoringPath() throws {
+        let customURL = URL(string: "https://example.com/asset.json?signature=abc123")!
+        let request = try TestRequest(baseURL: .custom(customURL), path: "/should-be-ignored").makeURLRequest()
+        XCTAssertEqual(request.url, customURL)
+    }
+}

--- a/firefox-ios/EcosiaTests/Core/UnleashTests.swift
+++ b/firefox-ios/EcosiaTests/Core/UnleashTests.swift
@@ -50,7 +50,7 @@ final class UnleashTests: XCTestCase {
         let context = ["foo": "bar"]
         var request = UnleashTests.stagingUnleashRequest
         request.queryParameters = context
-        let url = request.baseURL
+        let url = request.resolvedBaseURL
 
         XCTAssertTrue(url.absoluteString.hasPrefix(base.absoluteString))
         XCTAssertEqual(URLComponents(string: try request.makeURLRequest().url!.absoluteString)?.queryItems?.count, 1)
@@ -211,8 +211,8 @@ extension UnleashTests {
             .get
         }
 
-        var baseURL: URL {
-            URL(string: "https://ecosia.org")!
+        var baseURL: BaseURL {
+            .custom(URL(string: "https://ecosia.org")!)
         }
 
         var path: String {
@@ -230,7 +230,7 @@ extension UnleashTests {
         var body: Data?
 
         func makeURLRequest() throws -> URLRequest {
-            UnleashTests.mockMakeURLRequest(for: baseURL,
+            UnleashTests.mockMakeURLRequest(for: resolvedBaseURL,
                                             path: path,
                                             queryParameters: queryParameters,
                                             etag: etag,
@@ -250,8 +250,8 @@ extension UnleashTests {
             .get
         }
 
-        var baseURL: URL {
-            URL(string: "https://ecosia.org")!
+        var baseURL: BaseURL {
+            .custom(URL(string: "https://ecosia.org")!)
         }
 
         var path: String {
@@ -269,7 +269,7 @@ extension UnleashTests {
         var body: Data?
 
         func makeURLRequest() throws -> URLRequest {
-            UnleashTests.mockMakeURLRequest(for: baseURL,
+            UnleashTests.mockMakeURLRequest(for: resolvedBaseURL,
                                             path: path,
                                             queryParameters: queryParameters,
                                             etag: etag,


### PR DESCRIPTION
[MOB-4813]

## Context

Follow-up to https://github.com/ecosia/ios-browser/pull/1225.

## Approach

Refactoring our base Network layer to support different base URL types and include app identifying headers conditionally.

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [ ] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4813]: https://ecosia.atlassian.net/browse/MOB-4813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ