### PR TITLE
[MOB-4866] Remove "New"-Badge from Chat Modes

### DIFF
--- a/firefox-ios/Ecosia/UI/NTP/Upload/OmniboxUploadDrawerView.swift
+++ b/firefox-ios/Ecosia/UI/NTP/Upload/OmniboxUploadDrawerView.swift
@@ -28,8 +28,6 @@ private enum OmniboxUploadDrawerUX {
     static var chatModeSeparatorLeadingInset: CGFloat {
         chatModeRowHorizontalPadding + chatModeIconSize + chatModeIconSpacing
     }
-    static let newBadgeHorizontalPadding: CGFloat = .ecosia.space._1s
-    static let newBadgeVerticalPadding: CGFloat = .ecosia.space._2s
     /// Opacity of chat-mode rows that are disabled for signed-out users.
     static let disabledRowOpacity: CGFloat = 0.4
     static let signInIconWidth: CGFloat = 18
@@ -275,14 +273,9 @@ struct OmniboxUploadDrawerView: View {
                     .frame(width: UX.chatModeIconSize, height: UX.chatModeIconSize)
 
                 VStack(alignment: .leading, spacing: .ecosia.space._2s) {
-                    HStack(spacing: .ecosia.space._1s) {
-                        Text(mode.title)
-                            .font(.system(size: .ecosia.font._m, weight: .regular))
-                            .foregroundColor(theme.titleColor)
-                        if mode.isNew {
-                            newBadge
-                        }
-                    }
+                    Text(mode.title)
+                        .font(.system(size: .ecosia.font._m, weight: .regular))
+                        .foregroundColor(theme.titleColor)
                     Text(mode.subtitle)
                         .font(.system(size: .ecosia.font._s, weight: .regular))
                         .foregroundColor(theme.subtitleColor)
@@ -313,17 +306,6 @@ struct OmniboxUploadDrawerView: View {
         .accessibilityHint(mode.accessibilityHint)
         .accessibilityAddTraits(mode == selectedChatMode ? [.isSelected] : [])
         .accessibilityIdentifier(mode.accessibilityIdentifier)
-    }
-
-    /// Grellow "New" pill shown inline after a mode's title (e.g. Think longer).
-    private var newBadge: some View {
-        Text(String.localized(.new))
-            .font(.system(size: .ecosia.font._s, weight: .semibold))
-            .foregroundColor(theme.badgeTextColor)
-            .padding(.horizontal, UX.newBadgeHorizontalPadding)
-            .padding(.vertical, UX.newBadgeVerticalPadding)
-            .background(Capsule().fill(theme.badgeBackgroundColor))
-            .accessibilityHidden(true)
     }
 
     // MARK: - Footer
@@ -412,8 +394,6 @@ struct OmniboxUploadDrawerViewTheme: EcosiaThemeable {
     var doneBackgroundColor = Color.gray.opacity(0.2)
     var listBackgroundColor = Color.white
     var selectedCheckmarkColor = Color.green
-    var badgeBackgroundColor = Color.green
-    var badgeTextColor = Color.black
     var signInButtonBackgroundColor = Color.green
     var signInButtonTextColor = Color.black
 
@@ -432,9 +412,6 @@ struct OmniboxUploadDrawerViewTheme: EcosiaThemeable {
         // upload tiles and iOS inset-grouped cells).
         listBackgroundColor = Color(colors.backgroundElevation1)
         selectedCheckmarkColor = Color(colors.brandPrimary)
-        // Grellow pill + dark text in both themes, matching the design-system badge.
-        badgeBackgroundColor = Color(colors.buttonBackgroundFeatured)
-        badgeTextColor = Color(colors.textStaticDark)
         // Sign-in CTA uses the same featured grellow pill as the design-system primary button.
         signInButtonBackgroundColor = Color(colors.buttonBackgroundFeatured)
         signInButtonTextColor = Color(colors.textStaticDark)

--- a/firefox-ios/Ecosia/UI/NTP/Upload/OmniboxUploadTypes.swift
+++ b/firefox-ios/Ecosia/UI/NTP/Upload/OmniboxUploadTypes.swift
@@ -105,8 +105,6 @@ public extension OmniboxChatMode {
         }
     }
 
-    var isNew: Bool { self == .thinkLonger }
-
     /// `mode` field of the `mode_selection` analytics payload. Deliberately its
     /// own value rather than a reuse of `iconName` or the accessibility id, so
     /// renaming an asset or a test hook can't silently re-shape reported data.

--- a/firefox-ios/EcosiaTests/UI/NTP/OmniboxUploadDrawerTests.swift
+++ b/firefox-ios/EcosiaTests/UI/NTP/OmniboxUploadDrawerTests.swift
@@ -65,13 +65,6 @@ final class OmniboxUploadDrawerTests: XCTestCase {
         XCTAssertEqual(OmniboxChatMode.learning.accessibilityIdentifier, "OmniboxChatModeLearningOption")
     }
 
-    func testOnlyThinkLongerChatModeIsNew() {
-        XCTAssertTrue(OmniboxChatMode.thinkLonger.isNew)
-        XCTAssertFalse(OmniboxChatMode.standard.isNew)
-        XCTAssertFalse(OmniboxChatMode.displaySources.isNew)
-        XCTAssertFalse(OmniboxChatMode.learning.isNew)
-    }
-
     func testChatModeIconsLoadFromFrameworkBundle() {
         XCTAssertNotNil(UIImage.ecosia(named: "chatmodes-standard-ai-chat"))
         XCTAssertNotNil(UIImage.ecosia(named: "chatmodes-think-longer"))


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-4866]

## Context

Removes the "New"-Badge from the Chat Modes are.

## Approach

## Other

## Before merging

### Checklist

- [ ] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [ ] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4866]: https://ecosia.atlassian.net/browse/MOB-4866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ