### PR TITLE
Make the Ecosia debug scheme point at staging

### DIFF
--- a/firefox-ios/Client/Ecosia/BuildSettingsConfigurations/EcosiaDebug.xcconfig
+++ b/firefox-ios/Client/Ecosia/BuildSettingsConfigurations/EcosiaDebug.xcconfig
@@ -3,9 +3,8 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 // This is a debuggable version of the Ecosia config with the same Bundle ID utilized in production
-// (see Environment.swift for why bundle ID detection can't be used to route this scheme to staging).
-// ECOSIA_ENVIRONMENT_OVERRIDE below routes it to staging (ecosia-staging.xyz) for local testing,
-// while AUTH0_CLIENT_ID/Staging.xcconfig's Auth0 tenant match that domain.
+// (Environment.swift detects the Debug build itself and routes it to staging - ecosia-staging.xyz -
+// instead of production, since AUTH0_CLIENT_ID/Staging.xcconfig's Auth0 tenant match that domain).
 
 #include "../../Configuration/Debug.xcconfig"
 #include "Staging.xcconfig"
@@ -20,7 +19,6 @@ CODE_SIGN_ENTITLEMENTS = Ecosia/Entitlements/Ecosia.entitlements
 OTHER_SWIFT_FLAGS = $(OTHER_SWIFT_FLAGS_common) -DMOZ_CHANNEL_FENNEC
 OTHER_LDFLAGS = -ObjC -lxml2 -fprofile-instr-generate -ld_classic
 AUTH0_CLIENT_ID = zNU6cgqji5cE9qPkkXIlqMJbIwTPShdU
-ECOSIA_ENVIRONMENT_OVERRIDE = staging
 
 // Ecosia: For completeness — AppBuildChannel has no "debug" case, so this still resolves to .other.
 CHANNEL = debug

--- a/firefox-ios/Client/Ecosia/BuildSettingsConfigurations/EcosiaDebug.xcconfig
+++ b/firefox-ios/Client/Ecosia/BuildSettingsConfigurations/EcosiaDebug.xcconfig
@@ -2,8 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// This is a debuggable version of the Ecosia config with the same Bundle ID and setup utilized in production.
-// Points to Production as only the `Release` configuration sets the Environment to be PRODUCTION.
+// This is a debuggable version of the Ecosia config with the same Bundle ID utilized in production
+// (see Environment.swift for why bundle ID detection can't be used to route this scheme to staging).
+// ECOSIA_ENVIRONMENT_OVERRIDE below routes it to staging (ecosia-staging.xyz) for local testing,
+// while AUTH0_CLIENT_ID/Staging.xcconfig's Auth0 tenant match that domain.
 
 #include "../../Configuration/Debug.xcconfig"
 #include "Staging.xcconfig"
@@ -17,7 +19,8 @@ LEANPLUM_ENVIRONMENT = development
 CODE_SIGN_ENTITLEMENTS = Ecosia/Entitlements/Ecosia.entitlements
 OTHER_SWIFT_FLAGS = $(OTHER_SWIFT_FLAGS_common) -DMOZ_CHANNEL_FENNEC
 OTHER_LDFLAGS = -ObjC -lxml2 -fprofile-instr-generate -ld_classic
-AUTH0_CLIENT_ID=FBaIsy0X5hIh2sSmalmf5pACZ512dIYl
+AUTH0_CLIENT_ID = zNU6cgqji5cE9qPkkXIlqMJbIwTPShdU
+ECOSIA_ENVIRONMENT_OVERRIDE = staging
 
 // Ecosia: For completeness — AppBuildChannel has no "debug" case, so this still resolves to .other.
 CHANNEL = debug

--- a/firefox-ios/Client/Info.plist
+++ b/firefox-ios/Client/Info.plist
@@ -4,8 +4,6 @@
 <dict>
 	<key>AUTH0_CLIENT_ID</key>
 	<string>$(AUTH0_CLIENT_ID)</string>
-	<key>ECOSIA_ENVIRONMENT_OVERRIDE</key>
-	<string>$(ECOSIA_ENVIRONMENT_OVERRIDE)</string>
 	<key>AdjustAppToken</key>
 	<string>$(ADJUST_APP_TOKEN)</string>
 	<key>AppIdentifierPrefix</key>

--- a/firefox-ios/Client/Info.plist
+++ b/firefox-ios/Client/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>AUTH0_CLIENT_ID</key>
 	<string>$(AUTH0_CLIENT_ID)</string>
+	<key>ECOSIA_ENVIRONMENT_OVERRIDE</key>
+	<string>$(ECOSIA_ENVIRONMENT_OVERRIDE)</string>
 	<key>AdjustAppToken</key>
 	<string>$(ADJUST_APP_TOKEN)</string>
 	<key>AppIdentifierPrefix</key>

--- a/firefox-ios/Ecosia/Core/Environment/Environment.swift
+++ b/firefox-ios/Ecosia/Core/Environment/Environment.swift
@@ -13,12 +13,32 @@ public enum Environment: Equatable, Sendable {
 extension Environment {
 
     public static var current: Environment {
+        // EcosiaDebug.xcconfig sets ECOSIA_ENVIRONMENT_OVERRIDE=staging so the "Ecosia" debug
+        // scheme hits staging (ecosia-staging.xyz, login.ecosia-staging.xyz) for local testing,
+        // without changing MOZ_BUNDLE_ID away from production's - it deliberately keeps that
+        // bundle ID for parity with production (see EcosiaDebug.xcconfig), and reusing the
+        // staging bundle ID here would collide with the "Ecosia Beta" scheme when both are
+        // installed on the same device/simulator. Every other scheme leaves this key unset, so
+        // it falls through to the bundle ID detection below unchanged.
+        if let override = EnvironmentFetcher.valueFromMainBundleOrProcessInfo(forKey: "ECOSIA_ENVIRONMENT_OVERRIDE") {
+            switch override {
+            case "staging":
+                return .staging
+            case "production":
+                return .production
+            case "debug":
+                return .debug
+            default:
+                break
+            }
+        }
+
         /*
          * Why not xcconfig compilation flags?
          * - Project configs had SWIFT_ACTIVE_COMPILATION_CONDITIONS = ""; blocking xcconfig inheritance
          * - Multiple BetaDebug configs with same name, Xcode uses wrong one
          * - EcosiaTesting.xcconfig works because it sets explicit value, not empty string
-         * 
+         *
          * Solution: Bundle ID detection is more reliable than build config inheritance
          */
         guard let bundleId = Bundle.main.bundleIdentifier else {

--- a/firefox-ios/Ecosia/Core/Environment/Environment.swift
+++ b/firefox-ios/Ecosia/Core/Environment/Environment.swift
@@ -31,9 +31,10 @@ extension Environment {
         switch bundleId {
         case "com.ecosia.ecosiaapp":
             // EcosiaDebug.xcconfig deliberately keeps this the same as production's bundle ID for
-            // parity, so a genuine Debug build of it should hit staging instead - only a real
-            // Release build of this bundle ID is actual production.
-            return _isDebugAssertConfiguration() ? .staging : .production
+            // parity, so only a genuine Release build of it is actual production - any Debug
+            // build of this bundle ID (i.e. the "Ecosia" scheme) hits staging instead.
+            guard !_isDebugAssertConfiguration() else { return .staging }
+            return .production
         case "com.ecosia.ecosiaapp.firefox":
             return .staging
         default:

--- a/firefox-ios/Ecosia/Core/Environment/Environment.swift
+++ b/firefox-ios/Ecosia/Core/Environment/Environment.swift
@@ -13,33 +13,16 @@ public enum Environment: Equatable, Sendable {
 extension Environment {
 
     public static var current: Environment {
-        // EcosiaDebug.xcconfig sets ECOSIA_ENVIRONMENT_OVERRIDE=staging so the "Ecosia" debug
-        // scheme hits staging (ecosia-staging.xyz, login.ecosia-staging.xyz) for local testing,
-        // without changing MOZ_BUNDLE_ID away from production's - it deliberately keeps that
-        // bundle ID for parity with production (see EcosiaDebug.xcconfig), and reusing the
-        // staging bundle ID here would collide with the "Ecosia Beta" scheme when both are
-        // installed on the same device/simulator. Every other scheme leaves this key unset, so
-        // it falls through to the bundle ID detection below unchanged.
-        if let override = EnvironmentFetcher.valueFromMainBundleOrProcessInfo(forKey: "ECOSIA_ENVIRONMENT_OVERRIDE") {
-            switch override {
-            case "staging":
-                return .staging
-            case "production":
-                return .production
-            case "debug":
-                return .debug
-            default:
-                break
-            }
-        }
-
         /*
-         * Why not xcconfig compilation flags?
+         * Why not xcconfig compilation flags (SWIFT_ACTIVE_COMPILATION_CONDITIONS / #if DEBUG)?
          * - Project configs had SWIFT_ACTIVE_COMPILATION_CONDITIONS = ""; blocking xcconfig inheritance
          * - Multiple BetaDebug configs with same name, Xcode uses wrong one
          * - EcosiaTesting.xcconfig works because it sets explicit value, not empty string
          *
-         * Solution: Bundle ID detection is more reliable than build config inheritance
+         * Solution: Bundle ID detection is more reliable than build config inheritance. The one
+         * exception is below: _isDebugAssertConfiguration() isn't a custom macro - it reflects
+         * SWIFT_OPTIMIZATION_LEVEL (-Onone vs -O), which Xcode sets per-target automatically and
+         * isn't subject to either of the failure modes above.
          */
         guard let bundleId = Bundle.main.bundleIdentifier else {
             return .production
@@ -47,7 +30,10 @@ extension Environment {
 
         switch bundleId {
         case "com.ecosia.ecosiaapp":
-            return .production
+            // EcosiaDebug.xcconfig deliberately keeps this the same as production's bundle ID for
+            // parity, so a genuine Debug build of it should hit staging instead - only a real
+            // Release build of this bundle ID is actual production.
+            return _isDebugAssertConfiguration() ? .staging : .production
         case "com.ecosia.ecosiaapp.firefox":
             return .staging
         default:


### PR DESCRIPTION
## Context

Related to MOB-4236: while testing that PR locally on the "Ecosia" (plain debug) scheme, login failed with an Auth0 "Unknown client" error redirecting to `www.ecosia.org/accounts/error`. Root cause is unrelated to that PR's changes — it's a pre-existing environment/domain mismatch specific to the "Ecosia" debug scheme.

`EcosiaDebug.xcconfig` deliberately keeps production's bundle ID (`com.ecosia.ecosiaapp`) for parity with production ("This is a debuggable version of the Ecosia config with the same Bundle ID ... utilized in production"). `Environment.current` determines staging vs. production purely by sniffing `Bundle.main.bundleIdentifier`, so this scheme always resolved to `.production` — `www.ecosia.org`, `login.ecosia.org`, etc. — regardless of scheme name. Meanwhile `AUTH0_CLIENT_ID` was separately hand-pinned in the same file to a *staging* Auth0 application client id. Auth0 then validated that staging client against the production tenant and rejected it as unknown, so nobody could log in locally with this scheme.

This also explains the repeated "fix the staging auth0 id" churn (e.g. #1279) — every time the staging client id rotates, only the hardcoded value in `EcosiaDebug.xcconfig` needed manual updating, and the underlying domain/client mismatch was never actually addressed.

## Approach

`Environment.current` now special-cases the production bundle ID (`com.ecosia.ecosiaapp`): if the running binary is a genuine Debug build, it resolves to `.staging` instead of `.production`; a real Release build of that bundle ID (actual production) is unaffected. Every other bundle ID case (`com.ecosia.ecosiaapp.firefox` → staging, everything else → `.debug`) is untouched.

"Genuine Debug build" is detected with the Swift stdlib's `_isDebugAssertConfiguration()`, which tracks `SWIFT_OPTIMIZATION_LEVEL` (`-Onone` vs `-O`) — set per-target by Xcode automatically. This was chosen over `#if DEBUG` / `SWIFT_ACTIVE_COMPILATION_CONDITIONS` because the existing code comment in this file already documents that mechanism as unreliable here (empty-string xcconfig inheritance, duplicate same-named Debug configs); `_isDebugAssertConfiguration()` doesn't depend on that macro at all, so it sidesteps both failure modes. (An earlier version of this PR threaded a custom `ECOSIA_ENVIRONMENT_OVERRIDE` value through `Info.plist`, but a plain debug-build check is simpler and needed no new config plumbing.)

Also refreshed `AUTH0_CLIENT_ID` in `EcosiaDebug.xcconfig` to the current staging client id (`zNU6cgqji5cE9qPkkXIlqMJbIwTPShdU`), matching `Staging.xcconfig`, so the domain and client now belong to the same tenant.

Verified:
- Standalone `swiftc` check: `_isDebugAssertConfiguration()` returns `true` under `-Onone`, `false` under `-O`.
- Built the "Ecosia" scheme (Debug) and confirmed the built `Info.plist` has no leftover override key, the correct staging `AUTH0_CLIENT_ID`, and `CFBundleIdentifier` unchanged at `com.ecosia.ecosiaapp`.
- SwiftLint clean on `Environment.swift`.

## Before merging

### Checklist

- [ ] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [ ] If this PR changes snapshot-covered UI, I updated snapshot tests and `SnapshotArtifacts` references — **or** I added the `skip-snapshot-check` label because there is no visual impact
- [ ] I updated only the english localization source files if needed
- [ ] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed