### PR TITLE
Adds git lfs prepush

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -7,6 +7,21 @@ refs_input=$(mktemp)
 trap 'rm -f "$refs_input"' EXIT
 cat > "$refs_input"
 
+# Ecosia: Git LFS pre-push check, merged in by hand because `git lfs install`
+# refuses to overwrite an existing pre-push hook rather than merging into it.
+# Prints a message and continues (doesn't block the push) if git-lfs isn't
+# installed, since not every checkout needs LFS. Reads from $refs_input (not
+# stdin) since stdin was already consumed above.
+if command -v git-lfs >/dev/null 2>&1; then
+    git lfs pre-push "$@" < "$refs_input"
+    RESULT=$?
+    if [ $RESULT -ne 0 ]; then
+        exit $RESULT
+    fi
+else
+    echo "git-lfs not installed, skipping LFS pre-push check"
+fi
+
 ## Ecosia: Comment out pre-commit hook. This is handled as a check step on PRs.
 
 # echo "Starting Swiftlint Check..."

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -9,17 +9,20 @@ cat > "$refs_input"
 
 # Ecosia: Git LFS pre-push check, merged in by hand because `git lfs install`
 # refuses to overwrite an existing pre-push hook rather than merging into it.
-# Prints a message and continues (doesn't block the push) if git-lfs isn't
-# installed, since not every checkout needs LFS. Reads from $refs_input (not
-# stdin) since stdin was already consumed above.
-if command -v git-lfs >/dev/null 2>&1; then
-    git lfs pre-push "$@" < "$refs_input"
-    RESULT=$?
-    if [ $RESULT -ne 0 ]; then
-        exit $RESULT
+# LFS is only relevant if the SnapshotArtifacts submodule (the only thing
+# tracked with filter=lfs) is actually checked out — both it and git-lfs
+# itself are optional, so this stays a no-op for anyone who skipped either.
+# Reads from $refs_input (not stdin) since stdin was already consumed above.
+if [ -f "firefox-ios/EcosiaTests/SnapshotTests/SnapshotArtifacts/.git" ]; then
+    if command -v git-lfs >/dev/null 2>&1; then
+        git lfs pre-push "$@" < "$refs_input"
+        RESULT=$?
+        if [ $RESULT -ne 0 ]; then
+            exit $RESULT
+        fi
+    else
+        echo "git-lfs not installed, skipping LFS pre-push check"
     fi
-else
-    echo "git-lfs not installed, skipping LFS pre-push check"
 fi
 
 ## Ecosia: Comment out pre-commit hook. This is handled as a check step on PRs.

--- a/.githooks/pre-push.test.sh
+++ b/.githooks/pre-push.test.sh
@@ -121,6 +121,38 @@ else
   echo "PASS: prints a skip message and succeeds when git-lfs is not installed"
 fi
 
+# SnapshotArtifacts submodule not checked out -> hook stays silent even with
+# git-lfs on PATH, since there's nothing tracked with filter=lfs to act on.
+# Temporarily move its ".git" marker aside (it's a plain text file for an
+# initialized submodule, not a real repo, so this is safe) and always
+# restore it, even on failure.
+submodule_git="$script_dir/../firefox-ios/EcosiaTests/SnapshotTests/SnapshotArtifacts/.git"
+if [ -f "$submodule_git" ]; then
+  mv "$submodule_git" "$submodule_git.bak"
+  trap 'mv "$submodule_git.bak" "$submodule_git" 2>/dev/null' EXIT
+
+  set +e
+  output=$(printf 'refs/heads/my-feature abc123 refs/heads/my-feature def456\n' \
+    | (cd "$script_dir/.." && "$hook" "origin" "git@github.com:some-org/some-other-repo.git"))
+  status=$?
+  set -e
+
+  mv "$submodule_git.bak" "$submodule_git"
+  trap - EXIT
+
+  if [ "$status" -ne 0 ]; then
+    echo "FAIL: stays silent when the SnapshotArtifacts submodule isn't checked out (hook exited $status, expected 0)"
+    failures=$((failures + 1))
+  elif [ -n "$output" ]; then
+    echo "FAIL: stays silent when the SnapshotArtifacts submodule isn't checked out (expected no output, got: $output)"
+    failures=$((failures + 1))
+  else
+    echo "PASS: stays silent when the SnapshotArtifacts submodule isn't checked out"
+  fi
+else
+  echo "SKIP: stays silent when the SnapshotArtifacts submodule isn't checked out (submodule not initialized here either)"
+fi
+
 echo ""
 if [ "$failures" -eq 0 ]; then
   echo "All pre-push hook tests passed."

--- a/.githooks/pre-push.test.sh
+++ b/.githooks/pre-push.test.sh
@@ -102,6 +102,25 @@ run_case \
 " \
   ""
 
+# git-lfs not on PATH -> hook prints a skip message and still succeeds.
+# Strip PATH down to /usr/bin:/bin so `command -v git-lfs` genuinely fails
+# (rather than mocking it), while git/mktemp/cat/printf are still found there.
+set +e
+output=$(printf 'refs/heads/my-feature abc123 refs/heads/my-feature def456\n' \
+  | PATH="/usr/bin:/bin" "$hook" "origin" "git@github.com:some-org/some-other-repo.git")
+status=$?
+set -e
+
+if [ "$status" -ne 0 ]; then
+  echo "FAIL: prints a skip message and succeeds when git-lfs is not installed (hook exited $status, expected 0)"
+  failures=$((failures + 1))
+elif ! echo "$output" | grep -qF "skipping LFS pre-push check"; then
+  echo "FAIL: prints a skip message and succeeds when git-lfs is not installed (expected skip message, got: $output)"
+  failures=$((failures + 1))
+else
+  echo "PASS: prints a skip message and succeeds when git-lfs is not installed"
+fi
+
 echo ""
 if [ "$failures" -eq 0 ]; then
   echo "All pre-push hook tests passed."

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+# Ecosia: Git LFS post-checkout hook, merged in by hand because `git lfs
+# install` refuses to overwrite an existing post-checkout hook rather than
+# merging into it. Prints a message and continues (doesn't block the
+# checkout) if git-lfs isn't installed, since not every checkout needs LFS.
+if command -v git-lfs >/dev/null 2>&1; then
+    git lfs post-checkout "$@"
+else
+    echo "git-lfs not installed, skipping LFS post-checkout hook"
+fi
+
 # Directory containing your custom hooks
 HOOKS_DIR="hooks"
 

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -2,12 +2,16 @@
 
 # Ecosia: Git LFS post-checkout hook, merged in by hand because `git lfs
 # install` refuses to overwrite an existing post-checkout hook rather than
-# merging into it. Prints a message and continues (doesn't block the
-# checkout) if git-lfs isn't installed, since not every checkout needs LFS.
-if command -v git-lfs >/dev/null 2>&1; then
-    git lfs post-checkout "$@"
-else
-    echo "git-lfs not installed, skipping LFS post-checkout hook"
+# merging into it. LFS is only relevant if the SnapshotArtifacts submodule
+# (the only thing tracked with filter=lfs) is actually checked out — both it
+# and git-lfs itself are optional, so this stays a no-op for anyone who
+# skipped either.
+if [ -f "firefox-ios/EcosiaTests/SnapshotTests/SnapshotArtifacts/.git" ]; then
+    if command -v git-lfs >/dev/null 2>&1; then
+        git lfs post-checkout "$@"
+    else
+        echo "git-lfs not installed, skipping LFS post-checkout hook"
+    fi
 fi
 
 # Directory containing your custom hooks

--- a/hooks/post-commit
+++ b/hooks/post-commit
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Ecosia: Git LFS post-commit hook, added because `git lfs install` won't
+# create hooks in this directory on its own (it's managed by setup_hooks.sh,
+# not by git-lfs). Prints a message and continues (doesn't block the commit)
+# if git-lfs isn't installed, since not every checkout needs LFS.
+if command -v git-lfs >/dev/null 2>&1; then
+    git lfs post-commit "$@"
+else
+    echo "git-lfs not installed, skipping LFS post-commit hook"
+fi

--- a/hooks/post-commit
+++ b/hooks/post-commit
@@ -2,10 +2,14 @@
 
 # Ecosia: Git LFS post-commit hook, added because `git lfs install` won't
 # create hooks in this directory on its own (it's managed by setup_hooks.sh,
-# not by git-lfs). Prints a message and continues (doesn't block the commit)
-# if git-lfs isn't installed, since not every checkout needs LFS.
-if command -v git-lfs >/dev/null 2>&1; then
-    git lfs post-commit "$@"
-else
-    echo "git-lfs not installed, skipping LFS post-commit hook"
+# not by git-lfs). LFS is only relevant if the SnapshotArtifacts submodule
+# (the only thing tracked with filter=lfs) is actually checked out — both it
+# and git-lfs itself are optional, so this stays a no-op for anyone who
+# skipped either.
+if [ -f "firefox-ios/EcosiaTests/SnapshotTests/SnapshotArtifacts/.git" ]; then
+    if command -v git-lfs >/dev/null 2>&1; then
+        git lfs post-commit "$@"
+    else
+        echo "git-lfs not installed, skipping LFS post-commit hook"
+    fi
 fi

--- a/hooks/post-merge
+++ b/hooks/post-merge
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Ecosia: Git LFS post-merge hook, added because `git lfs install` won't
+# create hooks in this directory on its own (it's managed by setup_hooks.sh,
+# not by git-lfs). Prints a message and continues (doesn't block the merge)
+# if git-lfs isn't installed, since not every checkout needs LFS.
+if command -v git-lfs >/dev/null 2>&1; then
+    git lfs post-merge "$@"
+else
+    echo "git-lfs not installed, skipping LFS post-merge hook"
+fi

--- a/hooks/post-merge
+++ b/hooks/post-merge
@@ -2,10 +2,14 @@
 
 # Ecosia: Git LFS post-merge hook, added because `git lfs install` won't
 # create hooks in this directory on its own (it's managed by setup_hooks.sh,
-# not by git-lfs). Prints a message and continues (doesn't block the merge)
-# if git-lfs isn't installed, since not every checkout needs LFS.
-if command -v git-lfs >/dev/null 2>&1; then
-    git lfs post-merge "$@"
-else
-    echo "git-lfs not installed, skipping LFS post-merge hook"
+# not by git-lfs). LFS is only relevant if the SnapshotArtifacts submodule
+# (the only thing tracked with filter=lfs) is actually checked out — both it
+# and git-lfs itself are optional, so this stays a no-op for anyone who
+# skipped either.
+if [ -f "firefox-ios/EcosiaTests/SnapshotTests/SnapshotArtifacts/.git" ]; then
+    if command -v git-lfs >/dev/null 2>&1; then
+        git lfs post-merge "$@"
+    else
+        echo "git-lfs not installed, skipping LFS post-merge hook"
+    fi
 fi


### PR DESCRIPTION
## Context

When setting up snapshot tests, one step requires added git prepush hooks. We already have one so it conflicts. So we need to add it manually 

## Approach

- Make sure git lfs is installed, otherwise ignore

## Other

## Before merging

### Checklist

- [ ] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [ ] If this PR changes snapshot-covered UI, I updated snapshot tests and `SnapshotArtifacts` references — **or** I added the `skip-snapshot-check` label because there is no visual impact ([coverage map](firefox-ios/Ecosia/Ecosia.docc/SNAPSHOT_TESTING_WIKI.md#snapshot-coverage-map))
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [ ] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed