### PR TITLE
[DRAFT POC][MOB-4236] Dedicated ImpactManager

### DIFF
--- a/firefox-ios/Client/Ecosia/Settings/EcosiaDebugSettings.swift
+++ b/firefox-ios/Client/Ecosia/Settings/EcosiaDebugSettings.swift
@@ -768,7 +768,7 @@ final class DebugAddSeedsLoggedIn: HiddenSetting {
     }
 
     override var status: NSAttributedString? {
-        let currentSeeds = EcosiaAuthUIStateProvider.shared.seedCount
+        let currentSeeds = ImpactManager.shared.seedCount
         return NSAttributedString(string: "Current: \(currentSeeds) seeds", attributes: [:])
     }
 
@@ -798,7 +798,7 @@ final class DebugAddSeedsLoggedIn: HiddenSetting {
             }
             Task { @MainActor in
                 try? await Task.sleep(nanoseconds: 10_000_000_000)
-                EcosiaAuthUIStateProvider.shared.debugAddSeeds(5)
+                ImpactManager.shared.debugAddSeeds(5)
             }
         }
     }
@@ -839,7 +839,7 @@ final class DebugForceLevelUp: HiddenSetting {
             }
             Task { @MainActor in
                 try? await Task.sleep(nanoseconds: 10_000_000_000)
-                EcosiaAuthUIStateProvider.shared.debugTriggerLevelUpAnimation()
+                ImpactManager.shared.debugTriggerLevelUpAnimation()
             }
         }
     }
@@ -851,7 +851,7 @@ final class DebugAddCustomSeeds: HiddenSetting {
     }
 
     override var status: NSAttributedString? {
-        let currentSeeds = EcosiaAuthUIStateProvider.shared.seedCount
+        let currentSeeds = ImpactManager.shared.seedCount
         return NSAttributedString(string: "Current: \(currentSeeds) seeds | Input custom amount", attributes: [:])
     }
 
@@ -916,7 +916,7 @@ final class DebugAddCustomSeeds: HiddenSetting {
             }
             Task { @MainActor in
                 try? await Task.sleep(nanoseconds: 10_000_000_000)
-                EcosiaAuthUIStateProvider.shared.debugAddSeeds(count)
+                ImpactManager.shared.debugAddSeeds(count)
             }
         }
     }

--- a/firefox-ios/Client/Ecosia/UI/NTP/Header/NTPHeaderViewModel.swift
+++ b/firefox-ios/Client/Ecosia/UI/NTP/Header/NTPHeaderViewModel.swift
@@ -23,12 +23,13 @@ final class NTPHeaderViewModel: ObservableObject {
     private(set) var auth: EcosiaAuth
     var onTapAction: ((UIButton) -> Void)?
     private let authStateProvider = EcosiaAuthUIStateProvider.shared
+    private let impactManager = ImpactManager.shared
     private var cancellables = Set<AnyCancellable>()
 
-    var seedCount: Int { authStateProvider.seedCount }
+    var seedCount: Int { impactManager.seedCount }
     var isLoggedIn: Bool { authStateProvider.isLoggedIn }
     var userAvatarURL: URL? { authStateProvider.avatarURL }
-    var balanceIncrement: Int? { authStateProvider.balanceIncrement }
+    var balanceIncrement: Int? { impactManager.balanceIncrement }
     var shouldAnimateSeed: Bool { balanceIncrement != nil }
     @Published var showSeedSparkles: Bool = false
     @Published var showAccountImpactView: Bool = false
@@ -48,10 +49,11 @@ final class NTPHeaderViewModel: ObservableObject {
         self.auth = auth
         self.delegate = delegate
 
-        // Forward objectWillChange notifications from authStateProvider
-        // This ensures SwiftUI knows to update the view when auth state changes.
+        // Forward objectWillChange notifications from both authStateProvider and impactManager.
+        // This ensures SwiftUI knows to update the view when either changes.
         // receive(on: .main) so objectWillChange.send() runs on main actor for strict concurrency.
         authStateProvider.objectWillChange
+            .merge(with: impactManager.objectWillChange)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.objectWillChange.send()
@@ -115,7 +117,7 @@ final class NTPHeaderViewModel: ObservableObject {
 
     @MainActor
     func refreshSeedState() {
-        authStateProvider.refreshSeedState()
+        impactManager.refreshSeedState()
     }
 
     func presentAccountImpact() {

--- a/firefox-ios/Ecosia/Core/User.swift
+++ b/firefox-ios/Ecosia/Core/User.swift
@@ -77,7 +77,7 @@ public struct User: Codable, Equatable, @unchecked Sendable {
     public var referrals = Referrals.Model()
     @MainActor
     public var seedCount: Int {
-        EcosiaAuthUIStateProvider.shared.seedCount
+        ImpactManager.shared.seedCount
     }
     public internal(set) var id: String?
     public var whatsNewItemsVersionsShown = Set<String>()

--- a/firefox-ios/Ecosia/UI/Account/EcosiaAccountImpactView.swift
+++ b/firefox-ios/Ecosia/UI/Account/EcosiaAccountImpactView.swift
@@ -10,7 +10,7 @@ import Common
 @available(iOS 16.0, *)
 public struct EcosiaAccountImpactView: View {
     @ObservedObject private var viewModel: EcosiaAccountImpactViewModel
-    @ObservedObject private var authStateProvider = EcosiaAuthUIStateProvider.shared
+    @ObservedObject private var impactManager = ImpactManager.shared
     private let windowUUID: WindowUUID
     private let webViewUserAgent: String?
 
@@ -47,7 +47,7 @@ public struct EcosiaAccountImpactView: View {
                     avatarURL: viewModel.avatarURL,
                     progress: viewModel.levelProgress,
                     showSparkles: showSparkles,
-                    showProgress: !authStateProvider.hasRegisterVisitError,
+                    showProgress: !impactManager.hasRegisterVisitError,
                     windowUUID: windowUUID,
                     onLevelUpAnimationComplete: {
                         showSparkles = false
@@ -116,7 +116,7 @@ public struct EcosiaAccountImpactView: View {
         .background(theme.backgroundColor.ignoresSafeArea())
         .ecosiaThemed(windowUUID, $theme)
         .presentationBackgroundIfAvailable(theme.backgroundColor)
-        .onChange(of: authStateProvider.currentLevelNumber) { _ in
+        .onChange(of: impactManager.currentLevelNumber) { _ in
             let themeManager = AppContainer.shared.resolve() as ThemeManager
             theme.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
         }
@@ -191,7 +191,7 @@ public struct EcosiaAccountImpactViewTheme: EcosiaThemeable {
         avatarPlaceholderColor = Color(theme.colors.ecosia.backgroundTertiary)
         avatarIconColor = Color(theme.colors.ecosia.backgroundPrimary)
 
-        if EcosiaAuthUIStateProvider.shared.currentLevelNumber > 1 {
+        if ImpactManager.shared.currentLevelNumber > 1 {
             levelTextColor = Color(theme.colors.ecosia.textStaticDark)
             levelBackgroundColor = Color(theme.colors.ecosia.brandImpact)
         } else {

--- a/firefox-ios/Ecosia/UI/Account/EcosiaAccountImpactViewModel.swift
+++ b/firefox-ios/Ecosia/UI/Account/EcosiaAccountImpactViewModel.swift
@@ -17,6 +17,7 @@ public class EcosiaAccountImpactViewModel: ObservableObject {
     private let onLoginAction: () -> Void
     private let onDismissAction: () -> Void
     private let authStateProvider: EcosiaAuthUIStateProvider
+    private let impactManager: ImpactManager
     private var cancellables = Set<AnyCancellable>()
 
     // MARK: - Initialization
@@ -27,10 +28,12 @@ public class EcosiaAccountImpactViewModel: ObservableObject {
         self.onLoginAction = onLogin
         self.onDismissAction = onDismiss
         self.authStateProvider = EcosiaAuthUIStateProvider.shared
+        self.impactManager = ImpactManager.shared
 
-        // Forward objectWillChange notifications from authStateProvider
-        // This ensures SwiftUI knows to update the view when auth state changes
+        // Forward objectWillChange notifications from both - this ensures SwiftUI knows to
+        // update the view when either identity or impact state changes.
         authStateProvider.objectWillChange
+            .merge(with: impactManager.objectWillChange)
             .sink { [weak self] _ in
                 self?.objectWillChange.send()
             }
@@ -54,9 +57,9 @@ public class EcosiaAccountImpactViewModel: ObservableObject {
         authStateProvider.avatarURL
     }
 
-    /// Current seed count from centralized provider
+    /// Current seed count from the impact manager
     public var seedCount: Int {
-        authStateProvider.seedCount
+        impactManager.seedCount
     }
 
     // MARK: - Public Methods
@@ -118,11 +121,11 @@ extension EcosiaAccountImpactViewModel {
 
     /// The level text to display - always shows the level based on seed count
     public var levelDisplayText: String {
-        authStateProvider.levelDisplayText
+        impactManager.levelDisplayText
     }
 
     /// Progress for the avatar (0.0 to 1.0)
     public var levelProgress: Double {
-        authStateProvider.levelProgress
+        impactManager.levelProgress
     }
 }

--- a/firefox-ios/Ecosia/UI/Account/EcosiaAuthUIStateProvider.swift
+++ b/firefox-ios/Ecosia/UI/Account/EcosiaAuthUIStateProvider.swift
@@ -2,13 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
-@preconcurrency import Foundation
-import SwiftUI
+import Foundation
 import Combine
-import Common
 
-/// Centralized, reactive authentication state provider for consistent UI state across all components
-/// This eliminates the need for individual components to manage their own auth state observers
+/// Centralized, reactive identity/profile state provider for consistent UI state across all
+/// components. Seed/level/progress impact state lives in `ImpactManager` instead - a sibling,
+/// not a child of this type - so callers who only care about who's logged in don't pull in
+/// impact-tracking machinery, and vice versa.
 @MainActor
 public class EcosiaAuthUIStateProvider: ObservableObject {
 
@@ -24,34 +24,15 @@ public class EcosiaAuthUIStateProvider: ObservableObject {
     /// Current user profile information
     @Published public private(set) var userProfile: UserProfile?
 
-    /// Current seed count (server-based for logged in users, local for guests)
-    /// Initialized with local storage value to prevent flickering on app launch
-    @Published public private(set) var seedCount: Int = UserDefaultsSeedProgressManager.loadTotalSeedsCollected()
-
     /// Current user avatar URL
     @Published public private(set) var avatarURL: URL?
 
     /// Current username for display
     @Published public private(set) var username: String?
 
-    /// Balance increment for animations (temporary state)
-    @Published public private(set) var balanceIncrement: Int?
-
-    /// Current level number (from API for logged-in users, 1 for logged-out)
-    @Published public private(set) var currentLevelNumber: Int = 1
-
-    /// Current progress towards next level (from API for logged-in users, default 0.25 for initial state)
-    @Published public private(set) var currentProgress: Double = 0.25
-
-    /// Error state for register visit failures (read-only externally, set only by this class)
-    @Published public private(set) var hasRegisterVisitError: Bool = false
-
     // MARK: - Private Properties
 
-    private var authStateObserver: NSObjectProtocol?
     private var userProfileObserver: NSObjectProtocol?
-    private var seedProgressObserver: NSObjectProtocol?
-    private let accountsProvider: AccountsProviderProtocol
     /// Normalizing the avatar to match Web's Product behaviour.
     /// Our Auth Provider (Auth0) sends us a Gravatar URL when no profile image is retrieved from a user
     /// (e.g. Apple Sign In). As of now, we replace it with our tree-image in `EcosiaAvatar` by not setting any URL
@@ -59,44 +40,29 @@ public class EcosiaAuthUIStateProvider: ObservableObject {
         guard userProfile?.pictureURL?.baseDomain != gravatarURL?.baseDomain else { return nil }
         return userProfile?.pictureURL
     }
-    nonisolated(unsafe) private static var seedProgressManagerType: SeedProgressManagerProtocol.Type = UserDefaultsSeedProgressManager.self
 
     // MARK: - Singleton
-
-    /// Factory for creating accounts provider - can be configured before first access
-    nonisolated(unsafe) public static var accountsProviderFactory: () -> AccountsProviderProtocol = { AccountsProvider() }
 
     /// Shared instance for app-wide auth state
     nonisolated(unsafe) public static let shared: EcosiaAuthUIStateProvider = {
         MainActor.assumeIsolated {
-            EcosiaAuthUIStateProvider(accountsProvider: accountsProviderFactory())
+            EcosiaAuthUIStateProvider()
         }
     }()
 
-    public init(accountsProvider: AccountsProviderProtocol) {
-        self.accountsProvider = accountsProvider
-
+    public init() {
         // Initialize state synchronously to prevent flickering
         self.isLoggedIn = EcosiaAuthenticationService.shared.isLoggedIn
         self.userProfile = EcosiaAuthenticationService.shared.userProfile
         self.avatarURL = normalizedAvatarURL
         self.username = userProfile?.name
 
-        // If logged out, ensure seed count is loaded (already done in property initializer)
-        // If logged in, seed count will be updated from API when the NTP header appears
-
         setupAuthStateMonitoring()
     }
 
     deinit {
         MainActor.assumeIsolated {
-            if let observer = authStateObserver {
-                NotificationCenter.default.removeObserver(observer)
-            }
             if let observer = userProfileObserver {
-                NotificationCenter.default.removeObserver(observer)
-            }
-            if let observer = seedProgressObserver {
                 NotificationCenter.default.removeObserver(observer)
             }
         }
@@ -109,38 +75,12 @@ public class EcosiaAuthUIStateProvider: ObservableObject {
         username ?? String.localized(.guestUser)
     }
 
-    /// Computed property for level display text
-    /// Returns level number and name for logged-in users, empty string for logged-out users
-    public var levelDisplayText: String {
-        let levelNumber = currentLevelNumber
-        let levelName = GrowthPointsLevelSystem.levelName(for: levelNumber)
-        return "\(String.localized(.level)) \(levelNumber) - \(levelName)"
-    }
-
-    /// Computed property for level progress (0.0 to 1.0)
-    /// Returns progress from API for logged-in users, 0.25 default for initial/logged-out state
-    public var levelProgress: Double {
-        guard isLoggedIn else {
-            return 0.25 // Default progress for logged-out users
-        }
-        return currentProgress
-    }
-
     // MARK: - Private Methods
 
     private func setupAuthStateMonitoring() {
-        // Listen for auth state changes
-        authStateObserver = NotificationCenter.default.addObserver(
-            forName: .EcosiaAuthStateChanged,
-            object: nil,
-            queue: .main
-        ) { [weak self] notification in
-            Task { [notification] in
-                await self?.handleAuthStateChange(notification)
-            }
-        }
-
-        // Listen for user profile updates
+        // Listen for user profile updates (these carry login-state changes too - see
+        // handleUserProfileUpdate). Impact-related auth-state side effects (registering a visit,
+        // resetting local seed collection) live in ImpactManager, which listens independently.
         userProfileObserver = NotificationCenter.default.addObserver(
             forName: .EcosiaUserProfileUpdated,
             object: nil,
@@ -150,227 +90,13 @@ public class EcosiaAuthUIStateProvider: ObservableObject {
                 await self?.handleUserProfileUpdate()
             }
         }
-
-        // Listen for seed progress updates (for logged-out users)
-        seedProgressObserver = NotificationCenter.default.addObserver(
-            forName: UserDefaultsSeedProgressManager.progressUpdatedNotification,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            Task {
-                await self?.handleSeedProgressUpdate()
-            }
-        }
-    }
-
-    private func handleAuthStateChange(_ notification: Notification) async {
-        // Handle specific auth actions (business logic can be nonisolated)
-        if let actionType = notification.userInfo?["actionType"] as? EcosiaAuthActionType {
-            switch actionType {
-            case .userLoggedIn:
-                EcosiaLogger.accounts.info("User logged in - registering visit")
-                registerVisitIfNeeded()
-            case .userLoggedOut:
-                EcosiaLogger.accounts.info("User logged out - resetting to local seed collection")
-                await resetToLocalSeedCollection()
-                await handleLocalSeedCollection()
-            case .authStateLoaded:
-                break // State already updated above
-            }
-        }
     }
 
     @MainActor
     private func handleUserProfileUpdate() {
-        Task { @MainActor in
-            isLoggedIn = EcosiaAuthenticationService.shared.isLoggedIn
-        }
+        isLoggedIn = EcosiaAuthenticationService.shared.isLoggedIn
         userProfile = EcosiaAuthenticationService.shared.userProfile
         username = userProfile?.name
         avatarURL = normalizedAvatarURL
-    }
-
-    @MainActor
-    private func handleSeedProgressUpdate() {
-        // Only handle for logged-out users
-        guard !isLoggedIn else { return }
-
-        let newSeedCount = Self.seedProgressManagerType.loadTotalSeedsCollected()
-
-        // If seed count increased, show animation
-        if newSeedCount > seedCount {
-            let increment = newSeedCount - seedCount
-            EcosiaLogger.accounts.info("Seed progress updated for logged-out user: \(seedCount) → \(newSeedCount) (+\(increment))")
-            animateBalanceChange(from: seedCount, to: newSeedCount, increment: increment)
-        } else {
-            seedCount = newSeedCount
-        }
-    }
-
-    // MARK: - Seed Count Management
-
-    /// Registers a user visit to fetch the latest balance from the backend.
-    ///
-    /// Only proceeds if a valid access token is available (user is logged in).
-    /// Updates the balance and level information on success.
-    /// Sets `hasRegisterVisitError` to `true` on failure.
-    private func registerVisitIfNeeded() {
-        Task {
-            do {
-                guard let accessToken = EcosiaAuthenticationService.shared.accessToken, !accessToken.isEmpty else {
-                    EcosiaLogger.accounts.notice("Cannot register visit - no access token available")
-                    return
-                }
-
-                EcosiaLogger.accounts.info("Registering user visit for balance update")
-                let response = try await accountsProvider.registerVisit(accessToken: accessToken)
-                await updateBalance(response)
-
-                // Clear error on success
-                await MainActor.run {
-                    hasRegisterVisitError = false
-                }
-            } catch {
-                EcosiaLogger.accounts.debug("Could not register visit: \(error.localizedDescription)")
-
-                // Set error state
-                await MainActor.run {
-                    hasRegisterVisitError = true
-                    if #available(iOS 16.0, *) {
-                        EcosiaErrorToastPresenter.shared.presentRegisterVisitError()
-                    }
-                }
-            }
-        }
-    }
-
-    @MainActor
-    private func updateBalance(_ response: AccountVisitResponse) {
-        let newSeedCount = response.seeds.balanceAmount
-        let newLevelNumber = response.growthPoints.level.number
-        let newProgress = response.progressToNextLevel
-
-        // Update level and progress from API
-        currentLevelNumber = newLevelNumber
-        currentProgress = newProgress
-
-        // Trigger level-up animation if user leveled up
-        if response.didLevelUp {
-            EcosiaLogger.accounts.info("Level up detected: triggering animation for level \(newLevelNumber)")
-            triggerLevelUpAnimation()
-        }
-
-        if let increment = response.seedsIncrement {
-            EcosiaLogger.accounts.info("Balance updated with animation: \(seedCount) → \(newSeedCount) (+\(increment)), level=\(newLevelNumber), progress=\(newProgress)")
-            animateBalanceChange(from: seedCount, to: newSeedCount, increment: increment)
-        } else {
-            EcosiaLogger.accounts.info("Balance updated without animation: \(seedCount) → \(newSeedCount), level=\(newLevelNumber), progress=\(newProgress)")
-            seedCount = newSeedCount
-        }
-    }
-
-    @MainActor
-    private func animateBalanceChange(from oldValue: Int, to newValue: Int, increment: Int) {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-            self.balanceIncrement = increment
-
-            withAnimation(.easeIn(duration: 0.3)) {
-                self.seedCount = newValue
-            }
-
-            DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
-                withAnimation(.linear(duration: 0.57)) {
-                    self.balanceIncrement = nil
-                }
-            }
-        }
-    }
-
-    @MainActor
-    private func triggerLevelUpAnimation() {
-        EcosiaAccountNotificationCenter.postLevelUp(
-            newLevel: currentLevelNumber,
-            newProgress: currentProgress
-        )
-    }
-
-    /// Resets to local seed collection system after logout.
-    ///
-    /// Resets seeds to 0, level to 1, and clears lastAppOpenDate to allow immediate seed collection.
-    @MainActor
-    private func resetToLocalSeedCollection() {
-        EcosiaLogger.accounts.info("Resetting to local seed collection system")
-
-        Self.seedProgressManagerType.resetLocalSeedProgress()
-
-        seedCount = Self.seedProgressManagerType.loadTotalSeedsCollected()
-        currentLevelNumber = 1
-        currentProgress = 0.25
-    }
-
-    /// Handles daily seed collection for logged-out users.
-    ///
-    /// Collects one seed per day and animates the increment if a new seed was collected.
-    @MainActor
-    private func handleLocalSeedCollection() {
-        EcosiaLogger.accounts.info("Handling local seed collection for logged-out user")
-        Self.seedProgressManagerType.collectDailySeed()
-        let newSeedCount = Self.seedProgressManagerType.loadTotalSeedsCollected()
-
-        if newSeedCount > seedCount {
-            let increment = newSeedCount - seedCount
-            animateBalanceChange(from: seedCount, to: newSeedCount, increment: increment)
-        } else {
-            seedCount = newSeedCount
-        }
-    }
-
-    // MARK: - Public Methods
-
-    /// Refreshes seed state based on authentication status.
-    ///
-    /// Should be called when the NTP appears or app returns from background.
-    /// - For logged-in users: Registers a visit to fetch latest balance from server
-    /// - For logged-out users: Checks and collects daily seed
-    @MainActor
-    public func refreshSeedState() {
-        if isLoggedIn {
-            EcosiaLogger.accounts.debug("Refreshing seed state for logged-in user (server fetch)")
-            registerVisitIfNeeded()
-        } else {
-            EcosiaLogger.accounts.debug("Refreshing seed state for logged-out user (daily seed check)")
-            handleLocalSeedCollection()
-        }
-    }
-
-    // MARK: - Debug Methods
-
-    /// Debug method to simulate balance updates for testing animations
-    /// This allows QA to test seed addition and level-up animations without server calls
-    /// Available in all builds, accessible through hidden debug menu
-    @MainActor
-    public func debugUpdateBalance(_ response: AccountVisitResponse) {
-        updateBalance(response)
-        EcosiaLogger.accounts.info("Debug: Balance updated via debug method")
-    }
-
-    /// Debug method to directly trigger level-up animation without mock data
-    /// This allows QA to test the level-up sparkle animation independently
-    /// Available in all builds, accessible through hidden debug menu
-    @MainActor
-    public func debugTriggerLevelUpAnimation() {
-        triggerLevelUpAnimation()
-        EcosiaLogger.accounts.info("Debug: Level-up animation triggered directly")
-    }
-
-    /// Debug method to directly add seeds with animation for logged-in users
-    /// This allows QA to test seed increment animations without mock responses
-    /// Available in all builds, accessible through hidden debug menu
-    @MainActor
-    public func debugAddSeeds(_ count: Int) {
-        let currentSeeds = seedCount
-        let newSeeds = currentSeeds + count
-        animateBalanceChange(from: currentSeeds, to: newSeeds, increment: count)
-        EcosiaLogger.accounts.info("Debug: Added \(count) seeds for logged-in user (\(currentSeeds) → \(newSeeds))")
     }
 }

--- a/firefox-ios/Ecosia/UI/Account/ImpactManager.swift
+++ b/firefox-ios/Ecosia/UI/Account/ImpactManager.swift
@@ -91,16 +91,14 @@ public final class ImpactManager: ObservableObject {
         }
     }
 
-    /// Resolves the snapshot to seed `init`'s state with. Pulled out as a pure static function
-    /// (rather than inlined in `init`) so it can be unit tested directly against a mock
-    /// `loggedInImpactCacheType`, independent of the live `EcosiaAuthenticationService.shared`
-    /// state `init` otherwise reads from.
+    /// Resolves the snapshot to seed `init`'s state with. One polymorphic call through
+    /// `ImpactSnapshotReadable` - which store answers it depends only on login state, the call
+    /// shape is identical either way. Pulled out as a pure static function (rather than inlined
+    /// in `init`) so it can be unit tested directly against a mock `loggedInImpactCacheType`,
+    /// independent of the live `EcosiaAuthenticationService.shared` state `init` otherwise reads from.
     static func resolveInitialImpactSnapshot(isLoggedIn: Bool, userId: String?) -> ImpactSnapshot? {
-        guard isLoggedIn else {
-            return loggedOutImpactCacheType.currentSnapshot()
-        }
-        guard let userId else { return nil }
-        return loggedInImpactCacheType.load(forUserId: userId)
+        let cacheType: ImpactSnapshotReadable.Type = isLoggedIn ? loggedInImpactCacheType : loggedOutImpactCacheType
+        return cacheType.currentSnapshot(forUserId: userId)
     }
 
     // MARK: - Public Interface

--- a/firefox-ios/Ecosia/UI/Account/ImpactManager.swift
+++ b/firefox-ios/Ecosia/UI/Account/ImpactManager.swift
@@ -11,9 +11,12 @@ import Common
 /// whether a number came from the server (logged-in) or local collection (logged-out) - they
 /// just observe `seedCount`/`currentLevelNumber`/`currentProgress` and call `refreshSeedState()`.
 ///
-/// Tracks `isLoggedIn`/the current user id itself (independently of `EcosiaAuthUIStateProvider`,
-/// which owns identity/profile display) by listening to the same auth notifications, so it has
-/// no dependency on that type at all - the two are siblings, not layered.
+/// Reads `isLoggedIn`/the current user id straight from `authService` every time rather than
+/// caching a local copy kept in sync via notifications - `EcosiaAuthenticationService` is already
+/// the single source of truth and safe to read synchronously at any point, so a cached copy would
+/// just be a second thing that could drift from it. Listens to `.EcosiaAuthStateChanged` only to
+/// trigger the login/logout side effects (register a visit, reset local collection), not to track
+/// state itself - no dependency on `EcosiaAuthUIStateProvider` at all, the two are siblings.
 @MainActor
 public final class ImpactManager: ObservableObject {
 
@@ -36,13 +39,13 @@ public final class ImpactManager: ObservableObject {
 
     // MARK: - Private Properties
 
-    private var isLoggedIn = false
-    private var userId: String?
+    private var isLoggedIn: Bool { authService.isLoggedIn }
+    private var userId: String? { authService.userProfile?.sub }
 
     private var authStateObserver: NSObjectProtocol?
-    private var userProfileObserver: NSObjectProtocol?
     private var seedProgressObserver: NSObjectProtocol?
     private let accountsProvider: AccountsProviderProtocol
+    private let authService: EcosiaAuthenticationService
 
     /// Not `private`: swapped for a mock from tests via `@testable import`.
     nonisolated(unsafe) static var loggedOutImpactCacheType: SeedProgressManagerProtocol.Type = UserDefaultsSeedProgressManager.self
@@ -61,12 +64,9 @@ public final class ImpactManager: ObservableObject {
         }
     }()
 
-    public init(accountsProvider: AccountsProviderProtocol) {
+    public init(accountsProvider: AccountsProviderProtocol, authService: EcosiaAuthenticationService = .shared) {
         self.accountsProvider = accountsProvider
-
-        // Initialize state synchronously to prevent flickering
-        self.isLoggedIn = EcosiaAuthenticationService.shared.isLoggedIn
-        self.userId = EcosiaAuthenticationService.shared.userProfile?.sub
+        self.authService = authService
 
         // Seed real state synchronously: logged-out reads the local snapshot, logged-in reads
         // the last known server snapshot from cache (falls through to the placeholder above only
@@ -83,7 +83,7 @@ public final class ImpactManager: ObservableObject {
 
     deinit {
         MainActor.assumeIsolated {
-            [authStateObserver, userProfileObserver, seedProgressObserver].forEach {
+            [authStateObserver, seedProgressObserver].forEach {
                 if let observer = $0 {
                     NotificationCenter.default.removeObserver(observer)
                 }
@@ -125,7 +125,8 @@ public final class ImpactManager: ObservableObject {
     // MARK: - Private Methods
 
     private func setupObservers() {
-        // Listen for auth state changes
+        // Listen for auth state changes - only to trigger the login/logout side effects below,
+        // isLoggedIn/userId are read live from authService rather than cached from this.
         authStateObserver = NotificationCenter.default.addObserver(
             forName: .EcosiaAuthStateChanged,
             object: nil,
@@ -133,17 +134,6 @@ public final class ImpactManager: ObservableObject {
         ) { [weak self] notification in
             Task { [notification] in
                 await self?.handleAuthStateChange(notification)
-            }
-        }
-
-        // Listen for user profile updates (also carries login-state changes)
-        userProfileObserver = NotificationCenter.default.addObserver(
-            forName: .EcosiaUserProfileUpdated,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            Task {
-                await self?.handleUserProfileUpdate()
             }
         }
 
@@ -163,26 +153,15 @@ public final class ImpactManager: ObservableObject {
         guard let actionType = notification.userInfo?["actionType"] as? EcosiaAuthActionType else { return }
         switch actionType {
         case .userLoggedIn:
-            isLoggedIn = true
-            userId = EcosiaAuthenticationService.shared.userProfile?.sub
             EcosiaLogger.accounts.info("User logged in - registering visit")
             registerVisitIfNeeded()
         case .userLoggedOut:
             EcosiaLogger.accounts.info("User logged out - resetting to local seed collection")
             await resetToLocalSeedCollection()
             await handleLocalSeedCollection()
-            isLoggedIn = false
-            userId = nil
         case .authStateLoaded:
-            isLoggedIn = EcosiaAuthenticationService.shared.isLoggedIn
-            userId = EcosiaAuthenticationService.shared.userProfile?.sub
+            break // isLoggedIn/userId are read live, nothing to refresh here
         }
-    }
-
-    @MainActor
-    private func handleUserProfileUpdate() {
-        isLoggedIn = EcosiaAuthenticationService.shared.isLoggedIn
-        userId = EcosiaAuthenticationService.shared.userProfile?.sub
     }
 
     @MainActor
@@ -212,7 +191,7 @@ public final class ImpactManager: ObservableObject {
     private func registerVisitIfNeeded() {
         Task {
             do {
-                guard let accessToken = EcosiaAuthenticationService.shared.accessToken, !accessToken.isEmpty else {
+                guard let accessToken = authService.accessToken, !accessToken.isEmpty else {
                     EcosiaLogger.accounts.notice("Cannot register visit - no access token available")
                     return
                 }

--- a/firefox-ios/Ecosia/UI/Account/ImpactManager.swift
+++ b/firefox-ios/Ecosia/UI/Account/ImpactManager.swift
@@ -1,0 +1,388 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+@preconcurrency import Foundation
+import SwiftUI
+import Combine
+import Common
+
+/// Owns seed/level/progress state regardless of login state, so callers never need to know
+/// whether a number came from the server (logged-in) or local collection (logged-out) - they
+/// just observe `seedCount`/`currentLevelNumber`/`currentProgress` and call `refreshSeedState()`.
+///
+/// Tracks `isLoggedIn`/the current user id itself (independently of `EcosiaAuthUIStateProvider`,
+/// which owns identity/profile display) by listening to the same auth notifications, so it has
+/// no dependency on that type at all - the two are siblings, not layered.
+@MainActor
+public final class ImpactManager: ObservableObject {
+
+    // MARK: - Published Properties
+
+    /// Current seed count (server-based for logged in users, local for guests)
+    @Published public private(set) var seedCount: Int = 0
+
+    /// Current level number (from API for logged-in users, 1 for logged-out)
+    @Published public private(set) var currentLevelNumber: Int = 1
+
+    /// Current progress towards next level (from API for logged-in users, default 0.25 for initial state)
+    @Published public private(set) var currentProgress: Double = 0.25
+
+    /// Error state for register visit failures (read-only externally, set only by this class)
+    @Published public private(set) var hasRegisterVisitError: Bool = false
+
+    /// Balance increment for animations (temporary state)
+    @Published public private(set) var balanceIncrement: Int?
+
+    // MARK: - Private Properties
+
+    private var isLoggedIn = false
+    private var userId: String?
+
+    private var authStateObserver: NSObjectProtocol?
+    private var userProfileObserver: NSObjectProtocol?
+    private var seedProgressObserver: NSObjectProtocol?
+    private let accountsProvider: AccountsProviderProtocol
+
+    /// Not `private`: swapped for a mock from tests via `@testable import`.
+    nonisolated(unsafe) static var loggedOutImpactCacheType: SeedProgressManagerProtocol.Type = UserDefaultsSeedProgressManager.self
+    /// Not `private`: swapped for a mock from tests via `@testable import`.
+    nonisolated(unsafe) static var loggedInImpactCacheType: LoggedInImpactCacheProtocol.Type = UserDefaultsLoggedInImpactCache.self
+
+    // MARK: - Singleton
+
+    /// Factory for creating accounts provider - can be configured before first access
+    nonisolated(unsafe) public static var accountsProviderFactory: () -> AccountsProviderProtocol = { AccountsProvider() }
+
+    /// Shared instance for app-wide impact state
+    nonisolated(unsafe) public static let shared: ImpactManager = {
+        MainActor.assumeIsolated {
+            ImpactManager(accountsProvider: accountsProviderFactory())
+        }
+    }()
+
+    public init(accountsProvider: AccountsProviderProtocol) {
+        self.accountsProvider = accountsProvider
+
+        // Initialize state synchronously to prevent flickering
+        self.isLoggedIn = EcosiaAuthenticationService.shared.isLoggedIn
+        self.userId = EcosiaAuthenticationService.shared.userProfile?.sub
+
+        // Seed real state synchronously: logged-out reads the local snapshot, logged-in reads
+        // the last known server snapshot from cache (falls through to the placeholder above only
+        // on a first-ever login with nothing cached yet - registerVisitIfNeeded(), triggered
+        // separately, fills that in shortly after).
+        if let snapshot = Self.resolveInitialImpactSnapshot(isLoggedIn: isLoggedIn, userId: userId) {
+            seedCount = snapshot.seedCount
+            currentLevelNumber = snapshot.currentLevelNumber
+            currentProgress = snapshot.currentProgress
+        }
+
+        setupObservers()
+    }
+
+    deinit {
+        MainActor.assumeIsolated {
+            [authStateObserver, userProfileObserver, seedProgressObserver].forEach {
+                if let observer = $0 {
+                    NotificationCenter.default.removeObserver(observer)
+                }
+            }
+        }
+    }
+
+    /// Resolves the snapshot to seed `init`'s state with. Pulled out as a pure static function
+    /// (rather than inlined in `init`) so it can be unit tested directly against a mock
+    /// `loggedInImpactCacheType`, independent of the live `EcosiaAuthenticationService.shared`
+    /// state `init` otherwise reads from.
+    static func resolveInitialImpactSnapshot(isLoggedIn: Bool, userId: String?) -> ImpactSnapshot? {
+        guard isLoggedIn else {
+            return loggedOutImpactCacheType.currentSnapshot()
+        }
+        guard let userId else { return nil }
+        return loggedInImpactCacheType.load(forUserId: userId)
+    }
+
+    // MARK: - Public Interface
+
+    /// Computed property for level display text
+    /// Returns level number and name for logged-in users, empty string for logged-out users
+    public var levelDisplayText: String {
+        let levelNumber = currentLevelNumber
+        let levelName = GrowthPointsLevelSystem.levelName(for: levelNumber)
+        return "\(String.localized(.level)) \(levelNumber) - \(levelName)"
+    }
+
+    /// Computed property for level progress (0.0 to 1.0)
+    /// Returns progress from API for logged-in users, 0.25 default for initial/logged-out state
+    public var levelProgress: Double {
+        guard isLoggedIn else {
+            return 0.25 // Default progress for logged-out users
+        }
+        return currentProgress
+    }
+
+    // MARK: - Private Methods
+
+    private func setupObservers() {
+        // Listen for auth state changes
+        authStateObserver = NotificationCenter.default.addObserver(
+            forName: .EcosiaAuthStateChanged,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            Task { [notification] in
+                await self?.handleAuthStateChange(notification)
+            }
+        }
+
+        // Listen for user profile updates (also carries login-state changes)
+        userProfileObserver = NotificationCenter.default.addObserver(
+            forName: .EcosiaUserProfileUpdated,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task {
+                await self?.handleUserProfileUpdate()
+            }
+        }
+
+        // Listen for seed progress updates (for logged-out users)
+        seedProgressObserver = NotificationCenter.default.addObserver(
+            forName: UserDefaultsSeedProgressManager.progressUpdatedNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task {
+                await self?.handleSeedProgressUpdate()
+            }
+        }
+    }
+
+    private func handleAuthStateChange(_ notification: Notification) async {
+        guard let actionType = notification.userInfo?["actionType"] as? EcosiaAuthActionType else { return }
+        switch actionType {
+        case .userLoggedIn:
+            isLoggedIn = true
+            userId = EcosiaAuthenticationService.shared.userProfile?.sub
+            EcosiaLogger.accounts.info("User logged in - registering visit")
+            registerVisitIfNeeded()
+        case .userLoggedOut:
+            EcosiaLogger.accounts.info("User logged out - resetting to local seed collection")
+            await resetToLocalSeedCollection()
+            await handleLocalSeedCollection()
+            isLoggedIn = false
+            userId = nil
+        case .authStateLoaded:
+            isLoggedIn = EcosiaAuthenticationService.shared.isLoggedIn
+            userId = EcosiaAuthenticationService.shared.userProfile?.sub
+        }
+    }
+
+    @MainActor
+    private func handleUserProfileUpdate() {
+        isLoggedIn = EcosiaAuthenticationService.shared.isLoggedIn
+        userId = EcosiaAuthenticationService.shared.userProfile?.sub
+    }
+
+    @MainActor
+    private func handleSeedProgressUpdate() {
+        // Only handle for logged-out users
+        guard !isLoggedIn else { return }
+
+        let newSeedCount = Self.loggedOutImpactCacheType.loadTotalSeedsCollected()
+
+        // If seed count increased, show animation
+        if newSeedCount > seedCount {
+            let increment = newSeedCount - seedCount
+            EcosiaLogger.accounts.info("Seed progress updated for logged-out user: \(seedCount) → \(newSeedCount) (+\(increment))")
+            animateBalanceChange(from: seedCount, to: newSeedCount, increment: increment)
+        } else {
+            seedCount = newSeedCount
+        }
+    }
+
+    // MARK: - Seed Count Management
+
+    /// Registers a user visit to fetch the latest balance from the backend.
+    ///
+    /// Only proceeds if a valid access token is available (user is logged in).
+    /// Updates the balance and level information on success.
+    /// Sets `hasRegisterVisitError` to `true` on failure.
+    private func registerVisitIfNeeded() {
+        Task {
+            do {
+                guard let accessToken = EcosiaAuthenticationService.shared.accessToken, !accessToken.isEmpty else {
+                    EcosiaLogger.accounts.notice("Cannot register visit - no access token available")
+                    return
+                }
+
+                EcosiaLogger.accounts.info("Registering user visit for balance update")
+                let response = try await accountsProvider.registerVisit(accessToken: accessToken)
+                await updateBalance(response)
+
+                // Clear error on success
+                await MainActor.run {
+                    hasRegisterVisitError = false
+                }
+            } catch {
+                EcosiaLogger.accounts.debug("Could not register visit: \(error.localizedDescription)")
+
+                // Set error state
+                await MainActor.run {
+                    hasRegisterVisitError = true
+                    if #available(iOS 16.0, *) {
+                        EcosiaErrorToastPresenter.shared.presentRegisterVisitError()
+                    }
+                }
+            }
+        }
+    }
+
+    @MainActor
+    private func updateBalance(_ response: AccountVisitResponse) {
+        let newSeedCount = response.seeds.balanceAmount
+        let newLevelNumber = response.growthPoints.level.number
+        let newProgress = response.progressToNextLevel
+
+        // Update level and progress from API
+        currentLevelNumber = newLevelNumber
+        currentProgress = newProgress
+
+        persistLoggedInImpactSnapshot(seedCount: newSeedCount, currentLevelNumber: newLevelNumber, currentProgress: newProgress)
+
+        // Trigger level-up animation if user leveled up
+        if response.didLevelUp {
+            EcosiaLogger.accounts.info("Level up detected: triggering animation for level \(newLevelNumber)")
+            triggerLevelUpAnimation()
+        }
+
+        if let increment = response.seedsIncrement {
+            EcosiaLogger.accounts.info("Balance updated with animation: \(seedCount) → \(newSeedCount) (+\(increment)), level=\(newLevelNumber), progress=\(newProgress)")
+            animateBalanceChange(from: seedCount, to: newSeedCount, increment: increment)
+        } else {
+            EcosiaLogger.accounts.info("Balance updated without animation: \(seedCount) → \(newSeedCount), level=\(newLevelNumber), progress=\(newProgress)")
+            seedCount = newSeedCount
+        }
+    }
+
+    /// Writes through to `loggedInImpactCacheType` so a cold launch (or the profile screen) can
+    /// seed from these values next time, instead of flashing the logged-out cap.
+    private func persistLoggedInImpactSnapshot(seedCount: Int, currentLevelNumber: Int, currentProgress: Double) {
+        guard isLoggedIn, let userId else { return }
+        Self.loggedInImpactCacheType.save(
+            ImpactSnapshot(seedCount: seedCount, currentLevelNumber: currentLevelNumber, currentProgress: currentProgress),
+            userId: userId
+        )
+    }
+
+    @MainActor
+    private func animateBalanceChange(from oldValue: Int, to newValue: Int, increment: Int) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            self.balanceIncrement = increment
+
+            withAnimation(.easeIn(duration: 0.3)) {
+                self.seedCount = newValue
+            }
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
+                withAnimation(.linear(duration: 0.57)) {
+                    self.balanceIncrement = nil
+                }
+            }
+        }
+    }
+
+    @MainActor
+    private func triggerLevelUpAnimation() {
+        EcosiaAccountNotificationCenter.postLevelUp(
+            newLevel: currentLevelNumber,
+            newProgress: currentProgress
+        )
+    }
+
+    /// Resets to local seed collection system after logout.
+    ///
+    /// Resets seeds to 0, level to 1, and clears lastAppOpenDate to allow immediate seed collection.
+    @MainActor
+    private func resetToLocalSeedCollection() {
+        EcosiaLogger.accounts.info("Resetting to local seed collection system")
+
+        // Same vocabulary on both stores: the local manager re-arms collection from zero, the
+        // logged-in cache drops the stale server snapshot - so a later login by a different
+        // account doesn't briefly show this account's numbers either way.
+        Self.loggedOutImpactCacheType.clearOnLogout()
+        Self.loggedInImpactCacheType.clearOnLogout()
+
+        seedCount = Self.loggedOutImpactCacheType.loadTotalSeedsCollected()
+        currentLevelNumber = 1
+        currentProgress = 0.25
+    }
+
+    /// Handles daily seed collection for logged-out users.
+    ///
+    /// Collects one seed per day and animates the increment if a new seed was collected.
+    @MainActor
+    private func handleLocalSeedCollection() {
+        EcosiaLogger.accounts.info("Handling local seed collection for logged-out user")
+        Self.loggedOutImpactCacheType.collectDailySeed()
+        let newSeedCount = Self.loggedOutImpactCacheType.loadTotalSeedsCollected()
+
+        if newSeedCount > seedCount {
+            let increment = newSeedCount - seedCount
+            animateBalanceChange(from: seedCount, to: newSeedCount, increment: increment)
+        } else {
+            seedCount = newSeedCount
+        }
+    }
+
+    // MARK: - Public Methods
+
+    /// Refreshes seed state based on authentication status. Called every time regardless of
+    /// login state - callers don't branch on `isLoggedIn` themselves, this does it internally.
+    ///
+    /// Should be called when the NTP appears or app returns from background.
+    /// - For logged-in users: Registers a visit to fetch latest balance from server
+    /// - For logged-out users: Checks and collects daily seed
+    @MainActor
+    public func refreshSeedState() {
+        if isLoggedIn {
+            EcosiaLogger.accounts.debug("Refreshing seed state for logged-in user (server fetch)")
+            registerVisitIfNeeded()
+        } else {
+            EcosiaLogger.accounts.debug("Refreshing seed state for logged-out user (daily seed check)")
+            handleLocalSeedCollection()
+        }
+    }
+
+    // MARK: - Debug Methods
+
+    /// Debug method to simulate balance updates for testing animations
+    /// This allows QA to test seed addition and level-up animations without server calls
+    /// Available in all builds, accessible through hidden debug menu
+    @MainActor
+    public func debugUpdateBalance(_ response: AccountVisitResponse) {
+        updateBalance(response)
+        EcosiaLogger.accounts.info("Debug: Balance updated via debug method")
+    }
+
+    /// Debug method to directly trigger level-up animation without mock data
+    /// This allows QA to test the level-up sparkle animation independently
+    /// Available in all builds, accessible through hidden debug menu
+    @MainActor
+    public func debugTriggerLevelUpAnimation() {
+        triggerLevelUpAnimation()
+        EcosiaLogger.accounts.info("Debug: Level-up animation triggered directly")
+    }
+
+    /// Debug method to directly add seeds with animation for logged-in users
+    /// This allows QA to test seed increment animations without mock responses
+    /// Available in all builds, accessible through hidden debug menu
+    @MainActor
+    public func debugAddSeeds(_ count: Int) {
+        let currentSeeds = seedCount
+        let newSeeds = currentSeeds + count
+        animateBalanceChange(from: currentSeeds, to: newSeeds, increment: count)
+        EcosiaLogger.accounts.info("Debug: Added \(count) seeds for logged-in user (\(currentSeeds) → \(newSeeds))")
+    }
+}

--- a/firefox-ios/Ecosia/UI/Account/SeedProgressManager/LoggedInImpactCacheProtocol.swift
+++ b/firefox-ios/Ecosia/UI/Account/SeedProgressManager/LoggedInImpactCacheProtocol.swift
@@ -1,0 +1,44 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// A point-in-time impact snapshot - seedCount/currentLevelNumber/currentProgress - regardless of
+/// whether it came from the server (logged-in, via `LoggedInImpactCacheProtocol`) or was computed
+/// locally (logged-out, via `SeedProgressManagerProtocol.currentSnapshot()`). `ImpactManager`
+/// publishes these three values as flat properties either way, so the shape is shared on purpose.
+public struct ImpactSnapshot: Equatable {
+    public let seedCount: Int
+    public let currentLevelNumber: Int
+    public let currentProgress: Double
+
+    public init(seedCount: Int, currentLevelNumber: Int, currentProgress: Double) {
+        self.seedCount = seedCount
+        self.currentLevelNumber = currentLevelNumber
+        self.currentProgress = currentProgress
+    }
+}
+
+/// Persists the last known server-reported seed/level/progress for a logged-in user, so the UI can
+/// show real numbers immediately on cold launch instead of the logged-out cap
+/// (`UserDefaultsSeedProgressManager.maxSeedsForLoggedOutUsers`) while a fresh value is fetched.
+public protocol LoggedInImpactCacheProtocol {
+    /// Returns the cached snapshot, or `nil` if there is none or it belongs to a different user.
+    static func load(forUserId userId: String) -> ImpactSnapshot?
+
+    /// Persists a snapshot, tagged with the user it belongs to.
+    static func save(_ snapshot: ImpactSnapshot, userId: String)
+
+    /// Clears any cached snapshot, regardless of which user it belonged to.
+    static func clear()
+}
+
+extension LoggedInImpactCacheProtocol {
+    /// Shared vocabulary with `SeedProgressManagerProtocol.clearOnLogout()`: `ImpactManager`
+    /// calls both stores by this same name on logout, without needing to know each store's own
+    /// reason for clearing.
+    public static func clearOnLogout() {
+        clear()
+    }
+}

--- a/firefox-ios/Ecosia/UI/Account/SeedProgressManager/LoggedInImpactCacheProtocol.swift
+++ b/firefox-ios/Ecosia/UI/Account/SeedProgressManager/LoggedInImpactCacheProtocol.swift
@@ -20,10 +20,18 @@ public struct ImpactSnapshot: Equatable {
     }
 }
 
+/// A single, login-state-agnostic way to read the current impact snapshot: `ImpactManager` picks
+/// whichever store's `.Type` is relevant and calls this, without branching on the call shape
+/// itself - both `SeedProgressManagerProtocol` (userId ignored - one local slot, not per-account)
+/// and `LoggedInImpactCacheProtocol` (userId required, nil short-circuits to `nil`) conform.
+public protocol ImpactSnapshotReadable {
+    static func currentSnapshot(forUserId userId: String?) -> ImpactSnapshot?
+}
+
 /// Persists the last known server-reported seed/level/progress for a logged-in user, so the UI can
 /// show real numbers immediately on cold launch instead of the logged-out cap
 /// (`UserDefaultsSeedProgressManager.maxSeedsForLoggedOutUsers`) while a fresh value is fetched.
-public protocol LoggedInImpactCacheProtocol {
+public protocol LoggedInImpactCacheProtocol: ImpactSnapshotReadable {
     /// Returns the cached snapshot, or `nil` if there is none or it belongs to a different user.
     static func load(forUserId userId: String) -> ImpactSnapshot?
 
@@ -40,5 +48,12 @@ extension LoggedInImpactCacheProtocol {
     /// reason for clearing.
     public static func clearOnLogout() {
         clear()
+    }
+}
+
+extension LoggedInImpactCacheProtocol {
+    public static func currentSnapshot(forUserId userId: String?) -> ImpactSnapshot? {
+        guard let userId else { return nil }
+        return load(forUserId: userId)
     }
 }

--- a/firefox-ios/Ecosia/UI/Account/SeedProgressManager/SeedProgressManagerProtocol.swift
+++ b/firefox-ios/Ecosia/UI/Account/SeedProgressManager/SeedProgressManagerProtocol.swift
@@ -21,3 +21,22 @@ public protocol SeedProgressManagerProtocol {
     static func calculateInnerProgress() -> CGFloat
     static func collectDailySeed()
 }
+
+extension SeedProgressManagerProtocol {
+    /// Logged-out counterpart to `LoggedInImpactCacheProtocol.load(forUserId:)`: same `ImpactSnapshot`
+    /// shape, computed from local state instead of a cached server value, since logged-out users
+    /// don't have one. Composed entirely from the load methods above, so no conforming type needs
+    /// to implement this itself.
+    public static func currentSnapshot() -> ImpactSnapshot {
+        ImpactSnapshot(
+            seedCount: loadTotalSeedsCollected(),
+            currentLevelNumber: loadCurrentLevel(),
+            currentProgress: Double(calculateInnerProgress())
+        )
+    }
+
+    /// Shared vocabulary with `LoggedInImpactCacheProtocol.clearOnLogout()`.
+    public static func clearOnLogout() {
+        resetLocalSeedProgress()
+    }
+}

--- a/firefox-ios/Ecosia/UI/Account/SeedProgressManager/SeedProgressManagerProtocol.swift
+++ b/firefox-ios/Ecosia/UI/Account/SeedProgressManager/SeedProgressManagerProtocol.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public protocol SeedProgressManagerProtocol {
+public protocol SeedProgressManagerProtocol: ImpactSnapshotReadable {
     static var progressUpdatedNotification: Notification.Name { get }
     static var levelUpNotification: Notification.Name { get }
     static var seedCounterConfig: SeedCounterConfig? { get set }
@@ -38,5 +38,12 @@ extension SeedProgressManagerProtocol {
     /// Shared vocabulary with `LoggedInImpactCacheProtocol.clearOnLogout()`.
     public static func clearOnLogout() {
         resetLocalSeedProgress()
+    }
+}
+
+extension SeedProgressManagerProtocol {
+    /// `userId` is ignored: there's one local slot for logged-out collection, not one per account.
+    public static func currentSnapshot(forUserId userId: String?) -> ImpactSnapshot? {
+        currentSnapshot()
     }
 }

--- a/firefox-ios/Ecosia/UI/Account/SeedProgressManager/UserDefaultsLoggedInImpactCache.swift
+++ b/firefox-ios/Ecosia/UI/Account/SeedProgressManager/UserDefaultsLoggedInImpactCache.swift
@@ -1,0 +1,49 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// `UserDefaults`-backed implementation of `LoggedInImpactCacheProtocol`.
+///
+/// Keyed to the Auth0 `sub` that saved it, so a different account logging in on the same device
+/// never inherits stale numbers from the previous one - `load(forUserId:)` returns `nil` unless the
+/// stored snapshot belongs to the requested user.
+public final class UserDefaultsLoggedInImpactCache: LoggedInImpactCacheProtocol {
+
+    private static let seedCountKey = "LoggedInImpactCache.seedCount"
+    private static let currentLevelNumberKey = "LoggedInImpactCache.currentLevelNumber"
+    private static let currentProgressKey = "LoggedInImpactCache.currentProgress"
+    private static let userIdKey = "LoggedInImpactCache.userId"
+
+    private init() {}
+
+    public static func load(forUserId userId: String) -> ImpactSnapshot? {
+        let defaults = UserDefaults.standard
+        guard defaults.string(forKey: userIdKey) == userId,
+              defaults.object(forKey: seedCountKey) != nil else {
+            return nil
+        }
+        return ImpactSnapshot(
+            seedCount: defaults.integer(forKey: seedCountKey),
+            currentLevelNumber: defaults.integer(forKey: currentLevelNumberKey),
+            currentProgress: defaults.double(forKey: currentProgressKey)
+        )
+    }
+
+    public static func save(_ snapshot: ImpactSnapshot, userId: String) {
+        let defaults = UserDefaults.standard
+        defaults.set(snapshot.seedCount, forKey: seedCountKey)
+        defaults.set(snapshot.currentLevelNumber, forKey: currentLevelNumberKey)
+        defaults.set(snapshot.currentProgress, forKey: currentProgressKey)
+        defaults.set(userId, forKey: userIdKey)
+    }
+
+    public static func clear() {
+        let defaults = UserDefaults.standard
+        defaults.removeObject(forKey: seedCountKey)
+        defaults.removeObject(forKey: currentLevelNumberKey)
+        defaults.removeObject(forKey: currentProgressKey)
+        defaults.removeObject(forKey: userIdKey)
+    }
+}

--- a/firefox-ios/Ecosia/UI/NTP/Header/EcosiaAccountNavButton.swift
+++ b/firefox-ios/Ecosia/UI/NTP/Header/EcosiaAccountNavButton.swift
@@ -20,6 +20,7 @@ public struct EcosiaAccountNavButton: View {
     private let windowUUID: WindowUUID
     @State private var theme = EcosiaAccountNavButtonTheme()
     @ObservedObject private var authStateProvider = EcosiaAuthUIStateProvider.shared
+    @ObservedObject private var impactManager = ImpactManager.shared
 
     public init(
         seedCount: Int,
@@ -45,7 +46,7 @@ public struct EcosiaAccountNavButton: View {
     public var body: some View {
         Button(action: { onTap() }) {
             HStack(spacing: .ecosia.space._1s) {
-                if !authStateProvider.hasRegisterVisitError {
+                if !impactManager.hasRegisterVisitError {
                     EcosiaSeedView(
                         seedCount: seedCount,
                         seedIconSize: .ecosia.space._1l,
@@ -64,10 +65,10 @@ public struct EcosiaAccountNavButton: View {
             }
             .padding(.top, .ecosia.space._2s)
             .padding(.bottom, .ecosia.space._2s)
-            .padding(.leading, authStateProvider.hasRegisterVisitError ? .ecosia.space._2s : .ecosia.space._1s)
+            .padding(.leading, impactManager.hasRegisterVisitError ? .ecosia.space._2s : .ecosia.space._1s)
             .padding(.trailing, .ecosia.space._2s)
             .frame(minHeight: .ecosia.space._3l, maxHeight: .ecosia.space._3l)
-            .animation(.easeInOut(duration: 0.3), value: authStateProvider.hasRegisterVisitError)
+            .animation(.easeInOut(duration: 0.3), value: impactManager.hasRegisterVisitError)
         }
         .buttonStyle(EcosiaAccountNavButtonStyle(
             backgroundColor: theme.backgroundColor,

--- a/firefox-ios/EcosiaTests/ClimateImpactCounter/UserDefaultsLoggedInImpactCacheTests.swift
+++ b/firefox-ios/EcosiaTests/ClimateImpactCounter/UserDefaultsLoggedInImpactCacheTests.swift
@@ -1,0 +1,62 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+@testable import Ecosia
+import XCTest
+
+final class UserDefaultsLoggedInImpactCacheTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        UserDefaultsLoggedInImpactCache.clear()
+    }
+
+    override func tearDown() {
+        UserDefaultsLoggedInImpactCache.clear()
+        super.tearDown()
+    }
+
+    func test_load_returnsNil_whenNothingCached() {
+        XCTAssertNil(UserDefaultsLoggedInImpactCache.load(forUserId: "user-a"))
+    }
+
+    func test_save_thenLoad_returnsSameSnapshot_forSameUser() {
+        let snapshot = ImpactSnapshot(seedCount: 42, currentLevelNumber: 3, currentProgress: 0.6)
+
+        UserDefaultsLoggedInImpactCache.save(snapshot, userId: "user-a")
+
+        XCTAssertEqual(UserDefaultsLoggedInImpactCache.load(forUserId: "user-a"), snapshot)
+    }
+
+    func test_load_returnsNil_forDifferentUser() {
+        let snapshot = ImpactSnapshot(seedCount: 42, currentLevelNumber: 3, currentProgress: 0.6)
+        UserDefaultsLoggedInImpactCache.save(snapshot, userId: "user-a")
+
+        XCTAssertNil(UserDefaultsLoggedInImpactCache.load(forUserId: "user-b"),
+                     "A different account must never inherit another account's cached numbers")
+    }
+
+    func test_clear_removesCachedSnapshot() {
+        UserDefaultsLoggedInImpactCache.save(
+            ImpactSnapshot(seedCount: 42, currentLevelNumber: 3, currentProgress: 0.6),
+            userId: "user-a"
+        )
+
+        UserDefaultsLoggedInImpactCache.clear()
+
+        XCTAssertNil(UserDefaultsLoggedInImpactCache.load(forUserId: "user-a"))
+    }
+
+    func test_clearOnLogout_isEquivalentToClear() {
+        UserDefaultsLoggedInImpactCache.save(
+            ImpactSnapshot(seedCount: 42, currentLevelNumber: 3, currentProgress: 0.6),
+            userId: "user-a"
+        )
+
+        UserDefaultsLoggedInImpactCache.clearOnLogout()
+
+        XCTAssertNil(UserDefaultsLoggedInImpactCache.load(forUserId: "user-a"),
+                     "clearOnLogout() is the shared vocabulary with SeedProgressManagerProtocol - should behave exactly like clear()")
+    }
+}

--- a/firefox-ios/EcosiaTests/ClimateImpactCounter/UserDefaultsSeedProgressManagerTests.swift
+++ b/firefox-ios/EcosiaTests/ClimateImpactCounter/UserDefaultsSeedProgressManagerTests.swift
@@ -181,4 +181,27 @@ final class UserDefaultsSeedProgressManagerTests: XCTestCase {
         XCTAssertEqual(totalSeeds, UserDefaultsSeedProgressManager.maxSeedsForLoggedOutUsers)
         XCTAssertEqual(level, 1)
     }
+
+    // Test that currentSnapshot() reflects real local progress, not a hardcoded placeholder
+    func test_currentSnapshot_reflectsLocalProgress() {
+        UserDefaultsSeedProgressManager.addSeeds(2) // exactly reaches level 1's threshold (requiredSeeds: 2)
+
+        let snapshot = UserDefaultsSeedProgressManager.currentSnapshot()
+
+        XCTAssertEqual(snapshot.seedCount, 2)
+        XCTAssertEqual(snapshot.currentLevelNumber, 1)
+        XCTAssertEqual(snapshot.currentProgress, 1.0, accuracy: 0.0001)
+    }
+
+    // Test that clearOnLogout() is the same shared vocabulary as resetLocalSeedProgress()
+    func test_clearOnLogout_isEquivalentToResetLocalSeedProgress() {
+        UserDefaultsSeedProgressManager.addSeeds(2)
+
+        UserDefaultsSeedProgressManager.clearOnLogout()
+
+        XCTAssertEqual(UserDefaultsSeedProgressManager.loadCurrentLevel(), 1)
+        XCTAssertEqual(UserDefaultsSeedProgressManager.loadTotalSeedsCollected(), 0)
+        let lastOpenDateMessage = "Last app open date should be cleared to allow immediate seed collection"
+        XCTAssertNil(UserDefaultsSeedProgressManager.loadLastAppOpenDate(), lastOpenDateMessage)
+    }
 }

--- a/firefox-ios/EcosiaTests/UI/Account/ImpactManagerTests.swift
+++ b/firefox-ios/EcosiaTests/UI/Account/ImpactManagerTests.swift
@@ -1,0 +1,142 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+@testable import Ecosia
+import XCTest
+
+/// Records calls instead of touching real `UserDefaults`, so tests don't depend on
+/// `EcosiaAuthenticationService.shared`'s live (unmockable) singleton state.
+private final class MockLoggedInImpactCache: LoggedInImpactCacheProtocol {
+    nonisolated(unsafe) static var stored: [String: ImpactSnapshot] = [:]
+    nonisolated(unsafe) static var clearCallCount = 0
+    nonisolated(unsafe) static var onClear: (() -> Void)?
+
+    static func load(forUserId userId: String) -> ImpactSnapshot? {
+        stored[userId]
+    }
+
+    static func save(_ snapshot: ImpactSnapshot, userId: String) {
+        stored[userId] = snapshot
+    }
+
+    static func clear() {
+        clearCallCount += 1
+        stored.removeAll()
+        onClear?()
+    }
+
+    static func reset() {
+        stored.removeAll()
+        clearCallCount = 0
+        onClear = nil
+    }
+}
+
+@MainActor
+final class ImpactManagerTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        MockLoggedInImpactCache.reset()
+        ImpactManager.loggedInImpactCacheType = MockLoggedInImpactCache.self
+    }
+
+    override func tearDown() {
+        ImpactManager.loggedInImpactCacheType = UserDefaultsLoggedInImpactCache.self
+        MockLoggedInImpactCache.reset()
+        super.tearDown()
+    }
+
+    // MARK: - resolveInitialImpactSnapshot (cold-init read)
+
+    func test_resolveInitialSnapshot_returnsCachedValues_whenLoggedInAndCacheHit() {
+        let snapshot = ImpactSnapshot(seedCount: 120, currentLevelNumber: 4, currentProgress: 0.8)
+        MockLoggedInImpactCache.save(snapshot, userId: "auth0|user-a")
+
+        let resolved = ImpactManager.resolveInitialImpactSnapshot(isLoggedIn: true, userId: "auth0|user-a")
+
+        XCTAssertEqual(resolved, snapshot, "A logged-in user with a cached snapshot must not fall back to the logged-out default")
+    }
+
+    func test_resolveInitialSnapshot_returnsLocalManagerSnapshot_whenLoggedOut() {
+        // A stale cache entry under the same id must never leak into the logged-out branch.
+        MockLoggedInImpactCache.save(
+            ImpactSnapshot(seedCount: 999, currentLevelNumber: 9, currentProgress: 0.99),
+            userId: "auth0|user-a"
+        )
+
+        let resolved = ImpactManager.resolveInitialImpactSnapshot(isLoggedIn: false, userId: "auth0|user-a")
+
+        // Compared against a live call rather than a hardcoded literal, since
+        // UserDefaultsSeedProgressManager.calculateInnerProgress() depends on seedCounterConfig,
+        // which other test files may have set - this stays correct regardless of test order.
+        let expectedMessage = "Logged-out must read the real local snapshot, not fall back to nil/hardcoded defaults"
+        XCTAssertEqual(resolved, UserDefaultsSeedProgressManager.currentSnapshot(), expectedMessage)
+
+        let isolationMessage = "Logged-out must never read from the logged-in cache, even if an entry exists for this id"
+        XCTAssertNotEqual(resolved?.seedCount, 999, isolationMessage)
+    }
+
+    func test_resolveInitialSnapshot_returnsNil_whenNoUserId() {
+        let resolved = ImpactManager.resolveInitialImpactSnapshot(isLoggedIn: true, userId: nil)
+
+        XCTAssertNil(resolved)
+    }
+
+    func test_resolveInitialSnapshot_returnsNil_whenLoggedInButNoCacheEntry() {
+        let resolved = ImpactManager.resolveInitialImpactSnapshot(isLoggedIn: true, userId: "auth0|first-time-user")
+
+        XCTAssertNil(resolved)
+    }
+
+    func test_resolveInitialSnapshot_returnsNil_forDifferentUsersCachedEntry() {
+        MockLoggedInImpactCache.save(
+            ImpactSnapshot(seedCount: 120, currentLevelNumber: 4, currentProgress: 0.8),
+            userId: "auth0|previous-user"
+        )
+
+        let resolved = ImpactManager.resolveInitialImpactSnapshot(isLoggedIn: true, userId: "auth0|new-user")
+
+        XCTAssertNil(resolved, "A newly logged-in account must not briefly show a previous account's numbers")
+    }
+
+    // MARK: - Logout clears the cache (via the real notification flow)
+
+    func test_userLoggedOutNotification_clearsLoggedInImpactCache() {
+        MockLoggedInImpactCache.save(
+            ImpactSnapshot(seedCount: 120, currentLevelNumber: 4, currentProgress: 0.8),
+            userId: "auth0|user-a"
+        )
+
+        let expectation = expectation(description: "logged-in impact cache cleared on logout")
+        MockLoggedInImpactCache.onClear = { expectation.fulfill() }
+
+        let manager = ImpactManager(accountsProvider: AccountsProvider())
+        NotificationCenter.default.post(
+            name: .EcosiaAuthStateChanged,
+            object: nil,
+            userInfo: ["actionType": EcosiaAuthActionType.userLoggedOut]
+        )
+
+        wait(for: [expectation], timeout: 2.0)
+        XCTAssertEqual(MockLoggedInImpactCache.clearCallCount, 1)
+        // Referenced here (rather than discarded right after creation) so ARC keeps `manager`,
+        // and therefore its notification observers, alive for the whole wait above.
+        XCTAssertNotNil(manager)
+    }
+
+    // MARK: - clearOnLogout shared vocabulary
+
+    func test_clearOnLogout_isEquivalentToClear() {
+        MockLoggedInImpactCache.save(
+            ImpactSnapshot(seedCount: 120, currentLevelNumber: 4, currentProgress: 0.8),
+            userId: "auth0|user-a"
+        )
+
+        MockLoggedInImpactCache.clearOnLogout()
+
+        XCTAssertEqual(MockLoggedInImpactCache.clearCallCount, 1, "clearOnLogout() should delegate straight to clear()")
+        XCTAssertNil(MockLoggedInImpactCache.load(forUserId: "auth0|user-a"))
+    }
+}


### PR DESCRIPTION
[MOB-4236]

## Context

Separates concerns a bit more

Aligns semantically more closely to [impact stuff in core](https://github.com/ecosia/core/tree/main/accounts/impact)

## Approach

- `EcosiaAuthUIStateProvider` now only owns identity/profile stuff
    - `isLoggedIn`
    - `userProfile`
    - `avatarURL`
    - `username`.
- New `ImpactManager` owns everything seed/level/progress-related: 
    - both caches (`UserDefaultsSeedProgressManager` for logged-out, the new `LoggedInImpactCache` for logged-in)
    - `registerVisit`
    - the balance/level-up animations
    - `refreshSeedState()`. Callers call `refreshSeedState()` and read `seedCount`/`currentLevelNumber`/`currentProgress` without branching on login state themselves.
- `ImpactManager` tracks `isLoggedIn`/the current user id independently, by listening to the same auth notifications `EcosiaAuthUIStateProvider` does — the two are siblings, not layered, so there's no coupling between the two singletons.
- Updated every real consumer of the moved properties: `EcosiaAccountNavButton`, `EcosiaAccountImpactView`/`ViewModel`, `NTPHeaderViewModel`, `User.seedCount`, `EcosiaDebugSettings`

## Other

## Before merging

### Checklist

- [ ] I performed some relevant testing on a real device and/or simulator for both iPhone and iPad
- [ ] I wrote Unit Tests that confirm the expected behaviour
- [ ] If this PR changes snapshot-covered UI, I updated snapshot tests and `SnapshotArtifacts` references — **or** I added the `skip-snapshot-check` label because there is no visual impact
- [ ] I updated only the english localization source files if needed
- [ ] I added the `// Ecosia:` helper comments where needed
- [ ] I made sure that any change to the Analytics events included in PR won't alter current analytics (e.g. new users, upgrading users)
- [ ] I included documentation updates to the coding standards or Confluence doc, when needed

[MOB-4236]: https://ecosia.atlassian.net/browse/MOB-4236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ