### PR TITLE
[MOB-4674] Fix autocomplete bugs on Omnibox / Searchbar

### DIFF
--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/BrowserAddressToolbar.swift
@@ -457,6 +457,12 @@ public class BrowserAddressToolbar: UIView,
         locationView.plainUserText
     }
 
+    // Ecosia: Write counterpart to `overlayEditingText`, used by the suggestion list's
+    // "append" arrow to fill the address bar without submitting.
+    public func setOverlayEditingText(_ text: String) {
+        locationView.setPlainUserText(text)
+    }
+
     // MARK: - LocationViewDelegate
     func locationViewDidEnterText(_ text: String) {
         toolbarDelegate?.searchSuggestions(searchTerm: text)

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationTextField.swift
@@ -91,6 +91,17 @@ class LocationTextField: UITextField, UITextFieldDelegate, ThemeApplicable {
         textWithoutSuggestion() ?? text ?? ""
     }
 
+    // Ecosia: Write counterpart to `plainUserText`, for replacing the field's contents from
+    // code — the suggestion list's "append" arrow. Drops any inline autocomplete first so the
+    // appended query can't be spliced onto a stale completion, and parks the caret at the end
+    // so typing continues from the appended text.
+    func setPlainUserText(_ value: String) {
+        removeCompletion()
+        hideCursor = false
+        text = value
+        selectedTextRange = textRange(from: endOfDocument, to: endOfDocument)
+    }
+
     override var accessibilityCustomActions: [UIAccessibilityCustomAction]? {
         get {
             return accessibilityActionsSource?.accessibilityCustomActionsForView(self)

--- a/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
+++ b/BrowserKit/Sources/ToolbarKit/AddressToolbar/LocationView/LocationView.swift
@@ -215,6 +215,20 @@ final class LocationView: UIView,
         applyTheme(theme: theme)
     }
 
+    // Ecosia: Replace the field's contents from code (suggestion "append" arrow).
+    //
+    // This deliberately bypasses Redux. `configureURLTextField` refuses to write the text
+    // field while `didStartTyping` is set — which it always is once the user has typed
+    // enough to surface suggestions — so a state round-trip cannot deliver the appended
+    // query. That same guard is what makes writing directly safe: a later reconfigure
+    // won't clobber what we set here.
+    func setPlainUserText(_ text: String) {
+        urlTextField.setPlainUserText(text)
+        // Keep the cached term in step so a subsequent re-focus reports the appended query
+        // to `locationViewDidBeginEditing` rather than the pre-append one.
+        searchTerm = text
+    }
+
     private func layoutContainerView(isEditing: Bool, isURLTextFieldCentered: Bool) {
         var newConstraints: [NSLayoutConstraint] = []
         if isEditing || !isURLTextFieldCentered || isURLTextFieldWiderThanVisibleArea() {

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
@@ -139,6 +139,28 @@ extension BrowserViewController {
         let isPrivate = tabManager.selectedTab?.isPrivate ?? false
         addressToolbarContainer.applyUIMode(isPrivate: isPrivate, theme: themeManager.getCurrentTheme(for: windowUUID))
     }
+
+    /// Pushes text appended from a suggestion's "append" arrow into the address bar.
+    ///
+    /// The Redux round-trip cannot do this. Ecosia's reducer deliberately preserves
+    /// `didStartTyping` on `didSetTextInLocationView` (upstream clears it) so a suggestion
+    /// highlight can't overwrite the field mid-keystroke — and
+    /// `LocationView.configureURLTextField` bails on that same flag before writing the text
+    /// field. By the time the append arrow is reachable the user has necessarily typed, so
+    /// the flag is always set and the appended query never lands, leaving the address bar
+    /// out of sync with the suggestions list (which `appendSearch` updates directly).
+    ///
+    /// Clearing the flag instead is not an option: with the keyboard drag-dismissed it is
+    /// the only thing stopping `LocationView` from resigning first responder (MOB-4580),
+    /// which would tear the overlay down. So write the field directly — the same guard that
+    /// blocks the state update also stops a later reconfigure from clobbering this.
+    func applyAppendedSearchTermToAddressBar(_ text: String) {
+        // The NTP omnibox owns the overlay in that mode and `setLocationView` already
+        // wrote the pill directly.
+        guard !(searchController?.parent is HomepageViewController) else { return }
+
+        addressToolbarContainer.setOverlayLocationText(text)
+    }
 }
 
 // MARK: Present intro

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Omnibox.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Omnibox.swift
@@ -453,13 +453,32 @@ extension BrowserViewController {
 
     @objc fileprivate func handleOmniboxFastTap(_ gesture: UITapGestureRecognizer) {
         guard let tableView = gesture.view as? UITableView,
-              let indexPath = tableView.indexPathForRow(at: gesture.location(in: tableView)),
               let searchController else { return }
+        let location = gesture.location(in: tableView)
+        // The recogniser is attached to the table, so it also fires for touches
+        // that land on a cell's own controls — notably the "append" arrow, whose
+        // whole purpose is to fill the omnibox *without* searching. Selecting the
+        // row here would submit the query instead, and disabling interaction below
+        // would swallow the button's `touchUpInside` on the way out. Bail so the
+        // touch reaches the control untouched.
+        guard !Self.isInsideControl(tableView.hitTest(location, with: nil), upTo: tableView) else { return }
+        guard let indexPath = tableView.indexPathForRow(at: location) else { return }
         // Disable further interaction so the table's own delayed selection
         // gesture doesn't re-fire `didSelectRowAt` after we've handed off to
         // the submit pipeline. Re-enabled on the next omnibox attach.
         tableView.isUserInteractionEnabled = false
         searchController.tableView(tableView, didSelectRowAt: indexPath)
+    }
+
+    /// Whether `view` is a `UIControl` or nested inside one, searching no further
+    /// up than `limit` so the table itself is never considered.
+    private static func isInsideControl(_ view: UIView?, upTo limit: UIView) -> Bool {
+        var current = view
+        while let candidate = current, candidate !== limit {
+            if candidate is UIControl { return true }
+            current = candidate.superview
+        }
+        return false
     }
 
     fileprivate static func nearestViewController(of view: UIView) -> UIViewController? {

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -4826,6 +4826,9 @@ extension BrowserViewController: SearchViewControllerDelegate {
     func searchViewController(_ searchViewController: SearchViewController, didAppend text: String) {
         searchViewController.searchTelemetry?.interactionType = .pasted
         setLocationView(text: text, search: false)
+        // Ecosia: `setLocationView` cannot update the address bar while `didStartTyping` is
+        // set, which it always is by the time the append arrow is reachable.
+        applyAppendedSearchTermToAddressBar(text)
     }
 
     func searchViewControllerWillHide(_ searchViewController: SearchViewController) {

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/AddressToolbarContainer.swift
@@ -156,6 +156,12 @@ final class AddressToolbarContainer: UIView,
         toolbar.overlayEditingText
     }
 
+    // Ecosia: Write counterpart to `overlayLocationText`, used by the suggestion list's
+    // "append" arrow to fill the address bar without submitting.
+    func setOverlayLocationText(_ text: String) {
+        toolbar.setOverlayEditingText(text)
+    }
+
     init(isMinimalAddressBarEnabled: Bool, toolbarHelper: ToolbarHelperInterface = ToolbarHelper()) {
         self.isMinimalAddressBarEnabled = isMinimalAddressBarEnabled
         self.toolbarHelper = toolbarHelper


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-4674]

## Context

Fixes autocompletion bugs when tapping the arrows in the Omnibox autocomplete as well as when using the Searchbar.

## Approach

## Other

## Before merging

### Checklist

- [ ] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [ ] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4674]: https://ecosia.atlassian.net/browse/MOB-4674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ