### PR TITLE
[MOB-4926] Introduce X-Ecosia-App identification header

### DIFF
--- a/firefox-ios/Client/Ecosia/Extensions/Tab+Ecosia.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/Tab+Ecosia.swift
@@ -15,7 +15,8 @@ extension Tab {
     /// Mutations applied, in order:
     /// 1. **Cloudflare auth headers** – required for non-production environments.
     /// 2. **Language-region header** – enriches SERP requests for market selection.
-    /// 3. **Snowplow user id parameter** – appended to Ecosia URLs so the web SERP can
+    /// 3. **App header** – identifies the app and version to Ecosia backends, Ecosia hosts only.
+    /// 4. **Snowplow user id parameter** – appended to Ecosia URLs so the web SERP can
     ///    propagate it through its navigation links and link web Snowplow events back
     ///    to the native analytics identity. `ecosified()` sends the null UUID for
     ///    private tabs or when the user has opted out of analytics.
@@ -24,6 +25,9 @@ extension Tab {
         updated = updated.withCloudFlareAuthParameters()
         if updated.url?.isEcosiaSearchQuery() == true {
             updated.addLanguageRegionHeader()
+        }
+        if updated.url?.isEcosia() == true {
+            updated.addEcosiaAppHeader()
         }
         updated.url = updated.url.map { $0.ecosified(isIncognitoEnabled: isPrivate) }
         return updated

--- a/firefox-ios/Ecosia/Core/HTTPClient/Requestable/BaseRequest.swift
+++ b/firefox-ios/Ecosia/Core/HTTPClient/Requestable/BaseRequest.swift
@@ -69,7 +69,7 @@ public extension BaseRequest {
         // Ecosia: only attach app-identifying/Cloudflare Access headers when the host is
         // guaranteed to be ours — a `.custom` URL (CDN, presigned upload URL, ...) isn't.
         guard case .custom = baseURL else {
-            request.setValue("ios", forHTTPHeaderField: "X-Ecosia-App")
+            request.addEcosiaAppHeader()
             return request.withCloudFlareAuthParameters()
         }
         return request

--- a/firefox-ios/Ecosia/Core/URLRequest+Extensions.swift
+++ b/firefox-ios/Ecosia/Core/URLRequest+Extensions.swift
@@ -2,9 +2,18 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import Foundation
 
 extension URLRequest {
+
+    /// Name of the header identifying the Ecosia app to Ecosia backends.
+    public static let ecosiaAppHeaderField = "X-Ecosia-App"
+
+    /// Value of ``ecosiaAppHeaderField``: `<platform>[/<version>]`, e.g. `ios/12.5.0`.
+    public static var ecosiaAppHeaderValue: String {
+        "ios/\(AppInfo.ecosiaAppVersion)"
+    }
 
     @discardableResult
     public mutating func withCloudFlareAuthParameters(environment: Environment = EcosiaEnvironment.current) -> URLRequest {
@@ -26,5 +35,11 @@ extension URLRequest {
     /// to help SERP decide which market to serve.
     public mutating func addLanguageRegionHeader() {
         setValue(Locale.current.identifierWithDashedLanguageAndRegion, forHTTPHeaderField: "x-ecosia-app-language-region")
+    }
+
+    /// Identifies the app and its version to Ecosia backends.
+    /// Callers must scope this to Ecosia-owned hosts; it must never reach a third party.
+    public mutating func addEcosiaAppHeader() {
+        setValue(Self.ecosiaAppHeaderValue, forHTTPHeaderField: Self.ecosiaAppHeaderField)
     }
 }

--- a/firefox-ios/EcosiaTests/Core/BaseRequestTests.swift
+++ b/firefox-ios/EcosiaTests/Core/BaseRequestTests.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 @testable import Ecosia
 import XCTest
 
@@ -39,12 +40,12 @@ final class BaseRequestTests: XCTestCase {
 
     func testAPIRequestAttachesEcosiaAppHeader() throws {
         let request = try TestRequest(baseURL: .api).makeURLRequest()
-        XCTAssertEqual(request.value(forHTTPHeaderField: "X-Ecosia-App"), "ios")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "X-Ecosia-App"), "ios/\(AppInfo.ecosiaAppVersion)")
     }
 
     func testWebRequestAttachesEcosiaAppHeader() throws {
         let request = try TestRequest(baseURL: .web).makeURLRequest()
-        XCTAssertEqual(request.value(forHTTPHeaderField: "X-Ecosia-App"), "ios")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "X-Ecosia-App"), "ios/\(AppInfo.ecosiaAppVersion)")
     }
 
     func testCustomRequestDoesNotAttachEcosiaAppHeader() throws {

--- a/firefox-ios/EcosiaTests/Core/URLRequestTests.swift
+++ b/firefox-ios/EcosiaTests/Core/URLRequestTests.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import Common
 import XCTest
 @testable import Ecosia
 
@@ -26,6 +27,50 @@ final class URLRequestTests: XCTestCase {
 
         let expected = Locale.current.identifier.replacingOccurrences(of: "_", with: "-").lowercased()
         XCTAssertEqual(request.value(forHTTPHeaderField: "x-ecosia-app-language-region"), expected)
+    }
+
+    // MARK: - Ecosia app header
+
+    func testAddEcosiaAppHeader() {
+        // Given
+        var request = URLRequest(url: ecosiaURL)
+
+        // When
+        request.addEcosiaAppHeader()
+
+        // Then
+        XCTAssertEqual(request.value(forHTTPHeaderField: "X-Ecosia-App"), "ios/\(AppInfo.ecosiaAppVersion)")
+    }
+
+    func testAddEcosiaAppHeaderUsesPlatformSlashMarketingVersion() throws {
+        // Given
+        var request = URLRequest(url: ecosiaURL)
+
+        // When
+        request.addEcosiaAppHeader()
+
+        // Then
+        let value = try XCTUnwrap(request.value(forHTTPHeaderField: "X-Ecosia-App"))
+        let components = value.split(separator: "/", omittingEmptySubsequences: false).map(String.init)
+        XCTAssertEqual(components.count, 2)
+        XCTAssertEqual(components.first, "ios")
+        XCTAssertFalse(try XCTUnwrap(components.last).isEmpty)
+    }
+
+    func testAddEcosiaAppHeaderIsIdempotent() {
+        // Given
+        var request = URLRequest(url: ecosiaURL)
+
+        // When
+        request.addEcosiaAppHeader()
+        request.addEcosiaAppHeader()
+
+        // Then
+        XCTAssertEqual(request.value(forHTTPHeaderField: "X-Ecosia-App"), "ios/\(AppInfo.ecosiaAppVersion)")
+    }
+
+    func testEcosiaAppHeaderFieldName() {
+        XCTAssertEqual(URLRequest.ecosiaAppHeaderField, "X-Ecosia-App")
     }
 
     // MARK: - Cloudflare auth headers

--- a/firefox-ios/EcosiaTests/UI/TabManagement/TabEcosiaExtensionTests.swift
+++ b/firefox-ios/EcosiaTests/UI/TabManagement/TabEcosiaExtensionTests.swift
@@ -113,6 +113,32 @@ final class TabEcosiaExtensionTests: XCTestCase {
         XCTAssertNil(result.value(forHTTPHeaderField: "x-ecosia-app-language-region"))
     }
 
+    // MARK: - Ecosia app header
+
+    func testEcosiaAppHeaderAddedForEcosiaURL() {
+        let tab = makeTab(isPrivate: false)
+        let url = ecosiaURL("/")
+        let result = tab.ecosiaUpdatedRequest(URLRequest(url: url))
+
+        XCTAssertEqual(result.value(forHTTPHeaderField: "X-Ecosia-App"), "ios/\(AppInfo.ecosiaAppVersion)")
+    }
+
+    func testEcosiaAppHeaderAddedForEcosiaNonSERPURL() {
+        let tab = makeTab(isPrivate: false)
+        let url = ecosiaURL("/privacy")
+        let result = tab.ecosiaUpdatedRequest(URLRequest(url: url))
+
+        XCTAssertEqual(result.value(forHTTPHeaderField: "X-Ecosia-App"), "ios/\(AppInfo.ecosiaAppVersion)")
+    }
+
+    func testEcosiaAppHeaderNotAddedForNonEcosiaURL() {
+        let tab = makeTab(isPrivate: false)
+        let url = URL(string: "https://example.com/search?q=cats")!
+        let result = tab.ecosiaUpdatedRequest(URLRequest(url: url))
+
+        XCTAssertNil(result.value(forHTTPHeaderField: "X-Ecosia-App"))
+    }
+
     // MARK: - loadRequest integration
 
     func testLoadRequestPassesEcosifiedURLToWebView() {


### PR DESCRIPTION
[MOB-4926]

## Context

See ticket.

## Approach

Add the new header on Tab load just like the existing URL changes.

## Other

This is only affecting app-initiated flows, persistence will be covered on [MOB-2791](https://ecosia.atlassian.net/browse/MOB-2791).

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I wrote Unit Tests that confirm the expected behaviour
- [ ] If this PR changes snapshot-covered UI, I updated snapshot tests and `SnapshotArtifacts` references — **or** I added the `skip-snapshot-check` label because there is no visual impact ([coverage map](firefox-ios/Ecosia/Ecosia.docc/SNAPSHOT_TESTING_WIKI.md#snapshot-coverage-map))
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [ ] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4926]: https://ecosia.atlassian.net/browse/MOB-4926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MOB-2791]: https://ecosia.atlassian.net/browse/MOB-2791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ