### PR TITLE
Move Translation check to Release PR

### DIFF
--- a/.circleci/release-config.yml
+++ b/.circleci/release-config.yml
@@ -41,27 +41,6 @@ macos_common: &macos_common
   resource_class: m4pro.medium
 
 jobs:
-  check-translations:
-    docker:
-      - image: cimg/base:stable
-    steps:
-      - checkout
-      - run:
-          name: Check if this is a dry-run
-          command: |
-            if [[ "<< pipeline.parameters.dry-run-mode >>" == "true" ]]; then
-              echo "🧪 DRY RUN MODE: Will report missing translations but not fail"
-              echo "export DRY_RUN=true" >> $BASH_ENV
-            else
-              echo "🚀 PRODUCTION MODE: Will fail if translations are missing"
-              echo "export DRY_RUN=false" >> $BASH_ENV
-            fi
-      - run:
-          name: Verify translation completeness
-          command: |
-            source $BASH_ENV
-            bash firefox-ios/Ecosia/L10N/check_translations.sh
-
   execute-critical-health-checks-ios:
     docker:
       - image: cimg/openjdk:17.0
@@ -171,8 +150,6 @@ workflows:
   release-pipeline:
     when: << pipeline.parameters.is-release-pipeline >>
     jobs:
-      - check-translations:
-          name: L10N Translation Completeness Check
       - execute-critical-health-checks-ios:
           name: Critical Health Checks (release cut pipeline)
           context: napps

--- a/.github/workflows/merge_tests.yml
+++ b/.github/workflows/merge_tests.yml
@@ -23,6 +23,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          # Keep GITHUB_TOKEN out of .git/config, where later steps could read it.
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-safe-chain
 

--- a/.github/workflows/snapshot_tests.yml
+++ b/.github/workflows/snapshot_tests.yml
@@ -18,7 +18,10 @@ jobs:
         uses: actions/checkout@v5
         with:
           lfs: true
-          submodules: true    
+          submodules: true
+          # Keep GITHUB_TOKEN out of .git/config, where later steps could read it.
+          # LFS and submodules are fetched by this step, while it still has auth.
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-safe-chain
 

--- a/.github/workflows/swift_lint.yml
+++ b/.github/workflows/swift_lint.yml
@@ -12,6 +12,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          # Keep GITHUB_TOKEN out of .git/config, where later steps could read it.
+          persist-credentials: false
 
       - name: SwiftLint
         run: |

--- a/.github/workflows/translation_check.yml
+++ b/.github/workflows/translation_check.yml
@@ -1,0 +1,33 @@
+name: Translation Completeness Check
+
+on:
+  pull_request:
+    branches: [main, 'patch/**']
+    paths:
+      - 'firefox-ios/Client/Ecosia/BuildSettingsConfigurations/EcosiaCommon.xcconfig'
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Report missing translations without failing'
+        type: boolean
+        default: false
+
+jobs:
+  check_translations:
+    runs-on: ubuntu-latest
+    name: L10N Translation Completeness Check
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Check for MARKETING_VERSION change
+        id: check_marketing_version
+        if: github.event_name == 'pull_request'
+        run: sh ./check_marketing_version.sh
+
+      - name: Verify translation completeness
+        if: ( steps.check_marketing_version.outputs.skipnext != 'true' )
+        env:
+          DRY_RUN: ${{ inputs.dry-run }}
+        run: bash firefox-ios/Ecosia/L10N/check_translations.sh

--- a/.github/workflows/translation_check.yml
+++ b/.github/workflows/translation_check.yml
@@ -1,5 +1,8 @@
 name: Translation Completeness Check
 
+# Non-blocking by design: surfaces missing translations on the release PR
+# rather than gating the merge. A red result can be merged over.
+
 on:
   pull_request:
     branches: [main, 'patch/**']

--- a/.github/workflows/translation_check.yml
+++ b/.github/workflows/translation_check.yml
@@ -23,6 +23,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          # Keep GITHUB_TOKEN out of .git/config, where later steps could read it.
+          # The MARKETING_VERSION check fetches origin/main, which needs no auth
+          # on a public repo.
+          persist-credentials: false
 
       - name: Check for MARKETING_VERSION change
         id: check_marketing_version

--- a/.github/workflows/upload_release_notes_to_appstore.yml
+++ b/.github/workflows/upload_release_notes_to_appstore.yml
@@ -15,6 +15,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          # Keep GITHUB_TOKEN out of .git/config, where later steps could read it.
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-safe-chain
 

--- a/firefox-ios/Client/Ecosia/BuildSettingsConfigurations/EcosiaCommon.xcconfig
+++ b/firefox-ios/Client/Ecosia/BuildSettingsConfigurations/EcosiaCommon.xcconfig
@@ -22,7 +22,7 @@ MOZ_WALLPAPER_ASSET_URL=https://cdn.ecosia.org/static/mobile-wallpapers
 OTHER_LDFLAGS = $(inherited) -lxml2
 
 // Ecosia: App marketing version — bump this for every release.
-MARKETING_VERSION = 12.5.0
+MARKETING_VERSION = 12.5.1
 
 // Ecosia: Build performance setting.
 EAGER_LINKING = NO

--- a/firefox-ios/Client/Ecosia/BuildSettingsConfigurations/EcosiaCommon.xcconfig
+++ b/firefox-ios/Client/Ecosia/BuildSettingsConfigurations/EcosiaCommon.xcconfig
@@ -22,7 +22,7 @@ MOZ_WALLPAPER_ASSET_URL=https://cdn.ecosia.org/static/mobile-wallpapers
 OTHER_LDFLAGS = $(inherited) -lxml2
 
 // Ecosia: App marketing version — bump this for every release.
-MARKETING_VERSION = 12.5.1
+MARKETING_VERSION = 12.5.0
 
 // Ecosia: Build performance setting.
 EAGER_LINKING = NO

--- a/firefox-ios/Ecosia/Ecosia.docc/README.md
+++ b/firefox-ios/Ecosia/Ecosia.docc/README.md
@@ -277,7 +277,7 @@ We manage translations using [Transifex](https://docs.transifex.com/client/intro
    - **Other Languages:** Handled via regular Transifex translators or Transifex AI.
 4. **Integration:** When a language reaches 100% completion, Transifex automatically opens a PR.
    - The engineer who added the initial source strings should monitor, review, and merge this PR.
-   - Translation completeness is also validated during the release flow via CI check.
+   - Translation completeness is also surfaced on the release PR via a non-blocking CI check.
 
 ### Ecosify Mozilla Strings (only needed after upgrade)
 
@@ -330,9 +330,13 @@ Make sure that `fastlane` and `transifex`-cli is installed.
 
 ### 🌍 L10N Translation Completeness Check
 
-As part of the release pipeline, a quality gate verifies that all localization keys defined in the English source file (`en.lproj/Ecosia.strings`) have corresponding translations for every supported language (German, French, Dutch, Spanish, and Italian). This prevents shipping a release candidate with missing translations that would result in users seeing untranslated English strings.
+A check verifies that all localization keys defined in the English source file (`en.lproj/Ecosia.strings`) have corresponding translations for every supported language (German, French, Dutch, Spanish, and Italian). It exists to make missing translations visible before a release candidate ships with untranslated English strings showing to users.
 
-The check runs automatically in CI before the TestFlight build. If any keys are missing, the pipeline fails with a descriptive error listing the missing keys grouped by language.
+It runs on the release PR (`.github/workflows/translation_check.yml`), on the same trigger used by the snapshot tests: a PR against `main` or `patch/**` that bumps `MARKETING_VERSION` in `EcosiaCommon.xcconfig`. If any keys are missing, the check fails with a descriptive error listing them grouped by language.
+
+**The check is non-blocking.** It is there for visibility: a red result can be consciously ignored and the release PR merged anyway, since missing translations often arrive later in the release cycle via Transifex. Read the failure before dismissing it, though.
+
+It can also be triggered manually from the Actions tab, optionally in dry-run mode.
 
 **Running the check locally:**
 

--- a/firefox-ios/Project.swift
+++ b/firefox-ios/Project.swift
@@ -35,12 +35,24 @@ let project = Project(
     settings: .settings(configurations: BuildConfigurations.all),
     targets: allTargets,
     schemes: EcosiaSchemes.all,
-    // Ecosia: Register root agent instruction files as Xcode project files so
-    // that Xcode's Coding Assistant can index and use them. Files under
-    // Ecosia/Ecosia.docc/ are already covered by the Ecosia framework target's
-    // resource glob and don't need to be listed here.
+    // Ecosia: Register root agent instruction files, CI configuration and
+    // automation scripts as Xcode project files so they are browsable in Xcode
+    // and indexable by the Coding Assistant. Files under Ecosia/Ecosia.docc/ are
+    // already covered by the Ecosia framework target's resource glob and don't
+    // need to be listed here.
     additionalFiles: [
         "../AGENTS.md",
-        "../CLAUDE.md"
+        "../CLAUDE.md",
+        // Globs rather than folder references: Tuist can't infer the `folder`
+        // file type for a dot-prefixed directory, so Xcode shows it as an opaque
+        // file. `**` doesn't recurse under one either, so each level is spelled
+        // out and matched by extension to avoid picking up directories.
+        .glob(pattern: "../.circleci/*.yml"),
+        .glob(pattern: "../.github/workflows/*.yml"),
+        .glob(pattern: "../.github/actions/*/action.yml"),
+        .glob(pattern: "../.github/scripts/*.py"),
+        .glob(pattern: "../.github/ISSUE_TEMPLATE/*.md"),
+        .glob(pattern: "../*.sh"),
+        .glob(pattern: "../*.py")
     ] + BuildConfigurations.additionalFiles,
 )


### PR DESCRIPTION
[NO-TICKET]

## Context

Last release I realised that the translation completeness check is a bit hidden as a non-blocking action after merging to main.

Same is true for CHC, though at least we have alerts there. Out of scope for now since it uses the `build-and-deploy-firebase-and-browserstack` build to run on BrowserStack, so trickier to move.

## Approach

Moved it to the Release PR check next to Snapshot tests. More visible and still bypass-able if needed.

## Other

* Adding our CI and script files to Tuist to make them editable on Xcode.
* Doing the `persist-credentials: false` Aikido suggestion on all necessary actions even if low severity 

## Before merging

### Checklist

- [ ] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [ ] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed