### PR TITLE
Use xlarge runner for unit tests

### DIFF
--- a/.github/actions/perform_unit_tests/action.yml
+++ b/.github/actions/perform_unit_tests/action.yml
@@ -77,7 +77,7 @@ runs:
 
     - name: Publish Test Report
       if: always()
-      uses: mikepenz/action-junit-report@v5
+      uses: mikepenz/action-junit-report@v6
       with:
         report_paths: '**/test_output/xml/report.junit'
         github_token: ${{ inputs.github-token }}

--- a/.github/workflows/merge_tests.yml
+++ b/.github/workflows/merge_tests.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   execute_merge_tests:
-    runs-on: macos-26
+    runs-on: macos-26-xlarge
     name: Execute Merge Tests
 
     steps:


### PR DESCRIPTION
Try xlarge CI runner to speed up unit tests. 

Time went down by 50% from ~40min to ~20min.

I'd consider this a low hanging fruit and progress.  I put a reminder to myself to check costs end of September.

Side effect: Node upgrade was needed for the publish tests job
