### PR TITLE
[Do not merge] [MOB-4878] Adds register device token with braze call

### DIFF
--- a/firefox-ios/Client/Application/AppDelegate+PushNotifications.swift
+++ b/firefox-ios/Client/Application/AppDelegate+PushNotifications.swift
@@ -8,6 +8,7 @@ import UserNotifications
 import Account
 
 import struct MozillaAppServices.ConstellationState
+import Ecosia
 
 /**
  * This exists because the Sync code is extension-safe, and thus doesn't get
@@ -134,6 +135,9 @@ extension AppDelegate {
             RustFirefoxAccounts.shared.pushNotifications.disableNotifications()
             return
         }
+        
+        /* Ecosia: register the token with braze */
+        BrazeService.shared.registerDeviceToken(deviceToken)
 
         Task { [profile] in
             do {

--- a/firefox-ios/Ecosia/Braze/BrazeService.swift
+++ b/firefox-ios/Ecosia/Braze/BrazeService.swift
@@ -50,7 +50,7 @@ public final class BrazeService: NSObject {
 
     public func registerDeviceToken(_ deviceToken: Data) {
         braze?.notifications.register(deviceToken: deviceToken)
-        updateID(userId)
+        updateID(userId) // this is takingn
     }
 
     public func logCustomEvent(_ event: CustomEvent) {
@@ -60,7 +60,7 @@ public final class BrazeService: NSObject {
     // MARK: - APN Consent
 
     func requestAPNConsent() async throws -> Bool {
-        await UIApplication.shared.registerForRemoteNotifications()
+        UIApplication.shared.registerForRemoteNotifications()
         let notificationCenter = makeNotificationCenter()
         let granted = try await notificationCenter.requestAuthorization(options: [.badge, .sound, .alert])
         await retrieveUserCurrentNotificationAuthStatus() // Make sure status is always updated


### PR DESCRIPTION
[MOB-4878]

## Context

* Do not merge *

We are missing the call that registers APN token with Braze, this fixes it. 

## Approach

## Other

## Before merging

Need to make sure that this wasn't intended to be removed first.

### Checklist

- [ ] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [ ] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4878]: https://ecosia.atlassian.net/browse/MOB-4878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ