### PR TITLE
[DONT MERGE] Add configurable auth0 domain var

### DIFF
--- a/BrowserKit/Sources/Shared/UserAgent.swift
+++ b/BrowserKit/Sources/Shared/UserAgent.swift
@@ -192,7 +192,8 @@ struct CustomUserAgentConstant {
         // Ecosia: WKWebView doesn't propagate `customUserAgent` overrides to fetch/XHR/Worker requests, only to document navigations,
         // we want to keep these domains on the plain desktop UA so every request (navigation and subresource) uses the same string.
         "ecosia.org": UserAgent.desktopUserAgent(),
-        "ecosia-staging.xyz": UserAgent.desktopUserAgent()
+        "ecosia-staging.xyz": UserAgent.desktopUserAgent(),
+        "ecosia-dev.xyz": UserAgent.desktopUserAgent()
     ]
 }
 

--- a/firefox-ios/Client/Ecosia/BuildSettingsConfigurations/EcosiaDebug.xcconfig
+++ b/firefox-ios/Client/Ecosia/BuildSettingsConfigurations/EcosiaDebug.xcconfig
@@ -17,7 +17,7 @@ LEANPLUM_ENVIRONMENT = development
 CODE_SIGN_ENTITLEMENTS = Ecosia/Entitlements/Ecosia.entitlements
 OTHER_SWIFT_FLAGS = $(OTHER_SWIFT_FLAGS_common) -DMOZ_CHANNEL_FENNEC
 OTHER_LDFLAGS = -ObjC -lxml2 -fprofile-instr-generate -ld_classic
-AUTH0_CLIENT_ID=FBaIsy0X5hIh2sSmalmf5pACZ512dIYl
+AUTH0_CLIENT_ID=hKsyM2wK1Plol0SjS8WLJgPnQRqG4lo5
 AUTH0_DOMAIN=login.ecosia-dev.xyz
 
 // Ecosia: For completeness — AppBuildChannel has no "debug" case, so this still resolves to .other.

--- a/firefox-ios/Client/Ecosia/BuildSettingsConfigurations/EcosiaDebug.xcconfig
+++ b/firefox-ios/Client/Ecosia/BuildSettingsConfigurations/EcosiaDebug.xcconfig
@@ -14,10 +14,10 @@ MOZ_BUNDLE_DISPLAY_NAME = Ecosia
 MOZ_BUNDLE_ID = com.ecosia.ecosiaapp
 INCLUDE_SETTINGS_BUNDLE = YES
 LEANPLUM_ENVIRONMENT = development
-CODE_SIGN_ENTITLEMENTS = Ecosia/Entitlements/Ecosia.entitlements
+CODE_SIGN_ENTITLEMENTS = Ecosia/Entitlements/EcosiaDebug.entitlements
 OTHER_SWIFT_FLAGS = $(OTHER_SWIFT_FLAGS_common) -DMOZ_CHANNEL_FENNEC
 OTHER_LDFLAGS = -ObjC -lxml2 -fprofile-instr-generate -ld_classic
-AUTH0_CLIENT_ID=hKsyM2wK1Plol0SjS8WLJgPnQRqG4lo5
+AUTH0_CLIENT_ID=FBaIsy0X5hIh2sSmalmf5pACZ512dIYl
 AUTH0_DOMAIN=login.ecosia-dev.xyz
 
 // Ecosia: For completeness — AppBuildChannel has no "debug" case, so this still resolves to .other.

--- a/firefox-ios/Client/Ecosia/BuildSettingsConfigurations/EcosiaDebug.xcconfig
+++ b/firefox-ios/Client/Ecosia/BuildSettingsConfigurations/EcosiaDebug.xcconfig
@@ -18,6 +18,7 @@ CODE_SIGN_ENTITLEMENTS = Ecosia/Entitlements/Ecosia.entitlements
 OTHER_SWIFT_FLAGS = $(OTHER_SWIFT_FLAGS_common) -DMOZ_CHANNEL_FENNEC
 OTHER_LDFLAGS = -ObjC -lxml2 -fprofile-instr-generate -ld_classic
 AUTH0_CLIENT_ID=FBaIsy0X5hIh2sSmalmf5pACZ512dIYl
+AUTH0_DOMAIN=login.ecosia-dev.xyz
 
 // Ecosia: For completeness — AppBuildChannel has no "debug" case, so this still resolves to .other.
 CHANNEL = debug

--- a/firefox-ios/Client/Info.plist
+++ b/firefox-ios/Client/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>AUTH0_CLIENT_ID</key>
 	<string>$(AUTH0_CLIENT_ID)</string>
+	<key>AUTH0_DOMAIN</key>
+	<string>$(AUTH0_DOMAIN)</string>
 	<key>AdjustAppToken</key>
 	<string>$(ADJUST_APP_TOKEN)</string>
 	<key>AppIdentifierPrefix</key>

--- a/firefox-ios/Ecosia/Core/Environment/URLProvider.swift
+++ b/firefox-ios/Ecosia/Core/Environment/URLProvider.swift
@@ -299,8 +299,11 @@ public enum URLProvider {
     // MARK: - Auth0 Configuration
 
     /// Auth0 domain for authentication (custom domain)
+    /// Overridable via the `AUTH0_DOMAIN` build setting (see EcosiaDebug.xcconfig) for
+    /// environments — like the simulator debug build — that authenticate against a
+    /// separate Auth0 tenant/custom domain than the rest of `domain`.
     public var auth0Domain: String {
-        "login.\(domain)"
+        EnvironmentFetcher.valueFromMainBundleOrProcessInfo(forKey: "AUTH0_DOMAIN") ?? "login.\(domain)"
     }
 
     /// Auth0 cookie domain for session management

--- a/firefox-ios/Ecosia/Entitlements/EcosiaDebug.entitlements
+++ b/firefox-ios/Ecosia/Entitlements/EcosiaDebug.entitlements
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.ecosia</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudDocuments</string>
+	</array>
+	<key>com.apple.developer.ubiquity-container-identifiers</key>
+	<array>
+		<string>iCloud.ecosia</string>
+	</array>
+	<key>com.apple.developer.web-browser</key>
+	<true/>
+	<key>com.apple.developer.browser.app-installation</key>
+	<true/>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.ecosia.ecosiaapp</string>
+	</array>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)com.ecosia.ecosiaapp</string>
+	</array>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>webcredentials:login.ecosia.org</string>
+		<string>webcredentials:login.ecosia-dev.xyz</string>
+	</array>
+</dict>
+</plist>

--- a/tuist-setup.sh
+++ b/tuist-setup.sh
@@ -126,7 +126,7 @@ if [ ! -f "$file_path" ]; then
     touch "$file_path"
     echo -e "${GREEN}✓ Staging.xcconfig created${NC}\n"
     {
-        echo "AUTH0_CLIENT_ID=Msl19FhlbwPk6IGQw2D8gzmyTwyeRG5D"
+        echo "AUTH0_CLIENT_ID=zNU6cgqji5cE9qPkkXIlqMJbIwTPShdU"
         echo "CF_ACCESS_CLIENT_ID=$CF_ACCESS_CLIENT_ID"
         echo "CF_ACCESS_CLIENT_SECRET=$CF_ACCESS_CLIENT_SECRET"
     } >> $file_path

--- a/tuist-setup.sh
+++ b/tuist-setup.sh
@@ -126,7 +126,7 @@ if [ ! -f "$file_path" ]; then
     touch "$file_path"
     echo -e "${GREEN}✓ Staging.xcconfig created${NC}\n"
     {
-        echo "AUTH0_CLIENT_ID=FBaIsy0X5hIh2sSmalmf5pACZ512dIYl"
+        echo "AUTH0_CLIENT_ID=Msl19FhlbwPk6IGQw2D8gzmyTwyeRG5D"
         echo "CF_ACCESS_CLIENT_ID=$CF_ACCESS_CLIENT_ID"
         echo "CF_ACCESS_CLIENT_SECRET=$CF_ACCESS_CLIENT_SECRET"
     } >> $file_path


### PR DESCRIPTION
! This is a bigger discussion for the whole team before we move forward with it - i.e. whether we should invest in setting up ecosia-dev.xyz generally or not

## Context

Couldn't auth in the simulator, kept getting 401 'invalid request, unknown client' in the response

Seems that the configs for Ecosia->dev weren't right, and the staging auth0_client_id was also wrong

## Approach

Adding a new env var Auth0_domain, so it can be explicitly configured. 

### Checklist

- [ ] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [ ] If this PR changes snapshot-covered UI, I updated snapshot tests and `SnapshotArtifacts` references — **or** I added the `skip-snapshot-check` label because there is no visual impact ([coverage map](firefox-ios/Ecosia/Ecosia.docc/SNAPSHOT_TESTING_WIKI.md#snapshot-coverage-map))
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [ ] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed