### PR TITLE
Adds a commit URL to the release notes of upload

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -108,7 +108,7 @@ platform :ios do
       app: ENV["FIREBASE_APP_ID"],
       firebase_cli_token: ENV["FIREBASE_TOKEN"],
       ipa_path: ENV["IPA_PATH"],
-      release_notes: "#{ENV['CIRCLE_BRANCH']}\nhttps://github.com/ecosia/ios-browser/commit/#{ENV['CIRCLE_SHA1']}",
+      release_notes: "#{ENV['CIRCLE_BRANCH']}\nhttps://github.com/ecosia/ios-browser/tree/#{ENV['CIRCLE_SHA1']}",
       groups: "ecosia-internal-testers"
     )
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -108,7 +108,7 @@ platform :ios do
       app: ENV["FIREBASE_APP_ID"],
       firebase_cli_token: ENV["FIREBASE_TOKEN"],
       ipa_path: ENV["IPA_PATH"],
-      release_notes: ENV["CIRCLE_BRANCH"],
+      release_notes: "#{ENV['CIRCLE_BRANCH']}\nhttps://github.com/ecosia/ios-browser/commit/#{ENV['CIRCLE_SHA1']}",
       groups: "ecosia-internal-testers"
     )
   end


### PR DESCRIPTION
## Context

It is useful to know exactly which commit the build was made from..

## Approach

The commit SHA1 is already available so we can easily add it to the notes. 