### PR TITLE
[MOB-4854] Adds login account type to sentry log

### DIFF
--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
@@ -279,7 +279,6 @@ extension BrowserViewController {
                 configuredAuth.login()
             }
         } else {
-            // TODO: can we add the type of account here? to see if they are all coming from apple logins or not...
             EcosiaLogger.auth.sentry("🔐 [WEB-AUTH] Inconsistent state: web says logged out but native doesn't; " +
                                      "forcing logout+re-login to avoid user getting locked (provider: \(extractProviderLabel(from: ecosiaAuth.userProfile?.sub)))")
 

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
@@ -230,7 +230,7 @@ extension BrowserViewController {
             return false
         }
     }
-    
+
     /// The account is formatted with the first before the | as the provider, e.g. google-oauth2|username or apple|username, so we can extract it
     private func extractProviderLabel(from sub: String?) -> String {
         guard let sub, let prefix = sub.split(separator: "|").first else { return "unknown" }

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
@@ -231,6 +231,7 @@ extension BrowserViewController {
         }
     }
     
+    /// The account is formatted with the first before the | as the provider, e.g. google-oauth2|username or apple|username, so we can extract it
     private func extractProviderLabel(from sub: String?) -> String {
         guard let sub, let prefix = sub.split(separator: "|").first else { return "unknown" }
         return String(prefix)

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+Ecosia.swift
@@ -230,6 +230,11 @@ extension BrowserViewController {
             return false
         }
     }
+    
+    private func extractProviderLabel(from sub: String?) -> String {
+        guard let sub, let prefix = sub.split(separator: "|").first else { return "unknown" }
+        return String(prefix)
+    }
 
     private func handleSignInAndSignUpDetection(
         _ url: URL,
@@ -274,8 +279,9 @@ extension BrowserViewController {
                 configuredAuth.login()
             }
         } else {
+            // TODO: can we add the type of account here? to see if they are all coming from apple logins or not...
             EcosiaLogger.auth.sentry("🔐 [WEB-AUTH] Inconsistent state: web says logged out but native doesn't; " +
-                                     "forcing logout+re-login to avoid user getting locked")
+                                     "forcing logout+re-login to avoid user getting locked (provider: \(extractProviderLabel(from: ecosiaAuth.userProfile?.sub)))")
 
             ecosiaAuth
                 .onAuthFlowCompleted { _ in


### PR DESCRIPTION
<!--
Don't forget to add a prefix to the pr title in this format
[MOB-####] PR SHORT DESCRIPTION
-->

[MOB-4854]

## Context

As a follow up to this https://ecosia.atlassian.net/browse/MOB-4898, I realised that issues exist with just apple accounts.

There was already this ticket for apple related problems which I repurpose into all apple login issues. 

## Approach

I want to attach the attempted login type to the 'out of sync' sentry messages. I'm wondering if we will find that they are all from apple logins.
I have some hunches of where those issues come from too, but that's for the next iteration of that ticket.

## Other

## Before merging

### Checklist

- [ ] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [ ] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4854]: https://ecosia.atlassian.net/browse/MOB-4854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ