### PR TITLE
[MOB-4948] Search event: Handle cache and cloudflare hits using navigation response

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Before any change: determine if the file is Firefox core or Ecosia-owned, and fo
 
 | When you need… | See |
 | --- | --- |
-| Always / Ask first / Never | [firefox-ios/Ecosia/Ecosia.docc/agents/BOUNDARIES.md](firefox-ios/Ecosia/Ecosia.docc/agents/BOUNDARIES.md) |
+| Always / Ask first / Never / Comments | [firefox-ios/Ecosia/Ecosia.docc/agents/BOUNDARIES.md](firefox-ios/Ecosia/Ecosia.docc/agents/BOUNDARIES.md) |
 | Bootstrap, build, test, lint commands | [firefox-ios/Ecosia/Ecosia.docc/agents/COMMANDS.md](firefox-ios/Ecosia/Ecosia.docc/agents/COMMANDS.md) |
 | What to do before changing code | [firefox-ios/Ecosia/Ecosia.docc/agents/CONTEXT.md](firefox-ios/Ecosia/Ecosia.docc/agents/CONTEXT.md) |
 | PR naming, commits, code review | [firefox-ios/Ecosia/Ecosia.docc/agents/CODEREVIEW.md](firefox-ios/Ecosia/Ecosia.docc/agents/CODEREVIEW.md) |

--- a/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+EcosiaNavigationHandling.swift
+++ b/firefox-ios/Client/Ecosia/Extensions/BrowserViewController+EcosiaNavigationHandling.swift
@@ -6,6 +6,12 @@ import Foundation
 import WebKit
 import Ecosia
 
+struct PendingInappSearch {
+    let url: URL
+    /// Set for back/forward only, where a response is what proves a document was really loaded.
+    var awaitingNavigationResponse: Bool
+}
+
 // MARK: - Ecosia Web View Event Handling
 extension BrowserViewController {
 
@@ -36,20 +42,36 @@ extension BrowserViewController {
     }
 
     /// Handles any Ecosia-specific tracking when a navigation action is allowed.
-    /// Stores a pending URL to be tracked at didCommit.
+    /// Stores a pending search to be tracked at didCommit.
     private func ecosiaHandleNavigationAction(url: URL, navigationAction: WKNavigationAction) {
         // Clear any stale pending tracking from a previous navigation
-        pendingInappSearchUrl = nil
+        pendingInappSearch = nil
 
         guard url.isEcosiaSearchVertical() else { return }
 
-        // Back/forward navigations are suppressed: on web, bfcache keeps the page mounted so
-        // Vue never refires. Tab switching doesn't reach this delegate at all, so any other
-        // navigation type arriving here is a genuine user action and should always track.
-        guard navigationAction.navigationType != .backForward else { return }
+        // A bfcache restore reuses the document, so web's Vue never re-mounts and sends nothing.
+        pendingInappSearch = PendingInappSearch(
+            url: url,
+            awaitingNavigationResponse: navigationAction.navigationType == .backForward
+        )
+    }
 
-        // Store the URL; the event fires in ecosiaHandleDidCommit when content starts rendering
-        pendingInappSearchUrl = url
+    /// Only a real document load produces a response, and only here is the status visible.
+    /// Always arrives before didCommit.
+    func ecosiaHandleNavigationResponse(response: URLResponse, isForMainFrame: Bool) {
+        guard isForMainFrame,
+              let url = response.url,
+              url == pendingInappSearch?.url
+        else { return }
+
+        // An error page commits without rendering the SERP, so web's Vue never mounts.
+        if let statusCode = (response as? HTTPURLResponse)?.statusCode,
+           !(200..<400).contains(statusCode) {
+            pendingInappSearch = nil
+            return
+        }
+
+        pendingInappSearch?.awaitingNavigationResponse = false
     }
 
     /// Fires the in-app search event when the web content starts to be received (didCommit).
@@ -58,8 +80,9 @@ extension BrowserViewController {
     ///   - url: The URL that just committed
     ///   - isPrivate: Whether the tab is in private browsing mode
     func ecosiaHandleDidCommit(url: URL, isPrivate: Bool) {
-        guard url == pendingInappSearchUrl else { return }
-        pendingInappSearchUrl = nil
+        guard let pending = pendingInappSearch, url == pending.url else { return }
+        pendingInappSearch = nil
+        guard !pending.awaitingNavigationResponse else { return }
         Analytics.shared.inappSearch(url: url, isPrivate: isPrivate)
     }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Extensions/BrowserViewController+WebViewDelegates.swift
@@ -724,6 +724,9 @@ extension BrowserViewController: WKNavigationDelegate {
         let response = navigationResponse.response
         let responseURL = response.url
 
+        // Ecosia: Separates a real document load from a bfcache restore, and carries the status.
+        ecosiaHandleNavigationResponse(response: response, isForMainFrame: navigationResponse.isForMainFrame)
+
         tabManager[webView]?.mimeType = response.mimeType
         notificationCenter.post(name: .TabMimeTypeDidSet, withUserInfo: windowUUID.userInfo)
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -145,7 +145,7 @@ class BrowserViewController: UIViewController,
     // Ecosia: Bridges eligibility (checked in decidePolicyFor, where WKNavigationAction
     // and its navigationType are available) to the actual tracking call in didCommit.
     // Set when eligible, cleared on commit or on the next navigation.
-    var pendingInappSearchUrl: URL?
+    var pendingInappSearch: PendingInappSearch?
 
     /* Ecosia: TabTrayFlagManager removed in Firefox upgrade; tab tray refactor is always enabled
     lazy var isTabTrayRefactorEnabled: Bool = TabTrayFlagManager.isRefactorEnabled

--- a/firefox-ios/Ecosia/Ecosia.docc/agents/BOUNDARIES.md
+++ b/firefox-ios/Ecosia/Ecosia.docc/agents/BOUNDARIES.md
@@ -17,6 +17,19 @@ Rules that apply to every task. See [AGENTS.md](../../../AGENTS.md) for overview
 - Follow SwiftLint rules defined in `.swiftlint.yml`
 - Await user confirmation before pushing or making commits
 
+## Comments
+
+Default to none. Code that needs a comment to be understood usually means the code needs to be simplified.
+
+- Never restate the code. If the comment paraphrases the line below it, delete it.
+- Comment only non-obvious **why**: a constraint, a subtle failure mode, a deliberate trade-off.
+- Only a single line. Don't write essays in doc comments.
+- Never explain the same thing in two places.
+- Don't narrate the change itself ("now gated on…", "moved from…").
+- Comments that describe changes should only do so with reference to the main branch. Don't refer to things that never existed on main.
+- Same rules in tests. The test name carries the intent.
+- The `// Ecosia:` marker on Firefox core changes is exempt from "default to none" — it is required for upstream merges. Keep the reason after it to one line.
+
 ## Ask First
 
 Before doing any of these, ask the user:

--- a/firefox-ios/EcosiaTests/Analytics/AnalyticsSpyTests.swift
+++ b/firefox-ios/EcosiaTests/Analytics/AnalyticsSpyTests.swift
@@ -624,33 +624,73 @@ final class AnalyticsSpyTests: XCTestCase, @unchecked Sendable {
         let browser = BrowserViewController(profile: profileMock, tabManager: tabManagerMock)
 
         let rootURL = EcosiaEnvironment.current.urlProvider.root
+        // A nil responseStatus means no navigation response arrived, i.e. a bfcache restore.
+        struct Case {
+            let type: WKNavigationType
+            let responseStatus: Int?
+            let shouldTrack: Bool
+            let message: String
+        }
+
+        let url = URL(string: "\(rootURL)/search?q=test")!
         let testCases = [
-            (WKNavigationType.other, "\(rootURL)/search?q=test", true, "Tracks regular navigation"),
-            (WKNavigationType.reload, "\(rootURL)/search?q=test", true, "Tracks reload"),
-            (WKNavigationType.backForward, "\(rootURL)/search?q=test", false, "Does not track back/forward"),
+            Case(type: .other, responseStatus: 200, shouldTrack: true, message: "Tracks regular navigation"),
+            Case(type: .reload, responseStatus: 200, shouldTrack: true, message: "Tracks reload"),
+            Case(type: .backForward, responseStatus: 200, shouldTrack: true, message: "Tracks back/forward that reloads the document"),
+            Case(type: .backForward, responseStatus: nil, shouldTrack: false, message: "Does not track back/forward served from bfcache"),
+            Case(type: .other, responseStatus: 403, shouldTrack: false, message: "Does not track a challenge or forbidden response"),
+            Case(type: .other, responseStatus: 502, shouldTrack: false, message: "Does not track a server error page"),
         ]
 
-        for (type, urlString, shouldTrack, message) in testCases {
+        for testCase in testCases {
             analyticsSpy = AnalyticsSpy()
             Analytics.shared = analyticsSpy
-            let url = URL(string: urlString)!
-            let action = FakeNavigationAction(url: url, navigationType: type)
+            let action = FakeNavigationAction(url: url, navigationType: testCase.type)
             browser.webView(makeWebView(),
                             decidePolicyFor: action) { policy in
                 XCTAssertEqual(policy, .allow, "Should allow independent of tracking behavior")
             }
+            if let status = testCase.responseStatus {
+                browser.ecosiaHandleNavigationResponse(response: Self.makeResponse(url: url, statusCode: status),
+                                                       isForMainFrame: true)
+            }
             browser.ecosiaHandleDidCommit(url: url, isPrivate: false)
 
-            if shouldTrack {
+            if testCase.shouldTrack {
                 XCTAssertEqual(analyticsSpy.inappSearchUrlCalled?.absoluteString,
                                url.absoluteString,
-                               "Failure on: \(message)")
+                               "Failure on: \(testCase.message)")
             } else {
-                XCTAssertNil(analyticsSpy.inappSearchUrlCalled, "Failure on: \(message)")
+                XCTAssertNil(analyticsSpy.inappSearchUrlCalled, "Failure on: \(testCase.message)")
             }
             analyticsSpy = nil
             Analytics.shared = Analytics()
         }
+    }
+
+    func testWebViewDelegateDoesNotConfirmBackForwardSearchFromSubframeResponse() {
+        let browser = BrowserViewController(profile: profileMock, tabManager: tabManagerMock)
+        let rootURL = EcosiaEnvironment.current.urlProvider.root
+        let url = URL(string: "\(rootURL)/search?q=test")!
+
+        analyticsSpy = AnalyticsSpy()
+        Analytics.shared = analyticsSpy
+
+        let action = FakeNavigationAction(url: url, navigationType: .backForward)
+        browser.webView(makeWebView(), decidePolicyFor: action) { _ in }
+        browser.ecosiaHandleNavigationResponse(response: Self.makeResponse(url: url, statusCode: 200),
+                                               isForMainFrame: false)
+        browser.ecosiaHandleDidCommit(url: url, isPrivate: false)
+
+        XCTAssertNil(analyticsSpy.inappSearchUrlCalled,
+                     "A subframe response should not confirm a back/forward search")
+
+        analyticsSpy = nil
+        Analytics.shared = Analytics()
+    }
+
+    private static func makeResponse(url: URL, statusCode: Int) -> URLResponse {
+        HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil, headerFields: nil)!
     }
 
     func testWebViewDelegateTracksSearchEventOnSameURLWhenLinkActivated() {


### PR DESCRIPTION
[MOB-4948]

## Context

See ticket.

### Cause

Back/forward is two distinct cases and we treated them as one. When WebKit restores from the back-forward cache the document is reused, so the SERP's Vue app never re-mounts and web sends nothing. When the restore misses, the document is re-created and web fires. Suppressing all `.backForward` loses the second case, tracking all of them adds the first.

Two further gaps found while measuring on device:
- Cold launch with a restored SERP tab fired no native event while web did.
- Cloudflare challenge interstitials are served at the SERP URL, so a challenged search counted twice natively against web's once.

## Approach

Require a navigation response before firing. Only a real document load produces one, a cache restore does not (verified on device). This replaces the `navigationType` check, which cold launch showed is not stable per navigation (the same load reported `.other` then `.backForward` 18ms apart).

Firing stays at `didCommit` to keep Vue `mounted()` timing.

The response delegate is also the only place the status code is visible, so non-2xx/3xx drops the pending search. That covers the Cloudflare interstitial (confirmed 403) and SERP error pages, neither of which renders a SERP.

`EcosiaLogger.search.sentry` reports a response arriving after `didCommit`, the one assumption this rests on that WebKit does not document.

## Other

* Fixing and deliberately un-skipping AnalyticsSpyTests related to the search event since they are leaner now and an important flow that has regressed in the past.

* Added some bonus AI instructions for commenting to try and avoid constant over-commenting 🤞 

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I wrote Unit Tests that confirm the expected behaviour
- [ ] If this PR changes snapshot-covered UI, I updated snapshot tests and `SnapshotArtifacts` references — **or** I added the `skip-snapshot-check` label because there is no visual impact ([coverage map](firefox-ios/Ecosia/Ecosia.docc/SNAPSHOT_TESTING_WIKI.md#snapshot-coverage-map))
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [x] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4948]: https://ecosia.atlassian.net/browse/MOB-4948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ