### PR TITLE
Bump version to 12.5.1

### DIFF
--- a/firefox-ios/Client/Ecosia/BuildSettingsConfigurations/EcosiaCommon.xcconfig
+++ b/firefox-ios/Client/Ecosia/BuildSettingsConfigurations/EcosiaCommon.xcconfig
@@ -24,7 +24,7 @@ MOZ_WALLPAPER_ASSET_URL = https:/$()/cdn.ecosia.org/static/mobile-wallpapers
 OTHER_LDFLAGS = $(inherited) -lxml2
 
 // Ecosia: App marketing version — bump this for every release.
-MARKETING_VERSION = 12.5.0
+MARKETING_VERSION = 12.5.1
 
 // Ecosia: Build performance setting.
 EAGER_LINKING = NO


### PR DESCRIPTION
Triggers release 12.5.1: [ticket TBD]()

I think snapshots failing is expected as it's a WIP, just like [last release ](https://github.com/ecosia/ios-browser/pull/1264)