### PR TITLE
Update tree statistics fallback defaults

### DIFF
--- a/firefox-ios/Ecosia/Core/Statistics/Statistics.swift
+++ b/firefox-ios/Ecosia/Core/Statistics/Statistics.swift
@@ -37,16 +37,16 @@ public final class Statistics {
     }
 
     public static let shared = Statistics()
-    // Ecosia: defaults updated from live API on 2026-02-26 (previously Nov 2020 hardcoded values)
-    public internal(set) var treesPlanted = Double(244_418_472)                                    // "2025-12-01T16:34:00.0Z"
-    public internal(set) var treesPlantedLastUpdated = Date(timeIntervalSince1970: 1_764_606_840)  // 2025-12-01T16:34:00Z
-    public internal(set) var timePerTree = Double(2.2)
+    // Ecosia: defaults updated from live API on 2026-09-09 (previously 2026-02-26 hardcoded values)
+    public internal(set) var treesPlanted = Double(249_631_817)                                    // "2026-04-13T10:30:00.0Z"
+    public internal(set) var treesPlantedLastUpdated = Date(timeIntervalSince1970: 1_776_076_200)  // 2026-04-13T10:30:00Z
+    public internal(set) var timePerTree = Double(2.1267)
     public internal(set) var searchesPerTree = Double(50)
     public internal(set) var activeUsers = Double(20000000)
     public internal(set) var eurToUsdMultiplier = Double(1.08)
     public internal(set) var investmentPerSecond = Double(0.25)
-    public internal(set) var totalInvestments = Double(88_666_760)                                 // "2024-10-08T00:00:00.000000Z"
-    public internal(set) var totalInvestmentsLastUpdated = Date(timeIntervalSince1970: 1_728_345_600) // 2024-10-08T00:00:00Z
+    public internal(set) var totalInvestments = Double(99_870_541)                                 // "2026-03-12T00:00:00.000000Z"
+    public internal(set) var totalInvestmentsLastUpdated = Date(timeIntervalSince1970: 1_773_273_600) // 2026-03-12T00:00:00Z
 
     init() { }
 

--- a/firefox-ios/EcosiaTests/Core/StatisticsTests.swift
+++ b/firefox-ios/EcosiaTests/Core/StatisticsTests.swift
@@ -94,27 +94,26 @@ final class StatisticsTests: XCTestCase {
 
     // MARK: - Default-values regression
 
-    /// Pins the default values to the Dec 2025 API snapshot so any accidental change breaks this test.
-    /// Without calling fetchAndUpdate(), the hardcoded defaults now project within ~3.5M of live (vs. ~6M gap with Nov 2020 base).
+    /// Pins the default values to the Apr 2026 API snapshot so any accidental change breaks this test.
     func testDefaultValuesProduceKnownProjection() async {
         let freshStats = Statistics()
         let base = freshStats.treesPlanted
         let baseDate = freshStats.treesPlantedLastUpdated
         let timePerTree = freshStats.timePerTree
 
-        // Base values must match the Dec 2025 API snapshot
-        XCTAssertEqual(base, 244_418_472, "Default treesPlanted baseline changed — update from live API and update docs/fix")
-        XCTAssertEqual(baseDate, Date(timeIntervalSince1970: 1_764_606_840), "Default base date changed — update docs/fix") // 2025-12-01T16:34:00Z
-        XCTAssertEqual(timePerTree, 2.2, "Default timePerTree changed — update from live API and update docs/fix")
+        // Base values must match the Apr 2026 API snapshot
+        XCTAssertEqual(base, 249_631_817, "Default treesPlanted baseline changed — update from live API and update docs/fix")
+        XCTAssertEqual(baseDate, Date(timeIntervalSince1970: 1_776_076_200), "Default base date changed — update docs/fix") // 2026-04-13T10:30:00Z
+        XCTAssertEqual(timePerTree, 2.1267, "Default timePerTree changed — update from live API and update docs/fix")
 
-        // Projection for a fixed reference point (2026-02-26 00:00 UTC = 1_772_064_000)
-        let referenceDate = Date(timeIntervalSince1970: 1_772_064_000) // 2026-02-26 00:00 UTC
+        // Projection for a fixed reference point (2026-09-09 00:00 UTC = 1_788_912_000)
+        let referenceDate = Date(timeIntervalSince1970: 1_788_912_000) // 2026-09-09 00:00 UTC
         let elapsed = referenceDate.timeIntervalSince(baseDate)
         let projected = Int(elapsed / timePerTree + base - 1)
 
-        // Projection from Dec 2025 defaults should be ~247.8M on 2026-02-26
-        XCTAssertGreaterThan(projected, 246_000_000, "Projection from defaults should exceed 246M by Feb 2026")
-        XCTAssertLessThan(projected, 250_000_000, "Projection from defaults should be below 250M by Feb 2026")
+        // Projection from Apr 2026 defaults should be ~255.7M on 2026-09-09
+        XCTAssertGreaterThan(projected, 254_000_000, "Projection from defaults should exceed 254M by Sep 2026")
+        XCTAssertLessThan(projected, 257_000_000, "Projection from defaults should be below 257M by Sep 2026")
     }
 
     /// When fetchAndUpdate succeeds with live data, the subsequent projection matches the live count.


### PR DESCRIPTION
## Context

The hardcoded fallback values in `Statistics.swift` (used until the live tree-stats API responds) needs to be updated so fallback values are closer to current in new versions of the API.

## Approach

Applied the latest values from the tree API dump to the static defaults in [Statistics.swift](firefox-ios/Ecosia/Core/Statistics/Statistics.swift):

- `treesPlanted`: 244,418,472 → 249,631,817 (as of 2026-04-13)
- `timePerTree`: 2.2 → 2.1267
- `totalInvestments`: 88,666,760 → 99,870,541 (as of 2026-03-12)
- `activeUsers`, `eurToUsdMultiplier`, `investmentPerSecond` unchanged (dump values matched existing defaults)

## Before merging

### Checklist

- [ ] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [ ] If this PR changes snapshot-covered UI, I updated snapshot tests and `SnapshotArtifacts` references — **or** I added the `skip-snapshot-check` label because there is no visual impact
- [ ] I updated only the english localization source files if needed
- [ ] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed