### PR TITLE
[MOB-4263] Monitor Session Transfer errors

### DIFF
--- a/firefox-ios/Client/Ecosia/Account/Auth/EcosiaAuthFlow.swift
+++ b/firefox-ios/Client/Ecosia/Account/Auth/EcosiaAuthFlow.swift
@@ -241,12 +241,29 @@ final class EcosiaAuthFlow {
         await withCheckedContinuation { continuation in
             Task { @MainActor in
                 session.startMonitoring { [weak self] success in
-                    self?.activeSession = nil // Release session
-                    EcosiaLogger.auth.info("Ecosia auth flow completed: \(success)")
-                    onFlowCompleted?(success)
-                    continuation.resume()
+                    Task { @MainActor in
+                        self?.activeSession = nil // Release session
+                        EcosiaLogger.auth.info("Ecosia auth flow completed: \(success)")
+                        if !success {
+                            await self?.logOutNativelyAfterFailedSessionTransfer()
+                        }
+                        onFlowCompleted?(success)
+                        continuation.resume()
+                    }
                 }
             }
+        }
+    }
+
+    /// Ecosia: Mirrors Android's AuthViewModel.handleSessionTransferFailure - a failed session
+    /// transfer means the web session was never actually authenticated, so clear native credentials
+    /// too instead of leaving native "logged in" with no working web session. `triggerWebLogout:
+    /// false` since the web side already failed to authenticate; nothing there to log out of.
+    private func logOutNativelyAfterFailedSessionTransfer() async {
+        do {
+            try await authService.logout(triggerWebLogout: false)
+        } catch {
+            EcosiaLogger.auth.error("Native-only logout after failed session transfer also failed: \(error)")
         }
     }
 

--- a/firefox-ios/Client/Ecosia/Account/Auth/EcosiaAuthFlow.swift
+++ b/firefox-ios/Client/Ecosia/Account/Auth/EcosiaAuthFlow.swift
@@ -215,7 +215,11 @@ final class EcosiaAuthFlow {
         }
 
         // Get session transfer URL
-        let signUpURL = EcosiaEnvironment.current.urlProvider.signUpURL
+        // Ecosia: Debug hook for EcosiaDebugSettings' SimulateSessionTransferFailureSetting - loads
+        // /accounts/error directly instead of the real sign-up URL.
+        let signUpURL = SimulateSessionTransferFailureSetting.isEnabled
+            ? SimulateSessionTransferFailureSetting.forcedErrorPageURL
+            : EcosiaEnvironment.current.urlProvider.signUpURL
 
         EcosiaLogger.session.info("Retrieving session transfer token for SSO")
         await authService.getSessionTransferToken()
@@ -274,7 +278,11 @@ final class EcosiaAuthFlow {
         }
 
         // Get logout URL
-        let logoutURL = EcosiaEnvironment.current.urlProvider.logoutURL
+        // Ecosia: Debug hook for EcosiaDebugSettings' SimulateSessionTransferFailureSetting - see
+        // performSessionTransfer above.
+        let logoutURL = SimulateSessionTransferFailureSetting.isEnabled
+            ? SimulateSessionTransferFailureSetting.forcedErrorPageURL
+            : EcosiaEnvironment.current.urlProvider.logoutURL
 
         // Create invisible tab session for logout (must be on main thread for UI operations)
         EcosiaLogger.invisibleTabs.info("Creating invisible tab session for logout")

--- a/firefox-ios/Client/Ecosia/Account/Auth/EcosiaAuthFlow.swift
+++ b/firefox-ios/Client/Ecosia/Account/Auth/EcosiaAuthFlow.swift
@@ -13,7 +13,6 @@ public enum EcosiaAuthFlowResult {
 
 /// Orchestrates complete authentication flows with invisible tab sessions
 /// Provides core functionality for authentication operations
-/// Ecosia: @MainActor so callbacks and session/tab ops stay on main thread; avoids sending non-Sendable closures.
 @MainActor
 final class EcosiaAuthFlow {
 
@@ -214,9 +213,8 @@ final class EcosiaAuthFlow {
             throw AuthError.authFlowConfigurationError("BrowserViewController not available")
         }
 
-        // Get session transfer URL
-        // Ecosia: Debug hook for EcosiaDebugSettings' SimulateSessionTransferFailureSetting - loads
-        // /accounts/error directly instead of the real sign-up URL.
+        // Get session transfer URL.
+        // Debug hook: loads /accounts/error directly instead of the real sign-up URL.
         let signUpURL = SimulateSessionTransferFailureSetting.isEnabled
             ? SimulateSessionTransferFailureSetting.forcedErrorPageURL
             : EcosiaEnvironment.current.urlProvider.signUpURL
@@ -259,7 +257,7 @@ final class EcosiaAuthFlow {
         }
     }
 
-    /// Ecosia: A failed session transfer means the web session was never actually authenticated,
+    /// A failed session transfer means the web session was never actually authenticated,
     /// so clear native credentials too instead of leaving native "logged in" with no working web session.
     /// `triggerWebLogout: false` since the web side already failed to authenticate; nothing there to log out of.
     private func logOutNativelyAfterFailedSessionTransfer() async {
@@ -277,8 +275,7 @@ final class EcosiaAuthFlow {
         }
 
         // Get logout URL
-        // Ecosia: Debug hook for EcosiaDebugSettings' SimulateSessionTransferFailureSetting - see
-        // performSessionTransfer above.
+        // Debug hook: loads /accounts/error directly instead of the real sign-up URL.
         let logoutURL = SimulateSessionTransferFailureSetting.isEnabled
             ? SimulateSessionTransferFailureSetting.forcedErrorPageURL
             : EcosiaEnvironment.current.urlProvider.logoutURL

--- a/firefox-ios/Client/Ecosia/Account/Auth/EcosiaAuthFlow.swift
+++ b/firefox-ios/Client/Ecosia/Account/Auth/EcosiaAuthFlow.swift
@@ -259,10 +259,9 @@ final class EcosiaAuthFlow {
         }
     }
 
-    /// Ecosia: Mirrors Android's AuthViewModel.handleSessionTransferFailure - a failed session
-    /// transfer means the web session was never actually authenticated, so clear native credentials
-    /// too instead of leaving native "logged in" with no working web session. `triggerWebLogout:
-    /// false` since the web side already failed to authenticate; nothing there to log out of.
+    /// Ecosia: A failed session transfer means the web session was never actually authenticated,
+    /// so clear native credentials too instead of leaving native "logged in" with no working web session.
+    /// `triggerWebLogout: false` since the web side already failed to authenticate; nothing there to log out of.
     private func logOutNativelyAfterFailedSessionTransfer() async {
         do {
             try await authService.logout(triggerWebLogout: false)

--- a/firefox-ios/Client/Ecosia/Account/Auth/InvisibleTabSession.swift
+++ b/firefox-ios/Client/Ecosia/Account/Auth/InvisibleTabSession.swift
@@ -129,7 +129,7 @@ final class InvisibleTabSession: TabEventHandler {
 
         cleanup()
 
-        let success = classifySessionTransferOutcome()
+        let success = isSessionTransferSuccessful()
         if !success {
             EcosiaLogger.auth.sentry("Session transfer landed on a failure path: \(lastKnownURL?.redactedForLogging ?? "nil")")
         }
@@ -146,7 +146,7 @@ final class InvisibleTabSession: TabEventHandler {
 
     /// Classifies the invisible tab's final URL as success or failure: landing on the accounts error page, or being redirected
     /// back to sign-in, means the transfer didn't actually authenticate the web session, even though the tab closed normally.
-    private func classifySessionTransferOutcome() -> Bool {
+    private func isSessionTransferSuccessful() -> Bool {
         guard let finalURL = lastKnownURL, finalURL.isEcosia(urlProvider) else { return true }
 
         let path = finalURL.path.lowercased()

--- a/firefox-ios/Client/Ecosia/Account/Auth/InvisibleTabSession.swift
+++ b/firefox-ios/Client/Ecosia/Account/Auth/InvisibleTabSession.swift
@@ -131,7 +131,7 @@ final class InvisibleTabSession: TabEventHandler {
 
         let success = classifySessionTransferOutcome()
         if !success {
-            EcosiaLogger.auth.sentry("Session transfer landed on a failure path: \(lastKnownURL?.absoluteString ?? "nil")")
+            EcosiaLogger.auth.sentry("Session transfer landed on a failure path: \(lastKnownURL?.redactedForLogging ?? "nil")")
         }
         EcosiaLogger.invisibleTabs.info("Session completed for tab: \(tab.tabUUID), success: \(success)")
         // Ecosia: Ensure completion is called on main for strict concurrency (caller may update UI).

--- a/firefox-ios/Client/Ecosia/Account/Auth/InvisibleTabSession.swift
+++ b/firefox-ios/Client/Ecosia/Account/Auth/InvisibleTabSession.swift
@@ -21,7 +21,7 @@ final class InvisibleTabSession: TabEventHandler {
     // State
     private var isCompleted = false
     private var completion: ((Bool) -> Void)?
-    // Ecosia: Tracked live via KVO (see init) instead of read from tab.webView?.url at close time -
+    // Tracked live via KVO (see init) instead of read from tab.webView?.url at close time -
     // tabManager.removeTab has usually already torn down the webview by the time handleTabClosed()
     // runs, so tab.webView?.url would read back nil there.
     private var lastKnownURL: URL?
@@ -134,7 +134,7 @@ final class InvisibleTabSession: TabEventHandler {
             EcosiaLogger.auth.sentry("Session transfer landed on a failure path: \(lastKnownURL?.redactedForLogging ?? "nil")")
         }
         EcosiaLogger.invisibleTabs.info("Session completed for tab: \(tab.tabUUID), success: \(success)")
-        // Ecosia: Ensure completion is called on main for strict concurrency (caller may update UI).
+        // Ensure completion is called on main for strict concurrency (caller may update UI).
         let completionToCall = completion
         completion = nil
         if let completionToCall = completionToCall {
@@ -176,7 +176,7 @@ final class InvisibleTabSession: TabEventHandler {
         // Remove from invisible tracking
         InvisibleTabManager.shared.markTabAsVisible(tab)
 
-        // Ecosia: TabManager protocol has removeTab(_ tabUUID: TabUUID) with no completion
+        // TabManager protocol has removeTab(_ tabUUID: TabUUID) with no completion
         tabManager.removeTab(tab.tabUUID)
         tabManager.cleanupInvisibleTabTracking()
         EcosiaLogger.invisibleTabs.info("Tab closed: \(tab.tabUUID)")
@@ -197,7 +197,7 @@ final class InvisibleTabSession: TabEventHandler {
 
     // MARK: - Cleanup
 
-    /// Ecosia: Don't call cleanup() from deinit — cleanup() is main-actor/actor-isolated. Callers must ensure cleanup when session ends (e.g. handleTabClosed).
+    /// Don't call cleanup() from deinit — cleanup() is main-actor/actor-isolated. Callers must ensure cleanup when session ends (e.g. handleTabClosed).
     deinit {
         EcosiaLogger.invisibleTabs.debug("InvisibleTabSession deallocated")
     }

--- a/firefox-ios/Client/Ecosia/Account/Auth/InvisibleTabSession.swift
+++ b/firefox-ios/Client/Ecosia/Account/Auth/InvisibleTabSession.swift
@@ -21,6 +21,11 @@ final class InvisibleTabSession: TabEventHandler {
     // State
     private var isCompleted = false
     private var completion: ((Bool) -> Void)?
+    // Ecosia: Tracked live via KVO (see init) instead of read from tab.webView?.url at close time -
+    // tabManager.removeTab has usually already torn down the webview by the time handleTabClosed()
+    // runs, so tab.webView?.url would read back nil there.
+    private var lastKnownURL: URL?
+    private var urlObservation: NSKeyValueObservation?
 
     // MARK: - Initialization
 
@@ -41,8 +46,18 @@ final class InvisibleTabSession: TabEventHandler {
 
         // Create the tab immediately
         self.tab = try Self.createInvisibleTab(url: url, browserViewController: browserViewController)
+        self.lastKnownURL = url
 
         EcosiaLogger.invisibleTabs.info("InvisibleTabSession created for: \(url)")
+
+        // Ecosia: Attach as early as possible (not in startMonitoring) to avoid missing a fast
+        // redirect chain that finishes before monitoring starts.
+        urlObservation = tab.webView?.observe(\.url, options: [.new]) { [weak self] _, change in
+            guard let newURL = change.newValue ?? nil else { return }
+            Task { @MainActor in
+                self?.lastKnownURL = newURL
+            }
+        }
     }
 
     // MARK: - Session Management
@@ -114,15 +129,35 @@ final class InvisibleTabSession: TabEventHandler {
 
         cleanup()
 
-        EcosiaLogger.invisibleTabs.info("Session completed for tab: \(tab.tabUUID), success: true")
+        let success = classifySessionTransferOutcome()
+        if !success {
+            EcosiaLogger.auth.sentry("Session transfer landed on a failure path: \(lastKnownURL?.absoluteString ?? "nil")")
+        }
+        EcosiaLogger.invisibleTabs.info("Session completed for tab: \(tab.tabUUID), success: \(success)")
         // Ecosia: Ensure completion is called on main for strict concurrency (caller may update UI).
         let completionToCall = completion
         completion = nil
         if let completionToCall = completionToCall {
             Task { @MainActor in
-                completionToCall(true)
+                completionToCall(success)
             }
         }
+    }
+
+    /// Classifies the invisible tab's final URL as success or failure: landing on the accounts error page, or being redirected
+    /// back to sign-in, means the transfer didn't actually authenticate the web session, even though the tab closed normally.
+    private func classifySessionTransferOutcome() -> Bool {
+        guard let finalURL = lastKnownURL, finalURL.isEcosia(urlProvider) else { return true }
+
+        let path = finalURL.path.lowercased()
+        let errorPaths = urlProvider.errorPaths.map { $0.lowercased() }
+        let signInPath = urlProvider.signInURL.relativePath.lowercased()
+
+        return !(errorPaths.contains(path) || path.hasPrefix(signInPath))
+    }
+
+    private var urlProvider: URLProvider {
+        EcosiaEnvironment.current.urlProvider
     }
 
     private func cleanup() {

--- a/firefox-ios/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/AppSettingsTableViewController+Ecosia.swift
@@ -109,6 +109,7 @@ extension AppSettingsTableViewController {
             DebugAddCustomSeeds(settings: self),
             DebugForceLevelUp(settings: self),
             SimulateAuthErrorSetting(settings: self),
+            SimulateSessionTransferFailureSetting(settings: self),
             SimulateImpactAPIErrorSetting(settings: self)
         ]
 

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
@@ -273,8 +273,8 @@ extension BrowserViewController {
                 configuredAuth.login()
             }
         } else {
-            EcosiaLogger.auth.notice("🔐 [WEB-AUTH] Inconsistent state detected: web thinks user is logged out but native doesn't")
-            EcosiaLogger.auth.notice("🔐 [WEB-AUTH] Failing entire process to avoid user getting locked")
+            EcosiaLogger.auth.sentry("🔐 [WEB-AUTH] Inconsistent state: web says logged out but native doesn't; " +
+                                     "forcing logout+re-login to avoid user getting locked")
 
             ecosiaAuth
                 .onAuthFlowCompleted { _ in

--- a/firefox-ios/Client/Ecosia/Settings/EcosiaDebugSettings.swift
+++ b/firefox-ios/Client/Ecosia/Settings/EcosiaDebugSettings.swift
@@ -416,6 +416,59 @@ final class SimulateAuthErrorSetting: HiddenSetting {
     }
 }
 
+/// Forces the invisible tab used for SSO session transfer/cleanup to load /accounts/error directly
+/// instead of the normal sign-up/logout URL - mirroring Android's own QA-only shortcut
+/// (ForcedTransferError.OPEN_ERROR_PAGE), rather than trying to trigger a genuine server-side
+/// redirect there (fastify-passport appears to 401 directly on an OAuth callback error param,
+/// short-circuiting before any redirect). /accounts/error itself has no auth precondition, so this
+/// still exercises the real web page and classifySessionTransferOutcome()'s URL classification
+/// end-to-end, rather than faking the outcome natively.
+final class SimulateSessionTransferFailureSetting: HiddenSetting {
+    nonisolated public static let debugKey = "DebugSimulateSessionTransferFailure"
+
+    nonisolated public static var forcedErrorPageURL: URL {
+        let urlProvider = EcosiaEnvironment.current.urlProvider
+        var errorPath = urlProvider.errorPaths.first ?? "/accounts/error"
+        if errorPath.hasPrefix("/") { errorPath.removeFirst() }
+        return urlProvider.root.appendingPathComponent(errorPath)
+    }
+
+    override var title: NSAttributedString? {
+        return NSAttributedString(string: "Debug: Toggle - Simulate Session Transfer Failure", attributes: [:])
+    }
+
+    override var status: NSAttributedString? {
+        let status = Self.isEnabled ? "ON (session transfer will hit a real /accounts/error)" : "OFF"
+        return NSAttributedString(string: "\(status) (Click to toggle)", attributes: [:])
+    }
+
+    override func onClick(_ navigationController: UINavigationController?) {
+        let currentValue = Self.isEnabled
+        UserDefaults.standard.set(!currentValue, forKey: Self.debugKey)
+        settings.tableView.reloadData()
+
+        let alert = AlertController(
+            title: !currentValue ? "Session Transfer Failure Enabled ✅" : "Session Transfer Failure Disabled ✅",
+            message: !currentValue
+                ? "Next login/logout will complete natively but the invisible tab will hit a real " +
+                  "/accounts/error - check Sentry for the event, until you toggle this off."
+                : "Session transfer failures disabled.",
+            preferredStyle: .alert
+        )
+        navigationController?.topViewController?.present(alert, animated: true) {
+            // Ecosia: Task + sleep instead of DispatchQueue for strict concurrency
+            Task { @MainActor in
+                try? await Task.sleep(nanoseconds: 1_500_000_000)
+                alert.dismiss(animated: true)
+            }
+        }
+    }
+
+    nonisolated public static var isEnabled: Bool {
+        UserDefaults.standard.bool(forKey: debugKey)
+    }
+}
+
 final class SimulateImpactAPIErrorSetting: HiddenSetting {
     /// UserDefaults key for storing impact API error simulation state
     /// Note: Persists across app restarts - toggle again to disable

--- a/firefox-ios/Client/Ecosia/Settings/EcosiaDebugSettings.swift
+++ b/firefox-ios/Client/Ecosia/Settings/EcosiaDebugSettings.swift
@@ -118,7 +118,7 @@ final class CreateReferralCode: HiddenSetting {
             let alertTitle = "Code created"
             let alert = AlertController(title: alertTitle, message: User.shared.referrals.code, preferredStyle: .alert)
             navigationController?.topViewController?.present(alert, animated: true) {
-                // Ecosia: Task + sleep instead of DispatchQueue for strict concurrency
+                // Task + sleep instead of DispatchQueue for strict concurrency
                 Task { @MainActor in
                     try? await Task.sleep(nanoseconds: 1_500_000_000)
                     alert.dismiss(animated: true)
@@ -130,7 +130,7 @@ final class CreateReferralCode: HiddenSetting {
 
             let alert = AlertController(title: "Code erased!", message: "Reopen app to create new one", preferredStyle: .alert)
             navigationController?.topViewController?.present(alert, animated: true) {
-                // Ecosia: Task + sleep instead of DispatchQueue for strict concurrency
+                // Task + sleep instead of DispatchQueue for strict concurrency
                 Task { @MainActor in
                     try? await Task.sleep(nanoseconds: 1_500_000_000)
                     alert.dismiss(animated: true)
@@ -152,7 +152,7 @@ final class AddReferral: HiddenSetting {
         let alertTitle = "Referral count increased by one."
         let alert = AlertController(title: alertTitle, message: "Open NTP to see spotlight", preferredStyle: .alert)
         navigationController?.topViewController?.present(alert, animated: true) {
-            // Ecosia: Task + sleep instead of DispatchQueue for strict concurrency
+            // Task + sleep instead of DispatchQueue for strict concurrency
             Task { @MainActor in
                 try? await Task.sleep(nanoseconds: 1_500_000_000)
                 alert.dismiss(animated: true)
@@ -173,7 +173,7 @@ final class AddClaim: HiddenSetting {
         let alertTitle = "User got referred."
         let alert = AlertController(title: alertTitle, message: "Open NTP to see claim", preferredStyle: .alert)
         navigationController?.topViewController?.present(alert, animated: true) {
-            // Ecosia: Task + sleep instead of DispatchQueue for strict concurrency
+            // Task + sleep instead of DispatchQueue for strict concurrency
             Task { @MainActor in
                 try? await Task.sleep(nanoseconds: 1_500_000_000)
                 alert.dismiss(animated: true)
@@ -376,7 +376,7 @@ final class AnalyticsStagingUrlSetting: HiddenSetting {
 final class SimulateAuthErrorSetting: HiddenSetting {
     /// UserDefaults key for storing auth error simulation state
     /// Note: Persists across app restarts - toggle again to disable
-    /// Ecosia: nonisolated so async/non–main-actor code can read it without crossing isolation
+    /// nonisolated so async/non–main-actor code can read it without crossing isolation
     nonisolated public static let debugKey = "DebugSimulateAuthError"
 
     override var title: NSAttributedString? {
@@ -402,7 +402,7 @@ final class SimulateAuthErrorSetting: HiddenSetting {
             preferredStyle: .alert
         )
         navigationController?.topViewController?.present(alert, animated: true) {
-            // Ecosia: Task + sleep instead of DispatchQueue for strict concurrency
+            // Task + sleep instead of DispatchQueue for strict concurrency
             Task { @MainActor in
                 try? await Task.sleep(nanoseconds: 1_500_000_000)
                 alert.dismiss(animated: true)
@@ -456,7 +456,7 @@ final class SimulateSessionTransferFailureSetting: HiddenSetting {
             preferredStyle: .alert
         )
         navigationController?.topViewController?.present(alert, animated: true) {
-            // Ecosia: Task + sleep instead of DispatchQueue for strict concurrency
+            // Task + sleep instead of DispatchQueue for strict concurrency
             Task { @MainActor in
                 try? await Task.sleep(nanoseconds: 1_500_000_000)
                 alert.dismiss(animated: true)
@@ -472,7 +472,7 @@ final class SimulateSessionTransferFailureSetting: HiddenSetting {
 final class SimulateImpactAPIErrorSetting: HiddenSetting {
     /// UserDefaults key for storing impact API error simulation state
     /// Note: Persists across app restarts - toggle again to disable
-    /// Ecosia: nonisolated so async/non–main-actor code can read it without crossing isolation
+    /// nonisolated so async/non–main-actor code can read it without crossing isolation
     nonisolated public static let debugKey = "DebugSimulateImpactAPIError"
 
     override var title: NSAttributedString? {
@@ -707,7 +707,7 @@ final class DebugAddSeedsLoggedOut: HiddenSetting {
         )
 
         navigationController?.topViewController?.present(alert, animated: true) {
-            // Ecosia: Task + sleep instead of DispatchQueue for strict concurrency
+            // Task + sleep instead of DispatchQueue for strict concurrency
             Task { @MainActor in
                 try? await Task.sleep(nanoseconds: 2_000_000_000)
                 alert.dismiss(animated: true)
@@ -750,7 +750,7 @@ final class DebugAddSeedsLoggedIn: HiddenSetting {
         )
 
         navigationController?.topViewController?.present(alert, animated: true) {
-            // Ecosia: Task + sleep instead of DispatchQueue for strict concurrency
+            // Task + sleep instead of DispatchQueue for strict concurrency
             Task { @MainActor in
                 try? await Task.sleep(nanoseconds: 2_000_000_000)
                 alert.dismiss(animated: true)
@@ -791,7 +791,7 @@ final class DebugForceLevelUp: HiddenSetting {
         )
 
         navigationController?.topViewController?.present(alert, animated: true) {
-            // Ecosia: Task + sleep instead of DispatchQueue for strict concurrency
+            // Task + sleep instead of DispatchQueue for strict concurrency
             Task { @MainActor in
                 try? await Task.sleep(nanoseconds: 2_000_000_000)
                 alert.dismiss(animated: true)
@@ -868,7 +868,7 @@ final class DebugAddCustomSeeds: HiddenSetting {
         )
 
         navigationController?.topViewController?.present(confirmAlert, animated: true) {
-            // Ecosia: Task + sleep instead of DispatchQueue for strict concurrency
+            // Task + sleep instead of DispatchQueue for strict concurrency
             Task { @MainActor in
                 try? await Task.sleep(nanoseconds: 2_000_000_000)
                 confirmAlert.dismiss(animated: true)
@@ -926,7 +926,7 @@ final class RefreshStatisticsSetting: HiddenSetting {
                     preferredStyle: .alert
                 )
                 navigationController?.topViewController?.present(successAlert, animated: true) {
-                    // Ecosia: Task + sleep instead of DispatchQueue for strict concurrency
+                    // Task + sleep instead of DispatchQueue for strict concurrency
                     Task { @MainActor in
                         try? await Task.sleep(nanoseconds: 2_000_000_000)
                         successAlert.dismiss(animated: true)

--- a/firefox-ios/Client/Ecosia/Settings/EcosiaDebugSettings.swift
+++ b/firefox-ios/Client/Ecosia/Settings/EcosiaDebugSettings.swift
@@ -421,7 +421,7 @@ final class SimulateAuthErrorSetting: HiddenSetting {
 /// (ForcedTransferError.OPEN_ERROR_PAGE), rather than trying to trigger a genuine server-side
 /// redirect there (fastify-passport appears to 401 directly on an OAuth callback error param,
 /// short-circuiting before any redirect). /accounts/error itself has no auth precondition, so this
-/// still exercises the real web page and classifySessionTransferOutcome()'s URL classification
+/// still exercises the real web page and isSessionTransferSuccessful()'s URL classification
 /// end-to-end, rather than faking the outcome natively.
 final class SimulateSessionTransferFailureSetting: HiddenSetting {
     nonisolated public static let debugKey = "DebugSimulateSessionTransferFailure"

--- a/firefox-ios/Ecosia/Account/Auth/EcosiaAuthenticationService.swift
+++ b/firefox-ios/Ecosia/Account/Auth/EcosiaAuthenticationService.swift
@@ -381,7 +381,7 @@ extension EcosiaAuthenticationService {
             do {
                 return try await authProvider.getSSOCredentials()
             } catch {
-                EcosiaLogger.auth.error("Failed to retrieve SSO credentials: \(error)")
+                EcosiaLogger.auth.sentry("Failed to retrieve SSO credentials: \(error)")
             }
         }
         return nil

--- a/firefox-ios/Ecosia/Core/URL+Extensions.swift
+++ b/firefox-ios/Ecosia/Core/URL+Extensions.swift
@@ -10,6 +10,18 @@ extension URL {
         isEcosia() && path.contains("ai-chat")
     }
 
+    /// Host + path only, with query and fragment stripped. Use this instead of `absoluteString`
+    /// when logging a URL (e.g. to Sentry) - OAuth redirect URLs can carry authorization codes,
+    /// state tokens, or other user-identifying data in their query string.
+    public var redactedForLogging: String {
+        guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false) else {
+            return absoluteString
+        }
+        components.query = nil
+        components.fragment = nil
+        return components.string ?? absoluteString
+    }
+
     public enum EcosiaQueryItemName: String {
         case
         autoRedirect = "ar",

--- a/firefox-ios/Ecosia/UI/Account/EcosiaWebViewModal.swift
+++ b/firefox-ios/Ecosia/UI/Account/EcosiaWebViewModal.swift
@@ -198,7 +198,7 @@ private struct WebViewRepresentable: UIViewRepresentable {
             // OAuth reauth landing here is itself the bug (Google blocks OAuth from embedded
             // WebViews with a "disallowed_useragent"/"Use secure browsers" error). Flag it.
             if url.host?.contains("accounts.google.com") == true {
-                EcosiaLogger.auth.sentry("🔐 [WEBVIEW] Google OAuth navigation inside profile WebView: \(url)")
+                EcosiaLogger.auth.sentry("🔐 [WEBVIEW] Google OAuth navigation inside profile WebView: \(url.redactedForLogging)")
             }
 
             // If this is a back navigation to a page we loaded from a target="_blank" link,

--- a/firefox-ios/Ecosia/UI/Account/EcosiaWebViewModal.swift
+++ b/firefox-ios/Ecosia/UI/Account/EcosiaWebViewModal.swift
@@ -194,6 +194,13 @@ private struct WebViewRepresentable: UIViewRepresentable {
                 return
             }
 
+            // Ecosia: this plain WKWebView has no ASWebAuthenticationSession fallback, so a Google
+            // OAuth reauth landing here is itself the bug (Google blocks OAuth from embedded
+            // WebViews with a "disallowed_useragent"/"Use secure browsers" error). Flag it.
+            if url.host?.contains("accounts.google.com") == true {
+                EcosiaLogger.auth.sentry("🔐 [WEBVIEW] Google OAuth navigation inside profile WebView: \(url)")
+            }
+
             // If this is a back navigation to a page we loaded from a target="_blank" link,
             // prevent it and go back further (to the page before the blank link was clicked)
             if navigationAction.navigationType == .backForward,

--- a/firefox-ios/Ecosia/UI/Account/EcosiaWebViewModal.swift
+++ b/firefox-ios/Ecosia/UI/Account/EcosiaWebViewModal.swift
@@ -194,7 +194,7 @@ private struct WebViewRepresentable: UIViewRepresentable {
                 return
             }
 
-            // Ecosia: this plain WKWebView has no ASWebAuthenticationSession fallback, so a Google
+            // This plain WKWebView has no ASWebAuthenticationSession fallback, so a Google
             // OAuth reauth landing here is itself the bug (Google blocks OAuth from embedded
             // WebViews with a "disallowed_useragent"/"Use secure browsers" error). Flag it.
             if url.host?.contains("accounts.google.com") == true {


### PR DESCRIPTION
[MOB-4263]

## Context

Now that we have Sentry (https://github.com/ecosia/ios-browser/pull/1235), we want to monitor session transfer errors specifically since there were user reports linked to it.

## Approach

Sending session transfer errors (including specific Google page from ticket) to Sentry.

During this, I also found that **we were not correctly catching any session transfer error on web**. Turns out `InvisibleTabSession` returned success no matter what. I've added a new logic to actually check the URL and logout from Native if Web landed on `accounts/error`.

## Other

Adding a debug setting to enable QA

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [x] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4263]: https://ecosia.atlassian.net/browse/MOB-4263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ