### PR TITLE
Snapshot tests: adds/edits hooks

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -7,6 +7,21 @@ refs_input=$(mktemp)
 trap 'rm -f "$refs_input"' EXIT
 cat > "$refs_input"
 
+# Ecosia: Git LFS pre-push check, merged in by hand because `git lfs install`
+# refuses to overwrite an existing pre-push hook rather than merging into it.
+# Prints a message and continues (doesn't block the push) if git-lfs isn't
+# installed, since not every checkout needs LFS. Reads from $refs_input (not
+# stdin) since stdin was already consumed above.
+if command -v git-lfs >/dev/null 2>&1; then
+    git lfs pre-push "$@" < "$refs_input"
+    RESULT=$?
+    if [ $RESULT -ne 0 ]; then
+        exit $RESULT
+    fi
+else
+    echo "git-lfs not installed, skipping LFS pre-push check"
+fi
+
 ## Ecosia: Comment out pre-commit hook. This is handled as a check step on PRs.
 
 # echo "Starting Swiftlint Check..."

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -9,17 +9,20 @@ cat > "$refs_input"
 
 # Ecosia: Git LFS pre-push check, merged in by hand because `git lfs install`
 # refuses to overwrite an existing pre-push hook rather than merging into it.
-# Prints a message and continues (doesn't block the push) if git-lfs isn't
-# installed, since not every checkout needs LFS. Reads from $refs_input (not
-# stdin) since stdin was already consumed above.
-if command -v git-lfs >/dev/null 2>&1; then
-    git lfs pre-push "$@" < "$refs_input"
-    RESULT=$?
-    if [ $RESULT -ne 0 ]; then
-        exit $RESULT
+# LFS is only relevant if the SnapshotArtifacts submodule (the only thing
+# tracked with filter=lfs) is actually checked out — both it and git-lfs
+# itself are optional, so this stays a no-op for anyone who skipped either.
+# Reads from $refs_input (not stdin) since stdin was already consumed above.
+if [ -f "firefox-ios/EcosiaTests/SnapshotTests/SnapshotArtifacts/.git" ]; then
+    if command -v git-lfs >/dev/null 2>&1; then
+        git lfs pre-push "$@" < "$refs_input"
+        RESULT=$?
+        if [ $RESULT -ne 0 ]; then
+            exit $RESULT
+        fi
+    else
+        echo "git-lfs not installed, skipping LFS pre-push check"
     fi
-else
-    echo "git-lfs not installed, skipping LFS pre-push check"
 fi
 
 ## Ecosia: Comment out pre-commit hook. This is handled as a check step on PRs.

--- a/.githooks/pre-push.test.sh
+++ b/.githooks/pre-push.test.sh
@@ -121,6 +121,38 @@ else
   echo "PASS: prints a skip message and succeeds when git-lfs is not installed"
 fi
 
+# SnapshotArtifacts submodule not checked out -> hook stays silent even with
+# git-lfs on PATH, since there's nothing tracked with filter=lfs to act on.
+# Temporarily move its ".git" marker aside (it's a plain text file for an
+# initialized submodule, not a real repo, so this is safe) and always
+# restore it, even on failure.
+submodule_git="$script_dir/../firefox-ios/EcosiaTests/SnapshotTests/SnapshotArtifacts/.git"
+if [ -f "$submodule_git" ]; then
+  mv "$submodule_git" "$submodule_git.bak"
+  trap 'mv "$submodule_git.bak" "$submodule_git" 2>/dev/null' EXIT
+
+  set +e
+  output=$(printf 'refs/heads/my-feature abc123 refs/heads/my-feature def456\n' \
+    | (cd "$script_dir/.." && "$hook" "origin" "git@github.com:some-org/some-other-repo.git"))
+  status=$?
+  set -e
+
+  mv "$submodule_git.bak" "$submodule_git"
+  trap - EXIT
+
+  if [ "$status" -ne 0 ]; then
+    echo "FAIL: stays silent when the SnapshotArtifacts submodule isn't checked out (hook exited $status, expected 0)"
+    failures=$((failures + 1))
+  elif [ -n "$output" ]; then
+    echo "FAIL: stays silent when the SnapshotArtifacts submodule isn't checked out (expected no output, got: $output)"
+    failures=$((failures + 1))
+  else
+    echo "PASS: stays silent when the SnapshotArtifacts submodule isn't checked out"
+  fi
+else
+  echo "SKIP: stays silent when the SnapshotArtifacts submodule isn't checked out (submodule not initialized here either)"
+fi
+
 echo ""
 if [ "$failures" -eq 0 ]; then
   echo "All pre-push hook tests passed."

--- a/.githooks/pre-push.test.sh
+++ b/.githooks/pre-push.test.sh
@@ -102,6 +102,25 @@ run_case \
 " \
   ""
 
+# git-lfs not on PATH -> hook prints a skip message and still succeeds.
+# Strip PATH down to /usr/bin:/bin so `command -v git-lfs` genuinely fails
+# (rather than mocking it), while git/mktemp/cat/printf are still found there.
+set +e
+output=$(printf 'refs/heads/my-feature abc123 refs/heads/my-feature def456\n' \
+  | PATH="/usr/bin:/bin" "$hook" "origin" "git@github.com:some-org/some-other-repo.git")
+status=$?
+set -e
+
+if [ "$status" -ne 0 ]; then
+  echo "FAIL: prints a skip message and succeeds when git-lfs is not installed (hook exited $status, expected 0)"
+  failures=$((failures + 1))
+elif ! echo "$output" | grep -qF "skipping LFS pre-push check"; then
+  echo "FAIL: prints a skip message and succeeds when git-lfs is not installed (expected skip message, got: $output)"
+  failures=$((failures + 1))
+else
+  echo "PASS: prints a skip message and succeeds when git-lfs is not installed"
+fi
+
 echo ""
 if [ "$failures" -eq 0 ]; then
   echo "All pre-push hook tests passed."

--- a/firefox-ios/Ecosia/Ecosia.docc/SNAPSHOT_COVERAGE_MAP.md
+++ b/firefox-ios/Ecosia/Ecosia.docc/SNAPSHOT_COVERAGE_MAP.md
@@ -1,0 +1,18 @@
+# 📸 Snapshot Coverage Map
+
+When you change a component listed here, update its snapshot test and re-record references in the `SnapshotArtifacts` submodule in the same PR.
+
+The table below is generated from `firefox-ios/EcosiaTests/SnapshotTests/snapshot_coverage.json`. After adding coverage, update that file and run `./generate_snapshot_coverage_docs.sh` from the repo root.
+
+<!-- snapshot-coverage-map:start -->
+| UI area | Source (primary) | Snapshot test | Locales / themes |
+| --- | --- | --- | --- |
+| Welcome screen | `Ecosia/UI/ProductTour/WelcomeView.swift` | `OnboardingTests.testWelcomeScreen` | all locales, light only |
+| NTP header logo | `Client/Ecosia/UI/NTP/Header/NTPHeader.swift` | `HomepageComponentTests.testNTPHeaderLogo` | en, light + dark |
+| Customize button | `Client/Ecosia/UI/NTP/Header/NTPHeader.swift` | `HomepageComponentTests.testEcosiaCustomizeButton` | en, light + dark |
+| Account nav button (logged out) | `Client/Ecosia/UI/NTP/Header/NTPHeader.swift` | `HomepageComponentTests.testEcosiaAccountNavButton_loggedOut` | en, light + dark |
+| Impact cell | `Client/Ecosia/UI/NTP/Impact/NTPImpactCell.swift` | `HomepageComponentTests.testNTPImpactCell_withImpactRows` | en, light only |
+| NTP search bar | `Client/Ecosia/UI/NTP/SearchBar/NTPSearchBarView.swift` | `HomepageComponentTests.testNTPSearchBar_resting` | all locales, light + dark |
+| Pinned top site cell | `Client/Frontend/Home/TopSites/TopSiteItemCell.swift` | `HomepageComponentTests.testTopSiteItemCell_pinned` | en, light + dark |
+| Omnibox upload drawer | `Ecosia/UI/NTP/Upload/OmniboxUploadDrawerView.swift` | `NTPOmniboxUploadDrawerSnapshotTests.testOmniboxUploadDrawerSheet` | all locales, light + dark |
+<!-- snapshot-coverage-map:end -->

--- a/firefox-ios/Ecosia/Ecosia.docc/SNAPSHOT_TESTING_WIKI.md
+++ b/firefox-ios/Ecosia/Ecosia.docc/SNAPSHOT_TESTING_WIKI.md
@@ -5,22 +5,9 @@ The SnapshotTesting library is a Swift package that allows you to capture screen
 
 ## Snapshot coverage map
 
-When you change a component listed here, update its snapshot test and re-record references in the `SnapshotArtifacts` submodule in the same PR.
+When you change a component listed there, update its snapshot test and re-record references in the `SnapshotArtifacts` submodule in the same PR.
 
-The table below is generated from `firefox-ios/EcosiaTests/SnapshotTests/snapshot_coverage.json`. After adding coverage, update that file and run `./generate_snapshot_coverage_docs.sh` from the repo root.
-
-<!-- snapshot-coverage-map:start -->
-| UI area | Source (primary) | Snapshot test | Locales / themes |
-| --- | --- | --- | --- |
-| Welcome screen | `Ecosia/UI/ProductTour/WelcomeView.swift` | `OnboardingTests.testWelcomeScreen` | all locales, light only |
-| NTP header logo | `Client/Ecosia/UI/NTP/Header/NTPHeader.swift` | `HomepageComponentTests.testNTPHeaderLogo` | en, light + dark |
-| Customize button | `Client/Ecosia/UI/NTP/Header/NTPHeader.swift` | `HomepageComponentTests.testEcosiaCustomizeButton` | en, light + dark |
-| Account nav button (logged out) | `Client/Ecosia/UI/NTP/Header/NTPHeader.swift` | `HomepageComponentTests.testEcosiaAccountNavButton_loggedOut` | en, light + dark |
-| Impact cell | `Client/Ecosia/UI/NTP/Impact/NTPImpactCell.swift` | `HomepageComponentTests.testNTPImpactCell_withImpactRows` | en, light only |
-| NTP search bar | `Client/Ecosia/UI/NTP/SearchBar/NTPSearchBarView.swift` | `HomepageComponentTests.testNTPSearchBar_resting` | all locales, light + dark |
-| Pinned top site cell | `Client/Frontend/Home/TopSites/TopSiteItemCell.swift` | `HomepageComponentTests.testTopSiteItemCell_pinned` | en, light + dark |
-| Omnibox upload drawer | `Ecosia/UI/NTP/Upload/OmniboxUploadDrawerView.swift` | `NTPOmniboxUploadDrawerSnapshotTests.testOmniboxUploadDrawerSheet` | all locales, light + dark |
-<!-- snapshot-coverage-map:end -->
+See [SNAPSHOT_COVERAGE_MAP.md](SNAPSHOT_COVERAGE_MAP.md) — the table is generated from `firefox-ios/EcosiaTests/SnapshotTests/snapshot_coverage.json`; after adding coverage, update that file and run `./generate_snapshot_coverage_docs.sh` from the repo root rather than editing the table by hand.
 
 **Adding coverage for a new screen:** create a test under `EcosiaTests/SnapshotTests/`, register the class in `snapshot_configuration.json`, add an entry to `snapshot_coverage.json`, run `./generate_snapshot_coverage_docs.sh`, run `sh tuist-setup.sh`, and record references.
 

--- a/generate_snapshot_coverage_docs.sh
+++ b/generate_snapshot_coverage_docs.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Regenerates the snapshot coverage map table in SNAPSHOT_TESTING_WIKI.md from
+# Regenerates the snapshot coverage map table in SNAPSHOT_COVERAGE_MAP.md from
 # firefox-ios/EcosiaTests/SnapshotTests/snapshot_coverage.json.
 #
 # Usage: ./generate_snapshot_coverage_docs.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "$0")" && pwd)"
 coverage_file="$repo_root/firefox-ios/EcosiaTests/SnapshotTests/snapshot_coverage.json"
-wiki_file="$repo_root/firefox-ios/Ecosia/Ecosia.docc/SNAPSHOT_TESTING_WIKI.md"
+coverage_map_file="$repo_root/firefox-ios/Ecosia/Ecosia.docc/SNAPSHOT_COVERAGE_MAP.md"
 start_marker="<!-- snapshot-coverage-map:start -->"
 end_marker="<!-- snapshot-coverage-map:end -->"
 
@@ -17,8 +17,8 @@ if [ ! -f "$coverage_file" ]; then
   exit 1
 fi
 
-if [ ! -f "$wiki_file" ]; then
-  echo "Error: wiki file not found at $wiki_file"
+if [ ! -f "$coverage_map_file" ]; then
+  echo "Error: coverage map file not found at $coverage_map_file"
   exit 1
 fi
 
@@ -41,16 +41,16 @@ for entry in data["entries"]:
 PY
 )
 
-python3 - "$wiki_file" "$start_marker" "$end_marker" "$table" <<'PY'
+python3 - "$coverage_map_file" "$start_marker" "$end_marker" "$table" <<'PY'
 import pathlib
 import sys
 
-wiki_path = pathlib.Path(sys.argv[1])
+coverage_map_path = pathlib.Path(sys.argv[1])
 start_marker = sys.argv[2]
 end_marker = sys.argv[3]
 table = sys.argv[4]
 
-content = wiki_path.read_text(encoding="utf-8")
+content = coverage_map_path.read_text(encoding="utf-8")
 start = content.index(start_marker) + len(start_marker)
 end = content.index(end_marker)
 
@@ -61,7 +61,7 @@ updated = (
     + "\n"
     + content[end:]
 )
-wiki_path.write_text(updated, encoding="utf-8")
+coverage_map_path.write_text(updated, encoding="utf-8")
 PY
 
-echo "Updated snapshot coverage map in $wiki_file"
+echo "Updated snapshot coverage map in $coverage_map_file"

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+# Ecosia: Git LFS post-checkout hook, merged in by hand because `git lfs
+# install` refuses to overwrite an existing post-checkout hook rather than
+# merging into it. Prints a message and continues (doesn't block the
+# checkout) if git-lfs isn't installed, since not every checkout needs LFS.
+if command -v git-lfs >/dev/null 2>&1; then
+    git lfs post-checkout "$@"
+else
+    echo "git-lfs not installed, skipping LFS post-checkout hook"
+fi
+
 # Directory containing your custom hooks
 HOOKS_DIR="hooks"
 

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -2,12 +2,16 @@
 
 # Ecosia: Git LFS post-checkout hook, merged in by hand because `git lfs
 # install` refuses to overwrite an existing post-checkout hook rather than
-# merging into it. Prints a message and continues (doesn't block the
-# checkout) if git-lfs isn't installed, since not every checkout needs LFS.
-if command -v git-lfs >/dev/null 2>&1; then
-    git lfs post-checkout "$@"
-else
-    echo "git-lfs not installed, skipping LFS post-checkout hook"
+# merging into it. LFS is only relevant if the SnapshotArtifacts submodule
+# (the only thing tracked with filter=lfs) is actually checked out — both it
+# and git-lfs itself are optional, so this stays a no-op for anyone who
+# skipped either.
+if [ -f "firefox-ios/EcosiaTests/SnapshotTests/SnapshotArtifacts/.git" ]; then
+    if command -v git-lfs >/dev/null 2>&1; then
+        git lfs post-checkout "$@"
+    else
+        echo "git-lfs not installed, skipping LFS post-checkout hook"
+    fi
 fi
 
 # Directory containing your custom hooks

--- a/hooks/post-commit
+++ b/hooks/post-commit
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Ecosia: Git LFS post-commit hook, added because `git lfs install` won't
+# create hooks in this directory on its own (it's managed by setup_hooks.sh,
+# not by git-lfs). Prints a message and continues (doesn't block the commit)
+# if git-lfs isn't installed, since not every checkout needs LFS.
+if command -v git-lfs >/dev/null 2>&1; then
+    git lfs post-commit "$@"
+else
+    echo "git-lfs not installed, skipping LFS post-commit hook"
+fi

--- a/hooks/post-commit
+++ b/hooks/post-commit
@@ -2,10 +2,14 @@
 
 # Ecosia: Git LFS post-commit hook, added because `git lfs install` won't
 # create hooks in this directory on its own (it's managed by setup_hooks.sh,
-# not by git-lfs). Prints a message and continues (doesn't block the commit)
-# if git-lfs isn't installed, since not every checkout needs LFS.
-if command -v git-lfs >/dev/null 2>&1; then
-    git lfs post-commit "$@"
-else
-    echo "git-lfs not installed, skipping LFS post-commit hook"
+# not by git-lfs). LFS is only relevant if the SnapshotArtifacts submodule
+# (the only thing tracked with filter=lfs) is actually checked out — both it
+# and git-lfs itself are optional, so this stays a no-op for anyone who
+# skipped either.
+if [ -f "firefox-ios/EcosiaTests/SnapshotTests/SnapshotArtifacts/.git" ]; then
+    if command -v git-lfs >/dev/null 2>&1; then
+        git lfs post-commit "$@"
+    else
+        echo "git-lfs not installed, skipping LFS post-commit hook"
+    fi
 fi

--- a/hooks/post-merge
+++ b/hooks/post-merge
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Ecosia: Git LFS post-merge hook, added because `git lfs install` won't
+# create hooks in this directory on its own (it's managed by setup_hooks.sh,
+# not by git-lfs). Prints a message and continues (doesn't block the merge)
+# if git-lfs isn't installed, since not every checkout needs LFS.
+if command -v git-lfs >/dev/null 2>&1; then
+    git lfs post-merge "$@"
+else
+    echo "git-lfs not installed, skipping LFS post-merge hook"
+fi

--- a/hooks/post-merge
+++ b/hooks/post-merge
@@ -2,10 +2,14 @@
 
 # Ecosia: Git LFS post-merge hook, added because `git lfs install` won't
 # create hooks in this directory on its own (it's managed by setup_hooks.sh,
-# not by git-lfs). Prints a message and continues (doesn't block the merge)
-# if git-lfs isn't installed, since not every checkout needs LFS.
-if command -v git-lfs >/dev/null 2>&1; then
-    git lfs post-merge "$@"
-else
-    echo "git-lfs not installed, skipping LFS post-merge hook"
+# not by git-lfs). LFS is only relevant if the SnapshotArtifacts submodule
+# (the only thing tracked with filter=lfs) is actually checked out — both it
+# and git-lfs itself are optional, so this stays a no-op for anyone who
+# skipped either.
+if [ -f "firefox-ios/EcosiaTests/SnapshotTests/SnapshotArtifacts/.git" ]; then
+    if command -v git-lfs >/dev/null 2>&1; then
+        git lfs post-merge "$@"
+    else
+        echo "git-lfs not installed, skipping LFS post-merge hook"
+    fi
 fi


### PR DESCRIPTION
## Context

One step in setting up snapshot tests required `git lfs install`: this command tries to add a bunch of hooks and fails with a warning because we already have a prepush.

## Approach

- Add them manually here. 
- Make sure it skips silently if there's no submodule or lfs isn't installed (in those cases it assumes it's not wanted)
- Move the coverage map into it's own file + updating the script that generates it

### Checklist

- [x] I wrote Unit Tests that confirm the expected behaviour
- [x] I added the `// Ecosia:` helper comments where needed
- [x] I included documentation updates to the coding standards or Confluence doc, when needed