### PR TITLE
Adds Package.resolved to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,7 +170,7 @@ Tuist/Dependencies
 firefox-ios/Client.xcodeproj/xcshareddata/xcschemes
 firefox-ios/Client.xcodeproj/project.pbxproj
 BrowserKit/Package.resolved
-Package.resolved
+/Package.resolved
 
 # CI diagnostics written into the workspace by .github/actions/perform_unit_tests
 raw_build_for_testing.log

--- a/.gitignore
+++ b/.gitignore
@@ -170,6 +170,7 @@ Tuist/Dependencies
 firefox-ios/Client.xcodeproj/xcshareddata/xcschemes
 firefox-ios/Client.xcodeproj/project.pbxproj
 BrowserKit/Package.resolved
+Package.resolved
 
 # CI diagnostics written into the workspace by .github/actions/perform_unit_tests
 raw_build_for_testing.log


### PR DESCRIPTION
## Context

Package.resolved added to .gitignore

If you have the iOS-browser folder open in vscode, which is sometimes useful as it has a different and more complete view of everything, and have the swift extension, it will constantly look for and regenerate Package.resolved.
This PR just removes the noise..

