### PR TITLE
Lint only modified files in local SwiftLint build phase

### DIFF
--- a/firefox-ios/Tuist/ProjectDescriptionHelpers/BuildScripts.swift
+++ b/firefox-ios/Tuist/ProjectDescriptionHelpers/BuildScripts.swift
@@ -68,7 +68,9 @@ public enum BuildScripts {
 
             if which swiftlint > /dev/null; then
                 cd ${SWIFTLINT_ROOT}
-                swiftlint lint --strict --quiet
+                if [ -n "$MODIFIED_FILES" ]; then
+                    swiftlint lint --quiet ${MODIFIED_FILES}
+                fi
             else
                 echo "warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint"
             fi


### PR DESCRIPTION
## Summary
- The pre-build SwiftLint phase computed `MODIFIED_FILES` but never used it, so every local build ran `swiftlint lint --strict --quiet` against the whole project instead of just the changed files.
- Restores filtering to modified `.swift` files (matching the original upstream Firefox behavior), and guards against linting the whole project when there are no modified files.

## Test plan
- Build locally with a modified `.swift` file and confirm only that file is linted
- Build locally with no modified `.swift` files and confirm the lint step is skipped (no full-project lint)