### PR TITLE
Adds an optional prepush lint step

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -57,6 +57,20 @@
 
 # exit 0
 
+# Ecosia: Optional local SwiftLint check, off by default (linting is already
+# enforced as a CI check step on PRs). Opt in with:
+#   export IOS_BROWSER_LINT_ENABLED=true
+if [ "$IOS_BROWSER_LINT_ENABLED" = "true" ]; then
+    echo "IOS_BROWSER_LINT_ENABLED=true, running SwiftLint..."
+    swiftlint lint --quiet
+    RESULT=$?
+
+    if [ $RESULT -ne 0 ]; then
+        echo "SwiftLint found violations. Fix them, or push with --no-verify to skip."
+        exit 1
+    fi
+fi
+
 # Ecosia: print the correct compare URL for this push so PRs don't get opened
 # against mozilla-mobile/firefox-ios by accident via GitHub's "Compare & pull
 # request" banner (which defaults the base repo to the upstream fork parent).

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -62,7 +62,7 @@
 #   export IOS_BROWSER_LINT_ENABLED=true
 if [ "$IOS_BROWSER_LINT_ENABLED" = "true" ]; then
     echo "IOS_BROWSER_LINT_ENABLED=true, running SwiftLint..."
-    swiftlint lint --quiet
+    swiftlint lint --strict --quiet
     RESULT=$?
 
     if [ $RESULT -ne 0 ]; then

--- a/firefox-ios/Ecosia/Ecosia.docc/README.md
+++ b/firefox-ios/Ecosia/Ecosia.docc/README.md
@@ -91,8 +91,6 @@ Linting is enforced as a CI check on PRs, so the `pre-push` hook's SwiftLint che
 
     export IOS_BROWSER_LINT_ENABLED=true
 
-Note: this requires the repo’s `.githooks/pre-push` to be installed into `.git/hooks/pre-push` (e.g. by running `sh ./bootstrap.sh`, which copies `.githooks/*` into `.git/hooks`).
-
 With the flag unset (or `false`), `git push` behaves as normal. You can always skip the check for a single push with `git push --no-verify`.
 
 ## ⚙️ Building the code

--- a/firefox-ios/Ecosia/Ecosia.docc/README.md
+++ b/firefox-ios/Ecosia/Ecosia.docc/README.md
@@ -85,6 +85,16 @@ To ensure that these hooks are installed correctly in your local `.git/hooks` di
 
 This script will copy all the necessary hooks (such as `prepare-commit-msg`) to your local `.git/hooks` directory, ensuring they are executable.
 
+##### Optional: local SwiftLint pre-push check
+
+Linting is enforced as a CI check on PRs, so the `pre-push` hook's SwiftLint check is a no-op by default. If you'd like SwiftLint to run locally before each push (and block the push on violations), opt in by setting an environment variable:
+
+```shell
+export IOS_BROWSER_LINT_ENABLED=true
+```
+
+With the flag unset (or `false`), `git push` behaves as normal. You can always skip the check for a single push with `git push --no-verify`.
+
 ## ⚙️ Building the code
 
 ### Tuist

--- a/firefox-ios/Ecosia/Ecosia.docc/README.md
+++ b/firefox-ios/Ecosia/Ecosia.docc/README.md
@@ -89,9 +89,9 @@ This script will copy all the necessary hooks (such as `prepare-commit-msg`) to 
 
 Linting is enforced as a CI check on PRs, so the `pre-push` hook's SwiftLint check is a no-op by default. If you'd like SwiftLint to run locally before each push (and block the push on violations), opt in by setting an environment variable:
 
-```shell
-export IOS_BROWSER_LINT_ENABLED=true
-```
+    export IOS_BROWSER_LINT_ENABLED=true
+
+Note: this requires the repo’s `.githooks/pre-push` to be installed into `.git/hooks/pre-push` (e.g. by running `sh ./bootstrap.sh`, which copies `.githooks/*` into `.git/hooks`).
 
 With the flag unset (or `false`), `git push` behaves as normal. You can always skip the check for a single push with `git push --no-verify`.
 


### PR DESCRIPTION
## Context

I'd like to be able to opt-in to linting locally, may save some CI costs and effort

## Approach

Adds lint code to prepush hook, that only runs if a specific env var is set.
Can skip with --no-verify apparently (not tested)

It uses --quiet and --strict, so warnings are upgraded, but it doesnt print all the progress

## Other

## Before merging

### Checklist

- [ ] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [x] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [x] I included documentation updates to the coding standards or Confluence doc, when needed