### PR TITLE
Adds logic for clearing cookies from shared jar after logout

### DIFF
--- a/firefox-ios/Ecosia/Account/Auth/EcosiaAuthenticationService.swift
+++ b/firefox-ios/Ecosia/Account/Auth/EcosiaAuthenticationService.swift
@@ -185,6 +185,12 @@ public final class EcosiaAuthenticationService: @unchecked Sendable {
 
         if credentialsCleared {
             setupTokensWithCredentials(nil)
+            // Stale SSO credentials would otherwise let getSessionTokenCookie() hand out
+            // the previous user's session transfer token before the next login refreshes it.
+            ssoCredentials = nil
+            // A stale EASC cookie left in the native cookie jar (copied there for file uploads)
+            // would get attached to native requests for whichever user logs in next.
+            FileUploadAuthCookieSync.clearAuthSessionCookieFromSharedStorage()
             // Clear user profile on logout
             try await ImageCacheLoader.clearCache(for: userProfile?.pictureURL)
             userProfile = nil

--- a/firefox-ios/Ecosia/Core/FileUpload/FileUploadAuthCookieSync.swift
+++ b/firefox-ios/Ecosia/Core/FileUpload/FileUploadAuthCookieSync.swift
@@ -45,6 +45,19 @@ enum FileUploadAuthCookieSync {
 
         return easc ?? sharedCookies.first { $0.name == Cookie.authSession.rawValue }
     }
+
+    /// Removes any `EASC` cookie previously copied into `HTTPCookieStorage.shared`.
+    ///
+    /// `syncAuthSessionCookieToSharedStorage` copies `EASC` out of the WKWebView cookie jar so native
+    /// `URLSession` calls can see it, but that copy lives independently of the WKWebView store and isn't
+    /// cleared when the web session cookie is. Call this on logout so a stale session cookie for the
+    /// previous user can't be attached to native requests made under a different, newly logged-in user.
+    static func clearAuthSessionCookieFromSharedStorage() {
+        let cookies = HTTPCookieStorage.shared.cookies ?? []
+        cookies
+            .filter { $0.name == Cookie.authSession.rawValue }
+            .forEach { HTTPCookieStorage.shared.deleteCookie($0) }
+    }
 }
 
 enum FileUploadAuthDiagnostics {


### PR DESCRIPTION
## Context

We had some internal reports of failing logins, or weird behaviour on login, like sync failing.

Auth0 showed some warnings:`"message": "Session Transfer Token user mismatch: session_transfer_token user (apple|<redacted>) does not match user from previous session (google-oauth2|<redacted>)."`
      }

Which points at cookie state not being cleared correctly on logout

Will add before and after, once the fix is working

## Approach

## Other

## Before merging

### Checklist

- [ ] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [ ] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed