### PR TITLE
Fixes Auth0 ID

### DIFF
--- a/tuist-setup.sh
+++ b/tuist-setup.sh
@@ -126,7 +126,7 @@ if [ ! -f "$file_path" ]; then
     touch "$file_path"
     echo -e "${GREEN}✓ Staging.xcconfig created${NC}\n"
     {
-        echo "AUTH0_CLIENT_ID=FBaIsy0X5hIh2sSmalmf5pACZ512dIYl"
+        echo "AUTH0_CLIENT_ID=zNU6cgqji5cE9qPkkXIlqMJbIwTPShdU"
         echo "CF_ACCESS_CLIENT_ID=$CF_ACCESS_CLIENT_ID"
         echo "CF_ACCESS_CLIENT_SECRET=$CF_ACCESS_CLIENT_SECRET"
     } >> $file_path


### PR DESCRIPTION
## Context

The previous `AUTH0_CLIENT_ID` in the staging config was the dev tenant's client ID. It needs to be the staging tenant's client ID instead.

## Approach

Updated the default `AUTH0_CLIENT_ID` written to `Staging.xcconfig` in `tuist-setup.sh` to the staging tenant's client ID.

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [ ] If this PR changes snapshot-covered UI, I updated snapshot tests and `SnapshotArtifacts` references — **or** I added the `skip-snapshot-check` label because there is no visual impact ([coverage map](firefox-ios/Ecosia/Ecosia.docc/SNAPSHOT_TESTING_WIKI.md#snapshot-coverage-map))
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [ ] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed