### PR TITLE
[MOB-4892] Fix for "Mail App" button in settings

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/AppSettingsTableViewController.swift
@@ -18,7 +18,11 @@ protocol SettingsFlowDelegate: AnyObject,
                                PrivacySettingsDelegate,
                                AccountSettingsDelegate,
                                AboutSettingsDelegate,
+                               /* Ecosia: Fix "Mail App" button in settings (MOB-4892)
                                SupportSettingsDelegate {
+                               */
+                               SupportSettingsDelegate,
+                               BrowsingSettingsDelegate {
     @MainActor
     func showDevicePassCode()
 
@@ -456,7 +460,7 @@ class AppSettingsTableViewController: SettingsTableViewController,
         }
         let theme = themeManager.getCurrentTheme(for: windowUUID)
         let generalSettings: [Setting] = [
-            OpenWithSetting(settings: self, settingsDelegate: nil),
+            OpenWithSetting(settings: self, settingsDelegate: parentCoordinator),
             ThemeSetting(settings: self, settingsDelegate: parentCoordinator),
             SiriPageSetting(settings: self, settingsDelegate: parentCoordinator),
             BlockPopupSetting(prefs: profile.prefs),

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockSettingsFlowDelegate.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockSettingsFlowDelegate.swift
@@ -12,7 +12,11 @@ class MockSettingsFlowDelegate: SettingsFlowDelegate,
                                 PrivacySettingsDelegate,
                                 AccountSettingsDelegate,
                                 AboutSettingsDelegate,
+                                /* Ecosia: Fix "Mail App" button in settings (MOB-4892)
                                 SupportSettingsDelegate {
+                                */
+                                SupportSettingsDelegate,
+                                BrowsingSettingsDelegate {
     var showDevicePassCodeCalled = 0
     var showCreditCardSettingsCalled = 0
     var didFinishShowingSettingsCalled = 0
@@ -51,6 +55,8 @@ class MockSettingsFlowDelegate: SettingsFlowDelegate,
     func showQRCode(delegate: QRCodeViewControllerDelegate) {
         showQRCodeCalled += 1
     }
+    //Ecosia: BrowsingSettingsDelegate Fix protocol conformance
+    func pressedAutoPlay() {}
 
     // MARK: GeneralSettingsDelegate
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockSettingsFlowDelegate.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockSettingsFlowDelegate.swift
@@ -55,7 +55,7 @@ class MockSettingsFlowDelegate: SettingsFlowDelegate,
     func showQRCode(delegate: QRCodeViewControllerDelegate) {
         showQRCodeCalled += 1
     }
-    //Ecosia: BrowsingSettingsDelegate Fix protocol conformance
+    // Ecosia: BrowsingSettingsDelegate Fix protocol conformance
     func pressedAutoPlay() {}
 
     // MARK: GeneralSettingsDelegate


### PR DESCRIPTION
[MOB-4892](https://ecosia.atlassian.net/browse/MOB-4892)

Replaces: https://github.com/ecosia/ios-browser/pull/1255

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [ ] If this PR changes snapshot-covered UI, I updated snapshot tests and `SnapshotArtifacts` references — **or** I added the `skip-snapshot-check` label because there is no visual impact ([coverage map](firefox-ios/Ecosia/Ecosia.docc/SNAPSHOT_TESTING_WIKI.md#snapshot-coverage-map))
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [x] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4892]: https://ecosia.atlassian.net/browse/MOB-4892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ