### PR TITLE
[MOB-4898] Cleaning up more cookies on account switch

### DIFF
--- a/firefox-ios/Ecosia/Account/Auth/NativeToWebSSOAuth0Provider.swift
+++ b/firefox-ios/Ecosia/Account/Auth/NativeToWebSSOAuth0Provider.swift
@@ -53,11 +53,18 @@ public struct NativeToWebSSOAuth0Provider: Auth0ProviderProtocol, @unchecked Sen
         EcosiaLogger.auth.info("\(Cookie.authSession.name) cookie cleared successfully")
     }
 
-    /// Clears EASC (Ecosia Auth Session Cookie) cookies from the default web data store
+    /// Clears EASC (Ecosia Auth Session Cookie) cookies from the default web data store.
+    ///
+    /// Deletes every matching cookie, not just the first: the store can hold more than one `EASC`
+    /// at once if they differ by domain/path (e.g. a leftover from a previous session scoped
+    /// slightly differently), and leaving one behind lets the next login's session get confused
+    /// with the stale one.
     private func clearWebSessionCookies() async {
         let cookieStore = await WKWebsiteDataStore.default().httpCookieStore
-        guard let sessionCookie = await cookieStore.allCookies().first(where: { $0.name == Cookie.authSession.name }) else { return }
-        await cookieStore.deleteCookie(sessionCookie)
+        let sessionCookies = await cookieStore.allCookies().filter { $0.name == Cookie.authSession.name }
+        for cookie in sessionCookies {
+            await cookieStore.deleteCookie(cookie)
+        }
     }
 }
 

--- a/firefox-ios/Ecosia/Account/Auth/NativeToWebSSOAuth0Provider.swift
+++ b/firefox-ios/Ecosia/Account/Auth/NativeToWebSSOAuth0Provider.swift
@@ -56,7 +56,7 @@ public struct NativeToWebSSOAuth0Provider: Auth0ProviderProtocol, @unchecked Sen
     /// Clears `EASC` (Ecosia Auth Session Cookie) and any cookie scoped to the Auth0 tenant domain
     /// (e.g. `login.ecosia.org`) from the WKWebView's cookie store.
     ///
-    /// Deletes every matching cookie, not just the first: the store can hold more than one `EASC`
+    /// Deletes every matching cookie, the store can hold more than one `EASC`
     /// at once if they differ by domain/path (e.g. a leftover from a previous session scoped
     /// slightly differently), and leaving one behind lets the next login's session get confused
     /// with the stale one.
@@ -79,24 +79,6 @@ public struct NativeToWebSSOAuth0Provider: Auth0ProviderProtocol, @unchecked Sen
         }
         for cookie in cookiesToClear {
             await cookieStore.deleteCookie(cookie)
-        }
-    }
-}
-
-private extension WKWebsiteDataStore {
-    func dataRecords(ofTypes types: Set<String>) async -> [WKWebsiteDataRecord] {
-        await withCheckedContinuation { continuation in
-            fetchDataRecords(ofTypes: types) { records in
-                continuation.resume(returning: records)
-            }
-        }
-    }
-
-    func removeData(ofTypes types: Set<String>, for records: [WKWebsiteDataRecord]) async {
-        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-            removeData(ofTypes: types, for: records) {
-                continuation.resume()
-            }
         }
     }
 }

--- a/firefox-ios/Ecosia/Account/Auth/NativeToWebSSOAuth0Provider.swift
+++ b/firefox-ios/Ecosia/Account/Auth/NativeToWebSSOAuth0Provider.swift
@@ -54,16 +54,31 @@ public struct NativeToWebSSOAuth0Provider: Auth0ProviderProtocol, @unchecked Sen
         EcosiaLogger.auth.info("\(Cookie.authSession.name) cookie cleared successfully")
     }
 
-    /// Clears EASC (Ecosia Auth Session Cookie) cookies from the default web data store.
+    /// Clears `EASC` (Ecosia Auth Session Cookie) and any cookie scoped to the Auth0 tenant domain
+    /// (e.g. `login.ecosia.org`) from the WKWebView's cookie store.
     ///
     /// Deletes every matching cookie, not just the first: the store can hold more than one `EASC`
     /// at once if they differ by domain/path (e.g. a leftover from a previous session scoped
     /// slightly differently), and leaving one behind lets the next login's session get confused
     /// with the stale one.
+    ///
+    /// The Auth0-domain cookies matter for a separate reason: the native login uses
+    /// `.useEphemeralSession()` so it never leaves an Auth0 SSO session cookie behind, but the
+    /// invisible tab used for session transfer runs on the shared, persistent store. If Auth0's
+    /// custom domain sets its own SSO cookie there while processing the transfer token, nothing
+    /// clears it, and it can let a later, different account's transfer silently reuse the previous
+    /// user's still-valid Auth0 session. We don't know that cookie's name (it varies by
+    /// tenant/SDK), so it's matched by domain instead.
     private func clearWebSessionCookies() async {
         let cookieStore = await WKWebsiteDataStore.default().httpCookieStore
-        let sessionCookies = await cookieStore.allCookies().filter { $0.name == Cookie.authSession.name }
-        for cookie in sessionCookies {
+        let auth0Domain = settings.domain
+        let cookiesToClear = await cookieStore.allCookies().filter {
+            $0.name == Cookie.authSession.name ||
+            $0.domain == auth0Domain ||
+            $0.domain == ".\(auth0Domain)" ||
+            $0.domain.hasSuffix(".\(auth0Domain)")
+        }
+        for cookie in cookiesToClear {
             await cookieStore.deleteCookie(cookie)
         }
     }

--- a/firefox-ios/Ecosia/Account/Auth/NativeToWebSSOAuth0Provider.swift
+++ b/firefox-ios/Ecosia/Account/Auth/NativeToWebSSOAuth0Provider.swift
@@ -103,7 +103,7 @@ public struct NativeToWebSSOAuth0Provider: Auth0ProviderProtocol, @unchecked Sen
             WKWebsiteDataTypeIndexedDBDatabases,
             WKWebsiteDataTypeServiceWorkerRegistrations
         ]
-        let dataStore = WKWebsiteDataStore.default()
+        let dataStore = await WKWebsiteDataStore.default()
         let records = await dataStore.dataRecords(ofTypes: types)
         let domain = environment.urlProvider.domain
         let matching = records.filter { $0.displayName == domain || $0.displayName.hasSuffix(".\(domain)") }

--- a/firefox-ios/Ecosia/Account/Auth/NativeToWebSSOAuth0Provider.swift
+++ b/firefox-ios/Ecosia/Account/Auth/NativeToWebSSOAuth0Provider.swift
@@ -53,21 +53,13 @@ public struct NativeToWebSSOAuth0Provider: Auth0ProviderProtocol, @unchecked Sen
         EcosiaLogger.auth.info("\(Cookie.authSession.name) cookie cleared successfully")
     }
 
-    /// Clears `EASC` (Ecosia Auth Session Cookie) and any cookie scoped to the Auth0 tenant domain
-    /// (e.g. `login.ecosia.org`) from the WKWebView's cookie store.
+    /// Clears  all`EASC` (Ecosia Auth Session Cookie) cookies and any cookie scoped to the Auth0 tenant
+    /// domain (e.g. `login.ecosia.org`) from the WKWebView's cookie store.
     ///
-    /// Deletes every matching cookie, the store can hold more than one `EASC`
-    /// at once if they differ by domain/path (e.g. a leftover from a previous session scoped
-    /// slightly differently), and leaving one behind lets the next login's session get confused
-    /// with the stale one.
-    ///
-    /// The Auth0-domain cookies matter for a separate reason: the native login uses
-    /// `.useEphemeralSession()` so it never leaves an Auth0 SSO session cookie behind, but the
-    /// invisible tab used for session transfer runs on the shared, persistent store. If Auth0's
-    /// custom domain sets its own SSO cookie there while processing the transfer token, nothing
-    /// clears it, and it can let a later, different account's transfer silently reuse the previous
-    /// user's still-valid Auth0 session. We don't know that cookie's name (it varies by
-    /// tenant/SDK), so it's matched by domain instead.
+    /// The native login uses `.useEphemeralSession()` so it never leaves an Auth0 SSO session cookie behind, but the
+    /// invisible tab used for session transfer runs on shared, persistent store so we must explictly clear the SSO cookie that is
+    /// set by Auth0's custom domain - otherwise we risk silently re-using the previous user's still-valid Auth0 session.
+    /// We don't know that cookie's name because it varies by tenant/SDK, so it's matched by domain instead.
     private func clearWebSessionCookies() async {
         let cookieStore = await WKWebsiteDataStore.default().httpCookieStore
         let auth0Domain = settings.domain

--- a/firefox-ios/Ecosia/Account/Auth/NativeToWebSSOAuth0Provider.swift
+++ b/firefox-ios/Ecosia/Account/Auth/NativeToWebSSOAuth0Provider.swift
@@ -50,7 +50,6 @@ public struct NativeToWebSSOAuth0Provider: Auth0ProviderProtocol, @unchecked Sen
         // Skip calling webAuth.clearSession() to avoid Auth0's native logout alert
         // Logout happens immediately without any confirmation dialogs by clearing the auth session cookie
         await clearWebSessionCookies()
-        await clearWebStorage()
         EcosiaLogger.auth.info("\(Cookie.authSession.name) cookie cleared successfully")
     }
 
@@ -81,34 +80,6 @@ public struct NativeToWebSSOAuth0Provider: Auth0ProviderProtocol, @unchecked Sen
         for cookie in cookiesToClear {
             await cookieStore.deleteCookie(cookie)
         }
-    }
-
-    /// Clears client-side web storage (`localStorage`, `sessionStorage`, IndexedDB, Service Worker
-    /// registrations) for the Ecosia domain from the default web data store. Cookies are untouched
-    /// here — `EASC` is cleared separately by name in `clearWebSessionCookies()`, and everything
-    /// else (analytics, consent, feature-flag cookies) is intentionally left alone.
-    ///
-    /// The native-to-web session transfer depends on the web app noticing a new session and
-    /// re-running its own login handshake. If it caches "already logged in as X" client-side,
-    /// that cache surviving a logout can make it skip the handshake for the next login, even
-    /// though a fresh session-transfer cookie was set. Scoped to the Ecosia domain (matches by
-    /// eTLD+1, so `www.`/`login.`/`api.` subdomains are all covered) so unrelated sites the user
-    /// has visited in regular tabs keep their own storage untouched. Deliberately excludes asset/
-    /// offline caches (`FetchCache`, `OfflineWebApplicationCache`) since those hold cached static
-    /// resources, not login state — clearing them would just force re-downloads for no benefit.
-    private func clearWebStorage() async {
-        let types: Set<String> = [
-            WKWebsiteDataTypeLocalStorage,
-            WKWebsiteDataTypeSessionStorage,
-            WKWebsiteDataTypeIndexedDBDatabases,
-            WKWebsiteDataTypeServiceWorkerRegistrations
-        ]
-        let dataStore = await WKWebsiteDataStore.default()
-        let records = await dataStore.dataRecords(ofTypes: types)
-        let domain = environment.urlProvider.domain
-        let matching = records.filter { $0.displayName == domain || $0.displayName.hasSuffix(".\(domain)") }
-        guard !matching.isEmpty else { return }
-        await dataStore.removeData(ofTypes: types, for: matching)
     }
 }
 

--- a/firefox-ios/Ecosia/Account/Auth/NativeToWebSSOAuth0Provider.swift
+++ b/firefox-ios/Ecosia/Account/Auth/NativeToWebSSOAuth0Provider.swift
@@ -50,6 +50,7 @@ public struct NativeToWebSSOAuth0Provider: Auth0ProviderProtocol, @unchecked Sen
         // Skip calling webAuth.clearSession() to avoid Auth0's native logout alert
         // Logout happens immediately without any confirmation dialogs by clearing the auth session cookie
         await clearWebSessionCookies()
+        await clearWebStorage()
         EcosiaLogger.auth.info("\(Cookie.authSession.name) cookie cleared successfully")
     }
 
@@ -64,6 +65,52 @@ public struct NativeToWebSSOAuth0Provider: Auth0ProviderProtocol, @unchecked Sen
         let sessionCookies = await cookieStore.allCookies().filter { $0.name == Cookie.authSession.name }
         for cookie in sessionCookies {
             await cookieStore.deleteCookie(cookie)
+        }
+    }
+
+    /// Clears client-side web storage (`localStorage`, `sessionStorage`, IndexedDB, Service Worker
+    /// registrations) for the Ecosia domain from the default web data store. Cookies are untouched
+    /// here — `EASC` is cleared separately by name in `clearWebSessionCookies()`, and everything
+    /// else (analytics, consent, feature-flag cookies) is intentionally left alone.
+    ///
+    /// The native-to-web session transfer depends on the web app noticing a new session and
+    /// re-running its own login handshake. If it caches "already logged in as X" client-side,
+    /// that cache surviving a logout can make it skip the handshake for the next login, even
+    /// though a fresh session-transfer cookie was set. Scoped to the Ecosia domain (matches by
+    /// eTLD+1, so `www.`/`login.`/`api.` subdomains are all covered) so unrelated sites the user
+    /// has visited in regular tabs keep their own storage untouched. Deliberately excludes asset/
+    /// offline caches (`FetchCache`, `OfflineWebApplicationCache`) since those hold cached static
+    /// resources, not login state — clearing them would just force re-downloads for no benefit.
+    private func clearWebStorage() async {
+        let types: Set<String> = [
+            WKWebsiteDataTypeLocalStorage,
+            WKWebsiteDataTypeSessionStorage,
+            WKWebsiteDataTypeIndexedDBDatabases,
+            WKWebsiteDataTypeServiceWorkerRegistrations
+        ]
+        let dataStore = WKWebsiteDataStore.default()
+        let records = await dataStore.dataRecords(ofTypes: types)
+        let domain = environment.urlProvider.domain
+        let matching = records.filter { $0.displayName == domain || $0.displayName.hasSuffix(".\(domain)") }
+        guard !matching.isEmpty else { return }
+        await dataStore.removeData(ofTypes: types, for: matching)
+    }
+}
+
+private extension WKWebsiteDataStore {
+    func dataRecords(ofTypes types: Set<String>) async -> [WKWebsiteDataRecord] {
+        await withCheckedContinuation { continuation in
+            fetchDataRecords(ofTypes: types) { records in
+                continuation.resume(returning: records)
+            }
+        }
+    }
+
+    func removeData(ofTypes types: Set<String>, for records: [WKWebsiteDataRecord]) async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            removeData(ofTypes: types, for: records) {
+                continuation.resume()
+            }
         }
     }
 }

--- a/firefox-ios/Ecosia/Core/Cookie/AuthSessionCookieHandler.swift
+++ b/firefox-ios/Ecosia/Core/Cookie/AuthSessionCookieHandler.swift
@@ -2,12 +2,18 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-import Foundation
+import WebKit
 
 final class AuthSessionCookieHandler: BaseCookieHandler {
 
     init() {
         super.init(cookieName: Cookie.authSession.rawValue)
+    }
+
+    /// Mirrors `EASC` into `HTTPCookieStorage.shared` as soon as the WKWebView cookie store reports it,
+    /// so native `URLSession` calls can see the web session without waiting for an explicit sync point
+    override func received(_ cookie: HTTPCookie, in cookieStore: CookieStoreProtocol) {
+        HTTPCookieStorage.shared.setCookie(cookie)
     }
 
     /// Removes any `EASC` cookie previously copied into `HTTPCookieStorage.shared`.


### PR DESCRIPTION
[MOB-4898]

## Context

Testing other things, I realised that the account switching sometimes still wasn't working as expected - despite this ticket https://ecosia.atlassian.net/browse/MOB-4898 being through QA already. 

Initially in that ticket it was erroring, so that was solved in the [other PR](https://github.com/ecosia/ios-browser/pull/1256), this one now fixes the rest (hopefully)

## Approach

- I realised that during auth there is also web storage things scoped to auth0s domains, and those aren't being also cleared like they should

It's mentioned here: https://github.com/ecosia/core/blob/main/accounts/docs/iOS-Web-Authentication-Architecture.md#logout-flow that we don't clean up this stuff, but there's no why there. So we should confirm if that was a conscious (and still valid) reason or just stating the state of it

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I wrote Unit Tests that confirm the expected behaviour
- [ ] If this PR changes snapshot-covered UI, I updated snapshot tests and `SnapshotArtifacts` references — **or** I added the `skip-snapshot-check` label because there is no visual impact ([coverage map](firefox-ios/Ecosia/Ecosia.docc/SNAPSHOT_TESTING_WIKI.md#snapshot-coverage-map))
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [x] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4898]: https://ecosia.atlassian.net/browse/MOB-4898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ