### PR TITLE
[MOB-4603] Sentry integration

### DIFF
--- a/BrowserKit/Sources/Common/Constants/BrowserKitInformation.swift
+++ b/BrowserKit/Sources/Common/Constants/BrowserKitInformation.swift
@@ -13,12 +13,20 @@ public final class BrowserKitInformation: @unchecked Sendable {
     public var buildChannel: AppBuildChannel?
     public var nightlyAppVersion: String?
     public var sharedContainerIdentifier: String?
+    // Ecosia: Lets the app tell BrowserKit its own environment name (e.g. "staging"/"production") for
+    // Sentry tagging, without BrowserKit needing to know about Ecosia's Environment type. Firefox call
+    // sites can leave this nil and keep their existing Nightly/Production tagging.
+    public var environmentName: String?
 
     public func configure(buildChannel: AppBuildChannel,
                           nightlyAppVersion: String,
-                          sharedContainerIdentifier: String) {
+                          sharedContainerIdentifier: String,
+                          // Ecosia: set environment name
+                          environmentName: String? = nil) {
         self.buildChannel = buildChannel
         self.nightlyAppVersion = nightlyAppVersion
         self.sharedContainerIdentifier = sharedContainerIdentifier
+        // Ecosia: set environment name
+        self.environmentName = environmentName
     }
 }

--- a/BrowserKit/Sources/Common/Constants/BrowserKitInformation.swift
+++ b/BrowserKit/Sources/Common/Constants/BrowserKitInformation.swift
@@ -17,16 +17,24 @@ public final class BrowserKitInformation: @unchecked Sendable {
     // Sentry tagging, without BrowserKit needing to know about Ecosia's Environment type. Firefox call
     // sites can leave this nil and keep their existing Nightly/Production tagging.
     public var environmentName: String?
+    // Ecosia: Lets the app supply its own Sentry DSN directly, without going through the Info.plist
+    // SentryCloudDSN key Firefox's own CI injects. Firefox call sites can leave this nil and keep
+    // using their existing Info.plist-based DSN.
+    public var dsn: String?
 
     public func configure(buildChannel: AppBuildChannel,
                           nightlyAppVersion: String,
+                          /* Ecosia: added environmentName and dsn params below
+                          sharedContainerIdentifier: String) {
+                          */
                           sharedContainerIdentifier: String,
-                          // Ecosia: set environment name
-                          environmentName: String? = nil) {
+                          environmentName: String? = nil,
+                          dsn: String? = nil) {
         self.buildChannel = buildChannel
         self.nightlyAppVersion = nightlyAppVersion
         self.sharedContainerIdentifier = sharedContainerIdentifier
-        // Ecosia: set environment name
+        // Ecosia: set environment name and DSN
         self.environmentName = environmentName
+        self.dsn = dsn
     }
 }

--- a/BrowserKit/Sources/Common/Constants/BrowserKitInformation.swift
+++ b/BrowserKit/Sources/Common/Constants/BrowserKitInformation.swift
@@ -21,6 +21,10 @@ public final class BrowserKitInformation: @unchecked Sendable {
     // SentryCloudDSN key Firefox's own CI injects. Firefox call sites can leave this nil and keep
     // using their existing Info.plist-based DSN.
     public var dsn: String?
+    // Ecosia: Lets the app gate Sentry startup on its own rollout flag (e.g. an Unleash toggle),
+    // checked inside CrashManager.setup() so every call site is covered without needing its own
+    // guard. Defaults to false so Sentry stays off until the app explicitly enables it.
+    public var sentryReportingEnabled = false
 
     public func configure(buildChannel: AppBuildChannel,
                           nightlyAppVersion: String,

--- a/BrowserKit/Sources/Common/Logger/CrashManager.swift
+++ b/BrowserKit/Sources/Common/Logger/CrashManager.swift
@@ -127,7 +127,9 @@ public final class DefaultCrashManager: CrashManager, @unchecked Sendable {
         never set appInfo.dsn keep using sentryWrapper.dsn unchanged.
         guard shouldSetup,
               sendCrashReports,
-              let dsn = sentryWrapper.dsn else { return }
+              let dsn = sentryWrapper.dsn else {
+            return
+        }
         */
         let dsnOverride = appInfo.dsn
 

--- a/BrowserKit/Sources/Common/Logger/CrashManager.swift
+++ b/BrowserKit/Sources/Common/Logger/CrashManager.swift
@@ -122,11 +122,18 @@ public final class DefaultCrashManager: CrashManager, @unchecked Sendable {
     }
 
     public func setup(sendCrashReports: Bool) {
+        /* Ecosia: appInfo.dsn (set by the app, e.g. from Ecosia's URLProvider) takes precedence over
+        sentryWrapper.dsn (Firefox's own Info.plist SentryCloudDSN key); Firefox call sites that
+        never set appInfo.dsn keep using sentryWrapper.dsn unchanged.
         guard shouldSetup,
               sendCrashReports,
-              let dsn = sentryWrapper.dsn else {
-            return
-        }
+              let dsn = sentryWrapper.dsn else { return }
+        */
+        let dsnOverride = appInfo.dsn
+
+        guard shouldSetup,
+              sendCrashReports,
+              let dsn = dsnOverride ?? sentryWrapper.dsn else { return }
 
         sentryWrapper.startWithConfigureOptions(configure: { options in
             options.dsn = dsn
@@ -141,7 +148,10 @@ public final class DefaultCrashManager: CrashManager, @unchecked Sendable {
                     $0.lifecycle = .trace
                 }
             }
-            // Ecosia: setting correct envitonment tag
+            /* Ecosia: Use environmentTag (falls back to Firefox's own Nightly/Production naming
+            when Ecosia hasn't provided one) so Ecosia's staging/production tags come through.
+            options.environment = self.environment.rawValue
+            */
             options.environment = self.environmentTag
             options.releaseName = self.releaseName
             options.enableFileIOTracing = false

--- a/BrowserKit/Sources/Common/Logger/CrashManager.swift
+++ b/BrowserKit/Sources/Common/Logger/CrashManager.swift
@@ -59,10 +59,13 @@ public final class DefaultCrashManager: CrashManager, @unchecked Sendable {
     private var isValidReleaseName: Bool {
         if skipReleaseNameCheck { return true }
 
+        /* Ecosia: No build in this fork ever produces Mozilla's bundle IDs, so scoping this to
+        Ecosia's own bundle identifiers also keeps the Sentry option tuning below (sampleRate,
+        session tracking) from ever applying to a non-Ecosia app.
         return AppInfo.bundleIdentifier == "org.mozilla.ios.Firefox"
                 || AppInfo.bundleIdentifier == "org.mozilla.ios.FirefoxBeta"
-                // Ecosia: Allow Ecosia's own bundle identifiers to report to Ecosia's Sentry project.
-                || AppInfo.bundleIdentifier == "com.ecosia.ecosiaapp"
+        */
+        return AppInfo.bundleIdentifier == "com.ecosia.ecosiaapp"
                 || AppInfo.bundleIdentifier == "com.ecosia.ecosiaapp.firefox"
     }
 
@@ -135,6 +138,8 @@ public final class DefaultCrashManager: CrashManager, @unchecked Sendable {
 
         guard shouldSetup,
               sendCrashReports,
+              // Ecosia: lets the app gate every setup() call site on its own rollout flag at once.
+              appInfo.sentryReportingEnabled,
               let dsn = dsnOverride ?? sentryWrapper.dsn else { return }
 
         sentryWrapper.startWithConfigureOptions(configure: { options in

--- a/BrowserKit/Sources/Common/Logger/CrashManager.swift
+++ b/BrowserKit/Sources/Common/Logger/CrashManager.swift
@@ -61,6 +61,9 @@ public final class DefaultCrashManager: CrashManager, @unchecked Sendable {
 
         return AppInfo.bundleIdentifier == "org.mozilla.ios.Firefox"
                 || AppInfo.bundleIdentifier == "org.mozilla.ios.FirefoxBeta"
+                // Ecosia: Allow Ecosia's own bundle identifiers to report to Ecosia's Sentry project.
+                || AppInfo.bundleIdentifier == "com.ecosia.ecosiaapp"
+                || AppInfo.bundleIdentifier == "com.ecosia.ecosiaapp.firefox"
     }
 
     private var environment: Environment {
@@ -69,6 +72,14 @@ public final class DefaultCrashManager: CrashManager, @unchecked Sendable {
             environment = Environment.nightly
         }
         return environment
+    }
+
+    /// Ecosia: Sentry environment tag. Uses `appInfo.environmentName` when the app has provided one
+    /// (Ecosia sets this from its own `Environment.current` at launch, giving lowercase `staging`/
+    /// `production` values matching Ecosia's web projects), falling back to Firefox's own
+    /// Nightly/Production channel naming otherwise.
+    private var environmentTag: String {
+        return appInfo.environmentName ?? environment.rawValue
     }
 
     private var releaseName: String {
@@ -126,7 +137,8 @@ public final class DefaultCrashManager: CrashManager, @unchecked Sendable {
                     $0.lifecycle = .trace
                 }
             }
-            options.environment = self.environment.rawValue
+            // Ecosia: setting correct envitonment tag
+            options.environment = self.environmentTag
             options.releaseName = self.releaseName
             options.enableFileIOTracing = false
             options.enableNetworkTracking = false
@@ -206,6 +218,11 @@ public final class DefaultCrashManager: CrashManager, @unchecked Sendable {
         sentryWrapper.captureMessage(message: message, with: { scope in
             scope.setEnvironment(event.environment)
             scope.setExtras(event.extra)
+            // Ecosia: event.tags (set in makeEvent from the log's category) was built but never
+            // forwarded to Sentry, making category unsearchable in the issue list. Forward it.
+            if let tags = event.tags {
+                scope.setTags(tags)
+            }
         })
     }
 

--- a/BrowserKit/Sources/Common/Logger/CrashManager.swift
+++ b/BrowserKit/Sources/Common/Logger/CrashManager.swift
@@ -130,6 +130,10 @@ public final class DefaultCrashManager: CrashManager, @unchecked Sendable {
 
         sentryWrapper.startWithConfigureOptions(configure: { options in
             options.dsn = dsn
+            // Ecosia: Sample a fraction of events to control volume.
+            options.sampleRate = 0.5
+            // Ecosia: Unused Release Health tracking; avoids a payload per app open.
+            options.enableAutoSessionTracking = false
             if self.shouldEnableTraceProfiling {
                 options.tracesSampleRate = 0.2
                 options.configureProfiling = {

--- a/BrowserKit/Sources/Common/Logger/LoggerCategory.swift
+++ b/BrowserKit/Sources/Common/Logger/LoggerCategory.swift
@@ -23,6 +23,11 @@ public enum LoggerCategory: String {
     /// Related to coordinator navigation
     case coordinator
 
+    // Ecosia: Catch-all for Ecosia-originated errors not covered by another category (e.g. accounts/SSO
+    // failures). Add subsystem detail via the `extra` dict on `Logger.log(...)` rather than adding new
+    // categories per Ecosia feature.
+    case ecosia
+
     /// Related to experiments, nimbus and the messaging framework.
     case experiments
 

--- a/BrowserKit/Tests/CommonTests/LoggerTests/CrashManagerTests.swift
+++ b/BrowserKit/Tests/CommonTests/LoggerTests/CrashManagerTests.swift
@@ -77,6 +77,39 @@ final class CrashManagerTests: XCTestCase {
         XCTAssertEqual(sentryWrapper.configureScopeCalled, 1)
     }
 
+    // Ecosia: DSN precedence and environment tag, see BrowserKitInformation.dsn/environmentName.
+    func testSetup_appInfoDSNSet_prefersAppInfoDSNOverSentryWrapperDSN() {
+        sentryWrapper.dsn = "https://wrapper@o0.ingest.sentry.io/1"
+        setupAppInformation(buildChannel: .other, dsn: "https://appinfo@o0.ingest.sentry.io/2")
+        let subject = DefaultCrashManager(sentryWrapper: sentryWrapper,
+                                          isSimulator: false,
+                                          skipReleaseNameCheck: true)
+        subject.setup(sendCrashReports: true)
+
+        XCTAssertEqual(sentryWrapper.capturedOptions?.dsn, "https://appinfo@o0.ingest.sentry.io/2")
+    }
+
+    func testSetup_appInfoDSNNil_fallsBackToSentryWrapperDSN() {
+        sentryWrapper.dsn = "https://wrapper@o0.ingest.sentry.io/1"
+        let subject = DefaultCrashManager(sentryWrapper: sentryWrapper,
+                                          isSimulator: false,
+                                          skipReleaseNameCheck: true)
+        subject.setup(sendCrashReports: true)
+
+        XCTAssertEqual(sentryWrapper.capturedOptions?.dsn, "https://wrapper@o0.ingest.sentry.io/1")
+    }
+
+    func testSetup_environmentNameSet_usesEnvironmentNameAsEnvironmentTag() {
+        sentryWrapper.dsn = "https://wrapper@o0.ingest.sentry.io/1"
+        setupAppInformation(buildChannel: .other, environmentName: "staging")
+        let subject = DefaultCrashManager(sentryWrapper: sentryWrapper,
+                                          isSimulator: false,
+                                          skipReleaseNameCheck: true)
+        subject.setup(sendCrashReports: true)
+
+        XCTAssertEqual(sentryWrapper.capturedOptions?.environment, "staging")
+    }
+
     // MARK: - crashedLastLaunch
 
     func testCrashedLastLaunch_false() {
@@ -201,10 +234,20 @@ final class CrashManagerTests: XCTestCase {
 
 // MARK: - Helpers
 extension CrashManagerTests {
+    /* Ecosia: added environmentName and dsn params below
     private func setupAppInformation(buildChannel: AppBuildChannel) {
+    */
+    private func setupAppInformation(buildChannel: AppBuildChannel,
+                                     environmentName: String? = nil,
+                                     dsn: String? = nil) {
         BrowserKitInformation.shared.configure(buildChannel: buildChannel,
                                                nightlyAppVersion: "",
+                                               /* Ecosia: added environmentName and dsn args below
                                                sharedContainerIdentifier: "")
+                                               */
+                                               sharedContainerIdentifier: "",
+                                               environmentName: environmentName,
+                                               dsn: dsn)
     }
 }
 
@@ -218,8 +261,14 @@ private final class MockSentryWrapper: SentryWrapper, @unchecked Sendable {
     var dsn: String?
 
     var startWithConfigureOptionsCalled = 0
+    // Ecosia: Capture the configured Options so tests can assert on dsn/environment, not just call count.
+    var capturedOptions: Options?
     func startWithConfigureOptions(configure options: @escaping (Options) -> Void) {
         startWithConfigureOptionsCalled += 1
+        // Ecosia: Invoke the closure against a real Options to capture what was configured.
+        let capturedOptions = Options()
+        options(capturedOptions)
+        self.capturedOptions = capturedOptions
     }
 
     var savedMessage: String?

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -31,6 +31,17 @@ platform :ios do
     setup_circle_ci
   end
 
+  desc "Upload dSYMs from the last build to Sentry"
+  lane :upload_dsym_to_sentry do
+    ensure_env_vars(env_vars: ['SENTRY_AUTH_TOKEN'])
+    dsym_path = lane_context[SharedValues::DSYM_OUTPUT_PATH]
+    sentry_cli = File.expand_path("../firefox-ios/ThirdParty/sentry-cli", __dir__)
+    sh(
+      "#{sentry_cli} --auth-token \"#{ENV['SENTRY_AUTH_TOKEN']}\" upload-dif " \
+      "--org ecosiaorg --project ios-browser \"#{dsym_path}\""
+    )
+  end
+
   desc "Build Ecosia App"
   lane :build_ecosia_app do
     match(
@@ -53,6 +64,8 @@ platform :ios do
       cloned_source_packages_path: "firefox-ios/SourcePackages",
       export_options: {iCloudContainerEnvironment: 'Development'}
     )
+
+    upload_dsym_to_sentry
   end
 
   desc "Upload to Browserstack AppAutomate"
@@ -112,6 +125,7 @@ platform :ios do
       export_method: "app-store",
       configuration: "Development_TestFlight"
     )
+    upload_dsym_to_sentry
     pilot(
       skip_waiting_for_build_processing: true, 
       apple_id: "1541358670",
@@ -153,11 +167,13 @@ platform :ios do
 
     gym(
       scheme: "Ecosia",
-      workspace: workspace_path,      
+      workspace: workspace_path,
       export_method: "app-store",
       configuration: "Release",
       xcargs: testflight_archive_args
     )
+
+    upload_dsym_to_sentry
 
     inject_appstore_connect_api
     

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -35,11 +35,12 @@ platform :ios do
   lane :upload_dsym_to_sentry do
     ensure_env_vars(env_vars: ['SENTRY_AUTH_TOKEN'])
     dsym_path = lane_context[SharedValues::DSYM_OUTPUT_PATH]
+    UI.user_error!("No dSYM path found in DSYM_OUTPUT_PATH — run gym/build_app first") if dsym_path.to_s.empty?
+
     sentry_cli = File.expand_path("../firefox-ios/ThirdParty/sentry-cli", __dir__)
-    sh(
-      "#{sentry_cli} --auth-token \"#{ENV['SENTRY_AUTH_TOKEN']}\" upload-dif " \
-      "--org ecosiaorg --project browser-ios \"#{dsym_path}\""
-    )
+    # sentry-cli reads SENTRY_AUTH_TOKEN from the environment, so it's not passed on the command
+    # line here — that would leak it into CI logs and process listings.
+    sh("#{sentry_cli} upload-dif --org ecosiaorg --project browser-ios \"#{dsym_path}\"")
   end
 
   desc "Build Ecosia App"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -38,7 +38,7 @@ platform :ios do
     sentry_cli = File.expand_path("../firefox-ios/ThirdParty/sentry-cli", __dir__)
     sh(
       "#{sentry_cli} --auth-token \"#{ENV['SENTRY_AUTH_TOKEN']}\" upload-dif " \
-      "--org ecosiaorg --project ios-browser \"#{dsym_path}\""
+      "--org ecosiaorg --project browser-ios \"#{dsym_path}\""
     )
   end
 

--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -76,7 +76,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, FeatureFlaggable {
         // Configure app information for BrowserKit, needed for logger
         BrowserKitInformation.shared.configure(buildChannel: AppConstants.buildChannel,
                                                nightlyAppVersion: AppConstants.nightlyAppVersion,
-                                               sharedContainerIdentifier: AppInfo.sharedContainerIdentifier)
+                                               sharedContainerIdentifier: AppInfo.sharedContainerIdentifier,
+                                               // Ecosia: Tag Sentry events with Ecosia's own staging/production environment.
+                                               environmentName: EcosiaEnvironment.current.sentryTag)
         // Ecosia: Register URLProvider domains that need Ecosia's desktop UA.
         UserAgent.configureEcosiaDesktopUserAgentDomains([
             URLProvider.production.domain,

--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -74,11 +74,22 @@ class AppDelegate: UIResponder, UIApplicationDelegate, FeatureFlaggable {
 
         startRecordingStartupOpenURLTime()
         // Configure app information for BrowserKit, needed for logger
+        /* Ecosia: added environmentName and dsn args below, turning this call's trailing ")"
+        into ","
+        BrowserKitInformation.shared.configure(buildChannel: AppConstants.buildChannel,
+                                               nightlyAppVersion: AppConstants.nightlyAppVersion,
+                                               sharedContainerIdentifier: AppInfo.sharedContainerIdentifier)
+        */
         BrowserKitInformation.shared.configure(buildChannel: AppConstants.buildChannel,
                                                nightlyAppVersion: AppConstants.nightlyAppVersion,
                                                sharedContainerIdentifier: AppInfo.sharedContainerIdentifier,
                                                // Ecosia: Tag Sentry events with Ecosia's own staging/production environment.
-                                               environmentName: EcosiaEnvironment.current.sentryTag)
+                                               environmentName: EcosiaEnvironment.current.sentryTag,
+                                               // Ecosia: Only supply a DSN for beta/release builds, so local Debug/Testing
+                                               // builds never report to Sentry at all — same intent the CHANNEL xcconfig
+                                               // entries already express for those configs.
+                                               dsn: [.beta, .release].contains(AppConstants.buildChannel)
+                                                   ? EcosiaEnvironment.current.urlProvider.sentryDSN : nil)
         // Ecosia: Register URLProvider domains that need Ecosia's desktop UA.
         UserAgent.configureEcosiaDesktopUserAgentDomains([
             URLProvider.production.domain,

--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -224,6 +224,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, FeatureFlaggable {
             AppEventQueue.signal(event: .featureManagementInitialized)
             // Ecosia: Braze Service Initialization after feature flags are fetched for conditional initialization
             BrazeService.shared.initialize()
+            // Ecosia: Sentry setup is gated by Unleash, so it only runs once this fetch resolves.
+            appLaunchUtil?.setUpCrashReportingIfEnabled()
             // Ecosia: Lifecycle tracking. Needs to happen after Unleash start so that the flags are correctly added to the analytics context.
             ecosiaTrackLaunchActivity()
         }
@@ -342,6 +344,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, FeatureFlaggable {
         Task {
             await FeatureManagement.fetchConfiguration()
             Analytics.shared.activity(.resume)
+            // Ecosia: Also re-check here — Sentry setup is a no-op once already enabled, so this just
+            // catches the case where it wasn't enabled yet at launch (e.g. flag flipped ON since).
+            appLaunchUtil?.setUpCrashReportingIfEnabled()
         }
         MMP.sendSession()
         searchesCounter.subscribe(self) { searchCount in

--- a/firefox-ios/Client/Application/AppDelegate.swift
+++ b/firefox-ios/Client/Application/AppDelegate.swift
@@ -74,14 +74,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, FeatureFlaggable {
 
         startRecordingStartupOpenURLTime()
         // Configure app information for BrowserKit, needed for logger
-        /* Ecosia: added environmentName and dsn args below, turning this call's trailing ")"
-        into ","
         BrowserKitInformation.shared.configure(buildChannel: AppConstants.buildChannel,
                                                nightlyAppVersion: AppConstants.nightlyAppVersion,
+                                               /* Ecosia: added environmentName and dsn args below
                                                sharedContainerIdentifier: AppInfo.sharedContainerIdentifier)
-        */
-        BrowserKitInformation.shared.configure(buildChannel: AppConstants.buildChannel,
-                                               nightlyAppVersion: AppConstants.nightlyAppVersion,
+                                                */
                                                sharedContainerIdentifier: AppInfo.sharedContainerIdentifier,
                                                // Ecosia: Tag Sentry events with Ecosia's own staging/production environment.
                                                environmentName: EcosiaEnvironment.current.sentryTag,

--- a/firefox-ios/Client/Application/AppLaunchUtil.swift
+++ b/firefox-ios/Client/Application/AppLaunchUtil.swift
@@ -44,19 +44,11 @@ final class AppLaunchUtil: Sendable {
             #endif
         }
 
-        /* Ecosia: Sentry setup moved out of this early, synchronous path in all 3 places it's called
-        below — it's now gated by the mob_ios_sentry_reporting Unleash flag and only runs from
-        setUpCrashReportingIfEnabled(), called after FeatureManagement.fetchConfiguration() resolves
-        (see AppDelegate). We accept no crash coverage for the brief window before that resolves, in
-        exchange for a single decision point instead of persisting Unleash state across launches.
         // Need to get "settings.sendCrashReports" this way so that Sentry can be initialized before getting the Profile.
         let sendCrashReports = NSUserDefaultsPrefs(prefix: "profile").boolForKey(AppConstants.prefSendCrashReports) ?? true
-        */
 
         if termsOfServiceManager.isAffectedUser {
-            /* Ecosia: Sentry setup moved out — see note above.
             logger.setup(sendCrashReports: sendCrashReports)
-            */
             TelemetryWrapper.shared.setup(profile: profile)
             TelemetryWrapper.shared.recordStartUpTelemetry()
         }
@@ -66,9 +58,7 @@ final class AppLaunchUtil: Sendable {
             // 1. when ToS screen has been presented and user accepted it
             // 2. or when ToS screen is not presented because is not fresh install
             let isTermsOfServiceAccepted = termsOfServiceManager.isAccepted || !introScreenManager.shouldShowIntroScreen
-            /* Ecosia: Sentry setup moved out — see note above.
             logger.setup(sendCrashReports: sendCrashReports && isTermsOfServiceAccepted)
-            */
             if isTermsOfServiceAccepted {
                 TelemetryWrapper.shared.setup(profile: profile)
                 TelemetryWrapper.shared.recordStartUpTelemetry()
@@ -78,9 +68,7 @@ final class AppLaunchUtil: Sendable {
                 TelemetryContextualIdentifier.setupContextId(isGleanMetricsAllowed: false)
             }
         } else {
-            /* Ecosia: Sentry setup moved out — see note above.
             logger.setup(sendCrashReports: sendCrashReports)
-            */
             TelemetryWrapper.shared.setup(profile: profile)
             TelemetryWrapper.shared.recordStartUpTelemetry()
         }
@@ -165,13 +153,13 @@ final class AppLaunchUtil: Sendable {
         }
     }
 
-    // Ecosia: Starts Sentry once the `mob_ios_sentry_reporting` Unleash flag is known — called from
-    // AppDelegate after `FeatureManagement.fetchConfiguration()` resolves (both at launch and on
-    // foreground refresh). `logger.setup` is safe to call more than once; `CrashManager` no-ops once
-    // already enabled. Skips replicating the (expired, FXIOS-12249) `isAffectedUser` migration-cohort
-    // exception from the original logic this replaced.
+    // Ecosia: Refreshes BrowserKitInformation's Sentry rollout flag once the `mob_ios_sentry_reporting`
+    // Unleash flag is known — called from AppDelegate after `FeatureManagement.fetchConfiguration()`
+    // resolves (both at launch and on foreground refresh). `logger.setup` is safe to call more than
+    // once; `CrashManager` checks the flag itself, covering every call site, and no-ops once already
+    // enabled.
     func setUpCrashReportingIfEnabled() {
-        guard SentryReportingExperiment.isEnabled else { return }
+        BrowserKitInformation.shared.sentryReportingEnabled = SentryReportingExperiment.isEnabled
 
         let sendCrashReports = NSUserDefaultsPrefs(prefix: "profile").boolForKey(AppConstants.prefSendCrashReports) ?? true
         if termsOfServiceManager.isFeatureEnabled {

--- a/firefox-ios/Client/Application/AppLaunchUtil.swift
+++ b/firefox-ios/Client/Application/AppLaunchUtil.swift
@@ -8,6 +8,7 @@ import Shared
 import Account
 import Glean
 import MozillaAppServices
+import Ecosia
 
 final class AppLaunchUtil: Sendable {
     private let logger: Logger
@@ -43,11 +44,19 @@ final class AppLaunchUtil: Sendable {
             #endif
         }
 
+        /* Ecosia: Sentry setup moved out of this early, synchronous path in all 3 places it's called
+        below — it's now gated by the mob_ios_sentry_reporting Unleash flag and only runs from
+        setUpCrashReportingIfEnabled(), called after FeatureManagement.fetchConfiguration() resolves
+        (see AppDelegate). We accept no crash coverage for the brief window before that resolves, in
+        exchange for a single decision point instead of persisting Unleash state across launches.
         // Need to get "settings.sendCrashReports" this way so that Sentry can be initialized before getting the Profile.
         let sendCrashReports = NSUserDefaultsPrefs(prefix: "profile").boolForKey(AppConstants.prefSendCrashReports) ?? true
+        */
 
         if termsOfServiceManager.isAffectedUser {
+            /* Ecosia: Sentry setup moved out — see note above.
             logger.setup(sendCrashReports: sendCrashReports)
+            */
             TelemetryWrapper.shared.setup(profile: profile)
             TelemetryWrapper.shared.recordStartUpTelemetry()
         }
@@ -57,7 +66,9 @@ final class AppLaunchUtil: Sendable {
             // 1. when ToS screen has been presented and user accepted it
             // 2. or when ToS screen is not presented because is not fresh install
             let isTermsOfServiceAccepted = termsOfServiceManager.isAccepted || !introScreenManager.shouldShowIntroScreen
+            /* Ecosia: Sentry setup moved out — see note above.
             logger.setup(sendCrashReports: sendCrashReports && isTermsOfServiceAccepted)
+            */
             if isTermsOfServiceAccepted {
                 TelemetryWrapper.shared.setup(profile: profile)
                 TelemetryWrapper.shared.recordStartUpTelemetry()
@@ -67,7 +78,9 @@ final class AppLaunchUtil: Sendable {
                 TelemetryContextualIdentifier.setupContextId(isGleanMetricsAllowed: false)
             }
         } else {
+            /* Ecosia: Sentry setup moved out — see note above.
             logger.setup(sendCrashReports: sendCrashReports)
+            */
             TelemetryWrapper.shared.setup(profile: profile)
             TelemetryWrapper.shared.recordStartUpTelemetry()
         }
@@ -149,6 +162,23 @@ final class AppLaunchUtil: Sendable {
             #if canImport(FoundationModels)
                 AppleIntelligenceUtil().processAvailabilityState()
             #endif
+        }
+    }
+
+    // Ecosia: Starts Sentry once the `mob_ios_sentry_reporting` Unleash flag is known — called from
+    // AppDelegate after `FeatureManagement.fetchConfiguration()` resolves (both at launch and on
+    // foreground refresh). `logger.setup` is safe to call more than once; `CrashManager` no-ops once
+    // already enabled. Skips replicating the (expired, FXIOS-12249) `isAffectedUser` migration-cohort
+    // exception from the original logic this replaced.
+    func setUpCrashReportingIfEnabled() {
+        guard SentryReportingExperiment.isEnabled else { return }
+
+        let sendCrashReports = NSUserDefaultsPrefs(prefix: "profile").boolForKey(AppConstants.prefSendCrashReports) ?? true
+        if termsOfServiceManager.isFeatureEnabled {
+            let isTermsOfServiceAccepted = termsOfServiceManager.isAccepted || !introScreenManager.shouldShowIntroScreen
+            logger.setup(sendCrashReports: sendCrashReports && isTermsOfServiceAccepted)
+        } else {
+            logger.setup(sendCrashReports: sendCrashReports)
         }
     }
 

--- a/firefox-ios/Client/Ecosia/BuildSettingsConfigurations/Ecosia.xcconfig
+++ b/firefox-ios/Client/Ecosia/BuildSettingsConfigurations/Ecosia.xcconfig
@@ -11,3 +11,6 @@ MOZ_BUNDLE_ID = com.ecosia.ecosiaapp
 CODE_SIGN_ENTITLEMENTS = Ecosia/Entitlements/Ecosia.entitlements
 OTHER_SWIFT_FLAGS = $(OTHER_SWIFT_FLAGS_common) -DMOZ_CHANNEL_RELEASE
 OTHER_LDFLAGS = $(inherited) -ld_classic
+
+// Build channel drives AppConstants.buildChannel (MetricKit, app-hang tracking, Sentry send-gating).
+CHANNEL = release

--- a/firefox-ios/Client/Ecosia/BuildSettingsConfigurations/EcosiaBeta.xcconfig
+++ b/firefox-ios/Client/Ecosia/BuildSettingsConfigurations/EcosiaBeta.xcconfig
@@ -13,3 +13,6 @@ MOZ_BUNDLE_ID = com.ecosia.ecosiaapp.firefox
 CODE_SIGN_ENTITLEMENTS = Ecosia/Entitlements/EcosiaBeta.entitlements
 OTHER_SWIFT_FLAGS = $(OTHER_SWIFT_FLAGS_common) -DMOZ_CHANNEL_BETA
 OTHER_LDFLAGS = $(inherited) -ld_classic
+
+// Build channel drives AppConstants.buildChannel (MetricKit, app-hang tracking, Sentry send-gating).
+CHANNEL = beta

--- a/firefox-ios/Client/Ecosia/BuildSettingsConfigurations/EcosiaBetaDebug.xcconfig
+++ b/firefox-ios/Client/Ecosia/BuildSettingsConfigurations/EcosiaBetaDebug.xcconfig
@@ -16,3 +16,6 @@ LEANPLUM_ENVIRONMENT = development
 CODE_SIGN_ENTITLEMENTS = Ecosia/Entitlements/EcosiaBeta.entitlements
 OTHER_SWIFT_FLAGS = $(OTHER_SWIFT_FLAGS_common) -DMOZ_CHANNEL_FENNEC
 OTHER_LDFLAGS = -ObjC -lxml2 -fprofile-instr-generate -ld_classic
+
+// Ecosia: For completeness — AppBuildChannel has no "debug" case, so this still resolves to .other.
+CHANNEL = debug

--- a/firefox-ios/Client/Ecosia/BuildSettingsConfigurations/EcosiaDebug.xcconfig
+++ b/firefox-ios/Client/Ecosia/BuildSettingsConfigurations/EcosiaDebug.xcconfig
@@ -18,3 +18,6 @@ CODE_SIGN_ENTITLEMENTS = Ecosia/Entitlements/Ecosia.entitlements
 OTHER_SWIFT_FLAGS = $(OTHER_SWIFT_FLAGS_common) -DMOZ_CHANNEL_FENNEC
 OTHER_LDFLAGS = -ObjC -lxml2 -fprofile-instr-generate -ld_classic
 AUTH0_CLIENT_ID=FBaIsy0X5hIh2sSmalmf5pACZ512dIYl
+
+// Ecosia: For completeness — AppBuildChannel has no "debug" case, so this still resolves to .other.
+CHANNEL = debug

--- a/firefox-ios/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
@@ -64,6 +64,7 @@ extension AppSettingsTableViewController {
         var hiddenDebugSettings: [Setting] = [
             ExportBrowserDataSetting(settings: self),
             ForceCrashSetting(settings: self),
+            EcosiaLoggerForceErrorSetting(settings: self),
             PushBackInstallation(settings: self),
             OpenFiftyTabsDebugOption(settings: self, settingsDelegate: self),
             ToggleDefaultBrowserPromo(settings: self),

--- a/firefox-ios/Client/Ecosia/Settings/EcosiaDebugSettings.swift
+++ b/firefox-ios/Client/Ecosia/Settings/EcosiaDebugSettings.swift
@@ -22,7 +22,7 @@ final class EcosiaLoggerForceErrorSetting: HiddenSetting {
         EcosiaLogger.general.sentry("Ecosia debug: non-crashing test event")
 
         let alert = AlertController(title: "Sent ✅",
-                                    message: "Check the Xcode console for [Sentry] logs and the dashboard in a minute.",
+                                    message: "Check the Sentry dashboard in a minute.",
                                     preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "OK", style: .default))
         navigationController?.topViewController?.present(alert, animated: true)

--- a/firefox-ios/Client/Ecosia/Settings/EcosiaDebugSettings.swift
+++ b/firefox-ios/Client/Ecosia/Settings/EcosiaDebugSettings.swift
@@ -8,6 +8,27 @@ import Shared
 import Common
 import Ecosia
 
+// MARK: - Sentry Debug Settings
+
+/// Sends a message through `EcosiaLogger.general.sentry(...)` without crashing — this logs locally like
+/// `.error` AND forwards to Sentry via `DefaultLogger`/`CrashManager` in one call. Useful to confirm the
+/// DSN/network path works without the crash+relaunch round trip.
+final class EcosiaLoggerForceErrorSetting: HiddenSetting {
+    override var title: NSAttributedString? {
+        return NSAttributedString(string: "Debug: Send Non-Crashing Error to Sentry", attributes: [:])
+    }
+
+    override func onClick(_ navigationController: UINavigationController?) {
+        EcosiaLogger.general.sentry("Ecosia debug: non-crashing test event")
+
+        let alert = AlertController(title: "Sent ✅",
+                                    message: "Check the Xcode console for [Sentry] logs and the dashboard in a minute.",
+                                    preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        navigationController?.topViewController?.present(alert, animated: true)
+    }
+}
+
 final class PushBackInstallation: HiddenSetting {
     override var title: NSAttributedString? {
         return NSAttributedString(string: "Debug: Push back installation by 3 days (needs restart).", attributes: [:])

--- a/firefox-ios/Client/Info.plist
+++ b/firefox-ios/Client/Info.plist
@@ -120,6 +120,9 @@
 	<string>$(NIMBUS_URL)</string>
 	<key>PocketEnvironmentAPIKey</key>
 	<string>$(POCKET_API_KEY)</string>
+	<!-- Ecosia: Feeds AppConstants.buildChannel, gating Sentry send/breadcrumb behavior for beta vs release builds. -->
+	<key>CHANNEL</key>
+	<string>$(CHANNEL)</string>
 	<key>SentryCloudDSN</key>
 	<string>$(SENTRY_CLOUD_DSN)</string>
 	<key>UIAppFonts</key>

--- a/firefox-ios/Ecosia/Core/EcosiaLogger.swift
+++ b/firefox-ios/Ecosia/Core/EcosiaLogger.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Foundation
+import Common
 
 /// Ecosia-specific logging levels following established patterns
 public enum LogLevel {
@@ -10,6 +11,10 @@ public enum LogLevel {
     case info
     case warning
     case error
+    /// Same local console output as `.error`, plus forwards to Sentry via `DefaultLogger`
+    /// (category `.ecosia`). Reserve for failures worth visibility outside a live console
+    /// session — not every `.error` call needs this.
+    case sentry
 }
 
 /// Protocol for category-specific logging with default implementations
@@ -32,6 +37,12 @@ public extension EcosiaLoggerCategory {
 
     static func error(_ message: String) {
         EcosiaLogger.error("\(prefix) \(message)")
+    }
+
+    /// Logs locally like `.error` AND forwards to Sentry. Use for real failures worth visibility
+    /// outside a live console session — not every `.error` call needs this.
+    static func sentry(_ message: String, error: Error? = nil) {
+        EcosiaLogger.sentry("\(prefix) \(message)", error: error, subsystem: prefix)
     }
 }
 
@@ -78,6 +89,21 @@ public enum EcosiaLogger {
         print("[\(timestamp)] \(prefix): ❌ [ERROR] \(message)")
     }
 
+    /// Log an error message locally AND forward it to Sentry via `DefaultLogger` (category
+    /// `.ecosia`). `error`/`subsystem` populate the Sentry event's `extra` fields.
+    public static func sentry(_ message: String, error: Error? = nil, subsystem: String? = nil) {
+        print("[\(timestamp)] \(prefix): 📡 [SENTRY] \(message)")
+
+        var extra: [String: String] = [:]
+        if let subsystem { extra["subsystem"] = subsystem }
+        if let error { extra["error"] = error.localizedDescription }
+
+        DefaultLogger.shared.log(message,
+                                 level: .fatal,
+                                 category: .ecosia,
+                                 extra: extra.isEmpty ? nil : extra)
+    }
+
     /// Generic log method with level
     public static func log(_ message: String, level: LogLevel) {
         switch level {
@@ -89,6 +115,8 @@ public enum EcosiaLogger {
             warning(message)
         case .error:
             error(message)
+        case .sentry:
+            sentry(message)
         }
     }
 

--- a/firefox-ios/Ecosia/Core/EcosiaLogger.swift
+++ b/firefox-ios/Ecosia/Core/EcosiaLogger.swift
@@ -12,8 +12,10 @@ public enum LogLevel {
     case warning
     case error
     /// Same local console output as `.error`, plus forwards to Sentry via `DefaultLogger`
-    /// (category `.ecosia`). Reserve for failures worth visibility outside a live console
-    /// session — not every `.error` call needs this.
+    /// (category `.ecosia`). Forwarded at BrowserKit's `.fatal` level, not `.error` — that's not a
+    /// severity statement, it's required so `CrashManager.shouldSendEventFor` actually sends it as a
+    /// Sentry event instead of only a breadcrumb. Reserve for failures worth visibility outside a
+    /// live console session — not every `.error` call needs this.
     case sentry
 }
 
@@ -39,9 +41,9 @@ public extension EcosiaLoggerCategory {
         EcosiaLogger.error("\(prefix) \(message)")
     }
 
-    /// Logs locally like `.error` AND forwards to Sentry. Use for real failures worth visibility
-    /// outside a live console session — not every `.error` call needs this. Interpolate the error
-    /// into `message` yourself, same as `.error(...)` elsewhere in this file.
+    /// Logs locally like `.error` AND forwards to Sentry (see `LogLevel.sentry`). Use for real
+    /// failures worth visibility outside a live console session — not every `.error` call needs
+    /// this. Interpolate the error into `message` yourself, same as `.error(...)` elsewhere in this file.
     static func sentry(_ message: String) {
         EcosiaLogger.sentry("\(prefix) \(message)")
     }
@@ -90,7 +92,8 @@ public enum EcosiaLogger {
         print("[\(timestamp)] \(prefix): ❌ [ERROR] \(message)")
     }
 
-    /// Log an error message locally AND forward it to Sentry via `DefaultLogger` (category `.ecosia`).
+    /// Log an error message locally AND forward it to Sentry via `DefaultLogger` (category `.ecosia`,
+    /// level `.fatal` — see `LogLevel.sentry` for why).
     public static func sentry(_ message: String) {
         print("[\(timestamp)] \(prefix): 📡 [SENTRY] \(message)")
         DefaultLogger.shared.log(message, level: .fatal, category: .ecosia)

--- a/firefox-ios/Ecosia/Core/EcosiaLogger.swift
+++ b/firefox-ios/Ecosia/Core/EcosiaLogger.swift
@@ -11,12 +11,6 @@ public enum LogLevel {
     case info
     case warning
     case error
-    /// Same local console output as `.error`, plus forwards to Sentry via `DefaultLogger`
-    /// (category `.ecosia`). Forwarded at BrowserKit's `.fatal` level, not `.error` — that's not a
-    /// severity statement, it's required so `CrashManager.shouldSendEventFor` actually sends it as a
-    /// Sentry event instead of only a breadcrumb. Reserve for failures worth visibility outside a
-    /// live console session — not every `.error` call needs this.
-    case sentry
 }
 
 /// Protocol for category-specific logging with default implementations
@@ -41,8 +35,8 @@ public extension EcosiaLoggerCategory {
         EcosiaLogger.error("\(prefix) \(message)")
     }
 
-    /// Logs locally like `.error` AND forwards to Sentry (see `LogLevel.sentry`). Use for real
-    /// failures worth visibility outside a live console session — not every `.error` call needs
+    /// Logs locally like `.error` AND forwards to Sentry (see `EcosiaLogger.sentry(_:)`). Use for
+    /// real failures worth visibility outside a live console session — not every `.error` call needs
     /// this. Interpolate the error into `message` yourself, same as `.error(...)` elsewhere in this file.
     static func sentry(_ message: String) {
         EcosiaLogger.sentry("\(prefix) \(message)")
@@ -92,8 +86,12 @@ public enum EcosiaLogger {
         print("[\(timestamp)] \(prefix): ❌ [ERROR] \(message)")
     }
 
-    /// Log an error message locally AND forward it to Sentry via `DefaultLogger` (category `.ecosia`,
-    /// level `.fatal` — see `LogLevel.sentry` for why).
+    /// Log an error message locally like `.error`, AND forward it to Sentry via `DefaultLogger`
+    /// (category `.ecosia`). Forwarded at BrowserKit's `.fatal` level, not `.error` — that's not a
+    /// severity statement, it's required so `CrashManager.shouldSendEventFor` actually sends it as a
+    /// Sentry event instead of only a breadcrumb. Reserve for failures worth visibility outside a
+    /// live console session — not every `.error` call needs this. Not part of `LogLevel`/`log(_:level:)`
+    /// since it's a routing decision (also forward to Sentry), not a severity.
     public static func sentry(_ message: String) {
         print("[\(timestamp)] \(prefix): 📡 [SENTRY] \(message)")
         DefaultLogger.shared.log(message, level: .fatal, category: .ecosia)
@@ -110,8 +108,6 @@ public enum EcosiaLogger {
             warning(message)
         case .error:
             error(message)
-        case .sentry:
-            sentry(message)
         }
     }
 

--- a/firefox-ios/Ecosia/Core/EcosiaLogger.swift
+++ b/firefox-ios/Ecosia/Core/EcosiaLogger.swift
@@ -40,9 +40,10 @@ public extension EcosiaLoggerCategory {
     }
 
     /// Logs locally like `.error` AND forwards to Sentry. Use for real failures worth visibility
-    /// outside a live console session — not every `.error` call needs this.
-    static func sentry(_ message: String, error: Error? = nil) {
-        EcosiaLogger.sentry("\(prefix) \(message)", error: error, subsystem: prefix)
+    /// outside a live console session — not every `.error` call needs this. Interpolate the error
+    /// into `message` yourself, same as `.error(...)` elsewhere in this file.
+    static func sentry(_ message: String) {
+        EcosiaLogger.sentry("\(prefix) \(message)")
     }
 }
 
@@ -89,19 +90,10 @@ public enum EcosiaLogger {
         print("[\(timestamp)] \(prefix): ❌ [ERROR] \(message)")
     }
 
-    /// Log an error message locally AND forward it to Sentry via `DefaultLogger` (category
-    /// `.ecosia`). `error`/`subsystem` populate the Sentry event's `extra` fields.
-    public static func sentry(_ message: String, error: Error? = nil, subsystem: String? = nil) {
+    /// Log an error message locally AND forward it to Sentry via `DefaultLogger` (category `.ecosia`).
+    public static func sentry(_ message: String) {
         print("[\(timestamp)] \(prefix): 📡 [SENTRY] \(message)")
-
-        var extra: [String: String] = [:]
-        if let subsystem { extra["subsystem"] = subsystem }
-        if let error { extra["error"] = error.localizedDescription }
-
-        DefaultLogger.shared.log(message,
-                                 level: .fatal,
-                                 category: .ecosia,
-                                 extra: extra.isEmpty ? nil : extra)
+        DefaultLogger.shared.log(message, level: .fatal, category: .ecosia)
     }
 
     /// Generic log method with level

--- a/firefox-ios/Ecosia/Core/Environment/Environment.swift
+++ b/firefox-ios/Ecosia/Core/Environment/Environment.swift
@@ -49,3 +49,20 @@ extension Environment {
         }
     }
 }
+
+extension Environment {
+
+    /// Sentry environment tag for this build, matching the lowercase `staging`/`production` naming
+    /// Ecosia's web projects use (see `common/js/universal/src/ecosia-env.js` in the `core` repo).
+    /// Threaded into BrowserKit's `CrashManager` via `BrowserKitInformation.environmentName`.
+    public var sentryTag: String {
+        switch self {
+        case .production:
+            return "production"
+        case .staging:
+            return "staging"
+        case .debug:
+            return "debug"
+        }
+    }
+}

--- a/firefox-ios/Ecosia/Core/Environment/Environment.swift
+++ b/firefox-ios/Ecosia/Core/Environment/Environment.swift
@@ -52,8 +52,7 @@ extension Environment {
 
 extension Environment {
 
-    /// Sentry environment tag for this build, matching the lowercase `staging`/`production` naming
-    /// Ecosia's web projects use (see `common/js/universal/src/ecosia-env.js` in the `core` repo).
+    /// Sentry environment tag for this build.
     /// Threaded into BrowserKit's `CrashManager` via `BrowserKitInformation.environmentName`.
     public var sentryTag: String {
         switch self {

--- a/firefox-ios/Ecosia/Core/Environment/URLProvider.swift
+++ b/firefox-ios/Ecosia/Core/Environment/URLProvider.swift
@@ -65,6 +65,12 @@ public enum URLProvider {
         "sdk.fra-02.braze.eu"
     }
 
+    /// Sentry DSN for the "ios-browser" project under the ecosiaorg org — same for every environment;
+    /// `CrashManager`'s own environment tag distinguishes staging/production, not a separate DSN.
+    public var sentryDSN: String {
+        "https://cc2ce4301c3eb148cdad9812d61e6e09@o28395.ingest.us.sentry.io/4511830051651585"
+    }
+
     public var statistics: URL {
         URL(string: "https://d2wfixp891z15b.cloudfront.net")!
     }

--- a/firefox-ios/Ecosia/FeatureManagement/Unleash/Experiments/SentryReportingExperiment.swift
+++ b/firefox-ios/Ecosia/FeatureManagement/Unleash/Experiments/SentryReportingExperiment.swift
@@ -4,12 +4,8 @@
 
 import Foundation
 
-/// Gates Sentry crash reporting, for a gradual/budget-controlled rollout. Note: Unleash's own fetch
-/// happens asynchronously later in app launch than Sentry's original setup call site, so Sentry setup
-/// is deferred entirely to `AppLaunchUtil.setUpCrashReportingIfEnabled()`, called from `AppDelegate`
-/// after `FeatureManagement.fetchConfiguration()` resolves.
-/// `public` — unlike the other `Experiment` types here, this one is read from `AppLaunchUtil` in the
-/// `Client` target (a different module), not just from within `Ecosia` itself.
+/// Gates Sentry crash reporting for a gradual rollout. `public` since it's read from `AppLaunchUtil`
+/// in the `Client` target, not just within `Ecosia`.
 public struct SentryReportingExperiment {
 
     private init() {}

--- a/firefox-ios/Ecosia/FeatureManagement/Unleash/Experiments/SentryReportingExperiment.swift
+++ b/firefox-ios/Ecosia/FeatureManagement/Unleash/Experiments/SentryReportingExperiment.swift
@@ -1,0 +1,20 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// Gates Sentry crash reporting, for a gradual/budget-controlled rollout. Note: Unleash's own fetch
+/// happens asynchronously later in app launch than Sentry's original setup call site, so Sentry setup
+/// is deferred entirely to `AppLaunchUtil.setUpCrashReportingIfEnabled()`, called from `AppDelegate`
+/// after `FeatureManagement.fetchConfiguration()` resolves.
+/// `public` — unlike the other `Experiment` types here, this one is read from `AppLaunchUtil` in the
+/// `Client` target (a different module), not just from within `Ecosia` itself.
+public struct SentryReportingExperiment {
+
+    private init() {}
+
+    public static var isEnabled: Bool {
+        Unleash.isEnabled(.sentryReporting)
+    }
+}

--- a/firefox-ios/Ecosia/FeatureManagement/Unleash/Experiments/SentryReportingExperiment.swift
+++ b/firefox-ios/Ecosia/FeatureManagement/Unleash/Experiments/SentryReportingExperiment.swift
@@ -2,8 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import Foundation
-
 /// Gates Sentry crash reporting for a gradual rollout. `public` since it's read from `AppLaunchUtil`
 /// in the `Client` target, not just within `Ecosia`.
 public struct SentryReportingExperiment {

--- a/firefox-ios/Ecosia/FeatureManagement/Unleash/Unleash.Model.swift
+++ b/firefox-ios/Ecosia/FeatureManagement/Unleash/Unleash.Model.swift
@@ -28,6 +28,7 @@ extension Unleash {
             case newsletterCard = "mob_ios_newsletter_card"
             case fileUpload = "mob_ios_file_upload"
             case chatModes = "mob_ios_chat_modes"
+            case sentryReporting = "mob_ios_sentry_reporting"
         }
 
         public let name: String


### PR DESCRIPTION
[MOB-4603]

## Context

See ticket.

## Approach

Re-use Firefox integration and adjust for Ecosia.

Successfully confirmed that errors generated by the Firebase build [appear on Sentry dashboard](https://ecosiaorg.sentry.io/explore/errors/homepage/?dataset=errors&field=title&field=project&field=user.display&field=timestamp&name=All%20Errors&project=4511830051651585&query=&queryDataset=error-events&sort=-timestamp&statsPeriod=30d&yAxis=count%28%29) 🎉 

## Other

Noticed the test I adjusted doesn't run on ci, follow-up on [MOB-4844](https://ecosia.atlassian.net/browse/MOB-4844)

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [ ] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4603]: https://ecosia.atlassian.net/browse/MOB-4603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MOB-4844]: https://ecosia.atlassian.net/browse/MOB-4844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ