### PR TITLE
Fix wallpaper CDN URL truncation in EcosiaCommon.xcconfig

### DIFF
--- a/firefox-ios/Client/Ecosia/BuildSettingsConfigurations/EcosiaCommon.xcconfig
+++ b/firefox-ios/Client/Ecosia/BuildSettingsConfigurations/EcosiaCommon.xcconfig
@@ -16,7 +16,7 @@ MOZ_INTERNAL_URL_SCHEME = ecosia
 MOZ_TODAY_WIDGET_SEARCH_DISPLAY_NAME = Ecosia - Search
 MOZ_PRODUCT_NAME = Ecosia
 DEVELOPMENT_TEAM = 33YMRSYD2L
-// Ecosia: any "//" in part of in an xcconfig value is considered a comment so it's silently 
+// Ecosia: Any "//" in an xcconfig value is treated as a comment, so it is silently truncated.
 // truncated. Adding an empty macro - $() splits it.
 MOZ_WALLPAPER_ASSET_URL = https:/$()/cdn.ecosia.org/static/mobile-wallpapers
 

--- a/firefox-ios/Client/Ecosia/BuildSettingsConfigurations/EcosiaCommon.xcconfig
+++ b/firefox-ios/Client/Ecosia/BuildSettingsConfigurations/EcosiaCommon.xcconfig
@@ -16,8 +16,8 @@ MOZ_INTERNAL_URL_SCHEME = ecosia
 MOZ_TODAY_WIDGET_SEARCH_DISPLAY_NAME = Ecosia - Search
 MOZ_PRODUCT_NAME = Ecosia
 DEVELOPMENT_TEAM = 33YMRSYD2L
-// Ecosia: "//" in an xcconfig value starts a comment, silently truncating an unescaped
-// URL to its scheme (e.g. "https:") — $() splits the double slash so it isn't parsed as one.
+// Ecosia: any "//" in part of in an xcconfig value is considered a comment so it's silently 
+// truncated. Adding an empty macro - $() splits it.
 MOZ_WALLPAPER_ASSET_URL = https:/$()/cdn.ecosia.org/static/mobile-wallpapers
 
 // Ecosia: Add libxml2 on top of Firefox's -ObjC baseline.

--- a/firefox-ios/Client/Ecosia/BuildSettingsConfigurations/EcosiaCommon.xcconfig
+++ b/firefox-ios/Client/Ecosia/BuildSettingsConfigurations/EcosiaCommon.xcconfig
@@ -16,7 +16,9 @@ MOZ_INTERNAL_URL_SCHEME = ecosia
 MOZ_TODAY_WIDGET_SEARCH_DISPLAY_NAME = Ecosia - Search
 MOZ_PRODUCT_NAME = Ecosia
 DEVELOPMENT_TEAM = 33YMRSYD2L
-MOZ_WALLPAPER_ASSET_URL=https://cdn.ecosia.org/static/mobile-wallpapers
+// Ecosia: "//" in an xcconfig value starts a comment, silently truncating an unescaped
+// URL to its scheme (e.g. "https:") — $() splits the double slash so it isn't parsed as one.
+MOZ_WALLPAPER_ASSET_URL = https:/$()/cdn.ecosia.org/static/mobile-wallpapers
 
 // Ecosia: Add libxml2 on top of Firefox's -ObjC baseline.
 OTHER_LDFLAGS = $(inherited) -lxml2

--- a/firefox-ios/EcosiaTests/Core/BuildSettingsConfigurationTests.swift
+++ b/firefox-ios/EcosiaTests/Core/BuildSettingsConfigurationTests.swift
@@ -12,11 +12,8 @@ import XCTest
 /// file itself, the only place the bug is observable.
 final class BuildSettingsConfigurationTests: XCTestCase {
     func testWallpaperAssetURLDoesNotContainAnUnescapedDoubleSlash() throws {
-        let configPath = URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent() // Core
-            .deletingLastPathComponent() // EcosiaTests
-            .deletingLastPathComponent() // firefox-ios
-            .appendingPathComponent("Client/Ecosia/BuildSettingsConfigurations/EcosiaCommon.xcconfig")
+let configPath = URL(fileURLWithPath: RepoPath.root())
+            .appendingPathComponent("firefox-ios/Client/Ecosia/BuildSettingsConfigurations/EcosiaCommon.xcconfig")
 
         let contents = try String(contentsOf: configPath, encoding: .utf8)
         guard let line = contents.components(separatedBy: .newlines)

--- a/firefox-ios/EcosiaTests/Core/BuildSettingsConfigurationTests.swift
+++ b/firefox-ios/EcosiaTests/Core/BuildSettingsConfigurationTests.swift
@@ -1,0 +1,39 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import XCTest
+
+/// Regression test: `MOZ_WALLPAPER_ASSET_URL=https://cdn.ecosia.org/...` was silently truncated
+/// to `https:` because Xcode's xcconfig parser treats an unescaped `//` as the start of a line
+/// comment, even mid-value. `WallpaperURLProvider` can't catch this at runtime — it bypasses the
+/// real bundle lookup entirely under `AppConstants.isRunningTest` — so this reads the xcconfig
+/// file itself, the only place the bug is observable.
+final class BuildSettingsConfigurationTests: XCTestCase {
+    func testWallpaperAssetURLDoesNotContainAnUnescapedDoubleSlash() throws {
+        let configPath = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent() // Core
+            .deletingLastPathComponent() // EcosiaTests
+            .deletingLastPathComponent() // firefox-ios
+            .appendingPathComponent("Client/Ecosia/BuildSettingsConfigurations/EcosiaCommon.xcconfig")
+
+        let contents = try String(contentsOf: configPath, encoding: .utf8)
+        guard let line = contents.components(separatedBy: .newlines)
+            .first(where: { $0.hasPrefix("MOZ_WALLPAPER_ASSET_URL") }) else {
+            XCTFail("MOZ_WALLPAPER_ASSET_URL is no longer defined in \(configPath.lastPathComponent)")
+            return
+        }
+
+        let value = line.split(separator: "=", maxSplits: 1)[1].trimmingCharacters(in: .whitespaces)
+
+        XCTAssertFalse(
+            value.contains("//"),
+            """
+            "\(line)" contains an unescaped "//". Xcode's xcconfig parser treats that as a comment \
+            start and silently truncates the value. Split the slashes with an empty macro instead, \
+            e.g. https:/$()/host/path.
+            """
+        )
+    }
+}


### PR DESCRIPTION
## Context

The build config for wallpaper URL: `MOZ_WALLPAPER_ASSET_URL` in `EcosiaCommon.xcconfig` was being silently truncated to `https:`, common is imported everywhere so it was in every build configuration..
Xcode's `.xcconfig` parser treats an unescaped `//` as the start of a line comment (even mid-value) so `https://cdn.ecosia.org/static/mobile-wallpapers` was cut down to just `https:`. 
This then flows through `Info.plist`'s `MozWallpaperURLScheme` key into `WallpaperURLProvider` which produced a broken URL (e.g. `https:/metadata/v1/wallpapers.json`). 

That config is being read in [WallpaperURLProvider](https://github.com/ecosia/ios-browser/blob/main/firefox-ios/Client/Frontend/Home/Homepage/Wallpapers/v1/Utilities/WallpaperURLProvider.swift#L25) and [WallpaperDataService](https://github.com/ecosia/ios-browser/blob/main/firefox-ios/Client/Frontend/Home/Homepage/Wallpapers/v1/NetworkServices/WallpaperDataService.swift#L16)

This must've been here for a while...



## Open question

Since this has been here for a while, are we fixing it or disabling the wallpaper feature...?

## Approach

- Split the double slash with an empty macro (`https:/$()/cdn.ecosia.org/...`) so the value survives Xcode's xcconfig comment parsing — a standard workaround for URLs in `.xcconfig` files.
- Added `BuildSettingsConfigurationTests` to catch this class of regression: it reads `EcosiaCommon.xcconfig` directly and fails if `MOZ_WALLPAPER_ASSET_URL`'s value ever contains an unescaped `//` again. A unit test on `WallpaperURLProvider` itself can't catch this — it bypasses the real bundle/Info.plist lookup entirely under `AppConstants.isRunningTest`.

## Before merging

### Checklist

- [x] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [x] I wrote Unit Tests that confirm the expected behaviour
- [ ] If this PR changes snapshot-covered UI, I updated snapshot tests and `SnapshotArtifacts` references — **or** I added the `skip-snapshot-check` label because there is no visual impact ([coverage map](firefox-ios/Ecosia/Ecosia.docc/SNAPSHOT_TESTING_WIKI.md#snapshot-coverage-map))
- [ ] I updated only the [english localization source files](Client/Ecosia/L10N/es.lproj) if needed
- [x] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed
