### PR TITLE
Adds a open PR comment to prepush 

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -56,3 +56,24 @@
 # fi
 
 # exit 0
+
+# Ecosia: print the correct compare URL for this push so PRs don't get opened
+# against mozilla-mobile/firefox-ios by accident via GitHub's "Compare & pull
+# request" banner (which defaults the base repo to the upstream fork parent).
+remote_url="$2"
+case "$remote_url" in
+  *ecosia/ios-browser*)
+    while read -r local_ref local_sha remote_ref remote_sha; do
+      z40=0000000000000000000000000000000000000000
+      if [ "$local_sha" != "$z40" ]; then
+        branch=$(echo "$local_ref" | sed 's,.*/,,')
+        echo ""
+        echo "To open a PR, use this link (do NOT use GitHub's banner — it defaults to mozilla-mobile/firefox-ios):"
+        echo "  https://github.com/ecosia/ios-browser/compare/main...${branch}?expand=1"
+        echo ""
+      fi
+    done
+    ;;
+esac
+
+exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -63,14 +63,24 @@
 remote_url="$2"
 case "$remote_url" in
   *ecosia/ios-browser*)
+    # 256-color blue (33, "DodgerBlue") reads clearly on both light and dark terminal
+    # backgrounds, unlike the standard ANSI blue (34) which is often too dark to read
+    # on dark themes. Only colorize when stdout is a real terminal.
+    if [ -t 1 ]; then
+      blue='\033[38;5;33m'
+      reset='\033[0m'
+    else
+      blue=''
+      reset=''
+    fi
     while read -r local_ref local_sha remote_ref remote_sha; do
       z40=0000000000000000000000000000000000000000
       if [ "$local_sha" != "$z40" ]; then
         branch=$(echo "$local_ref" | sed 's,.*/,,')
-        echo ""
-        echo "To open a PR, use this link (do NOT use GitHub's banner — it defaults to mozilla-mobile/firefox-ios):"
-        echo "  https://github.com/ecosia/ios-browser/compare/main...${branch}?expand=1"
-        echo ""
+        printf '\n'
+        printf "${blue}To open a PR, use this link (do NOT use GitHub's banner — it defaults to mozilla-mobile/firefox-ios):${reset}\n"
+        printf "${blue}  https://github.com/ecosia/ios-browser/compare/main...%s?expand=1${reset}\n" "$branch"
+        printf '\n'
       fi
     done
     ;;

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -75,13 +75,20 @@ case "$remote_url" in
     fi
     while read -r local_ref local_sha remote_ref remote_sha; do
       z40=0000000000000000000000000000000000000000
-      if [ "$local_sha" != "$z40" ]; then
-        branch=$(echo "$local_ref" | sed 's,.*/,,')
-        printf '\n'
-        printf "${blue}To open a PR, use this link (do NOT use GitHub's banner — it defaults to mozilla-mobile/firefox-ios):${reset}\n"
-        printf "${blue}  https://github.com/ecosia/ios-browser/compare/main...%s?expand=1${reset}\n" "$branch"
-        printf '\n'
-      fi
+      # Only branches get a PR link (skip tags etc.), and strip the refs/heads/
+      # prefix rather than everything up to the last "/" so names like
+      # "feature/foo" keep their full path instead of becoming "foo".
+      case "$local_ref" in
+        refs/heads/*)
+          if [ "$local_sha" != "$z40" ]; then
+            branch=${local_ref#refs/heads/}
+            printf '\n'
+            printf "${blue}To open a PR, use this link (do NOT use GitHub's banner — it defaults to mozilla-mobile/firefox-ios):${reset}\n"
+            printf "${blue}  https://github.com/ecosia/ios-browser/compare/main...%s?expand=1${reset}\n" "$branch"
+            printf '\n'
+          fi
+          ;;
+      esac
     done
     ;;
 esac

--- a/.githooks/pre-push.test.sh
+++ b/.githooks/pre-push.test.sh
@@ -1,0 +1,92 @@
+#!/bin/sh
+# Ecosia: exercises the "print PR compare link" section of .githooks/pre-push.
+#
+# Not wired into CI — hooks are a local dev convenience (installed by bootstrap.sh),
+# not part of the build. Run manually after editing pre-push:
+#   sh .githooks/pre-push.test.sh
+
+set -eu
+
+script_dir=$(cd "$(dirname "$0")" && pwd)
+hook="$script_dir/pre-push"
+failures=0
+
+# args: description, remote_name, remote_url, stdin, expected_grep_pattern (empty string = expect no output)
+run_case() {
+  description="$1"
+  remote_name="$2"
+  remote_url="$3"
+  stdin_data="$4"
+  expected="$5"
+
+  output=$(printf '%s' "$stdin_data" | "$hook" "$remote_name" "$remote_url")
+  status=$?
+
+  if [ "$status" -ne 0 ]; then
+    echo "FAIL: $description (hook exited $status, expected 0)"
+    failures=$((failures + 1))
+    return
+  fi
+
+  if [ -z "$expected" ]; then
+    if [ -n "$output" ]; then
+      echo "FAIL: $description (expected no output, got: $output)"
+      failures=$((failures + 1))
+    else
+      echo "PASS: $description"
+    fi
+    return
+  fi
+
+  if echo "$output" | grep -qF "$expected"; then
+    echo "PASS: $description"
+  else
+    echo "FAIL: $description (expected to find: $expected)"
+    echo "  --- actual output ---"
+    echo "$output" | sed 's/^/  /'
+    failures=$((failures + 1))
+  fi
+}
+
+z40=0000000000000000000000000000000000000000
+
+# ecosia/ios-browser remote, pushing a new commit on a feature branch -> prints the compare link
+run_case \
+  "prints compare link for ecosia/ios-browser push" \
+  "origin" "git@github.com:ecosia/ios-browser.git" \
+  "refs/heads/my-feature abc123 refs/heads/my-feature def456
+" \
+  "https://github.com/ecosia/ios-browser/compare/main...my-feature?expand=1"
+
+# https remote form should match too
+run_case \
+  "prints compare link for https remote URL" \
+  "origin" "https://github.com/ecosia/ios-browser.git" \
+  "refs/heads/another-branch abc123 refs/heads/another-branch def456
+" \
+  "https://github.com/ecosia/ios-browser/compare/main...another-branch?expand=1"
+
+# unrelated remote -> no output at all
+run_case \
+  "stays silent for a non-ios-browser remote" \
+  "origin" "git@github.com:some-org/some-other-repo.git" \
+  "refs/heads/my-feature abc123 refs/heads/my-feature def456
+" \
+  ""
+
+# deleting a remote branch (local_sha is all zeros) -> nothing to compare, no output
+run_case \
+  "stays silent when deleting a remote branch" \
+  "origin" "git@github.com:ecosia/ios-browser.git" \
+  "refs/heads/my-feature $z40 refs/heads/my-feature def456
+" \
+  ""
+
+echo ""
+if [ "$failures" -eq 0 ]; then
+  echo "All pre-push hook tests passed."
+  exit 0
+else
+  echo "$failures pre-push hook test(s) failed."
+  exit 1
+fi

--- a/.githooks/pre-push.test.sh
+++ b/.githooks/pre-push.test.sh
@@ -82,6 +82,22 @@ run_case \
 " \
   ""
 
+# branch names with slashes must keep their full path, not just the last segment
+run_case \
+  "preserves full branch name for feature/foo" \
+  "origin" "git@github.com:ecosia/ios-browser.git" \
+  "refs/heads/feature/foo abc123 refs/heads/feature/foo def456
+" \
+  "https://github.com/ecosia/ios-browser/compare/main...feature/foo?expand=1"
+
+# pushing a tag isn't something you open a PR for -> no output
+run_case \
+  "stays silent when pushing a tag" \
+  "origin" "git@github.com:ecosia/ios-browser.git" \
+  "refs/tags/v1.0.0 abc123 refs/tags/v1.0.0 def456
+" \
+  ""
+
 echo ""
 if [ "$failures" -eq 0 ]; then
   echo "All pre-push hook tests passed."

--- a/.githooks/pre-push.test.sh
+++ b/.githooks/pre-push.test.sh
@@ -19,8 +19,12 @@ run_case() {
   stdin_data="$4"
   expected="$5"
 
+  # set -e would otherwise abort the whole script on a non-zero exit here,
+  # before status=$? ever runs, defeating the check below.
+  set +e
   output=$(printf '%s' "$stdin_data" | "$hook" "$remote_name" "$remote_url")
   status=$?
+  set -e
 
   if [ "$status" -ne 0 ]; then
     echo "FAIL: $description (hook exited $status, expected 0)"


### PR DESCRIPTION
## Context

I had the situation where I accidentally opened PRs against Firefox instead of our repo, which is annoying.

This adds an extra "use this link to open PR" comment to the output so you don't even have to think about that anymore.

I chose blue because I figured that works on white and black terminals. See screenshot

<img width="802" height="236" alt="Screenshot 2026-08-27 at 18 13 10" src="https://github.com/user-attachments/assets/013f42f8-aca0-4a4f-8983-3542ca854a33" />

