### PR TITLE
[MOB-4820] Add accessibility identifiers for automated tests

### DIFF
--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxAttachmentTileView.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxAttachmentTileView.swift
@@ -117,6 +117,7 @@ final class OmniboxAttachmentTileView: UIView, ThemeApplicable {
         removeButtonContainer.addSubviews(removeGlassBlur, removeGlassTint, removeIconView)
         removeButton.accessibilityLabel = String.localized(.cancel)
         removeButton.addTarget(self, action: #selector(removeTapped), for: .touchUpInside)
+        configureAccessibility()
 
         widthConstraint = widthAnchor.constraint(equalToConstant: UX.fileSize.width)
         heightConstraint = heightAnchor.constraint(equalToConstant: UX.fileSize.height)
@@ -191,6 +192,29 @@ final class OmniboxAttachmentTileView: UIView, ThemeApplicable {
             widthConstraint,
             heightConstraint
         ].compactMap { $0 })
+    }
+
+    /// Identifiers for the tile and its state-bearing subviews. The spinner and the
+    /// preview image are otherwise invisible to UI automation: a plain `UIView` and a
+    /// `UIImageView` are not accessibility elements by default, so neither would appear
+    /// in the query tree. Promoting them also gives VoiceOver something to announce for
+    /// an upload that is still in flight.
+    private func configureAccessibility() {
+        accessibilityIdentifier = EcosiaAccessibilityIdentifiers.OmniboxUpload.attachmentTile
+
+        loader.accessibilityIdentifier = EcosiaAccessibilityIdentifiers.OmniboxUpload.attachmentSpinner
+        loader.isAccessibilityElement = true
+        loader.accessibilityLabel = String.localized(.uploadAttachmentUploadingAccessibilityLabel)
+        loader.accessibilityTraits = .updatesFrequently
+
+        imageView.accessibilityIdentifier = EcosiaAccessibilityIdentifiers.OmniboxUpload.attachmentImage
+        imageView.isAccessibilityElement = true
+        imageView.accessibilityLabel = String.localized(.uploadAttachmentImageAccessibilityLabel)
+        imageView.accessibilityTraits = .image
+
+        fileNameLabel.accessibilityIdentifier = EcosiaAccessibilityIdentifiers.OmniboxUpload.attachmentFileName
+        fileSizeLabel.accessibilityIdentifier = EcosiaAccessibilityIdentifiers.OmniboxUpload.attachmentFileSize
+        removeButton.accessibilityIdentifier = EcosiaAccessibilityIdentifiers.OmniboxUpload.attachmentRemoveButton
     }
 
     func configure(attachment: OmniboxAttachment, previewImage: UIImage?) {

--- a/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxAttachmentsStripView.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/SearchBar/Upload/OmniboxAttachmentsStripView.swift
@@ -50,6 +50,7 @@ final class OmniboxAttachmentsStripView: UIView, ThemeApplicable, UIScrollViewDe
 
     private func setup() {
         clipsToBounds = true
+        accessibilityIdentifier = EcosiaAccessibilityIdentifiers.OmniboxUpload.attachmentsStrip
         addSubview(scrollView)
         scrollView.delegate = self
         scrollView.addSubview(stackView)

--- a/firefox-ios/Ecosia/L10N/String.swift
+++ b/firefox-ios/Ecosia/L10N/String.swift
@@ -321,6 +321,8 @@ extension String {
 
         // Omnibox file upload (attachment strip)
         case uploadAttachmentFailed = "Upload failed"
+        case uploadAttachmentUploadingAccessibilityLabel = "Uploading attachment"
+        case uploadAttachmentImageAccessibilityLabel = "Attached image"
         case uploadSubmitWaitingForUpload = "Waiting for the attachment to finish uploading"
         case uploadSubmitUploadFailed = "Remove the failed attachment or try uploading again"
         case chatModeChipRemoveAccessibilityLabel = "Remove chat mode"

--- a/firefox-ios/Ecosia/L10N/en.lproj/Ecosia.strings
+++ b/firefox-ios/Ecosia/L10N/en.lproj/Ecosia.strings
@@ -337,3 +337,7 @@
 "Real change\nat your fingertips" = "Real change\nat your fingertips";
 "Join 20 million people making a difference every day" = "Join 20 million people making a difference every day";
 "Next" = "Next";
+
+// Accessiblity Strings for File Uploads
+"Uploading attachment" = "Uploading attachment";
+"Attached image" = "Attached image";

--- a/firefox-ios/Ecosia/UI/Components/EcosiaErrorView.swift
+++ b/firefox-ios/Ecosia/UI/Components/EcosiaErrorView.swift
@@ -56,7 +56,7 @@ public struct EcosiaErrorView: View {
                 .frame(width: .ecosia.space._1l, height: .ecosia.space._1l)
                 .foregroundColor(theme.iconColor)
                 .accessibilityLabel(String.localized(.ecosiaErrorViewAccessibilityImageLabel))
-                .accessibilityIdentifier("error_view_image")
+                .accessibilityIdentifier(EcosiaAccessibilityIdentifiers.ErrorView.image)
 
             textContent
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -100,6 +100,7 @@ public struct EcosiaErrorView: View {
         .accessibilityHidden(onCloseTapped == nil)
         .accessibilityLabel(String.localized(.close))
         .accessibilityAddTraits(.isButton)
+        .accessibilityIdentifier(EcosiaAccessibilityIdentifiers.ErrorView.closeButton)
     }
 
     private var cardBackground: some View {

--- a/firefox-ios/Ecosia/UI/EcosiaAccessibilityIdentifiers.swift
+++ b/firefox-ios/Ecosia/UI/EcosiaAccessibilityIdentifiers.swift
@@ -55,5 +55,33 @@ public struct EcosiaAccessibilityIdentifiers {
         public static let signInSheetBody = "omnibox_upload_sign_in_sheet_body"
         public static let signInButton = "omnibox_upload_sign_in_button"
         public static let createAccountButton = "omnibox_upload_create_account_button"
+
+        /// Attachment previews above the omnibox text field. Every id below except
+        /// `attachmentsStrip` repeats once per attachment, so a query matches as many
+        /// elements as there are tiles rather than exactly one.
+        public static let attachmentsStrip = "omnibox_upload_attachments_strip"
+        public static let attachmentTile = "omnibox_upload_attachment_tile"
+        /// Present only while that tile is still uploading — absence means the upload settled.
+        public static let attachmentSpinner = "omnibox_upload_attachment_spinner"
+        public static let attachmentFileName = "omnibox_upload_attachment_file_name"
+        public static let attachmentFileSize = "omnibox_upload_attachment_file_size"
+        public static let attachmentImage = "omnibox_upload_attachment_image"
+        public static let attachmentRemoveButton = "omnibox_upload_attachment_remove_button"
+    }
+
+    public struct ErrorView {
+        public static let image = "error_view_image"
+        public static let closeButton = "error_view_close_button"
+    }
+
+    /// Wallet-style stacked error toasts (`EcosiaErrorToastStack`). The collapsed and
+    /// expanded layouts both exist in the view tree at all times; only the active one
+    /// stays in the accessibility tree, so the presence of `expandedStack` is what
+    /// distinguishes an expanded stack from a collapsed one.
+    public struct ErrorToast {
+        public static let container = "ecosia_error_toast_container"
+        public static let collapsedStack = "ecosia_error_toast_collapsed_stack"
+        public static let expandedStack = "ecosia_error_toast_expanded_stack"
+        public static let card = "ecosia_error_toast_card"
     }
 }

--- a/firefox-ios/Ecosia/UI/Toast/EcosiaErrorToastStack.swift
+++ b/firefox-ios/Ecosia/UI/Toast/EcosiaErrorToastStack.swift
@@ -126,13 +126,20 @@ public struct EcosiaErrorToastStack: View {
                 sizingPass
 
                 ZStack(alignment: .top) {
+                    // Both layouts stay mounted so the expand/collapse transition can
+                    // cross-fade, but only the visible one belongs in the accessibility
+                    // tree — otherwise VoiceOver (and UI automation) sees every card twice.
                     collapsedStack
                         .opacity(isExpanded ? 0 : 1)
                         .allowsHitTesting(!isExpanded)
+                        .accessibilityHidden(isExpanded)
+                        .accessibilityIdentifier(EcosiaAccessibilityIdentifiers.ErrorToast.collapsedStack)
 
                     expandedStack
                         .opacity(isExpanded ? 1 : 0)
                         .allowsHitTesting(isExpanded)
+                        .accessibilityHidden(!isExpanded)
+                        .accessibilityIdentifier(EcosiaAccessibilityIdentifiers.ErrorToast.expandedStack)
                 }
                 .frame(height: containerHeight, alignment: .top)
                 .animation(expandAnimation, value: isExpanded)
@@ -141,6 +148,7 @@ public struct EcosiaErrorToastStack: View {
             .contentShape(Rectangle())
             .onTapGesture(perform: toggleExpanded)
             .accessibilityAddTraits(.isButton)
+            .accessibilityIdentifier(EcosiaAccessibilityIdentifiers.ErrorToast.container)
             .offset(y: isVisible ? 0 : -(frontCardHeight + .ecosia.space._1l))
             .opacity(isVisible ? 1 : 0)
             .animation(entranceAnimation, value: isVisible)
@@ -276,6 +284,9 @@ public struct EcosiaErrorToastStack: View {
                 content
             }
         }
+        // Repeats once per message. The hidden sizing pass renders these too, but it is
+        // `.accessibilityHidden(true)`, so its copies never reach the query tree.
+        .accessibilityIdentifier(EcosiaAccessibilityIdentifiers.ErrorToast.card)
         .shadow(
             color: showsShadow ? Color.black.opacity(0.12) : .clear,
             radius: showsShadow ? 8 : 0,


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-4820]

## Context

Add missing accessibility identifiers for Files Uploads & Chat Modes

## Approach

## Other

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I wrote Unit Tests that confirm the expected behaviour
  - This will be implicitly tested via the Automated Tests 
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [ ] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4820]: https://ecosia.atlassian.net/browse/MOB-4820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ