### PR TITLE
[MOB-4839] Revert "[MOB-4782] Include back forward for search event (#1215)"

### DIFF
--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+EcosiaNavigationHandling.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+EcosiaNavigationHandling.swift
@@ -31,17 +31,22 @@ extension BrowserViewController {
         if ecosiaEcosifyNavigationIfNeeded(url: url, tab: tab) {
             return true
         }
-        ecosiaHandleNavigationAction(url: url)
+        ecosiaHandleNavigationAction(url: url, navigationAction: navigationAction)
         return false
     }
 
     /// Handles any Ecosia-specific tracking when a navigation action is allowed.
     /// Stores a pending URL to be tracked at didCommit.
-    private func ecosiaHandleNavigationAction(url: URL) {
+    private func ecosiaHandleNavigationAction(url: URL, navigationAction: WKNavigationAction) {
         // Clear any stale pending tracking from a previous navigation
         pendingInappSearchUrl = nil
 
         guard url.isEcosiaSearchVertical() else { return }
+
+        // Back/forward navigations are suppressed: on web, bfcache keeps the page mounted so
+        // Vue never refires. Tab switching doesn't reach this delegate at all, so any other
+        // navigation type arriving here is a genuine user action and should always track.
+        guard navigationAction.navigationType != .backForward else { return }
 
         // Store the URL; the event fires in ecosiaHandleDidCommit when content starts rendering
         pendingInappSearchUrl = url

--- a/firefox-ios/EcosiaTests/Analytics/AnalyticsSpyTests.swift
+++ b/firefox-ios/EcosiaTests/Analytics/AnalyticsSpyTests.swift
@@ -627,7 +627,7 @@ final class AnalyticsSpyTests: XCTestCase, @unchecked Sendable {
         let testCases = [
             (WKNavigationType.other, "\(rootURL)/search?q=test", true, "Tracks regular navigation"),
             (WKNavigationType.reload, "\(rootURL)/search?q=test", true, "Tracks reload"),
-            (WKNavigationType.backForward, "\(rootURL)/search?q=test", true, "Tracks back/forward"),
+            (WKNavigationType.backForward, "\(rootURL)/search?q=test", false, "Does not track back/forward"),
         ]
 
         for (type, urlString, shouldTrack, message) in testCases {


### PR DESCRIPTION
[MOB-4839]

## Context

See ticket.

## Approach

Reverts https://github.com/ecosia/ios-browser/pull/1215.

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [ ] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4839]: https://ecosia.atlassian.net/browse/MOB-4839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ