### PR TITLE
[MOB-4603] Sentry: Add re-used Send Crash Reports setting

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -597,10 +597,25 @@ class AppSettingsTableViewController: SettingsTableViewController,
         return [SettingSection(title: NSAttributedString(string: .AppSettingsSupport),
                                children: supportSettings)]
         */
-        let supportSettings: [Setting] = [
+        var supportSettings: [Setting] = [
             HelpCenterSetting(),
             EcosiaSendFeedbackSetting(settings: self)
         ]
+
+        if let profile, SentryReportingExperiment.isEnabled {
+            // Ecosia: Firefox's own send-crash-reports toggle and strings (neither string is
+            // Mozilla-branded), minus the "Learn More" link - BoolSetting instead of
+            // SendDataSetting, which is `final` and always renders one. Matches Firefox's own
+            // placement under Support. Gated on the Sentry rollout experiment.
+            supportSettings.append(BoolSetting(
+                prefs: profile.prefs,
+                theme: themeManager.getCurrentTheme(for: windowUUID),
+                prefKey: AppConstants.prefSendCrashReports,
+                defaultValue: true,
+                titleText: .SendCrashReportsSettingTitle,
+                statusText: .SendCrashReportsSettingMessageV2
+            ))
+        }
 
         return [SettingSection(title: NSAttributedString(string: .AppSettingsSupport),
                                children: supportSettings)]

--- a/firefox-ios/EcosiaTests/Settings/AppSettingsTableViewController+EcosiaTests.swift
+++ b/firefox-ios/EcosiaTests/Settings/AppSettingsTableViewController+EcosiaTests.swift
@@ -1,0 +1,95 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+@testable import Client
+@testable import Ecosia
+
+import Common
+import XCTest
+// swiftlint:disable implicitly_unwrapped_optional
+
+final class AppSettingsTableViewControllerEcosiaTests: XCTestCase {
+    private var profile: MockProfile!
+    private var tabManager: TabManager!
+    private var delegate: MockSettingsFlowDelegate!
+    private var settingsDelegate: MockSettingsDelegate!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        Unleash.clearInstanceModel()
+        await DependencyHelperMock().bootstrapDependencies()
+        profile = MockProfile()
+        LegacyFeatureFlagsManager.shared.initializeDeveloperFeatures(with: profile)
+        tabManager = await TabManagerImplementation(profile: profile,
+                                                    uuid: ReservedWindowUUID(uuid: .XCTestDefaultUUID, isNew: false))
+        delegate = MockSettingsFlowDelegate()
+        settingsDelegate = MockSettingsDelegate()
+    }
+
+    override func tearDown() async throws {
+        Unleash.clearInstanceModel()
+        DependencyHelperMock().reset()
+        profile = nil
+        tabManager = nil
+        delegate = nil
+        settingsDelegate = nil
+        try await super.tearDown()
+    }
+
+    @MainActor
+    func testSendCrashReportsSetting_whenSentryExperimentEnabled_isShown() {
+        setSentryReportingExperiment(enabled: true)
+        let subject = createSubject()
+
+        XCTAssertNotNil(sendCrashReportsSetting(in: subject))
+    }
+
+    @MainActor
+    func testSendCrashReportsSetting_whenSentryExperimentDisabled_isHidden() {
+        setSentryReportingExperiment(enabled: false)
+        let subject = createSubject()
+
+        XCTAssertNil(sendCrashReportsSetting(in: subject))
+    }
+
+    @MainActor
+    func testSendCrashReportsSetting_whenShown_isBackedByPrefSendCrashReportsKey() {
+        setSentryReportingExperiment(enabled: true)
+        let subject = createSubject()
+
+        XCTAssertEqual(sendCrashReportsSetting(in: subject)?.prefKey, AppConstants.prefSendCrashReports)
+    }
+
+    // MARK: - Helper
+
+    private func setSentryReportingExperiment(enabled: Bool) {
+        let toggle = Unleash.Toggle(name: Unleash.Toggle.Name.sentryReporting.rawValue,
+                                    enabled: enabled,
+                                    variant: Unleash.Variant(name: "", enabled: false, payload: nil))
+        Unleash.model = Unleash.Model(toggles: enabled ? Set([toggle]) : [])
+    }
+
+    @MainActor
+    private func sendCrashReportsSetting(in subject: AppSettingsTableViewController) -> BoolSetting? {
+        let supportSection = subject.generateSettings().first {
+            $0.title?.string == String.AppSettingsSupport
+        }
+        return supportSection?.children.compactMap { $0 as? BoolSetting }
+            .first { $0.prefKey == AppConstants.prefSendCrashReports }
+    }
+
+    @MainActor
+    private func createSubject() -> AppSettingsTableViewController {
+        let subject = AppSettingsTableViewController(with: profile,
+                                                     and: tabManager,
+                                                     settingsDelegate: settingsDelegate,
+                                                     parentCoordinator: delegate,
+                                                     gleanUsageReportingMetricsService: GleanUsageReportingMetricsService(profile: profile),
+                                                     appAuthenticator: MockAppAuthenticator(),
+                                                     applicationHelper: MockApplicationHelper())
+        trackForMemoryLeaks(subject)
+        return subject
+    }
+}
+// swiftlint:enable implicitly_unwrapped_optional


### PR DESCRIPTION
[MOB-4603]

## Context

Follow-up to https://github.com/ecosia/ios-browser/pull/1235

## Approach

Adding a Send Crash Reports setting re-using Firefox strings.

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [x] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4603]: https://ecosia.atlassian.net/browse/MOB-4603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ